### PR TITLE
Add Canned & Bottled section to drink menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -80,6 +80,7 @@
   .icon-tequila { background: rgba(18,133,120,0.15); }
   .icon-frozen { background: rgba(100,180,255,0.18); }
   .icon-special { background: rgba(190,67,48,0.12); }
+  .icon-canned  { background: rgba(140,200,120,0.18); }
   .menu-section-title { font-family: 'Lilita One', cursive; font-size: 18px; letter-spacing: 1px; line-height: 1; color: var(--teal); }
   .menu-section-sub { font-family: 'Permanent Marker', cursive; font-size: 11px; color: var(--muted); margin-top: 2px; }
   .menu-items { display: flex; flex-direction: column; gap: 5px; }
@@ -391,6 +392,7 @@ const CATEGORY_DEFS = [
   { id:'tequila', icon:'🌶️', iconClass:'icon-tequila', title:'Infused Tequila', sub:'Rotating infused marg tequila',   placeholder:'e.g. Jalapeño-Pineapple Blanco...' },
   { id:'frozen',  icon:'🧊', iconClass:'icon-frozen',  title:'Frozen Marg',     sub:'Current frozen margarita flavor', placeholder:'e.g. Strawberry Basil...' },
   { id:'special', icon:'⭐', iconClass:'icon-special', title:'Monthly Specials', sub:'Featured cocktails & promos',    placeholder:'e.g. The Valentina — raspberry, grapefruit...' },
+  { id:'canned',  icon:'🍻', iconClass:'icon-canned',  title:'Canned & Bottled', sub:'Canned & bottled offerings',     placeholder:'e.g. Modelo Especial (can), Topo Chico...' },
 ];
 
 // In-memory menu state — loaded from JSONBin on init


### PR DESCRIPTION
Adds a new 'canned' category to CATEGORY_DEFS with a 🍻 icon and soft green background. The section appears automatically in both the public view and manager view since all rendering iterates CATEGORY_DEFS.

https://claude.ai/code/session_011d9PqciY33oVc9Kj6J5FQd