### PR TITLE
Update README to reflect current app functionality

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,34 @@
 # El Roy's Drink Menu
 
-A live, single-page drink menu for El Roy's — built as a zero-dependency HTML file that runs anywhere. Staff can update the menu in real time using a manager PIN, then push it to a GroupMe group in one tap. The public-facing view updates instantly via Firebase.
+A live, single-page drink menu for El Roy's — built as a zero-dependency HTML file that runs anywhere. Staff can update the menu in real time using a manager PIN, save changes to the database, and push a formatted update to a GroupMe group. The public-facing view updates instantly via Firebase.
 
 ---
 
 ## Features
 
-- **Live public menu** — displays current beers on tap, infused tequilas, frozen marg flavors, and monthly specials
-- **Manager mode** — PIN-protected editing interface; add, reorder, or remove items per category
+- **Live public menu** — displays beers on tap, infused tequilas, frozen marg flavors, monthly specials, and canned & bottled offerings
+- **Item descriptions** — optional per-item descriptions visible to the public via an expandable tap/click
+- **86'd items** — mark items out of stock; they remain visible on the public menu with a strikethrough and "86'D" tag
+- **Manager mode** — PIN-protected editing interface; add or remove items per category, toggle 86 status, and write item descriptions
+- **Save vs. Send Update** — save menu changes to the database without notifying the group; send only when ready
+- **Draft indicators** — green dot per item means it hasn't been announced yet; the Send Update button shows a change count when there are unsent changes
 - **Owner mode** — separate owner PIN locks down admin settings so only you can change credentials and PINs
-- **GroupMe integration** — sends a formatted menu message to a GroupMe group via a bot
+- **GroupMe integration** — sends a formatted patch-notes message to a GroupMe group via a bot
 - **Firebase cloud sync** — menu state and config sync across devices in real time via Firebase Realtime Database
 - **Offline-capable** — falls back to localStorage if Firebase is unavailable
 - **Zero dependencies** — single `index.html` file, no build step, no server required
+
+---
+
+## Menu Categories
+
+| Category | Description |
+|---|---|
+| 🍺 Beers on Tap | Current draft beer offerings |
+| 🌶️ Infused Tequila | Rotating infused margarita tequilas |
+| 🧊 Frozen Marg | Current frozen margarita flavor(s) |
+| ⭐ Monthly Specials | Featured cocktails and promos |
+| 🍻 Canned & Bottled | Canned and bottled offerings |
 
 ---
 
@@ -60,18 +76,20 @@ No backend required — Firebase handles all data persistence.
 
 ### Viewing the Menu (Public)
 
-Open the page URL in any browser. The menu loads automatically from Firebase and shows all current items by category.
+Open the page URL in any browser. The menu loads automatically from Firebase and shows all current items by category. Items marked 86'd appear with a strikethrough and red "86'D" tag. Items with a description show a **›** icon — tap or click to expand.
 
 ### Updating the Menu (Manager)
 
 1. Click **⚙ Manager** and enter your manager PIN
 2. Use the **Manager** tab to edit each category:
-   - Type an item name and press **Add**
-   - Drag items to reorder (drag handle on the left)
-   - Click **✕** to remove an item
-3. Changes are **drafts** until you send them — a yellow indicator appears when there are unsaved changes
-4. Click **Send to GroupMe** to publish the menu and notify your group
-   - This also updates the **Last Updated** timestamp in the header
+   - Type an item name in the input field and press **+** (or Enter) to add it
+   - Click **86** on an item to mark it out of stock; click **↩** to restore it
+   - Click **📝** to add or edit an item description
+   - Click **✕** to remove an item permanently
+3. Items not yet announced to the group show a **green dot**; the Send Update button shows a change count when unsent changes exist
+4. At the bottom of the manager screen:
+   - **💾 SAVE** — saves all changes to Firebase without sending a GroupMe message
+   - **🔥 SEND UPDATE** — saves changes and sends a patch-notes message to your GroupMe group, including any previously saved-but-not-sent changes; also updates the **Last Updated** timestamp in the header
 
 ### Changing Admin Settings (Owner)
 
@@ -82,8 +100,9 @@ Open the page URL in any browser. The menu loads automatically from Firebase and
 ### Access Levels
 
 | Action | Manager PIN | Owner PIN |
-|--------|------------|-----------|
+|---|---|---|
 | Edit menu items | ✅ | ✅ |
+| Save to database | ✅ | ✅ |
 | Send to GroupMe | ✅ | ✅ |
 | View admin settings | ❌ (hidden) | ✅ |
 | Change Firebase / Bot ID | ❌ | ✅ |


### PR DESCRIPTION
- Add Canned & Bottled to the category list (with full table of all 5 categories)
- Document the new Save / Send Update two-button workflow
- Add sections for 86'd items, item descriptions, and draft indicators
- Remove incorrect reference to drag-to-reorder (not implemented)
- Fix button labels (was "Send to GroupMe", now "💾 SAVE" and "🔥 SEND UPDATE")
- Clarify that Last Updated only changes on Send Update, not Save
- Update Access Levels table to include "Save to database" row

https://claude.ai/code/session_011d9PqciY33oVc9Kj6J5FQd