### PR TITLE
Add typable hex code inputs to Design & Branding color pickers

### DIFF
--- a/app.js
+++ b/app.js
@@ -262,7 +262,25 @@ function onFontSelectChange(selectId) {
 function updateColorLabel(inputId) {
   const input = document.getElementById(inputId);
   const label = document.getElementById(inputId + '-label');
-  if (input && label) label.textContent = input.value;
+  if (input && label) label.value = input.value;
+}
+
+function syncHexInput(colorInputId) {
+  const hexInput = document.getElementById(colorInputId + '-label');
+  const colorInput = document.getElementById(colorInputId);
+  if (!hexInput || !colorInput) return;
+  const val = hexInput.value.trim();
+  if (/^#[0-9a-fA-F]{6}$/.test(val)) {
+    colorInput.value = val;
+    // Live preview: apply immediately without saving
+    const d = {
+      ...currentDesign,
+      primaryColor: document.getElementById('design-primary-color')?.value || currentDesign.primaryColor,
+      accentColor:  document.getElementById('design-accent-color')?.value  || currentDesign.accentColor,
+      bgColor:      document.getElementById('design-bg-color')?.value      || currentDesign.bgColor,
+    };
+    applyDesign(d);
+  }
 }
 
 function handleLogoUpload(event) {

--- a/index.html
+++ b/index.html
@@ -177,7 +177,9 @@
           <div class="design-control">
             <div class="design-color-row">
               <input type="color" id="design-primary-color" value="#2d3748" oninput="updateColorLabel('design-primary-color')"/>
-              <span class="design-color-label" id="design-primary-color-label">#2d3748</span>
+              <input type="text" class="design-hex-input" id="design-primary-color-label"
+                maxlength="7" placeholder="#000000"
+                oninput="syncHexInput('design-primary-color')">
             </div>
           </div>
         </div>
@@ -187,7 +189,9 @@
           <div class="design-control">
             <div class="design-color-row">
               <input type="color" id="design-accent-color" value="#4299e1" oninput="updateColorLabel('design-accent-color')"/>
-              <span class="design-color-label" id="design-accent-color-label">#4299e1</span>
+              <input type="text" class="design-hex-input" id="design-accent-color-label"
+                maxlength="7" placeholder="#000000"
+                oninput="syncHexInput('design-accent-color')">
             </div>
           </div>
         </div>
@@ -197,7 +201,9 @@
           <div class="design-control">
             <div class="design-color-row">
               <input type="color" id="design-bg-color" value="#f0f4f8" oninput="updateColorLabel('design-bg-color')"/>
-              <span class="design-color-label" id="design-bg-color-label">#f0f4f8</span>
+              <input type="text" class="design-hex-input" id="design-bg-color-label"
+                maxlength="7" placeholder="#000000"
+                oninput="syncHexInput('design-bg-color')">
             </div>
           </div>
         </div>

--- a/style.css
+++ b/style.css
@@ -341,6 +341,7 @@
   .design-select { width: 100%; background: var(--surface); border: 1px solid var(--border); border-radius: 8px; color: var(--text); font-family: var(--font-body); font-size: 13px; padding: 8px 12px; outline: none; cursor: pointer; box-sizing: border-box; }
   .design-color-row { display: flex; align-items: center; gap: 8px; }
   .design-color-row input[type="color"] { width: 42px; height: 36px; border: 1px solid var(--border); border-radius: 7px; cursor: pointer; padding: 2px; background: var(--surface); flex-shrink: 0; }
-  .design-color-label { font-size: 12px; color: var(--muted); font-family: monospace; }
+  .design-hex-input { width: 90px; background: var(--surface); border: 1px solid var(--border); border-radius: 7px; color: var(--text); font-family: monospace; font-size: 12px; padding: 4px 8px; outline: none; transition: border-color 0.2s; box-sizing: border-box; }
+  .design-hex-input:focus { border-color: var(--fire); }
   .design-logo-preview { width: 64px; height: 64px; object-fit: contain; border-radius: 8px; border: 1px solid var(--border); display: none; }
   .design-save-row { display: flex; justify-content: flex-end; margin-top: 6px; }


### PR DESCRIPTION
## Summary
- Replaces the read-only hex label spans with editable `<input type="text">` fields in the Admin → Design & Branding color picker rows
- Typing a valid 6-digit hex code (`#rrggbb`) syncs the native color picker and triggers a live preview via `applyDesign()`
- Removes now-dead `.design-color-label` CSS rule
- Adds `.design-hex-input` styles matching existing design input conventions

Closes #43

## Test plan
- [ ] Open Admin tab → Design & Branding
- [ ] Verify hex inputs show the current color value and are editable
- [ ] Type a valid hex (e.g. `#ff0000`) and confirm the color picker and live preview update
- [ ] Type an incomplete hex and confirm no crash / no premature update
- [ ] Use the native color picker and confirm the hex input updates to match
- [ ] Save Design and confirm values persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)