### PR TITLE
v0.4.1 — Fix PREVIEW badge always showing in live deploy

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,7 +1,7 @@
 // ─── CONFIG ───────────────────────────────────────────────────────────────────
 const APP_VERSION = 'v0.4';
-const IS_PREVIEW = window.location.hostname.includes('vercel.app') &&
-  !/^el-roys[^-]/.test(window.location.hostname);
+const IS_PREVIEW = window.location.hostname.endsWith('.vercel.app') &&
+  window.location.hostname !== 'el-roys-drink-menu.vercel.app';
 
 let BOT_ID    = '';
 let MENU_URL  = localStorage.getItem('hf_menu_url') || '';


### PR DESCRIPTION
## Summary
- Fixes #82 — the PREVIEW badge was appearing in the footer on the live Vercel deployment
- The old regex `/^el-roys[^-]/` never matched `el-roys-drink-menu.vercel.app` because the hyphen after `el-roys` was excluded, so `IS_PREVIEW` was always `true` on every `.vercel.app` hostname
- Replaced with an exact hostname check: `!== 'el-roys-drink-menu.vercel.app'`

## Change
One-line fix in `app.js:3-4`. No other changes.

## Test plan
- [ ] Deploy to Vercel production — footer shows version only, no PREVIEW badge
- [ ] Deploy a preview branch to Vercel — footer shows version + PREVIEW badge
- [ ] Local / non-Vercel host — no PREVIEW badge

🤖 Generated with [Claude Code](https://claude.com/claude-code)