### PR TITLE
fix: announce toast messages to screen readers (closes #67)

### DIFF
--- a/index.html
+++ b/index.html
@@ -327,7 +327,7 @@
   </div>
 </div>
 
-<div class="toast" id="toast"></div>
+<div class="toast" id="toast" role="status" aria-live="polite" aria-atomic="true"></div>
 
 <script src="app.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Adds `role="status"`, `aria-live="polite"`, and `aria-atomic="true"` to the toast `<div>`
- Screen readers will now announce toast messages (save confirmations, errors, etc.) without requiring the user to move focus to them
- No JS changes needed — `showToast()` already sets `textContent` directly, which triggers the live region

## Test plan
- [ ] Sign in and save the menu — confirm VoiceOver/NVDA reads the "Saved" toast
- [ ] Trigger an error — confirm the toast message is announced
- [ ] Verify toast still appears/dismisses visually as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)