### PR TITLE
fix: make collapsible category headers keyboard accessible (closes #68)

### DIFF
--- a/app.js
+++ b/app.js
@@ -728,7 +728,10 @@ function renderPublicView() {
         }).join('')
       : `<div class="empty-menu">Nothing listed yet.</div>`;
     section.innerHTML = `
-      <div class="menu-section-header collapsible-header" onclick="togglePublicCategory('${cat.id}')">
+      <div class="menu-section-header collapsible-header" role="button" tabindex="0"
+           aria-expanded="${isCollapsed ? 'false' : 'true'}"
+           onclick="togglePublicCategory('${cat.id}')"
+           onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();togglePublicCategory('${cat.id}')}">
         <div class="menu-icon" style="background:${escHtml(cat.color)}">${cat.icon}</div>
         <div><div class="menu-section-title">${escHtml(cat.title)}</div><div class="menu-section-sub">${escHtml(cat.sub || '')}</div></div>
         <span class="category-chevron">›</span>
@@ -745,14 +748,22 @@ function togglePublicDesc(el) {
 
 function togglePublicCategory(catId) {
   const section = document.getElementById('pub-section-' + catId);
-  if (section) section.classList.toggle('collapsed');
+  if (section) {
+    section.classList.toggle('collapsed');
+    const hdr = section.querySelector('.collapsible-header');
+    if (hdr) hdr.setAttribute('aria-expanded', section.classList.contains('collapsed') ? 'false' : 'true');
+  }
   updateCollapseAllBtn();
 }
 
 function toggleAllCategories() {
   const sections = document.querySelectorAll('#public-categories .menu-section');
   const anyExpanded = Array.from(sections).some(s => !s.classList.contains('collapsed'));
-  sections.forEach(s => s.classList.toggle('collapsed', anyExpanded));
+  sections.forEach(s => {
+    s.classList.toggle('collapsed', anyExpanded);
+    const hdr = s.querySelector('.collapsible-header');
+    if (hdr) hdr.setAttribute('aria-expanded', anyExpanded ? 'false' : 'true');
+  });
   updateCollapseAllBtn();
 }
 
@@ -1054,7 +1065,10 @@ function renderManagerCategories() {
     card.className = 'cat-card';
     card.id = 'mgr-card-' + cat.id;
     card.innerHTML = `
-      <div class="cat-header collapsible-header" onclick="toggleManagerCategory('${cat.id}')">
+      <div class="cat-header collapsible-header" role="button" tabindex="0"
+           aria-expanded="true"
+           onclick="toggleManagerCategory('${cat.id}')"
+           onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleManagerCategory('${cat.id}')}">
         <div class="cat-icon" style="background:${escHtml(cat.color)}">${cat.icon}</div>
         <div><div class="cat-title">${escHtml(cat.title)}</div><div class="cat-sub">${escHtml(cat.sub || '')}</div></div>
         <span class="category-chevron">›</span>
@@ -1080,7 +1094,11 @@ function renderManagerCategories() {
 
 function toggleManagerCategory(catId) {
   const card = document.getElementById('mgr-card-' + catId);
-  if (card) card.classList.toggle('collapsed');
+  if (card) {
+    card.classList.toggle('collapsed');
+    const hdr = card.querySelector('.collapsible-header');
+    if (hdr) hdr.setAttribute('aria-expanded', card.classList.contains('collapsed') ? 'false' : 'true');
+  }
 }
 
 function renderManagerItems(catId) {


### PR DESCRIPTION
## Summary

- Adds `role="button"`, `tabindex="0"`, `aria-expanded`, and `onkeydown` (Enter/Space) handlers to collapsible category headers in both the public and manager views
- Updates `togglePublicCategory()`, `toggleManagerCategory()`, and `toggleAllCategories()` to keep `aria-expanded` in sync after every toggle, including batch collapse/expand

## Test plan

- [ ] Tab to a public category header and press Enter or Space — category should collapse/expand
- [ ] Tab to a manager category header and press Enter or Space — category should collapse/expand
- [ ] Click "Collapse All" / "Expand All" — verify `aria-expanded` reflects the new state on all headers
- [ ] Verify existing mouse click behavior is unchanged on both header types

🤖 Generated with [Claude Code](https://claude.com/claude-code)