### PR TITLE
fix: make user dropdown keyboard accessible (closes #70)

### DIFF
--- a/app.js
+++ b/app.js
@@ -901,13 +901,32 @@ function onActionBtnClick() {
 
 function toggleUserDropdown() {
   const chip = document.getElementById('user-chip');
-  chip.classList.toggle('open');
+  const isOpen = chip.classList.toggle('open');
+  chip.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+  if (isOpen) {
+    const firstFocusable = document.querySelector('#user-dropdown button, #user-dropdown a');
+    if (firstFocusable) firstFocusable.focus();
+  }
 }
 
 // Close dropdown when clicking outside
 document.addEventListener('click', function(e) {
   const chip = document.getElementById('user-chip');
-  if (chip && !chip.contains(e.target)) chip.classList.remove('open');
+  if (chip && !chip.contains(e.target)) {
+    chip.classList.remove('open');
+    chip.setAttribute('aria-expanded', 'false');
+  }
+});
+
+// Close dropdown on Escape
+document.addEventListener('keydown', function(e) {
+  if (e.key !== 'Escape') return;
+  const chip = document.getElementById('user-chip');
+  if (chip && chip.classList.contains('open')) {
+    chip.classList.remove('open');
+    chip.setAttribute('aria-expanded', 'false');
+    chip.focus();
+  }
 });
 
 function openAuthOverlay() {

--- a/index.html
+++ b/index.html
@@ -16,7 +16,14 @@
     <div class="header-sub" id="last-updated-label">Last Updated: —</div>
     <button class="manager-btn" id="action-btn" onclick="onActionBtnClick()" style="display:none">⚙ Manager</button>
     <button class="header-signin-btn" id="signin-btn" onclick="openAuthOverlay()">Sign In</button>
-    <div class="user-chip" id="user-chip" style="display:none" onclick="toggleUserDropdown()">
+    <div class="user-chip" id="user-chip" style="display:none"
+         onclick="toggleUserDropdown()"
+         onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleUserDropdown()}"
+         tabindex="0"
+         role="button"
+         aria-haspopup="true"
+         aria-expanded="false"
+         aria-label="User menu">
       <span id="user-initials">?</span>
       <span>▾</span>
       <div class="user-dropdown" id="user-dropdown">


### PR DESCRIPTION
Adds keyboard support to the user chip dropdown: Enter/Space opens it, Escape closes it and returns focus to chip. Updates aria-expanded to reflect open state.