### PR TITLE
security: move Firebase writes server-side and add .ok guards (#52, #53)

### DIFF
--- a/api/firebase-write.js
+++ b/api/firebase-write.js
@@ -1,5 +1,5 @@
 export default async function handler(req, res) {
-  if (req.method !== 'GET') return res.status(405).end();
+  if (req.method !== 'POST') return res.status(405).end();
 
   const sbUrl     = process.env.SUPABASE_URL;
   const sbService = process.env.SUPABASE_SERVICE_ROLE_KEY;
@@ -17,14 +17,25 @@ export default async function handler(req, res) {
   const { id: uid } = await userRes.json();
   if (!uid) return res.status(401).json({ error: 'Invalid token' });
 
-  // Read role with service key (bypasses RLS)
+  // Check role
   const roleRes = await fetch(
     `${sbUrl}/rest/v1/profiles?id=eq.${uid}&select=role`,
     { headers: { 'apikey': sbService, 'Authorization': `Bearer ${sbService}` } }
   );
+  if (!roleRes.ok) return res.status(500).json({ error: 'Failed to fetch role' });
   const [profile] = await roleRes.json();
-  const role = profile?.role || 'none';
-  if (role !== 'manager' && role !== 'admin') return res.status(403).json({ error: 'Forbidden' });
+  if (profile?.role !== 'manager' && profile?.role !== 'admin')
+    return res.status(403).json({ error: 'Forbidden' });
 
-  res.json({ fbSecret: process.env.FIREBASE_SECRET });
+  // Write to Firebase
+  const { fbUrl, state } = req.body;
+  if (!fbUrl || state === undefined) return res.status(400).json({ error: 'Missing fbUrl or state' });
+
+  const r = await fetch(`${fbUrl}/menu.json?auth=${fbSecret}`, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(state)
+  });
+  if (!r.ok) return res.status(502).json({ error: `Firebase write failed: ${r.status}` });
+  res.status(200).end();
 }

--- a/api/role.js
+++ b/api/role.js
@@ -21,6 +21,7 @@ export default async function handler(req, res) {
     `${sbUrl}/rest/v1/profiles?id=eq.${uid}&select=role,name`,
     { headers: { 'apikey': sbService, 'Authorization': `Bearer ${sbService}` } }
   );
+  if (!roleRes.ok) return res.status(500).json({ error: 'Failed to fetch role' });
   const [profile] = await roleRes.json();
   res.json({ role: profile?.role || 'none', name: profile?.name || '' });
 }

--- a/api/send-groupme.js
+++ b/api/send-groupme.js
@@ -24,6 +24,7 @@ export default async function handler(req, res) {
     `${sbUrl}/rest/v1/profiles?id=eq.${uid}&select=role`,
     { headers: { 'apikey': sbService, 'Authorization': `Bearer ${sbService}` } }
   );
+  if (!roleRes.ok) return res.status(500).json({ error: 'Failed to fetch role' });
   const [profile] = await roleRes.json();
   if (profile?.role !== 'manager' && profile?.role !== 'admin')
     return res.status(403).json({ error: 'Forbidden' });

--- a/app.js
+++ b/app.js
@@ -5,7 +5,6 @@ const IS_PREVIEW = window.location.hostname.endsWith('.vercel.app') &&
 
 let BOT_ID    = '';
 let MENU_URL  = localStorage.getItem('hf_menu_url') || '';
-let FB_SECRET = '';
 let FB_URL    = localStorage.getItem('hf_fb_url') || 'https://el-roy-s-drink-menu-default-rtdb.firebaseio.com';
 
 let SUPABASE_URL      = '';
@@ -95,11 +94,14 @@ async function fbRead() {
 }
 
 async function fbWrite(state) {
-  if (!FB_SECRET || !FB_URL) return;
-  const res = await fetch(`${FB_URL}/menu.json?auth=${FB_SECRET}`, {
-    method: 'PUT',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(state)
+  if (!FB_URL || !currentUser?.accessToken) return;
+  const res = await fetch('/api/firebase-write', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${currentUser.accessToken}`
+    },
+    body: JSON.stringify({ fbUrl: FB_URL, state })
   });
   if (!res.ok) throw new Error(`Firebase write failed: ${res.status}`);
 }
@@ -817,17 +819,6 @@ async function sbGetProfile(accessToken) {
   return { role: role || 'none', name: name || '' };
 }
 
-async function fetchFirebaseSecret() {
-  if (!currentUser?.accessToken) return;
-  try {
-    const r = await fetch('/api/firebase-config', {
-      headers: { 'Authorization': `Bearer ${currentUser.accessToken}` }
-    });
-    if (!r.ok) return;
-    const { fbSecret } = await r.json();
-    if (fbSecret) FB_SECRET = fbSecret;
-  } catch(e) {}
-}
 
 function _scheduleTokenRefresh(expiresAt) {
   if (_tokenRefreshTimer) clearTimeout(_tokenRefreshTimer);
@@ -898,7 +889,6 @@ function applyRole(role) {
   const pruneSection = document.getElementById('prune-section');
   if (pruneSection) pruneSection.style.display = isAdmin ? '' : 'none';
   renderUserHeader();
-  if (isManager) fetchFirebaseSecret();
 }
 
 // ─── AUTH OVERLAY ─────────────────────────────────────────────────────────────
@@ -1194,7 +1184,7 @@ function renderManagerItems(catId) {
 }
 
 async function persistState() {
-  if (!FB_SECRET || !FB_URL) return;
+  if (!FB_URL || !currentUser?.accessToken) return;
   try {
     menuState._config = {
       menuUrl: MENU_URL, fbUrl: FB_URL,


### PR DESCRIPTION
## Summary
- **Issue #52** — Moves Firebase writes server-side via new `api/firebase-write.js` endpoint. The `FIREBASE_SECRET` env var is no longer sent to the client; writes are authenticated via the user's Supabase JWT and role-checked server-side. Removes `fetchFirebaseSecret()`, `FB_SECRET`, and `api/firebase-config.js`.
- **Issue #53** — Adds missing `if (!roleRes.ok)` guards before `.json()` calls in `api/role.js` and `api/send-groupme.js` (and the new `api/firebase-write.js` follows the same pattern from the start).

## Test plan
- [ ] Deploy to Vercel and verify manager can save/send updates (Firebase writes succeed)
- [ ] Verify unauthenticated requests to `/api/firebase-write` return 401
- [ ] Verify non-manager/admin accounts get 403 from `/api/firebase-write`
- [ ] Confirm `FIREBASE_SECRET` no longer appears in any network responses to the client
- [ ] Verify role endpoint and GroupMe send still work as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)