### PR TITLE
fix: add GroupMe message length cap (#54)

### DIFF
--- a/api/send-groupme.js
+++ b/api/send-groupme.js
@@ -33,10 +33,15 @@ export default async function handler(req, res) {
   const { text } = req.body;
   if (!text) return res.status(400).json({ error: 'Missing text' });
 
+  const MAX_LEN = 1000;
+  const safeText = text.length > MAX_LEN
+    ? text.slice(0, MAX_LEN - 16) + '... (truncated)'
+    : text;
+
   const r = await fetch('https://api.groupme.com/v3/bots/post', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify({ bot_id: botId, text })
+    body: JSON.stringify({ bot_id: botId, text: safeText })
   });
   res.status(r.ok || r.status === 202 ? 202 : r.status).end();
 }

--- a/app.js
+++ b/app.js
@@ -1542,6 +1542,10 @@ async function sendUpdate() {
   if (MENU_URL) lines.push(`📋 Full menu: ${MENU_URL}`);
   const patchMessage = lines.join('\n').trim();
 
+  if (patchMessage.length > 1000) {
+    showToast('Update is long and will be truncated in GroupMe.', 'info');
+  }
+
   const confirmBtn = document.getElementById('confirm-btn');
   confirmBtn.disabled = true;
   confirmBtn.textContent = 'SENDING...';


### PR DESCRIPTION
Closes #54

Adds a 1000-character server-side cap in `api/send-groupme.js` with graceful truncation, and a client-side warning toast in `sendUpdate()` when the message exceeds the threshold.