### PR TITLE
fix: restore item name on cancel when field is cleared (#59)

### DIFF
--- a/app.js
+++ b/app.js
@@ -1383,12 +1383,13 @@ async function saveDesc(catId, itemId, val) {
 
 function removeItem(catId, itemId) {
   const item = findItem(catId, itemId);
-  if (!item) return;
-  if (!confirm(`Remove "${item.name}" from the menu?`)) return;
+  if (!item) return false;
+  if (!confirm('Remove this item from the menu?')) return false;
   item.onMenu = false;
   invalidateDiff();
   renderManagerItems(catId);
   updateDraftIndicator();
+  return true;
 }
 
 function renderPruneSection() {
@@ -1438,7 +1439,15 @@ async function pruneRemoved(catId) {
 
 function renameItem(catId, itemId, newName) {
   const name = newName.trim();
-  if (!name) { removeItem(catId, itemId); return; }
+  if (!name) {
+    const item = findItem(catId, itemId);
+    const removed = removeItem(catId, itemId);
+    if (!removed && item) {
+      const input = document.querySelector(`#wrapper-${itemId} .item-name input`);
+      if (input) input.value = item.name;
+    }
+    return;
+  }
   const item = findItem(catId, itemId);
   if (item && item.name !== name) { item.name = name; invalidateDiff(); renderManagerItems(catId); updateDraftIndicator(); }
 }


### PR DESCRIPTION
Closes #59

Fixes two issues in the item removal flow:

- **Confusing dialog message**: `removeItem()` previously showed `Remove "" from the menu?` when called on an item with an empty name. Now shows `Remove this item from the menu?` unconditionally.
- **No recovery on cancel**: If a manager cleared an item's name field and tabbed away, `renameItem()` would call `removeItem()`. If they cancelled, the field was left empty with no way back. Now, if the user cancels, the original name is restored to the input field.

`removeItem()` now returns `true`/`false` so `renameItem()` can detect cancellation.