### PR TITLE
fix: add approval notice to sign-up form (#55)

### DIFF
--- a/index.html
+++ b/index.html
@@ -302,6 +302,7 @@
       </div>
       <div class="auth-error" id="auth-error"></div>
       <button class="auth-submit-btn" id="auth-submit-btn" onclick="handleAuthSubmit()">Sign In</button>
+      <p class="auth-approval-notice">New accounts require admin approval before menu access is granted.</p>
       <div class="auth-toggle">
         <span id="auth-toggle-text">Don't have an account?</span>
         <button class="auth-toggle-btn" id="auth-toggle-btn" onclick="toggleAuthMode()">Sign Up</button>

--- a/style.css
+++ b/style.css
@@ -120,6 +120,7 @@
   .auth-submit-btn:disabled { opacity: 0.6; cursor: default; }
   .auth-toggle { font-size: 12px; color: var(--muted); }
   .auth-toggle-btn { background: none; border: none; color: var(--teal); font-size: 12px; cursor: pointer; padding: 0 4px; text-decoration: underline; font-family: var(--font-body); }
+  .auth-approval-notice { font-size: 11px; color: var(--muted); margin: -4px 0 10px; line-height: 1.5; text-align: center; opacity: 0.8; }
   .pin-cancel { background: none; border: none; color: var(--muted); font-size: 12px; cursor: pointer; margin-top: 14px; display: block; width: 100%; padding: 6px; transition: color 0.15s; }
   .pin-cancel:hover { color: var(--charcoal); }
   /* ── MANAGER VIEW (dark) ── */


### PR DESCRIPTION
Closes #55

Adds `<p class="auth-approval-notice">` below the submit button in the auth overlay with muted 11px text: "New accounts require admin approval before menu access is granted."

Styled using `var(--muted)` — no hardcoded colors. No JS changes required.