### PR TITLE
refactor: v0.5.1 API auth middleware extraction

### DIFF
--- a/api/_auth.js
+++ b/api/_auth.js
@@ -1,0 +1,38 @@
+// Shared auth helper — Vercel ignores files prefixed with _ as API endpoints.
+
+/**
+ * Verifies the Bearer token in the Authorization header and checks that the
+ * caller's role is one of the allowed roles.
+ *
+ * @param {import('http').IncomingMessage} req
+ * @param {...string} roles - Allowed roles (e.g. 'manager', 'admin')
+ * @returns {Promise<{uid: string, role: string}>}
+ * @throws {{status: number, message: string}} on auth failure
+ */
+export async function requireRole(req, ...roles) {
+  const sbUrl     = process.env.SUPABASE_URL;
+  const sbService = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!sbUrl || !sbService) throw { status: 500, message: 'Server misconfigured' };
+
+  const token = (req.headers['authorization'] || '').replace('Bearer ', '').trim();
+  if (!token) throw { status: 401, message: 'Unauthorized' };
+
+  // Verify token and get uid
+  const userRes = await fetch(`${sbUrl}/auth/v1/user`, {
+    headers: { 'Authorization': `Bearer ${token}`, 'apikey': sbService }
+  });
+  if (!userRes.ok) throw { status: 401, message: 'Invalid token' };
+  const { id: uid } = await userRes.json();
+  if (!uid) throw { status: 401, message: 'Invalid token' };
+
+  // Check role
+  const roleRes = await fetch(
+    `${sbUrl}/rest/v1/profiles?id=eq.${uid}&select=role`,
+    { headers: { 'apikey': sbService, 'Authorization': `Bearer ${sbService}` } }
+  );
+  if (!roleRes.ok) throw { status: 500, message: 'Failed to fetch role' };
+  const [profile] = await roleRes.json();
+  if (!roles.includes(profile?.role)) throw { status: 403, message: 'Forbidden' };
+
+  return { uid, role: profile.role };
+}

--- a/api/firebase-write.js
+++ b/api/firebase-write.js
@@ -1,31 +1,16 @@
+import { requireRole } from './_auth.js';
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).end();
 
-  const sbUrl     = process.env.SUPABASE_URL;
-  const sbService = process.env.SUPABASE_SERVICE_ROLE_KEY;
-  const fbSecret  = process.env.FIREBASE_SECRET;
-  if (!sbUrl || !sbService || !fbSecret) return res.status(500).json({ error: 'Server misconfigured' });
+  const fbSecret = process.env.FIREBASE_SECRET;
+  if (!fbSecret) return res.status(500).json({ error: 'Server misconfigured' });
 
-  const token = (req.headers['authorization'] || '').replace('Bearer ', '').trim();
-  if (!token) return res.status(401).json({ error: 'Unauthorized' });
-
-  // Verify token and get uid
-  const userRes = await fetch(`${sbUrl}/auth/v1/user`, {
-    headers: { 'Authorization': `Bearer ${token}`, 'apikey': sbService }
-  });
-  if (!userRes.ok) return res.status(401).json({ error: 'Invalid token' });
-  const { id: uid } = await userRes.json();
-  if (!uid) return res.status(401).json({ error: 'Invalid token' });
-
-  // Check role
-  const roleRes = await fetch(
-    `${sbUrl}/rest/v1/profiles?id=eq.${uid}&select=role`,
-    { headers: { 'apikey': sbService, 'Authorization': `Bearer ${sbService}` } }
-  );
-  if (!roleRes.ok) return res.status(500).json({ error: 'Failed to fetch role' });
-  const [profile] = await roleRes.json();
-  if (profile?.role !== 'manager' && profile?.role !== 'admin')
-    return res.status(403).json({ error: 'Forbidden' });
+  try {
+    await requireRole(req, 'manager', 'admin');
+  } catch (e) {
+    return res.status(e.status).json({ error: e.message });
+  }
 
   // Write to Firebase
   const { fbUrl, state } = req.body;

--- a/api/send-groupme.js
+++ b/api/send-groupme.js
@@ -1,33 +1,16 @@
+import { requireRole } from './_auth.js';
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).end();
 
-  const botId     = process.env.GROUPME_BOT_ID;
-  const sbUrl     = process.env.SUPABASE_URL;
-  const sbService = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
+  const botId = process.env.GROUPME_BOT_ID;
   if (!botId) return res.status(500).json({ error: 'GROUPME_BOT_ID not configured' });
 
-  // Verify token
-  const token = (req.headers['authorization'] || '').replace('Bearer ', '').trim();
-  if (!token || !sbUrl || !sbService) return res.status(401).json({ error: 'Unauthorized' });
-
-  // Get user from token
-  const userRes = await fetch(`${sbUrl}/auth/v1/user`, {
-    headers: { 'Authorization': `Bearer ${token}`, 'apikey': sbService }
-  });
-  if (!userRes.ok) return res.status(401).json({ error: 'Invalid token' });
-  const { id: uid } = await userRes.json();
-  if (!uid) return res.status(401).json({ error: 'Invalid token' });
-
-  // Check role
-  const roleRes = await fetch(
-    `${sbUrl}/rest/v1/profiles?id=eq.${uid}&select=role`,
-    { headers: { 'apikey': sbService, 'Authorization': `Bearer ${sbService}` } }
-  );
-  if (!roleRes.ok) return res.status(500).json({ error: 'Failed to fetch role' });
-  const [profile] = await roleRes.json();
-  if (profile?.role !== 'manager' && profile?.role !== 'admin')
-    return res.status(403).json({ error: 'Forbidden' });
+  try {
+    await requireRole(req, 'manager', 'admin');
+  } catch (e) {
+    return res.status(e.status).json({ error: e.message });
+  }
 
   // Forward to GroupMe
   const { text } = req.body;


### PR DESCRIPTION
## Summary
- Add `api/_auth.js` with `requireRole(req, ...roles)` shared helper (Vercel ignores `_`-prefixed files as endpoints)
- Refactor `api/firebase-write.js` to use `requireRole(req, 'manager', 'admin')` instead of ~20 lines of inline auth
- Refactor `api/send-groupme.js` same way
- `api/role.js` unchanged — it fetches `role,name` together and doesn't enforce a specific role set, so `requireRole` doesn't fit

## Test plan
- [ ] Manager can save menu (Firebase write still authorized)
- [ ] Manager can send GroupMe update (GroupMe proxy still authorized)
- [ ] Non-manager/non-admin token is rejected with 403
- [ ] Missing/invalid token is rejected with 401
- [ ] No console errors on load

🤖 Generated with [Claude Code](https://claude.com/claude-code)