### PR TITLE
fix(v0.5.3): accessibility and style fixes

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 // ─── CONFIG ───────────────────────────────────────────────────────────────────
-const APP_VERSION = 'v0.5.2';
+const APP_VERSION = 'v0.5.3';
 const IS_PREVIEW = window.location.hostname.endsWith('.vercel.app') &&
   window.location.hostname !== 'el-roys-drink-menu.vercel.app';
 
@@ -405,7 +405,7 @@ function renderCategoriesTab() {
           <input type="text" class="catmgr-input" id="ce-ph-${cat.id}" value="${escHtml(cat.placeholder || '')}" placeholder="Add item input hint"/>
         </div>
         <div class="catmgr-save-row">
-          <button class="btn-small btn-danger" onclick="toggleCategoryEdit('${cat.id}')">Cancel</button>
+          <button class="btn-small" onclick="toggleCategoryEdit('${cat.id}')">Cancel</button>
           <button class="btn-small" onclick="saveCategoryEdit('${cat.id}')">Save</button>
         </div>
       </div>`;
@@ -723,7 +723,7 @@ function renderPublicView() {
             </div>` : '';
           return `<div class="${classes}" ${onClick}>
             <div class="item-main-row">
-              <div class="dot"></div>
+              <div class="dot" aria-hidden="true"></div>
               <span class="item-name-text">${escHtml(i.name)}</span>
               ${is86 ? `<span class="eighty-sixed-tag">86'D</span>` : ''}
               ${hasDetail ? `<span class="item-expand-icon" role="button" tabindex="0" aria-label="Show description" aria-expanded="false" onclick="event.stopPropagation();togglePublicDesc(this.closest('.menu-item'))" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();event.stopPropagation();togglePublicDesc(this.closest('.menu-item'))}">›</span>` : ''}
@@ -1158,7 +1158,7 @@ function renderManagerItems(catId) {
     const rowClass = ['current-item', isNew ? 'is-new' : '', is86 ? 'is-eighty-sixed' : ''].filter(Boolean).join(' ');
     wrapper.innerHTML = `
       <div class="${rowClass}">
-        <div class="item-status-dot" title="${statusTitle}"></div>
+        <div class="item-status-dot" role="img" aria-label="${statusTitle}" title="${statusTitle}"></div>
         <div class="item-name"><input type="text" value="${escHtml(item.name)}"
           aria-label="Item name"
           onblur="renameItem('${catId}','${item.id}',this.value)"
@@ -1462,7 +1462,7 @@ function updateDraftIndicator() {
   const diff = getCachedDiff();
   const total = diff.reduce((n, s) => n + s.added.length + s.removed.length + s.eightySixed.length + s.restored.length, 0);
   if (total > 0) {
-    btn.innerHTML = `🔥 SEND UPDATE <span style="font-size:13px;opacity:0.85;">(${total} CHANGE${total > 1 ? 'S' : ''})</span>`;
+    btn.innerHTML = `🔥 SEND UPDATE <span class="send-update-count">(${total} CHANGE${total > 1 ? 'S' : ''})</span>`;
     btn.style.boxShadow = '0 4px 22px rgba(255,77,0,0.55)';
   } else {
     btn.innerHTML = '🔥 SEND UPDATE';

--- a/style.css
+++ b/style.css
@@ -164,8 +164,9 @@
   .item-name { flex: 1; }
   .item-name input { background: none; border: none; outline: none; color: var(--text); font-family: var(--font-body); font-size: 13px; width: 100%; padding: 0; }
   .item-name input::placeholder { color: var(--muted); opacity: 0.45; }
-  .del-item { background: none; border: none; color: var(--muted); cursor: pointer; font-size: 16px; padding: 2px 3px; border-radius: 4px; transition: all 0.14s; flex-shrink: 0; line-height: 1; opacity: 0.4; }
+  .del-item { background: none; border: none; color: var(--muted); cursor: pointer; font-size: 16px; padding: 2px 3px; border-radius: 4px; transition: all 0.14s; flex-shrink: 0; line-height: 1; opacity: 0.6; }
   .del-item:hover { color: var(--red); opacity: 1; }
+  .send-update-count { font-size: 13px; opacity: 0.85; }
   .empty-state { color: var(--muted); font-size: 12px; font-style: italic; padding: 6px 0 2px; opacity: 0.5; }
   .add-item-wrap { position: relative; margin-top: 9px; }
   .add-item-area { display: flex; gap: 7px; }


### PR DESCRIPTION
## Summary

- **#80** — Add `aria-hidden="true"` to decorative dot in public menu (`app.js:726`)
- **#78** — Remove `btn-danger` from category Cancel button — was incorrectly styled as destructive (`app.js:408`)
- **#76** — Add `role="img"` and `aria-label` to `.item-status-dot` so status is conveyed to screen readers (`app.js:1161`)
- **#81** — Replace inline `style="font-size:13px;opacity:0.85;"` on SEND UPDATE badge with `.send-update-count` CSS class (`app.js:1465`, `style.css`)
- **#79** — Raise `.del-item` resting `opacity` from `0.4` → `0.6` to meet WCAG 3:1 non-text contrast (`style.css:167`)
- Bump `APP_VERSION` to `v0.5.3`

## Test plan
- [ ] Public menu: inspect decorative dot — should have `aria-hidden="true"`
- [ ] Admin → Categories: edit a category — Cancel button should be neutral (grey), not red
- [ ] Manager view: item status dot should have `role="img"` and a descriptive `aria-label`
- [ ] Manager view: SEND UPDATE button with pending changes — badge should use `.send-update-count` class, not inline style
- [ ] Manager view: delete (×) buttons at rest should be slightly more visible (opacity 0.6 vs 0.4 before)
- [ ] Footer shows `v0.5.3`

🤖 Generated with [Claude Code](https://claude.com/claude-code)