### PR TITLE
feat(v0.5.4): Google OAuth + SMS OTP sign-in

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 // ─── CONFIG ───────────────────────────────────────────────────────────────────
-const APP_VERSION = 'v0.5.3';
+const APP_VERSION = 'v0.5.4';
 const IS_PREVIEW = window.location.hostname.endsWith('.vercel.app') &&
   window.location.hostname !== 'el-roys-drink-menu.vercel.app';
 
@@ -24,6 +24,7 @@ let isFirstSetup  = !FB_URL;
 let isManagerMode = false;
 let syncInterval  = null;
 let _authMode     = 'signin'; // 'signin' | 'signup'
+let _smsStep      = 'phone';  // 'phone' | 'otp'
 let _tokenRefreshTimer = null;
 
 // ─── CATEGORY DEFINITIONS ────────────────────────────────────────────────────
@@ -570,8 +571,27 @@ async function init() {
     showPublicViewWithError('⚠️ Could not load menu data. Check your Firebase configuration in Admin settings.');
   }
 
-  // Restore Supabase session if stored tokens exist
-  await _tryRestoreSession();
+  // Restore Supabase session — OAuth callback takes priority over stored tokens
+  const handledOAuth = await _tryHandleOAuthCallback();
+  if (!handledOAuth) await _tryRestoreSession();
+}
+
+async function _tryHandleOAuthCallback() {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return false;
+  const params = new URLSearchParams(window.location.search);
+  const code = params.get('code');
+  const verifier = sessionStorage.getItem('hf_pkce_verifier');
+  if (!code || !verifier) return false;
+  history.replaceState({}, '', window.location.pathname);
+  sessionStorage.removeItem('hf_pkce_verifier');
+  const data = await sbExchangeOAuthCode(code, verifier);
+  if (!data.access_token) return false;
+  const { role, name } = await sbGetProfile(data.access_token);
+  _applySession(data, role, name);
+  applyRole(role);
+  renderUserHeader();
+  if (role === 'none') showToast('Signed in. Contact admin to get manager access.');
+  return true;
 }
 
 async function _tryRestoreSession() {
@@ -783,6 +803,53 @@ function updateCollapseAllBtn() {
 }
 
 // ─── SUPABASE AUTH (REST — no SDK) ───────────────────────────────────────────
+async function _generatePKCE() {
+  const array = crypto.getRandomValues(new Uint8Array(32));
+  const verifier = btoa(String.fromCharCode(...array))
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  const hash = await crypto.subtle.digest('SHA-256', new TextEncoder().encode(verifier));
+  const challenge = btoa(String.fromCharCode(...new Uint8Array(hash)))
+    .replace(/\+/g, '-').replace(/\//g, '_').replace(/=/g, '');
+  return { verifier, challenge };
+}
+
+async function sbOAuthRedirect(provider) {
+  const { verifier, challenge } = await _generatePKCE();
+  sessionStorage.setItem('hf_pkce_verifier', verifier);
+  const redirectTo = window.location.origin + window.location.pathname;
+  const url = `${SUPABASE_URL}/auth/v1/authorize?provider=${provider}`
+    + `&redirect_to=${encodeURIComponent(redirectTo)}`
+    + `&code_challenge=${challenge}&code_challenge_method=S256`;
+  window.location.href = url;
+}
+
+async function sbExchangeOAuthCode(code, verifier) {
+  const r = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=authorization_code`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY },
+    body: JSON.stringify({ code, code_verifier: verifier })
+  });
+  return r.json();
+}
+
+async function sbSendOtp(phone) {
+  const r = await fetch(`${SUPABASE_URL}/auth/v1/otp`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY },
+    body: JSON.stringify({ phone })
+  });
+  return r.json();
+}
+
+async function sbVerifyOtp(phone, token) {
+  const r = await fetch(`${SUPABASE_URL}/auth/v1/token?grant_type=otp`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY },
+    body: JSON.stringify({ phone, token })
+  });
+  return r.json();
+}
+
 async function sbSignUp(email, password, name) {
   const r = await fetch(`${SUPABASE_URL}/auth/v1/signup`, {
     method: 'POST',
@@ -963,6 +1030,7 @@ function openAuthOverlay() {
   document.getElementById('auth-error').textContent = '';
   document.getElementById('auth-email').value    = '';
   document.getElementById('auth-password').value = '';
+  hideSmsSection(); // reset SMS state and restore main form visibility
   if (!noConfig) document.getElementById('auth-email').focus();
   document.addEventListener('keydown', _authFocusTrap);
 }
@@ -1026,6 +1094,70 @@ async function handleAuthSubmit() {
   } finally {
     btn.disabled = false;
     btn.textContent = _authMode === 'signin' ? 'Sign In' : 'Sign Up';
+  }
+}
+
+function showSmsSection() {
+  _smsStep = 'phone';
+  document.getElementById('auth-social-section').style.display = 'none';
+  document.getElementById('auth-name-field').style.display     = 'none';
+  document.getElementById('auth-lastname-field').style.display = 'none';
+  document.getElementById('auth-email').closest('.auth-field').style.display    = 'none';
+  document.getElementById('auth-password').closest('.auth-field').style.display = 'none';
+  document.getElementById('auth-submit-btn').style.display     = 'none';
+  document.querySelector('.auth-toggle').style.display         = 'none';
+  document.getElementById('auth-otp-field').style.display      = 'none';
+  document.getElementById('auth-sms-section').style.display    = '';
+  document.getElementById('auth-sms-error').textContent        = '';
+  document.getElementById('auth-phone').value = '';
+  document.getElementById('auth-otp').value   = '';
+  document.getElementById('auth-sms-send-btn').textContent = 'Send Code';
+  document.getElementById('auth-sms-send-btn').disabled    = false;
+  document.getElementById('auth-phone').focus();
+}
+
+function hideSmsSection() {
+  document.getElementById('auth-sms-section').style.display    = 'none';
+  document.getElementById('auth-social-section').style.display = '';
+  document.getElementById('auth-email').closest('.auth-field').style.display    = '';
+  document.getElementById('auth-password').closest('.auth-field').style.display = '';
+  document.getElementById('auth-submit-btn').style.display     = '';
+  document.querySelector('.auth-toggle').style.display         = '';
+  _smsStep = 'phone';
+}
+
+async function handleSmsFlow() {
+  const btn   = document.getElementById('auth-sms-send-btn');
+  const errEl = document.getElementById('auth-sms-error');
+  errEl.textContent = '';
+  if (_smsStep === 'phone') {
+    const phone = document.getElementById('auth-phone').value.trim();
+    if (!phone) { errEl.textContent = 'Enter a phone number.'; return; }
+    btn.textContent = 'Sending…'; btn.disabled = true;
+    const res = await sbSendOtp(phone);
+    btn.disabled = false;
+    if (res.error) { errEl.textContent = res.error.message || 'Failed to send code.'; btn.textContent = 'Send Code'; return; }
+    _smsStep = 'otp';
+    document.getElementById('auth-otp-field').style.display = '';
+    btn.textContent = 'Verify Code';
+    document.getElementById('auth-otp').focus();
+  } else {
+    const phone = document.getElementById('auth-phone').value.trim();
+    const token = document.getElementById('auth-otp').value.trim();
+    if (!token) { errEl.textContent = 'Enter the 6-digit code.'; return; }
+    btn.textContent = 'Verifying…'; btn.disabled = true;
+    const data = await sbVerifyOtp(phone, token);
+    btn.disabled = false;
+    if (data.error || !data.access_token) {
+      errEl.textContent = data.error?.message || 'Invalid code.';
+      btn.textContent = 'Verify Code'; return;
+    }
+    const { role, name } = await sbGetProfile(data.access_token);
+    _applySession(data, role, name);
+    closeAuthOverlay();
+    applyRole(role);
+    renderUserHeader();
+    if (role === 'none') showToast('Signed in. Contact admin to get manager access.', 'info');
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -286,6 +286,30 @@
     <p id="auth-subtitle">Sign in to your account</p>
     <div id="auth-no-config" style="display:none" class="auth-hint-msg">Supabase is not configured. Check server environment variables.</div>
     <div id="auth-form-wrap">
+      <div id="auth-social-section">
+        <div class="auth-social-row">
+          <button class="auth-social-btn" onclick="sbOAuthRedirect('google')" aria-label="Sign in with Google">
+            <svg viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg" aria-hidden="true"><path d="M22.56 12.25c0-.78-.07-1.53-.2-2.25H12v4.26h5.92c-.26 1.37-1.04 2.53-2.21 3.31v2.77h3.57c2.08-1.92 3.28-4.74 3.28-8.09z" fill="#4285F4"/><path d="M12 23c2.97 0 5.46-.98 7.28-2.66l-3.57-2.77c-.98.66-2.23 1.06-3.71 1.06-2.86 0-5.29-1.93-6.16-4.53H2.18v2.84C3.99 20.53 7.7 23 12 23z" fill="#34A853"/><path d="M5.84 14.09c-.22-.66-.35-1.36-.35-2.09s.13-1.43.35-2.09V7.07H2.18C1.43 8.55 1 10.22 1 12s.43 3.45 1.18 4.93l3.66-2.84z" fill="#FBBC05"/><path d="M12 5.38c1.62 0 3.06.56 4.21 1.64l3.15-3.15C17.45 2.09 14.97 1 12 1 7.7 1 3.99 3.47 2.18 7.07l3.66 2.84c.87-2.6 3.3-4.53 6.16-4.53z" fill="#EA4335"/></svg>
+            Google
+          </button>
+          <button class="auth-social-btn" onclick="showSmsSection()" aria-label="Sign in with SMS code">
+            <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M21 15a2 2 0 0 1-2 2H7l-4 4V5a2 2 0 0 1 2-2h14a2 2 0 0 1 2 2z"/></svg>
+            SMS Code
+          </button>
+        </div>
+        <div class="auth-divider">or use email</div>
+      </div>
+      <div id="auth-sms-section" style="display:none">
+        <div class="auth-field">
+          <input id="auth-phone" type="tel" placeholder="Phone number (+1...)" autocomplete="tel"/>
+        </div>
+        <div class="auth-field" id="auth-otp-field" style="display:none">
+          <input id="auth-otp" type="text" inputmode="numeric" maxlength="6" placeholder="6-digit code" autocomplete="one-time-code"/>
+        </div>
+        <div class="auth-error" id="auth-sms-error"></div>
+        <button class="auth-submit-btn" id="auth-sms-send-btn" onclick="handleSmsFlow()">Send Code</button>
+        <button class="pin-cancel" onclick="hideSmsSection()">← Back</button>
+      </div>
       <div class="auth-field" id="auth-name-field" style="display:none">
         <input type="text" id="auth-firstname" placeholder="First name" autocomplete="given-name"/>
       </div>

--- a/style.css
+++ b/style.css
@@ -126,6 +126,12 @@
   .auth-approval-notice { font-size: 11px; color: var(--muted); margin: -4px 0 10px; line-height: 1.5; text-align: center; opacity: 0.8; }
   .pin-cancel { background: none; border: none; color: var(--muted); font-size: 12px; cursor: pointer; margin-top: 14px; display: block; width: 100%; padding: 6px; transition: color 0.15s; }
   .pin-cancel:hover { color: var(--charcoal); }
+  .auth-social-row { display: flex; gap: 10px; margin-bottom: 14px; }
+  .auth-social-btn { flex: 1; display: flex; flex-direction: column; align-items: center; justify-content: center; gap: 5px; padding: 11px 8px; background: var(--surface); border: 1px solid var(--border); border-radius: 9px; font-family: var(--font-body); font-size: 11px; color: var(--charcoal); cursor: pointer; transition: border-color 0.15s, background 0.15s; }
+  .auth-social-btn:hover { border-color: var(--teal); background: var(--cream); }
+  .auth-social-btn svg { width: 20px; height: 20px; }
+  .auth-divider { display: flex; align-items: center; gap: 10px; margin-bottom: 14px; font-size: 10px; letter-spacing: 1px; color: var(--muted); text-transform: uppercase; }
+  .auth-divider::before, .auth-divider::after { content: ''; flex: 1; height: 1px; background: var(--border); }
   /* ── MANAGER VIEW (dark) ── */
   #manager-view { display: none; }
   .section-label { font-family: var(--font-heading); font-size: 11px; letter-spacing: 4px; color: var(--fire); margin-bottom: 14px; display: flex; align-items: center; gap: 10px; }


### PR DESCRIPTION
## Summary

- **Google OAuth** — PKCE redirect flow via Supabase. No SDK. `_generatePKCE()` uses `crypto.subtle`. `sbOAuthRedirect()` redirects to Supabase; `sbExchangeOAuthCode()` exchanges the callback `?code=` for tokens. `_tryHandleOAuthCallback()` runs on page load to complete the flow and strip the URL.
- **SMS OTP** — Supabase Phone provider + Twilio. `sbSendOtp()` → `sbSendOtp()`. Two-step sub-flow in the auth overlay: enter phone → send code → enter OTP → verify. `showSmsSection()` / `hideSmsSection()` toggle the view.
- **Both providers** funnel into the existing `_applySession()` / `sbGetProfile()` pipeline — new accounts start with `role: none` and require admin promotion, same as email signup.
- **Social buttons** (Google + SMS Code) are shown in both sign-in and sign-up modes.
- **Apple Sign In** deferred to v0.9 (issue #138).
- Version bumped to `v0.5.4`.

## Supabase Dashboard Setup Required Before Testing

1. Authentication → Providers → **Google**: enable, add Google OAuth credentials, set redirect URI to `https://<project>.supabase.co/auth/v1/callback`
2. Authentication → Providers → **Phone**: enable, add Twilio Account SID + Auth Token + phone number
3. Authentication → URL Configuration → **Redirect URLs**: add `https://el-roys-drink-menu.vercel.app` and `https://*.vercel.app`
4. **Site URL**: `https://el-roys-drink-menu.vercel.app`

## Test Plan
- [ ] Auth overlay shows Google and SMS Code buttons above email form (sign-in mode)
- [ ] Auth overlay shows Google and SMS Code buttons in sign-up mode too
- [ ] Google button → redirected to Google OAuth → return to app → signed in, role resolved
- [ ] SMS Code button → phone input shown → enter number → Send Code → OTP field appears → enter code → signed in
- [ ] New OAuth/SMS account → toast: "Contact admin to get manager access"
- [ ] Back button in SMS flow returns to main auth form
- [ ] Page refresh after OAuth sign-in → session restored normally via stored tokens
- [ ] Footer shows `v0.5.4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)