### PR TITLE
fix(v0.5.5): security fixes — SSRF, XSS, OAuth, SMS rate limit, font injection

### DIFF
--- a/api/firebase-write.js
+++ b/api/firebase-write.js
@@ -12,9 +12,12 @@ export default async function handler(req, res) {
     return res.status(e.status).json({ error: e.message });
   }
 
-  // Write to Firebase
-  const { fbUrl, state } = req.body;
-  if (!fbUrl || state === undefined) return res.status(400).json({ error: 'Missing fbUrl or state' });
+  // Derive Firebase URL from server env — never trust client-supplied URLs
+  const fbUrl = (process.env.FIREBASE_URL || '').replace(/\/+$/, '');
+  if (!fbUrl) return res.status(500).json({ error: 'Server misconfigured' });
+
+  const { state } = req.body;
+  if (state === undefined) return res.status(400).json({ error: 'Missing state' });
 
   const r = await fetch(`${fbUrl}/menu.json?auth=${fbSecret}`, {
     method: 'PUT',

--- a/app.js
+++ b/app.js
@@ -79,7 +79,7 @@ function defaultState() {
 }
 
 function uid() { return Math.random().toString(36).slice(2,9); }
-function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/</g,'&lt;'); }
+function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/"/g,'&quot;').replace(/'/g,'&#39;').replace(/</g,'&lt;').replace(/>/g,'&gt;'); }
 function lsSet(key, val) {
   try { localStorage.setItem(key, val); }
   catch(e) { showToast('⚠️ Storage full — data not saved locally.', 'error'); }
@@ -376,38 +376,38 @@ function renderCategoriesTab() {
     const isLast  = idx === CATEGORY_DEFS.length - 1;
     card.innerHTML = `
       <div class="catmgr-row">
-        <div class="catmgr-icon" style="background:${escHtml(cat.color)}">${cat.icon}</div>
+        <div class="catmgr-icon" style="background:${escHtml(cat.color)}">${escHtml(cat.icon)}</div>
         <div class="catmgr-info">
           <div class="catmgr-title">${escHtml(cat.title)}</div>
           <div class="catmgr-sub">${escHtml(cat.sub || '')}</div>
         </div>
         <div class="catmgr-actions">
-          <button class="btn-small" onclick="moveCategoryUp('${cat.id}')" ${isFirst ? 'disabled' : ''} title="Move up">↑</button>
-          <button class="btn-small" onclick="moveCategoryDown('${cat.id}')" ${isLast ? 'disabled' : ''} title="Move down">↓</button>
-          <button class="btn-small" onclick="toggleCategoryEdit('${cat.id}')">✏️</button>
-          <button class="btn-small btn-danger" onclick="deleteCategory('${cat.id}')">×</button>
+          <button class="btn-small" onclick="moveCategoryUp('${escHtml(cat.id)}')" ${isFirst ? 'disabled' : ''} title="Move up">↑</button>
+          <button class="btn-small" onclick="moveCategoryDown('${escHtml(cat.id)}')" ${isLast ? 'disabled' : ''} title="Move down">↓</button>
+          <button class="btn-small" onclick="toggleCategoryEdit('${escHtml(cat.id)}')">✏️</button>
+          <button class="btn-small btn-danger" onclick="deleteCategory('${escHtml(cat.id)}')">×</button>
         </div>
       </div>
-      <div class="catmgr-edit" id="catmgr-edit-${cat.id}" style="display:none">
+      <div class="catmgr-edit" id="catmgr-edit-${escHtml(cat.id)}" style="display:none">
         <div class="catmgr-field-row">
           <label>Icon</label>
-          <input type="text" class="catmgr-input catmgr-icon-input" id="ce-icon-${cat.id}" value="${escHtml(cat.icon)}" maxlength="4" placeholder="Emoji"/>
+          <input type="text" class="catmgr-input catmgr-icon-input" id="ce-icon-${escHtml(cat.id)}" value="${escHtml(cat.icon)}" maxlength="4" placeholder="Emoji"/>
         </div>
         <div class="catmgr-field-row">
           <label>Title</label>
-          <input type="text" class="catmgr-input" id="ce-title-${cat.id}" value="${escHtml(cat.title)}" placeholder="Category title"/>
+          <input type="text" class="catmgr-input" id="ce-title-${escHtml(cat.id)}" value="${escHtml(cat.title)}" placeholder="Category title"/>
         </div>
         <div class="catmgr-field-row">
           <label>Subtitle</label>
-          <input type="text" class="catmgr-input" id="ce-sub-${cat.id}" value="${escHtml(cat.sub || '')}" placeholder="Short description"/>
+          <input type="text" class="catmgr-input" id="ce-sub-${escHtml(cat.id)}" value="${escHtml(cat.sub || '')}" placeholder="Short description"/>
         </div>
         <div class="catmgr-field-row">
           <label>Hint text</label>
-          <input type="text" class="catmgr-input" id="ce-ph-${cat.id}" value="${escHtml(cat.placeholder || '')}" placeholder="Add item input hint"/>
+          <input type="text" class="catmgr-input" id="ce-ph-${escHtml(cat.id)}" value="${escHtml(cat.placeholder || '')}" placeholder="Add item input hint"/>
         </div>
         <div class="catmgr-save-row">
-          <button class="btn-small" onclick="toggleCategoryEdit('${cat.id}')">Cancel</button>
-          <button class="btn-small" onclick="saveCategoryEdit('${cat.id}')">Save</button>
+          <button class="btn-small" onclick="toggleCategoryEdit('${escHtml(cat.id)}')">Cancel</button>
+          <button class="btn-small" onclick="saveCategoryEdit('${escHtml(cat.id)}')">Save</button>
         </div>
       </div>`;
     container.appendChild(card);
@@ -755,9 +755,9 @@ function renderPublicView() {
     section.innerHTML = `
       <div class="menu-section-header collapsible-header" role="button" tabindex="0"
            aria-expanded="${isCollapsed ? 'false' : 'true'}"
-           onclick="togglePublicCategory('${cat.id}')"
-           onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();togglePublicCategory('${cat.id}')}">
-        <div class="menu-icon" style="background:${escHtml(cat.color)}">${cat.icon}</div>
+           onclick="togglePublicCategory('${escHtml(cat.id)}')"
+           onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();togglePublicCategory('${escHtml(cat.id)}')}">
+        <div class="menu-icon" style="background:${escHtml(cat.color)}">${escHtml(cat.icon)}</div>
         <div><div class="menu-section-title">${escHtml(cat.title)}</div><div class="menu-section-sub">${escHtml(cat.sub || '')}</div></div>
         <span class="category-chevron">›</span>
       </div>
@@ -1236,24 +1236,24 @@ function renderManagerCategories() {
     card.innerHTML = `
       <div class="cat-header collapsible-header" role="button" tabindex="0"
            aria-expanded="true"
-           onclick="toggleManagerCategory('${cat.id}')"
-           onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleManagerCategory('${cat.id}')}">
-        <div class="cat-icon" style="background:${escHtml(cat.color)}">${cat.icon}</div>
+           onclick="toggleManagerCategory('${escHtml(cat.id)}')"
+           onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleManagerCategory('${escHtml(cat.id)}')}">
+        <div class="cat-icon" style="background:${escHtml(cat.color)}">${escHtml(cat.icon)}</div>
         <div><div class="cat-title">${escHtml(cat.title)}</div><div class="cat-sub">${escHtml(cat.sub || '')}</div></div>
         <span class="category-chevron">›</span>
       </div>
       <div class="current-section">
         <div class="current-label">On Menu Now</div>
-        <div class="current-items" id="mgr-items-${cat.id}"></div>
+        <div class="current-items" id="mgr-items-${escHtml(cat.id)}"></div>
         <div class="add-item-wrap">
           <div class="add-item-area">
-            <input class="add-item-input" id="new-input-${cat.id}" type="text" placeholder="${escHtml(cat.placeholder || 'Add item...')}"
-              oninput="showAutocomplete('${cat.id}')"
-              onblur="setTimeout(()=>hideAutocomplete('${cat.id}'),150)"
-              onkeydown="handleAddItemKeydown(event,'${cat.id}')"/>
-            <button class="add-item-btn" onclick="addItem('${cat.id}')" aria-label="Add item to ${escHtml(cat.label)}">+</button>
+            <input class="add-item-input" id="new-input-${escHtml(cat.id)}" type="text" placeholder="${escHtml(cat.placeholder || 'Add item...')}"
+              oninput="showAutocomplete('${escHtml(cat.id)}')"
+              onblur="setTimeout(()=>hideAutocomplete('${escHtml(cat.id)}'),150)"
+              onkeydown="handleAddItemKeydown(event,'${escHtml(cat.id)}')"/>
+            <button class="add-item-btn" onclick="addItem('${escHtml(cat.id)}')" aria-label="Add item to ${escHtml(cat.label)}">+</button>
           </div>
-          <div class="autocomplete-list" id="ac-${cat.id}"></div>
+          <div class="autocomplete-list" id="ac-${escHtml(cat.id)}"></div>
         </div>
       </div>`;
     container.appendChild(card);
@@ -1651,7 +1651,7 @@ function openPreview() {
     diff.forEach(s => {
       const block = document.createElement('div');
       block.className = 'preview-block';
-      let html = `<div class="preview-cat">${s.icon} ${s.label}</div>`;
+      let html = `<div class="preview-cat">${escHtml(s.icon)} ${escHtml(s.label)}</div>`;
       s.added.forEach(n       => { html += `<div class="preview-line add"><span>✅</span> + ${escHtml(n)}</div>`; });
       s.removed.forEach(n     => { html += `<div class="preview-line remove"><span>❌</span> − ${escHtml(n)}</div>`; });
       s.eightySixed.forEach(n => { html += `<div class="preview-line remove"><span>🚫</span> 86'd: ${escHtml(n)}</div>`; });

--- a/app.js
+++ b/app.js
@@ -111,7 +111,7 @@ async function fbWrite(state) {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${currentUser.accessToken}`
     },
-    body: JSON.stringify({ fbUrl: FB_URL, state })
+    body: JSON.stringify({ state })
   });
   if (!res.ok) throw new Error(`Firebase write failed: ${res.status}`);
 }

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 // ─── CONFIG ───────────────────────────────────────────────────────────────────
-const APP_VERSION = 'v0.5.4';
+const APP_VERSION = 'v0.5.5';
 const IS_PREVIEW = window.location.hostname.endsWith('.vercel.app') &&
   window.location.hostname !== 'el-roys-drink-menu.vercel.app';
 
@@ -25,6 +25,8 @@ let isManagerMode = false;
 let syncInterval  = null;
 let _authMode     = 'signin'; // 'signin' | 'signup'
 let _smsStep      = 'phone';  // 'phone' | 'otp'
+let _smsPhone     = '';
+let _smsRateLimitTimer = null;
 let _tokenRefreshTimer = null;
 
 // ─── CATEGORY DEFINITIONS ────────────────────────────────────────────────────
@@ -917,80 +919,6 @@ async function sbOAuthRedirect(provider) {
   window.location.href = url;
 }
 
-// #147: Rate-limited SMS OTP flow. Prevents rapid repeated sends that abuse Twilio credits.
-let _smsStep = 'phone'; // 'phone' | 'otp'
-let _smsPhone = '';
-let _smsRateLimitTimer = null;
-
-async function handleSmsFlow(btnEl) {
-  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return;
-  if (_smsStep === 'phone') {
-    const phone = (document.getElementById('auth-sms-phone')?.value || '').trim();
-    if (!phone) return;
-    btnEl.disabled = true;
-    btnEl.textContent = 'Sending…';
-    try {
-      const r = await fetch(`${SUPABASE_URL}/auth/v1/otp`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY },
-        body: JSON.stringify({ phone })
-      });
-      if (!r.ok) throw await r.json();
-      _smsPhone = phone;
-      _smsStep = 'otp';
-      // Start 60-second countdown to prevent rapid resends.
-      let remaining = 60;
-      btnEl.disabled = true;
-      btnEl.textContent = `Resend in ${remaining}s`;
-      _smsRateLimitTimer = setInterval(() => {
-        remaining -= 1;
-        if (remaining <= 0) {
-          clearInterval(_smsRateLimitTimer);
-          _smsRateLimitTimer = null;
-          btnEl.disabled = false;
-          btnEl.textContent = 'Resend Code';
-        } else {
-          btnEl.textContent = `Resend in ${remaining}s`;
-        }
-      }, 1000);
-    } catch(err) {
-      const msg = err?.msg || err?.message || 'Failed to send code.';
-      const errEl = document.getElementById('auth-error');
-      if (errEl) errEl.textContent = msg;
-      btnEl.disabled = false;
-      btnEl.textContent = 'Send Code';
-    }
-  } else {
-    // OTP verification step
-    const token = (document.getElementById('auth-sms-otp')?.value || '').trim();
-    if (!token) return;
-    btnEl.disabled = true;
-    btnEl.textContent = 'Verifying…';
-    try {
-      const r = await fetch(`${SUPABASE_URL}/auth/v1/verify`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY },
-        body: JSON.stringify({ type: 'sms', phone: _smsPhone, token })
-      });
-      if (!r.ok) throw await r.json();
-      const data = await r.json();
-      if (data.access_token) {
-        const profile = await sbGetProfile(data.access_token);
-        _applySession(data, profile.role, profile.name);
-        closeAuthOverlay();
-        applyRole(profile.role);
-        _smsStep = 'phone';
-        _smsPhone = '';
-      }
-    } catch(err) {
-      const msg = err?.msg || err?.message || 'Verification failed.';
-      const errEl = document.getElementById('auth-error');
-      if (errEl) errEl.textContent = msg;
-      btnEl.disabled = false;
-      btnEl.textContent = 'Verify Code';
-    }
-  }
-}
 
 function _scheduleTokenRefresh(expiresAt) {
   if (_tokenRefreshTimer) clearTimeout(_tokenRefreshTimer);
@@ -1226,8 +1154,11 @@ function hideSmsSection() {
   document.getElementById('auth-submit-btn').style.display     = '';
   document.querySelector('.auth-toggle').style.display         = '';
   _smsStep = 'phone';
+  _smsPhone = '';
+  if (_smsRateLimitTimer) { clearInterval(_smsRateLimitTimer); _smsRateLimitTimer = null; }
 }
 
+// #147: Rate-limited SMS OTP flow. Prevents rapid repeated sends that abuse Twilio credits.
 async function handleSmsFlow() {
   const btn   = document.getElementById('auth-sms-send-btn');
   const errEl = document.getElementById('auth-sms-error');
@@ -1237,18 +1168,31 @@ async function handleSmsFlow() {
     if (!phone) { errEl.textContent = 'Enter a phone number.'; return; }
     btn.textContent = 'Sending…'; btn.disabled = true;
     const res = await sbSendOtp(phone);
-    btn.disabled = false;
-    if (res.error) { errEl.textContent = res.error.message || 'Failed to send code.'; btn.textContent = 'Send Code'; return; }
+    if (res.error) { errEl.textContent = res.error.message || 'Failed to send code.'; btn.disabled = false; btn.textContent = 'Send Code'; return; }
+    _smsPhone = phone;
     _smsStep = 'otp';
     document.getElementById('auth-otp-field').style.display = '';
-    btn.textContent = 'Verify Code';
+    // Start 60-second countdown to prevent rapid resends.
+    let remaining = 60;
+    btn.disabled = true;
+    btn.textContent = `Resend in ${remaining}s`;
+    _smsRateLimitTimer = setInterval(() => {
+      remaining -= 1;
+      if (remaining <= 0) {
+        clearInterval(_smsRateLimitTimer);
+        _smsRateLimitTimer = null;
+        btn.disabled = false;
+        btn.textContent = 'Resend Code';
+      } else {
+        btn.textContent = `Resend in ${remaining}s`;
+      }
+    }, 1000);
     document.getElementById('auth-otp').focus();
   } else {
-    const phone = document.getElementById('auth-phone').value.trim();
     const token = document.getElementById('auth-otp').value.trim();
     if (!token) { errEl.textContent = 'Enter the 6-digit code.'; return; }
     btn.textContent = 'Verifying…'; btn.disabled = true;
-    const data = await sbVerifyOtp(phone, token);
+    const data = await sbVerifyOtp(_smsPhone, token);
     btn.disabled = false;
     if (data.error || !data.access_token) {
       errEl.textContent = data.error?.message || 'Invalid code.';

--- a/app.js
+++ b/app.js
@@ -160,12 +160,19 @@ function lightenHex(hex, amount) {
 
 function loadGoogleFont(fontName) {
   if (!fontName) return;
+  // Default fonts are self-hosted in lib/fonts/ — no external request needed.
   if (['DM Sans','Lilita One','Permanent Marker'].includes(fontName)) return;
   const id = 'gfont-' + fontName.replace(/\s+/g,'-').toLowerCase();
   if (document.getElementById(id)) return;
   const link = document.createElement('link');
   link.id = id; link.rel = 'stylesheet';
-  link.href = `https://fonts.googleapis.com/css2?family=${fontName.replace(/\s+/g,'+')}:wght@400;700&display=swap`;
+  // NOTE (#148): Google Fonts CDN serves dynamically-generated CSS responses, so
+  // Subresource Integrity (SRI) hashes cannot be applied — the response content
+  // changes with each request. The default fonts (DM Sans, Lilita One, Permanent
+  // Marker) are self-hosted in lib/fonts/ for full SRI compliance. Any additional
+  // fonts selected via the Design panel are loaded from the CDN without SRI.
+  // TODO: self-host additional fonts for SRI compliance.
+  link.href = `https://fonts.googleapis.com/css2?family=${encodeURIComponent(fontName).replace(/%20/g,'+')}:wght@400;700&display=swap`;
   document.head.appendChild(link);
 }
 
@@ -202,17 +209,30 @@ function applyDesign(design) {
   const titleEl = document.querySelector('header h1');
   if (titleEl && design.menuTitle) titleEl.textContent = design.menuTitle;
 
-  if (design.headingFont) {
-    loadGoogleFont(design.headingFont);
-    root.style.setProperty('--font-heading', `'${design.headingFont}', cursive`);
+  // #149: Validate font names against the allowlist before applying as CSS values
+  // to prevent CSS injection via unsanitized font names from the database.
+  const FONT_ALLOWLIST = new Set([...HEADING_FONTS, ...BODY_FONTS, ...ACCENT_FONTS]);
+  function _safeFont(name, fallback) {
+    if (!name) return null;
+    if (FONT_ALLOWLIST.has(name)) return name;
+    console.warn(`[security] Rejected invalid font name: "${name}" — falling back to "${fallback}"`);
+    return fallback;
   }
-  if (design.bodyFont) {
-    loadGoogleFont(design.bodyFont);
-    root.style.setProperty('--font-body', `'${design.bodyFont}', sans-serif`);
+
+  const headingFont = _safeFont(design.headingFont, 'Lilita One');
+  if (headingFont) {
+    loadGoogleFont(headingFont);
+    root.style.setProperty('--font-heading', `'${headingFont}', cursive`);
   }
-  if (design.accentFont) {
-    loadGoogleFont(design.accentFont);
-    root.style.setProperty('--font-accent', `'${design.accentFont}', cursive`);
+  const bodyFont = _safeFont(design.bodyFont, 'DM Sans');
+  if (bodyFont) {
+    loadGoogleFont(bodyFont);
+    root.style.setProperty('--font-body', `'${bodyFont}', sans-serif`);
+  }
+  const accentFont = _safeFont(design.accentFont, 'Permanent Marker');
+  if (accentFont) {
+    loadGoogleFont(accentFont);
+    root.style.setProperty('--font-accent', `'${accentFont}', cursive`);
   }
   const brand = (design.brandName || '').trim();
   const title = (design.menuTitle || '').trim();
@@ -889,6 +909,88 @@ async function sbGetProfile(accessToken) {
   return { role: role || 'none', name: name || '' };
 }
 
+// #145: URL-encode the provider name to prevent open-redirect / URL injection.
+async function sbOAuthRedirect(provider) {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return;
+  const redirectTo = encodeURIComponent(window.location.origin);
+  const url = `${SUPABASE_URL}/auth/v1/authorize?provider=${encodeURIComponent(provider)}&redirect_to=${redirectTo}`;
+  window.location.href = url;
+}
+
+// #147: Rate-limited SMS OTP flow. Prevents rapid repeated sends that abuse Twilio credits.
+let _smsStep = 'phone'; // 'phone' | 'otp'
+let _smsPhone = '';
+let _smsRateLimitTimer = null;
+
+async function handleSmsFlow(btnEl) {
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return;
+  if (_smsStep === 'phone') {
+    const phone = (document.getElementById('auth-sms-phone')?.value || '').trim();
+    if (!phone) return;
+    btnEl.disabled = true;
+    btnEl.textContent = 'Sending…';
+    try {
+      const r = await fetch(`${SUPABASE_URL}/auth/v1/otp`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY },
+        body: JSON.stringify({ phone })
+      });
+      if (!r.ok) throw await r.json();
+      _smsPhone = phone;
+      _smsStep = 'otp';
+      // Start 60-second countdown to prevent rapid resends.
+      let remaining = 60;
+      btnEl.disabled = true;
+      btnEl.textContent = `Resend in ${remaining}s`;
+      _smsRateLimitTimer = setInterval(() => {
+        remaining -= 1;
+        if (remaining <= 0) {
+          clearInterval(_smsRateLimitTimer);
+          _smsRateLimitTimer = null;
+          btnEl.disabled = false;
+          btnEl.textContent = 'Resend Code';
+        } else {
+          btnEl.textContent = `Resend in ${remaining}s`;
+        }
+      }, 1000);
+    } catch(err) {
+      const msg = err?.msg || err?.message || 'Failed to send code.';
+      const errEl = document.getElementById('auth-error');
+      if (errEl) errEl.textContent = msg;
+      btnEl.disabled = false;
+      btnEl.textContent = 'Send Code';
+    }
+  } else {
+    // OTP verification step
+    const token = (document.getElementById('auth-sms-otp')?.value || '').trim();
+    if (!token) return;
+    btnEl.disabled = true;
+    btnEl.textContent = 'Verifying…';
+    try {
+      const r = await fetch(`${SUPABASE_URL}/auth/v1/verify`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', 'apikey': SUPABASE_ANON_KEY },
+        body: JSON.stringify({ type: 'sms', phone: _smsPhone, token })
+      });
+      if (!r.ok) throw await r.json();
+      const data = await r.json();
+      if (data.access_token) {
+        const profile = await sbGetProfile(data.access_token);
+        _applySession(data, profile.role, profile.name);
+        closeAuthOverlay();
+        applyRole(profile.role);
+        _smsStep = 'phone';
+        _smsPhone = '';
+      }
+    } catch(err) {
+      const msg = err?.msg || err?.message || 'Verification failed.';
+      const errEl = document.getElementById('auth-error');
+      if (errEl) errEl.textContent = msg;
+      btnEl.disabled = false;
+      btnEl.textContent = 'Verify Code';
+    }
+  }
+}
 
 function _scheduleTokenRefresh(expiresAt) {
   if (_tokenRefreshTimer) clearTimeout(_tokenRefreshTimer);


### PR DESCRIPTION
## Summary

Security fixes from Martin's audit. All findings tracked in milestone [v0.5.5](https://github.com/stiehl122/El-Roys-Drink-Menu/milestone/14).

## Issues Fixed

### 🔴 Critical
- Closes #140 — SSRF in `firebase-write.js` allowed `FIREBASE_SECRET` exfiltration via client-controlled `fbUrl`. Server now derives Firebase URL from `FIREBASE_URL` env var; client no longer sends a URL.

### 🟠 High (XSS)
- Closes #141 — Stored XSS: `cat.icon` now wrapped with `escHtml()` in all innerHTML contexts
- Closes #142 — `cat.id` attribute injection: all inline `onclick` and `id` attribute interpolations now use `escHtml(cat.id)`
- Closes #143 — `s.icon` and `s.label` in preview modal now escaped with `escHtml()`
- Also hardened `escHtml()` to cover all 5 HTML-special characters (`&`, `<`, `>`, `"`, `'`)

### 🟡 Medium
- Closes #145 — `provider` param in `sbOAuthRedirect` now wrapped with `encodeURIComponent()`
- Closes #147 — SMS OTP send button disabled for 60s after successful send, with countdown display
- Closes #149 — Font names validated against a `FONT_ALLOWLIST` before CSS application; invalid values fall back to defaults with `console.warn`

### 🔵 Low (acknowledged)
- Closes #148 — Default fonts are self-hosted; `loadGoogleFont()` for design-picker fonts documented as known SRI limitation with TODO to self-host

## Still Open (out of scope for this PR)
- **#144** — Firebase security rules restricting `_config` reads — requires Supabase/Firebase dashboard change, no code change
- **#146** — Auth tokens in localStorage — XSS surface is now resolved; longer-term fix (HttpOnly cookies) tracked separately

## Deployment Note
`FIREBASE_URL` env var must be set in Vercel (already added: `https://el-roy-s-drink-menu-default-rtdb.firebaseio.com/`).

## Test Plan
- [ ] Firebase writes still work after removing `fbUrl` from client payload
- [ ] Category icons with special characters (`<`, `>`, `"`) render safely without executing as HTML
- [ ] Google OAuth redirect still works with URL-encoded provider param
- [ ] SMS Code → Send Code → button shows "Resend in 60s" countdown, re-enables after 60s
- [ ] Setting an invalid font name in Admin → Design falls back to default font

🤖 Generated with [Claude Code](https://claude.com/claude-code)