### PR TITLE
fix(v0.6.2): save dirty state, poll errors, autocomplete iOS, font sizes

### DIFF
--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 // ─── CONFIG ───────────────────────────────────────────────────────────────────
-const APP_VERSION = 'v0.6.1';
+const APP_VERSION = 'v0.6.2';
 const IS_PREVIEW = window.location.hostname.endsWith('.vercel.app') &&
   window.location.hostname !== 'el-roys-drink-menu.vercel.app';
 
@@ -92,7 +92,10 @@ function findItem(catId, itemId) {
 }
 let _diffCache = null;
 let _diffDirty = true;
-function invalidateDiff() { _diffDirty = true; }
+let _dirty = false;
+let _pollFailCount = 0;
+function invalidateDiff() { _diffDirty = true; _dirty = true; updateSaveBtn(); }
+function updateSaveBtn() { const btn = document.getElementById('save-btn'); if (btn) btn.disabled = !_dirty; }
 function getCachedDiff() {
   if (_diffDirty) { _diffCache = computeDiff(); _diffDirty = false; }
   return _diffCache;
@@ -710,7 +713,16 @@ function startPolling() {
         renderPublicView();
         updateLastUpdatedLabel();
       }
-    } catch(e) {}
+      _pollFailCount = 0;
+      const syncEl = document.getElementById('sync-status');
+      if (syncEl && syncEl.classList.contains('sync-poll-error')) { syncEl.textContent = ''; syncEl.className = ''; }
+    } catch(e) {
+      _pollFailCount++;
+      if (_pollFailCount >= 3) {
+        const syncEl = document.getElementById('sync-status');
+        if (syncEl) { syncEl.textContent = '⚠️ Sync paused — reconnecting…'; syncEl.className = 'sync-poll-error'; }
+      }
+    }
   }, 60000);
 }
 
@@ -1226,6 +1238,7 @@ function enterManager() {
   document.getElementById('menu-url-input').value  = MENU_URL  || '';
   switchTab('manager');
   updateDraftIndicator();
+  updateSaveBtn();
   renderManagerCategories();
 }
 
@@ -1384,6 +1397,8 @@ async function saveMenu() {
   menuState._meta = { ...(menuState._meta || {}), lastUpdatedTs: ts.toString() };
   lsSet(LS_KEYS.lastUpdated, ts.toString());
   await persistState();
+  _dirty = false;
+  updateSaveBtn();
   updateLastUpdatedLabel();
   showToast('✅ Menu saved!', 'success');
 }
@@ -1444,10 +1459,6 @@ function showAutocomplete(catId) {
   list.innerHTML = matches.map(r =>
     `<div class="autocomplete-item" onmousedown="selectAutocomplete(event,'${catId}','${escHtml(r.name)}')">${escHtml(r.name)}</div>`
   ).join('');
-  const rect = document.getElementById('new-input-' + catId).getBoundingClientRect();
-  list.style.top   = (rect.bottom + 2) + 'px';
-  list.style.left  = rect.left + 'px';
-  list.style.width = rect.width + 'px';
   list.classList.add('open');
 }
 

--- a/style.css
+++ b/style.css
@@ -66,10 +66,10 @@
   .logo-mark { font-family: var(--font-accent); font-size: 12px; letter-spacing: 3px; color: var(--yellow); display: block; margin-bottom: 4px; text-shadow: 0 1px 4px rgba(0,0,0,0.3); }
   header h1 { font-family: var(--font-heading); font-size: 40px; letter-spacing: 2px; line-height: 1; color: var(--cream); text-shadow: 0 2px 10px rgba(0,0,0,0.3); }
   .header-sub { margin-top: 5px; color: rgba(253,244,236,0.72); font-family: var(--font-accent); font-size: 12px; letter-spacing: 0.5px; }
-  .manager-btn { position: absolute; top: 18px; left: 14px; background: rgba(253,244,236,0.15); border: 1px solid rgba(253,244,236,0.38); border-radius: 8px; color: var(--cream); font-family: var(--font-body); font-size: 11px; letter-spacing: 1px; text-transform: uppercase; padding: 7px 11px; cursor: pointer; transition: all 0.15s; backdrop-filter: blur(4px); }
+  .manager-btn { position: absolute; top: 18px; left: 14px; background: rgba(253,244,236,0.15); border: 1px solid rgba(253,244,236,0.38); border-radius: 8px; color: var(--cream); font-family: var(--font-body); font-size: 12px; letter-spacing: 1px; text-transform: uppercase; padding: 7px 11px; cursor: pointer; transition: all 0.15s; backdrop-filter: blur(4px); }
   .manager-btn:hover { background: rgba(253,244,236,0.27); }
   .manager-btn.active { background: var(--terra); border-color: var(--terra); }
-  .header-signin-btn { position: absolute; top: 18px; right: 14px; background: rgba(253,244,236,0.15); border: 1px solid rgba(253,244,236,0.38); border-radius: 8px; color: var(--cream); font-family: var(--font-body); font-size: 11px; letter-spacing: 1px; text-transform: uppercase; padding: 7px 11px; cursor: pointer; transition: all 0.15s; backdrop-filter: blur(4px); }
+  .header-signin-btn { position: absolute; top: 18px; right: 14px; background: rgba(253,244,236,0.15); border: 1px solid rgba(253,244,236,0.38); border-radius: 8px; color: var(--cream); font-family: var(--font-body); font-size: 12px; letter-spacing: 1px; text-transform: uppercase; padding: 7px 11px; cursor: pointer; transition: all 0.15s; backdrop-filter: blur(4px); }
   .header-signin-btn:hover { background: rgba(253,244,236,0.27); }
   /* Avatar chip */
   .user-chip { position: absolute; top: 14px; right: 14px; display: flex; align-items: center; gap: 5px; background: rgba(253,244,236,0.15); border: 1px solid rgba(253,244,236,0.38); border-radius: 20px; padding: 5px 10px; cursor: pointer; color: var(--cream); font-size: 12px; user-select: none; }
@@ -179,7 +179,7 @@
   .empty-state-icon { display: inline-flex; align-items: center; justify-content: center; width: 18px; height: 18px; border: 1px dashed var(--muted); border-radius: 50%; font-size: 14px; font-style: normal; opacity: 0.5; flex-shrink: 0; }
   .add-item-wrap { position: relative; margin-top: 9px; }
   .add-item-area { display: flex; gap: 7px; }
-  .autocomplete-list { position: fixed; background: var(--card); border: 1px solid var(--border); border-radius: 8px; max-height: 180px; overflow-y: auto; z-index: 9999; display: none; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
+  .autocomplete-list { position: absolute; top: 100%; left: 0; width: 100%; background: var(--card); border: 1px solid var(--border); border-radius: 8px; max-height: 180px; overflow-y: auto; z-index: 9999; display: none; box-shadow: 0 4px 12px rgba(0,0,0,0.3); }
   .autocomplete-list.open { display: block; }
   .autocomplete-item { padding: 8px 12px; cursor: pointer; font-family: var(--font-body); font-size: 13px; color: var(--text); }
   .autocomplete-item:hover, .autocomplete-item.ac-selected { background: var(--surface); color: var(--fire); }
@@ -193,12 +193,14 @@
   .btn-row { display:flex; gap:10px; margin-top:18px; }
   .save-btn { flex:0 0 auto; padding:14px 22px; border-radius:12px; border:none; cursor:pointer; font-family:var(--font-heading); font-size:15px; letter-spacing:1px; background:var(--surface); color:var(--text); transition:opacity .15s; box-shadow:0 2px 8px rgba(0,0,0,0.12); }
   .save-btn:hover { opacity:0.8; }
+  .save-btn:disabled { opacity:0.4; cursor:not-allowed; }
   .send-btn { flex:1; background: linear-gradient(135deg, var(--terra), var(--terra-dk)); border: none; border-radius: 12px; color: white; font-family: var(--font-heading); font-size: 20px; letter-spacing: 2px; padding: 16px; cursor: pointer; transition: transform 0.14s, box-shadow 0.14s; box-shadow: 0 4px 18px rgba(190,67,48,0.35); }
   .send-btn:hover { transform: translateY(-1px); box-shadow: 0 7px 26px rgba(190,67,48,0.5); }
   .send-btn:active { transform: translateY(0); }
   .send-btn:disabled { background: var(--border); box-shadow: none; cursor: not-allowed; transform: none; }
   #sync-status:empty { display: none; }
   #sync-status.sync-error { display: inline-block; background: var(--red); color: #fff; font-size: 11px; font-family: var(--font-body); padding: 4px 10px; border-radius: 6px; margin-top: 8px; }
+  #sync-status.sync-poll-error { display: inline-block; background: var(--terra); color: #fff; font-size: 11px; font-family: var(--font-body); padding: 4px 10px; border-radius: 6px; margin-top: 8px; opacity: 0.75; }
 
   /* ── MODAL ── */
   .modal-bg { position: fixed; inset: 0; background: rgba(0,0,0,0.72); display: flex; align-items: center; justify-content: center; z-index: 50; padding: 16px; opacity: 0; pointer-events: none; transition: opacity 0.2s; }
@@ -308,7 +310,7 @@
   /* ── 86'D — PUBLIC ── */
   .menu-item.is-eighty-sixed .item-name-text { text-decoration: line-through; color: var(--muted); }
   .menu-item.is-eighty-sixed { opacity: 0.5; }
-  .eighty-sixed-tag { font-size: 10px; color: var(--red); letter-spacing: 1px; font-weight: 600; flex-shrink: 0; margin-left: auto; }
+  .eighty-sixed-tag { font-size: 12px; color: var(--red); letter-spacing: 1px; font-weight: 600; flex-shrink: 0; margin-left: auto; }
 
   /* ── TABS ── */
   .tab-bar { display: flex; gap: 4px; margin-bottom: 16px; background: var(--surface); border: 1px solid var(--border); border-radius: 10px; padding: 4px; overflow-x: auto; scrollbar-width: none; }
@@ -430,7 +432,7 @@
   display: inline-block;
   background: var(--fire, #e86a3f);
   color: #fff;
-  font-size: 9px;
+  font-size: 11px;
   font-weight: 700;
   letter-spacing: 1px;
   padding: 1px 5px;


### PR DESCRIPTION
## Summary

- closes #56 — Save button now disabled until unsaved changes exist; re-disabled after save
- closes #58 — Amber "Sync paused — reconnecting…" banner after 3 consecutive poll failures; clears on next success
- closes #60 — Autocomplete dropdown switched to `position: absolute` to fix clipping under keyboard on iOS Safari
- closes #77 — Sub-12px font sizes bumped to minimum legible sizes (`.manager-btn`, `.header-signin-btn` → 12px; `.eighty-sixed-tag` → 12px; `.footer-preview-badge` → 11px)
- Bumps `APP_VERSION` to `v0.6.2`

## Test plan

- [ ] Open manager view — Save button is disabled (dimmed) with no pending changes
- [ ] Make any edit — Save button enables; click Save — button disables again
- [ ] Simulate 3+ poll failures — amber sync banner appears; restore Firebase — banner clears
- [ ] Test autocomplete on iOS Safari with keyboard open — dropdown appears below input, not clipped
- [ ] Inspect `.eighty-sixed-tag`, `.manager-btn`, `.header-signin-btn`, `.footer-preview-badge` computed font sizes
- [ ] Footer shows `v0.6.2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)