### PR TITLE
feat(v0.6.3–v0.6.4): USERS tab + preview toolbar + persistent session

### DIFF
--- a/api/users.js
+++ b/api/users.js
@@ -1,0 +1,76 @@
+import { requireRole } from './_auth.js';
+
+export default async function handler(req, res) {
+  const sbUrl     = process.env.SUPABASE_URL;
+  const sbService = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!sbUrl || !sbService) return res.status(500).json({ error: 'Server misconfigured' });
+
+  let caller;
+  try {
+    caller = await requireRole(req, 'admin');
+  } catch (e) {
+    return res.status(e.status).json({ error: e.message });
+  }
+
+  if (req.method === 'GET') {
+    // Fetch all auth users (for emails)
+    const authRes = await fetch(`${sbUrl}/auth/v1/admin/users?per_page=200`, {
+      headers: { 'apikey': sbService, 'Authorization': `Bearer ${sbService}` }
+    });
+    if (!authRes.ok) return res.status(500).json({ error: 'Failed to fetch users' });
+    const { users: authUsers } = await authRes.json();
+
+    // Fetch all profiles (name + role)
+    const profilesRes = await fetch(`${sbUrl}/rest/v1/profiles?select=id,role,name`, {
+      headers: { 'apikey': sbService, 'Authorization': `Bearer ${sbService}` }
+    });
+    if (!profilesRes.ok) return res.status(500).json({ error: 'Failed to fetch profiles' });
+    const profiles = await profilesRes.json();
+
+    const profileMap = Object.fromEntries(profiles.map(p => [p.id, p]));
+    const users = (authUsers || []).map(u => ({
+      id:    u.id,
+      email: u.email,
+      name:  profileMap[u.id]?.name || '',
+      role:  profileMap[u.id]?.role || 'none',
+    }));
+
+    return res.json(users);
+  }
+
+  if (req.method === 'PATCH') {
+    const { userId, role, name } = req.body || {};
+    if (!userId) return res.status(400).json({ error: 'userId required' });
+
+    if (role !== undefined && userId === caller.uid) {
+      return res.status(400).json({ error: 'Cannot change your own role' });
+    }
+
+    const update = {};
+    if (role !== undefined) {
+      if (!['none', 'manager', 'admin'].includes(role)) {
+        return res.status(400).json({ error: 'Invalid role' });
+      }
+      update.role = role;
+    }
+    if (name !== undefined) {
+      update.name = String(name).trim().slice(0, 100);
+    }
+    if (!Object.keys(update).length) return res.status(400).json({ error: 'Nothing to update' });
+
+    const updateRes = await fetch(`${sbUrl}/rest/v1/profiles?id=eq.${userId}`, {
+      method: 'PATCH',
+      headers: {
+        'apikey': sbService,
+        'Authorization': `Bearer ${sbService}`,
+        'Content-Type': 'application/json',
+        'Prefer': 'return=minimal',
+      },
+      body: JSON.stringify(update),
+    });
+    if (!updateRes.ok) return res.status(500).json({ error: 'Failed to update' });
+    return res.status(204).end();
+  }
+
+  return res.status(405).end();
+}

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 // ─── CONFIG ───────────────────────────────────────────────────────────────────
-const APP_VERSION = 'v0.6.2';
+const APP_VERSION = 'v0.6.3';
 const IS_PREVIEW = window.location.hostname.endsWith('.vercel.app') &&
   window.location.hostname !== 'el-roys-drink-menu.vercel.app';
 
@@ -1004,6 +1004,7 @@ function applyRole(role) {
   const isAdmin   = role === 'admin';
   document.getElementById('tab-btn-admin').style.display    = isAdmin ? '' : 'none';
   document.getElementById('tab-btn-database').style.display = isAdmin ? '' : 'none';
+  document.getElementById('tab-btn-users').style.display    = isAdmin ? '' : 'none';
   const pruneSection = document.getElementById('prune-section');
   if (pruneSection) pruneSection.style.display = isAdmin ? '' : 'none';
   renderUserHeader();
@@ -1861,9 +1862,118 @@ document.getElementById('prune-items-wrap').addEventListener('click', e => {
   pruneSingleItem(btn.dataset.catid, btn.dataset.name);
 });
 
+// ─── USER MANAGEMENT ─────────────────────────────────────────────────────────
+async function loadUsers() {
+  const wrap = document.getElementById('users-list');
+  wrap.innerHTML = '<div class="db-empty">Loading...</div>';
+  try {
+    const r = await fetch('/api/users', {
+      headers: { 'Authorization': `Bearer ${currentUser?.accessToken}` }
+    });
+    if (!r.ok) throw new Error(await r.text());
+    renderUsersTab(await r.json());
+  } catch (e) {
+    wrap.innerHTML = '<div class="db-empty db-error">Failed to load users.</div>';
+  }
+}
+
+function renderUsersTab(users) {
+  const wrap = document.getElementById('users-list');
+  if (!users.length) {
+    wrap.innerHTML = '<div class="db-empty">No accounts found.</div>';
+    return;
+  }
+  const roleLabel = { none: 'No Access', manager: 'Manager', admin: 'Admin' };
+  wrap.innerHTML = users.map(u => {
+    const isSelf = u.id === currentUser?.uid;
+    const roleControls = isSelf
+      ? `<span class="user-mgmt-self-note">(your account — role locked)</span>`
+      : `<select id="user-role-${escHtml(u.id)}" class="user-mgmt-role-select">
+           <option value="none"    ${u.role === 'none'    ? 'selected' : ''}>No Access</option>
+           <option value="manager" ${u.role === 'manager' ? 'selected' : ''}>Manager</option>
+           <option value="admin"   ${u.role === 'admin'   ? 'selected' : ''}>Admin</option>
+         </select>
+         <button class="btn-small" onclick="saveUserRole('${escHtml(u.id)}')">Save Role</button>`;
+    return `
+      <div class="config-card">
+        <div class="user-mgmt-top">
+          <div class="user-mgmt-identity">
+            <div class="input-row">
+              <input type="text" id="user-name-${escHtml(u.id)}" value="${escHtml(u.name)}" placeholder="Display name" />
+              <button class="btn-small" onclick="saveUserName('${escHtml(u.id)}')">Save</button>
+            </div>
+            <div class="user-mgmt-email">${escHtml(u.email)}</div>
+          </div>
+          <span class="user-role-badge user-role-badge--${escHtml(u.role)}">${escHtml(roleLabel[u.role] || u.role)}</span>
+        </div>
+        <div class="input-row user-mgmt-role-row">${roleControls}</div>
+      </div>`;
+  }).join('');
+}
+
+async function saveUserRole(userId) {
+  const select = document.getElementById(`user-role-${userId}`);
+  if (!select) return;
+  const role = select.value;
+  try {
+    const r = await fetch('/api/users', {
+      method: 'PATCH',
+      headers: { 'Authorization': `Bearer ${currentUser?.accessToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId, role }),
+    });
+    if (!r.ok) { showToast((await r.json()).error || 'Failed to update role.', 'error'); return; }
+    showToast('Role updated.', 'success');
+    const badge = select.closest('.config-card')?.querySelector('.user-role-badge');
+    if (badge) {
+      const label = { none: 'No Access', manager: 'Manager', admin: 'Admin' };
+      badge.className = `user-role-badge user-role-badge--${role}`;
+      badge.textContent = label[role] || role;
+    }
+  } catch (e) {
+    showToast('Network error.', 'error');
+  }
+}
+
+async function saveUserName(userId) {
+  const input = document.getElementById(`user-name-${userId}`);
+  if (!input) return;
+  try {
+    const r = await fetch('/api/users', {
+      method: 'PATCH',
+      headers: { 'Authorization': `Bearer ${currentUser?.accessToken}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({ userId, name: input.value }),
+    });
+    if (!r.ok) { showToast((await r.json()).error || 'Failed to update name.', 'error'); return; }
+    showToast('Name updated.', 'success');
+  } catch (e) {
+    showToast('Network error.', 'error');
+  }
+}
+
+function openInviteModal() {
+  const url = MENU_URL || window.location.origin;
+  const brand = document.getElementById('design-brand-name')?.value?.trim() || 'the menu';
+  document.getElementById('invite-text-output').value =
+    `You've been invited to manage ${brand}!\n\nVisit ${url} and tap "Sign In" to create your account. Once you've signed up, ask an admin to approve your access.`;
+  document.getElementById('invite-modal-bg').classList.add('open');
+}
+
+function closeInviteModal() {
+  document.getElementById('invite-modal-bg').classList.remove('open');
+}
+
+async function copyInviteText() {
+  await navigator.clipboard.writeText(document.getElementById('invite-text-output').value);
+  showToast('Copied!', 'success');
+}
+
+document.getElementById('invite-modal-bg').addEventListener('click', e => {
+  if (e.target === document.getElementById('invite-modal-bg')) closeInviteModal();
+});
+
 // ─── TAB SWITCHING ────────────────────────────────────────────────────────────
 function switchTab(name) {
-  ['manager','categories','admin','database'].forEach(t => {
+  ['manager','categories','admin','database','users'].forEach(t => {
     const btn   = document.getElementById('tab-btn-'   + t);
     const panel = document.getElementById('tab-panel-' + t);
     if (btn)   { btn.classList.toggle('active', t === name); btn.setAttribute('aria-selected', t === name ? 'true' : 'false'); }
@@ -1872,6 +1982,7 @@ function switchTab(name) {
   if (name === 'database')   { renderDatabaseTab(); renderPruneSection(); }
   if (name === 'categories') { renderCategoriesTab(); }
   if (name === 'admin')      { renderDesignSection(); }
+  if (name === 'users')      { loadUsers(); }
 }
 
 const dbFilters = { recipe: 'all', status: 'all' };

--- a/app.js
+++ b/app.js
@@ -1,7 +1,9 @@
 // ─── CONFIG ───────────────────────────────────────────────────────────────────
-const APP_VERSION = 'v0.6.3';
-const IS_PREVIEW = window.location.hostname.endsWith('.vercel.app') &&
-  window.location.hostname !== 'el-roys-drink-menu.vercel.app';
+const APP_VERSION = 'v0.6.4';
+const IS_PREVIEW = (window.location.hostname.endsWith('.vercel.app') &&
+  window.location.hostname !== 'el-roys-drink-menu.vercel.app') ||
+  window.location.hostname === 'localhost' ||
+  window.location.hostname === '127.0.0.1';
 
 const LS_KEYS = {
   fbUrl:        'hf_fb_url',
@@ -10,6 +12,8 @@ const LS_KEYS = {
   accessToken:  'hf_sb_access_token',
   refreshToken: 'hf_sb_refresh_token',
   expiresAt:    'hf_sb_expires_at',
+  uid:          'hf_sb_uid',
+  email:        'hf_sb_email',
 };
 
 let BOT_ID    = '';
@@ -634,24 +638,60 @@ async function _tryHandleRecoveryCallback() {
 
 async function _tryRestoreSession() {
   if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return;
-  const storedRefresh  = localStorage.getItem(LS_KEYS.refreshToken);
+  const storedAccess    = localStorage.getItem(LS_KEYS.accessToken);
+  const storedRefresh   = localStorage.getItem(LS_KEYS.refreshToken);
   const storedExpiresAt = Number(localStorage.getItem(LS_KEYS.expiresAt) || 0);
+  const storedUid       = localStorage.getItem(LS_KEYS.uid)   || '';
+  const storedEmail     = localStorage.getItem(LS_KEYS.email) || '';
   if (!storedRefresh) return;
-  try {
-    const data = await sbRefreshToken(storedRefresh);
+
+  // If access token is still valid (2-min buffer), use it directly — skip refresh call.
+  // This avoids unnecessary network round-trips and is resilient to Supabase cold starts.
+  if (storedAccess && storedExpiresAt > Date.now() + 120_000) {
+    try {
+      const profile = await sbGetProfile(storedAccess);
+      currentUser = {
+        uid: storedUid, email: storedEmail,
+        name: profile.name, role: profile.role,
+        accessToken: storedAccess, refreshToken: storedRefresh,
+        expiresAt: storedExpiresAt,
+      };
+      _scheduleTokenRefresh(storedExpiresAt);
+      applyRole(profile.role);
+      return;
+    } catch(e) { /* fall through to refresh */ }
+  }
+
+  // Access token expired or unusable — exchange refresh token for a new one.
+  const _doRefresh = async () => {
+    const refresh = localStorage.getItem(LS_KEYS.refreshToken);
+    if (!refresh) throw new Error('no refresh token');
+    const data = await sbRefreshToken(refresh);
     let role = 'none', name = '';
     if (data.access_token) {
       const profile = await sbGetProfile(data.access_token);
-      role = profile.role;
-      name = profile.name;
+      role = profile.role; name = profile.name;
     }
     _applySession(data, role, name);
     applyRole(role);
+  };
+
+  try {
+    await _doRefresh();
   } catch(e) {
-    // Stored session is invalid — clear it silently
-    localStorage.removeItem(LS_KEYS.accessToken);
-    localStorage.removeItem(LS_KEYS.refreshToken);
-    localStorage.removeItem(LS_KEYS.expiresAt);
+    // First attempt failed — Supabase may be cold-starting. Retry once after 2s
+    // before giving up and clearing tokens.
+    setTimeout(async () => {
+      try {
+        await _doRefresh();
+      } catch(e2) {
+        localStorage.removeItem(LS_KEYS.accessToken);
+        localStorage.removeItem(LS_KEYS.refreshToken);
+        localStorage.removeItem(LS_KEYS.expiresAt);
+        localStorage.removeItem(LS_KEYS.uid);
+        localStorage.removeItem(LS_KEYS.email);
+      }
+    }, 2000);
   }
 }
 
@@ -973,6 +1013,8 @@ function _applySession(data, role, name) {
   lsSet(LS_KEYS.accessToken,  currentUser.accessToken);
   lsSet(LS_KEYS.refreshToken, currentUser.refreshToken);
   lsSet(LS_KEYS.expiresAt,    String(currentUser.expiresAt));
+  lsSet(LS_KEYS.uid,          userId);
+  lsSet(LS_KEYS.email,        email);
   _scheduleTokenRefresh(currentUser.expiresAt);
 }
 
@@ -1219,6 +1261,8 @@ function signOut() {
   localStorage.removeItem(LS_KEYS.accessToken);
   localStorage.removeItem(LS_KEYS.refreshToken);
   localStorage.removeItem(LS_KEYS.expiresAt);
+  localStorage.removeItem(LS_KEYS.uid);
+  localStorage.removeItem(LS_KEYS.email);
   if (isManagerMode) exitManager();
   renderUserHeader();
 }
@@ -2080,4 +2124,53 @@ setInterval(() => {
   });
 })();
 
+// ─── PREVIEW ROLE-SWITCHER TOOLBAR ───────────────────────────────────────────
+let _previewRole = null; // tracks active mock role; null = using real session
+
+function _initPreviewToolbar() {
+  if (!IS_PREVIEW) return;
+  const toolbar = document.createElement('div');
+  toolbar.id = 'preview-toolbar';
+  toolbar.setAttribute('aria-label', 'Preview role switcher');
+  toolbar.innerHTML = `
+    <div class="preview-toolbar-label">PREVIEW</div>
+    <button class="preview-toolbar-btn" data-role="public"  onclick="_setPreviewRole('public')">Public</button>
+    <button class="preview-toolbar-btn" data-role="manager" onclick="_setPreviewRole('manager')">Manager</button>
+    <button class="preview-toolbar-btn" data-role="admin"   onclick="_setPreviewRole('admin')">Admin</button>
+    <div class="preview-toolbar-divider"></div>
+    <button class="preview-toolbar-btn preview-toolbar-login" onclick="openAuthOverlay()">Login</button>
+  `;
+  document.body.appendChild(toolbar);
+  _updatePreviewToolbar();
+}
+
+function _setPreviewRole(role) {
+  _previewRole = role;
+  if (role === 'public') {
+    if (isManagerMode) exitManager();
+    currentUser = null;
+    applyRole('none');
+    renderUserHeader();
+  } else {
+    // Mock session — no real tokens; writes will fail gracefully
+    currentUser = {
+      uid: 'preview-user', email: 'preview@preview.test',
+      name: 'Preview User', role,
+      accessToken: null, refreshToken: null, expiresAt: 0,
+    };
+    applyRole(role);
+    renderUserHeader();
+    if (!isManagerMode) enterManager();
+  }
+  _updatePreviewToolbar();
+}
+
+function _updatePreviewToolbar() {
+  const active = _previewRole ?? (currentUser?.role || 'public');
+  document.querySelectorAll('#preview-toolbar .preview-toolbar-btn[data-role]').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.role === active);
+  });
+}
+
 init();
+if (IS_PREVIEW) _initPreviewToolbar();

--- a/index.html
+++ b/index.html
@@ -67,6 +67,7 @@
       <button class="tab-btn"        id="tab-btn-categories" role="tab" aria-selected="false" aria-controls="tab-panel-categories" onclick="switchTab('categories')">CATEGORIES</button>
       <button class="tab-btn"        id="tab-btn-admin"      role="tab" aria-selected="false" aria-controls="tab-panel-admin"      onclick="switchTab('admin')">ADMIN</button>
       <button class="tab-btn"        id="tab-btn-database"   role="tab" aria-selected="false" aria-controls="tab-panel-database"   onclick="switchTab('database')">DATABASE</button>
+      <button class="tab-btn"        id="tab-btn-users"      role="tab" aria-selected="false" aria-controls="tab-panel-users"      onclick="switchTab('users')">USERS</button>
     </div>
 
     <!-- MANAGER PANEL: Edit Menu -->
@@ -242,6 +243,15 @@
       </div>
     </div>
 
+    <!-- USERS PANEL: Staff Account Management -->
+    <div class="tab-panel" id="tab-panel-users" role="tabpanel" aria-labelledby="tab-btn-users">
+      <div class="section-label">Staff Accounts</div>
+      <div class="users-invite-row">
+        <button class="btn-small" onclick="openInviteModal()">+ Invite Staff</button>
+      </div>
+      <div id="users-list"></div>
+    </div>
+
     <!-- DATABASE PANEL: Recipe Spreadsheet -->
     <div class="tab-panel" id="tab-panel-database" role="tabpanel" aria-labelledby="tab-btn-database">
       <div class="section-label">Recipe Database</div>
@@ -379,6 +389,19 @@
     <div class="modal-actions">
       <button class="btn-cancel" onclick="closeModal()">Cancel</button>
       <button class="btn-confirm" id="confirm-btn" onclick="sendUpdate()">SEND TO GROUP</button>
+    </div>
+  </div>
+</div>
+
+<!-- INVITE MODAL -->
+<div class="modal-bg" id="invite-modal-bg">
+  <div class="modal">
+    <h2>INVITE STAFF</h2>
+    <div class="modal-sub">Copy this message and send it to new staff members.</div>
+    <textarea id="invite-text-output" class="config-json-textarea" readonly spellcheck="false"></textarea>
+    <div class="modal-actions">
+      <button class="btn-cancel" onclick="closeInviteModal()">Done</button>
+      <button class="btn-confirm" onclick="copyInviteText()">COPY MESSAGE</button>
     </div>
   </div>
 </div>

--- a/style.css
+++ b/style.css
@@ -320,6 +320,20 @@
   .tab-panel { display: none; }
   .tab-panel.active { display: block; }
 
+  /* ── USERS TAB ── */
+  .users-invite-row { display:flex; justify-content:flex-end; margin-bottom:12px; }
+  .user-mgmt-top { display:flex; align-items:flex-start; justify-content:space-between; gap:12px; margin-bottom:10px; }
+  .user-mgmt-identity { flex:1; min-width:0; }
+  .user-mgmt-email { font-size:11px; color:var(--muted); margin-top:4px; overflow:hidden; text-overflow:ellipsis; white-space:nowrap; }
+  .user-role-badge { flex-shrink:0; display:inline-block; border-radius:6px; padding:3px 9px; font-size:11px; font-weight:600; letter-spacing:0.5px; text-transform:uppercase; white-space:nowrap; }
+  .user-role-badge--none { background:var(--surface); color:var(--muted); border:1px solid var(--border); }
+  .user-role-badge--manager { background:var(--ember); color:#fff; }
+  .user-role-badge--admin { background:var(--fire); color:#fff; }
+  .user-mgmt-role-row { margin-top:4px; }
+  .user-mgmt-role-select { flex:1; background:var(--surface); border:1px solid var(--border); border-radius:8px; color:var(--text); font-family:var(--font-body); font-size:13px; padding:9px 13px; outline:none; cursor:pointer; transition:border-color 0.2s; }
+  .user-mgmt-role-select:focus { border-color:var(--fire); }
+  .user-mgmt-self-note { font-size:11px; color:var(--muted); align-self:center; font-style:italic; }
+
   /* ── DATABASE TAB ── */
   .db-search-row { padding: 12px 0 8px; }
   .db-search-row input { width: 100%; box-sizing: border-box; padding: 8px 12px; border-radius: 6px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 0.95rem; }

--- a/style.css
+++ b/style.css
@@ -334,6 +334,16 @@
   .user-mgmt-role-select:focus { border-color:var(--fire); }
   .user-mgmt-self-note { font-size:11px; color:var(--muted); align-self:center; font-style:italic; }
 
+  /* ── PREVIEW TOOLBAR ── */
+  #preview-toolbar { position:fixed; right:0; top:50%; transform:translateY(-50%); z-index:110; display:flex; flex-direction:column; align-items:stretch; background:var(--card); border:1px solid var(--border); border-right:none; border-radius:10px 0 0 10px; padding:8px 6px; gap:4px; min-width:72px; box-shadow:-2px 0 14px rgba(0,0,0,0.18); }
+  .preview-toolbar-label { font-size:9px; font-weight:700; letter-spacing:1.5px; text-align:center; color:var(--muted); text-transform:uppercase; padding:2px 0 4px; }
+  .preview-toolbar-btn { background:var(--surface); border:1px solid var(--border); border-radius:6px; color:var(--muted); font-size:11px; font-family:var(--font-body); padding:7px 8px; cursor:pointer; text-align:center; transition:all 0.14s; white-space:nowrap; }
+  .preview-toolbar-btn:hover { border-color:var(--ember); color:var(--ember); }
+  .preview-toolbar-btn.active { background:var(--ember); border-color:var(--ember); color:#fff; font-weight:600; }
+  .preview-toolbar-login { color:var(--fire); border-color:var(--fire); }
+  .preview-toolbar-login:hover { background:var(--fire); color:#fff; border-color:var(--fire); }
+  .preview-toolbar-divider { height:1px; background:var(--border); margin:2px 0; }
+
   /* ── DATABASE TAB ── */
   .db-search-row { padding: 12px 0 8px; }
   .db-search-row input { width: 100%; box-sizing: border-box; padding: 8px 12px; border-radius: 6px; border: 1px solid var(--border); background: var(--surface); color: var(--text); font-size: 0.95rem; }


### PR DESCRIPTION
## Summary

### v0.6.3 — USERS tab (role management, name editing, staff invite)
- New admin-only **USERS** tab in the manager screen
- List all staff accounts with email, name (editable), and role
- Role dropdown per user (none / manager / admin) with save; self-role change blocked server-side
- **Invite Staff** button → copyable pre-written invite message with site URL
- New `api/users.js` — GET joins `auth.users` + `profiles`; PATCH updates role or name (admin-only via `requireRole`)

### v0.6.4 — Preview toolbar + persistent session
- **Preview role-switcher toolbar** (IS_PREVIEW builds + localhost): fixed right-edge vertical panel with Public / Manager / Admin / Login buttons — switch role perspective without real auth, for QA and design review
- **Persistent session fix**: `_tryRestoreSession` now reuses a still-valid access token directly (skips the refresh network call), making page load faster and resilient to Supabase free-tier cold starts
- **Retry on failure**: if the refresh call fails (cold start), retries once after 2s before clearing tokens — prevents spurious sign-outs
- **Persists uid + email** to localStorage so session can reconstruct without extra network round-trip

## Files changed

| File | Change |
|---|---|
| `api/users.js` | New — GET/PATCH user management endpoint |
| `app.js` | USERS tab logic; preview toolbar (`_initPreviewToolbar`, `_setPreviewRole`); rewritten `_tryRestoreSession` with optimistic restore + retry; `uid`/`email` LS_KEYS |
| `index.html` | USERS tab button + panel; invite modal |
| `style.css` | User card styles; role badges; preview toolbar styles |

Relates to #161

## Test plan

**USERS tab (v0.6.3)**
- [ ] Admin sees USERS tab; manager does not
- [ ] All accounts listed with name, email, role badge
- [ ] Role dropdown saves; badge updates in place
- [ ] Own account role selector disabled (server returns 400)
- [ ] Name save updates display name
- [ ] Invite Staff → modal with URL; COPY MESSAGE works

**Preview toolbar (v0.6.4)**
- [ ] Toolbar appears on localhost and Vercel preview URLs
- [ ] Toolbar does NOT appear on `el-roys-drink-menu.vercel.app`
- [ ] Public → signed-out view; Manager → manager tabs; Admin → all tabs visible
- [ ] Login button opens real auth overlay

**Persistent session (v0.6.4)**
- [ ] Sign in, close tab, reopen — no password prompt (session restored)
- [ ] Page load does not make unnecessary refresh call when token still valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)