### PR TITLE
Fix manager entry to open the current menu directly

### DIFF
--- a/.agents/skills/creative-change-investigator/SKILL.md
+++ b/.agents/skills/creative-change-investigator/SKILL.md
@@ -1,0 +1,147 @@
+---
+name: creative-change-investigator
+description: Investigate the codebase and recommend creative feature, UX, route, or implementation improvements. Use when the user wants exploratory solution ideas, feature/change recommendations, alternative directions, or a grounded investigation of a specific improvement area. If the ask is broad or blank, scan for promising directions and ask the user what to prioritize before going deeper.
+---
+
+# Creative Change Investigator
+
+Use this skill when the user wants informed idea generation rather than an
+immediate implementation.
+
+This skill has two modes:
+
+- broad exploration mode: the user invokes it without a concrete target and
+  wants options
+- scoped investigation mode: the user names a route, feature, workflow, bug
+  area, or improvement target and wants better solutions
+
+If the user brings up multiple distinct investigation targets, split them into
+separate tracks and use sub-agents to investigate each one in parallel when
+that capability is available.
+
+## Ground Rules
+
+- stay grounded in the actual repo before suggesting changes
+- prefer ideas that respect the zero-dependency, no-build-tool setup
+- preserve the two-restaurant, four-menu model
+- preserve auth, per-menu access, live polling, and save-vs-send behavior
+- preserve route-owned public pages and use the default public renderer only as
+  fallback context
+- avoid generic product advice that ignores current architecture
+
+## Broad Exploration Mode
+
+Use this when the prompt is effectively blank or only asks for ideas,
+directions, recommendations, or "what should we work on?"
+
+### Workflow
+
+1. Scan the repo structure and identify the highest-leverage surfaces:
+   - public routes
+   - shared manager/admin flows
+   - auth/access flows
+   - persistence and Supabase-backed hydration
+   - notifications, featured items, history, and preview behavior
+2. Read only the files needed to understand the most promising opportunity
+   areas.
+3. Produce 3-6 concrete directions worth exploring.
+4. For each direction, include:
+   - what it improves
+   - why it is promising now
+   - likely files or functions involved
+   - main risk or tradeoff
+5. Pause and ask the user which direction to prioritize, unless they clearly
+   asked for a full recommendation.
+
+### Output Shape
+
+When pausing for user direction, keep it decision-friendly:
+
+- one short summary sentence
+- 3-6 labeled options
+- one recommended option, if there is a clear best bet
+- one short question asking what to put the most stock in
+
+## Scoped Investigation Mode
+
+Use this when the user names a specific area such as a route, screen, feature,
+workflow, performance issue, UX problem, or implementation idea.
+
+### Workflow
+
+1. Find the relevant files, functions, and adjacent constraints.
+2. Read enough surrounding code to understand how the target area interacts
+   with the rest of the app.
+3. Identify the real constraint set:
+   - user-visible behavior that must be preserved
+   - data and auth boundaries
+   - route ownership vs. shared runtime responsibilities
+   - accessibility or release/version implications
+4. Generate 2-4 credible solution paths.
+5. Compare them on:
+   - user impact
+   - implementation complexity
+   - regression risk
+   - fit with current architecture
+6. Recommend the strongest path and explain why it wins.
+
+## Multi-Topic Investigation
+
+Use this when the user names multiple routes, features, workflows, or possible
+improvements in the same request.
+
+### Workflow
+
+1. Break the request into distinct investigation targets.
+2. Spawn one sub-agent per target when the targets are meaningfully separate and
+   can be explored in parallel.
+3. Give each sub-agent a narrow scope so it investigates only its assigned
+   route, feature, or workflow.
+4. Keep final synthesis in the main thread:
+   - compare the findings
+   - remove overlap
+   - surface conflicts or shared dependencies
+   - recommend what deserves the most attention first
+5. If the targets are too tightly coupled for clean parallel work, investigate
+   them together instead of forcing delegation.
+
+### Output
+
+Return:
+
+- the distinct areas investigated
+- the best idea or solution path for each area
+- shared risks or architectural overlap
+- the recommended priority order across the areas
+
+## Idea Quality Bar
+
+Recommendations should be:
+
+- specific to this app, not generic SaaS advice
+- actionable enough that implementation could start from the recommendation
+- creative in approach, but still compatible with current constraints
+- honest about tradeoffs and regression risk
+
+Good recommendation themes include:
+
+- route-owned public experience improvements
+- manager/admin workflow simplification
+- safer or clearer save/send/draft behavior
+- menu discovery and switching improvements
+- featured or notification flow improvements
+- release/version visibility improvements
+- targeted data-flow or hydration simplifications
+
+## Suggested Output
+
+Return:
+
+- what area was investigated
+- what files or functions were most relevant
+- the best solution options
+- the recommended direction
+- open questions that could change the recommendation
+
+If the request is broad, stop before implementation and ask the user what to
+prioritize next.

--- a/.agents/skills/supabase-data-maintainer/SKILL.md
+++ b/.agents/skills/supabase-data-maintainer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: supabase-data-maintainer
-description: Maintain Supabase-backed menu resolution, hydration, persistence, and offline fallback behavior. Use when work touches `sbResolveMenu()`, `loadActiveMenuState()`, persistence, cache invalidation, history, featured refreshes, or legacy menu-link normalization.
+description: Maintain Supabase-backed menu resolution, hydration, persistence, polling, and legacy menu-link normalization. Use when work touches `sbResolveMenu()`, `loadActiveMenuState()`, persistence, cache invalidation, history, featured refreshes, live updates, or legacy menu-link normalization.
 ---
 
 # Supabase Data Maintainer
@@ -13,7 +13,7 @@ Use this skill when the user asks to debug or change the shared data layer.
 - active-menu resolution
 - state hydration
 - persistence paths
-- localStorage fallback behavior
+- polling and live update behavior
 - related refresh flows for featured content, history, and notifications
 
 ## Core Rules
@@ -21,7 +21,7 @@ Use this skill when the user asks to debug or change the shared data layer.
 - preserve the hardcoded `RESTAURANTS` and `MENUS` model
 - preserve legacy public-link normalization such as old `?menu=el-roys`
   behavior
-- preserve localStorage fallback behavior
+- preserve live database-backed menu reads and polling behavior
 - do not silently change menu IDs, slugs, or restaurant/menu mapping
 - avoid schema or migration work unless the user explicitly asks for it
 
@@ -34,7 +34,7 @@ Use this skill when the user asks to debug or change the shared data layer.
    - persistence
    - cache invalidation
    - fallback logic
-3. Trace both online and offline assumptions.
+3. Trace both steady-state reads and live-update assumptions.
 4. Confirm active-menu context stays correct across reads, writes, history,
    featured refreshes, and notifications state.
 5. Prefer targeted normalization or hydration fixes over broad rewrites.
@@ -50,6 +50,6 @@ Use this skill when the user asks to debug or change the shared data layer.
 
 Report:
 - which data path changed
-- whether the defect lived in resolution, hydration, persistence, or fallback
+- whether the defect lived in resolution, hydration, persistence, polling, or fallback cleanup
 - the files touched
 - what online/offline verification still needs to happen

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -7,13 +7,13 @@ A zero-dependency web app that runs the live public and manager-facing menus for
 - **Leroy's Lounge**
 - **El Roy's Cantina**
 
-Each restaurant has two menus, **Drinks** and **Food**, for four total menus. Managers are still assigned per menu, so bartenders and kitchen staff can have separate access. Public rendering is now **custom-design first**: each restaurant is expected to provide uploaded HTML/CSS design files, and the legacy category-accordion renderer exists only as a fallback when a design is disabled or missing.
+Each restaurant has two menus, **Drinks** and **Food**, for four total menus. Managers are still assigned per menu, so bartenders and kitchen staff can have separate access. Public rendering is now **custom-design first**: each restaurant's public page is owned by its route files, and the legacy category-accordion renderer exists only as a fallback when a route implementation is disabled or unavailable.
 
 ## Architecture
 
 - **Three files:** `index.html` (markup), `style.css` (styles), `app.js` (logic). No build step, bundler, or package manager.
 - **Supabase PostgREST** — primary read/write path for restaurants, menus, categories, items, menu metadata, featured groups, and update history.
-- **localStorage fallback** — caches menu state, timestamps, and auth/session state for degraded or offline reads.
+- **localStorage/session cache** — legacy cache paths still exist in parts of the shared runtime, but live public menu behavior is database-backed and refreshed through polling.
 - **Supabase Auth + role API** — email/password auth in the client; `/api/role` and `/api/users` enforce role and per-menu access.
 - **Route-owned public pages** — restaurant public designs now live directly in the repo route files such as `leroyslounge/index.html` and `elroyscantina/index.html`. Stitch is the source of truth for those pages.
 - **Vercel API routes** — required for config, roles, notifications, and user management.
@@ -113,21 +113,22 @@ New accounts still start with `role: none`. Admins grant access per menu across 
 - Do not introduce dependencies.
 - No build tools.
 - Preserve Supabase auth and role flows.
-- Preserve offline/localStorage fallback behavior.
+- Preserve live polling, database-backed menu updates, Supabase auth, and role flows.
 - Ignore `supabase/migrations/*.sql` during normal UI/API work unless the task is explicitly about schema/data changes.
 - In `style.css`, use CSS custom properties for colors. No hardcoded hex values in new style rules.
 - Preserve accessibility patterns: tab widgets, dialog behavior, keyboard support, ARIA states, and live regions.
 
 ## Custom Design / Stitch Workflow
 
-Both restaurants are expected to run on uploaded custom HTML/CSS designs.
+Both restaurants are expected to run on route-owned public pages sourced from Stitch.
 
 ### Runtime behavior
 
 1. `renderPublicView()` always tries the route-specific public implementation first.
 2. Public restaurant design lives in the route files, not in `designs/` and not in an admin-upload flow.
 3. If a dedicated route implementation is unavailable or disabled, the app falls back to the default accordion renderer.
-4. Route-specific public styling is part of the page implementation and manager/admin mode exits back to the shared interface.
+4. Dedicated restaurant routes boot directly into their route-owned shell so they do not flash the shared `CURRENT MENU` loading shell on first paint.
+5. Route-specific public styling is part of the page implementation and manager/admin mode exits back to the shared interface.
 
 ### `/stitch`
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Each restaurant has two menus, Drinks and Food, for four total menus. The public
 
 - `index.html`, `style.css`, `app.js`: no build step, bundler, or package manager
 - Supabase PostgREST: primary read/write path for restaurants, menus, categories, items, menu metadata, featured groups, history, and auth-backed user data
-- `localStorage`: offline/degraded-read cache for menu data, timestamps, and session state
+- `localStorage`: session/cache layer used by parts of the shared runtime; live menu behavior is database-backed
 - Supabase Auth: client email/password auth with recovery handling
 - Vercel API routes in [`api/`](api): config delivery, role lookup, user management, and notifications
 - Route-owned public pages in [`leroyslounge/index.html`](leroyslounge/index.html) and [`elroyscantina/index.html`](elroyscantina/index.html)
@@ -47,7 +47,7 @@ Current app version in code: `v0.8.1` from [`app.js:2`](app.js#L2).
 - Leroy's Lounge public route: `/leroyslounge`
 - El Roy's Cantina public route: `/elroyscantina`
 
-The shared app detects route ownership and renders the matching public restaurant page when possible. Manager/admin flows still live in the shared app shell.
+The shared app detects route ownership and renders the matching public restaurant page when possible. Dedicated restaurant routes now boot route-first so they do not first-paint the shared `CURRENT MENU` shell. Manager/admin flows still live in the shared app shell.
 
 ## Repo Layout
 
@@ -195,7 +195,7 @@ When doing normal UI work:
 - do not add dependencies
 - do not add a bundler
 - keep the app working as plain HTML/CSS/JS
-- preserve Supabase auth and localStorage fallback behavior
+- preserve Supabase auth, live polling, and database-backed menu updates
 
 ## Database Files
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="/lib/fonts/fonts.css">
 <link rel="stylesheet" href="/style.css">
 </head>
-<body>
+<body class="settings-shell-pending">
 <main id="site-picker-view" class="site-picker-view" hidden>
   <div class="site-picker-card">
     <p class="site-picker-kicker">Current Menu</p>

--- a/app.js
+++ b/app.js
@@ -397,6 +397,7 @@ function _togglePublicShellMode(mode) {
   const siteWrapper = document.getElementById('restaurant-site-wrapper');
   const defaultShell = document.getElementById('public-default-shell');
   const useSiteWrapper = mode === 'site' && !!siteWrapper;
+  document.body.classList.remove('route-shell-pending');
   if (siteWrapper) {
     if (useSiteWrapper) siteWrapper.removeAttribute('hidden');
     else siteWrapper.setAttribute('hidden', 'hidden');
@@ -1364,6 +1365,7 @@ async function init() {
   _appPageMode = getAppPageModeFromPath();
   const detectedSiteRestaurant = getSiteRestaurantFromPath();
   _siteRestaurant = isValidRestaurant(detectedSiteRestaurant?.id) ? detectedSiteRestaurant : null;
+  const isDedicatedRoute = isDedicatedRestaurantPage();
   if (_appPageMode === 'picker') {
     showPickerPage();
     return;
@@ -1371,14 +1373,19 @@ async function init() {
   showAppShell();
   migrateLocalStorage();
   if (MENU_ID && !KNOWN_MENU_ORDER.includes(MENU_ID)) _clearActiveMenuContext({ clearCache: true });
-  document.getElementById('loading-view').style.display = 'block';
-  document.getElementById('public-view').style.display = 'none';
+  document.getElementById('loading-view').style.display = isDedicatedRoute ? 'none' : 'block';
+  document.getElementById('public-view').style.display = isDedicatedRoute ? 'block' : 'none';
 
   if (_siteRestaurant && !new URLSearchParams(location.search).get('menu')) {
     primeSiteRestaurantMenu(_siteRestaurant);
   }
 
-  await Promise.all([loadLocalConfig(), loadSupabaseConfig()]);
+  if (_siteRestaurant) {
+    showRouteBootView();
+  }
+
+  loadLocalConfig();
+  await loadSupabaseConfig();
 
   if (SUPABASE_URL) await sbResolveMenu();
 
@@ -1391,12 +1398,12 @@ async function init() {
       menuState = defaultState();
     }
     applyDesign(currentDesign);
-    showPublicView();
+    await showPublicView();
   } else {
     try {
       await loadActiveMenuState();
       applyDesign(currentDesign);
-      showPublicView();
+      await showPublicView();
     } catch(e) {
       // Fallback to localStorage cache
       const cached = readCachedMenuState(_siteRestaurant?.id || RESTAURANT_ID || '');
@@ -1406,7 +1413,7 @@ async function init() {
         menuState = defaultState();
       }
       applyDesign(currentDesign);
-      showPublicViewWithError('⚠️ Could not load menu data. Check your connection.');
+      await showPublicViewWithError('⚠️ Could not load menu data. Check your connection.');
     }
   }
 
@@ -1496,25 +1503,56 @@ async function _tryRestoreSession() {
   }
 }
 
-function showPublicView() {
+async function showPublicView() {
   document.getElementById('loading-view').style.display = 'none';
-  document.getElementById('public-view').style.display = 'block';
-  _togglePublicShellMode('default');
   const switchBtn = document.getElementById('public-switch-menu-btn');
   if (switchBtn) switchBtn.style.display = _hasMultipleMenus ? '' : 'none';
+  if (!isDedicatedRestaurantPage()) _togglePublicShellMode('default');
+  document.getElementById('public-view').style.display = 'block';
   updateLastUpdatedLabel();
-  renderPublicView();
+  await renderPublicView();
   startPolling();
 }
 
-function showPublicViewWithError(msg) {
+async function showPublicViewWithError(msg) {
   document.getElementById('loading-view').style.display = 'none';
   document.getElementById('public-view').style.display = 'block';
+  if (showRouteLoadError(msg)) return;
   _togglePublicShellMode('default');
   const el = document.getElementById('public-error');
   el.textContent = msg;
   el.classList.add('visible');
-  renderPublicView();
+  await renderPublicView();
+}
+
+function showRouteBootView() {
+  if (!isDedicatedRestaurantPage()) return;
+  const publicView = document.getElementById('public-view');
+  const loadingView = document.getElementById('loading-view');
+  if (loadingView) loadingView.style.display = 'none';
+  if (publicView) publicView.style.display = 'block';
+  if (typeof window.renderRouteBootShell === 'function') {
+    const didRender = window.renderRouteBootShell();
+    if (didRender !== false) {
+      _togglePublicShellMode('site');
+      return;
+    }
+  }
+  _togglePublicShellMode('site');
+}
+
+function showRouteLoadError(message) {
+  if (!isDedicatedRestaurantPage()) return false;
+  showRouteBootView();
+  const siteWrapper = document.getElementById('restaurant-site-wrapper');
+  if (!siteWrapper) return false;
+  siteWrapper.querySelector('.route-load-error')?.remove();
+  const banner = document.createElement('div');
+  banner.className = 'error-banner visible route-load-error';
+  banner.setAttribute('role', 'alert');
+  banner.textContent = message;
+  siteWrapper.prepend(banner);
+  return true;
 }
 
 function _setLoadingMessage(message, opts = {}) {
@@ -1946,194 +1984,6 @@ function _renderDefaultPublicView() {
   updateCollapseAllBtn();
 }
 
-function _getVisiblePublicItemsForRoute(categoryId) {
-  const state = menuState[categoryId] || { items: [] };
-  return (state.items || []).filter(item => item.onMenu !== false && item.visibility !== 'off_menu');
-}
-
-function _buildLeroyRouteItemHtml(item, options = {}) {
-  const {
-    badgeText = '',
-  } = options;
-  const is86 = !!item?.eightySixed;
-  const desc = (item?.desc || '').trim();
-  const hasDesc = !!desc;
-  const rowClasses = ['ll-board-row', hasDesc ? 'll-board-row--expandable' : '', is86 ? 'll-board-row--sold' : ''].filter(Boolean).join(' ');
-  const cardClasses = ['ll-board-item', 'menu-item', hasDesc ? 'has-detail' : '', is86 ? 'menu-item-86d ll-board-item--sold' : ''].filter(Boolean).join(' ');
-  const toggleHandler = hasDesc ? ' onclick="togglePublicDesc(this.closest(\'.menu-item\'))"' : '';
-  const expandIcon = hasDesc
-    ? `<span class="material-symbols-outlined item-expand-icon ll-board-expand" role="button" tabindex="0" aria-label="Show description" aria-expanded="false" onclick="event.stopPropagation();togglePublicDesc(this.closest('.menu-item'))" onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();event.stopPropagation();togglePublicDesc(this.closest('.menu-item'))}">expand_more</span>`
-    : '';
-  return `<article class="${cardClasses}">
-    <div class="${rowClasses}"${toggleHandler}>
-      ${is86 ? '<span class="ll-board-strike" aria-hidden="true"></span>' : ''}
-      <div class="ll-board-item-main">
-        <div class="ll-board-item-name-wrap">
-          <h3 class="ll-board-item-name menu-item-name">${escHtml(item?.name || '')}</h3>
-          ${badgeText ? `<span class="ll-board-chip">${escHtml(badgeText)}</span>` : ''}
-        </div>
-      </div>
-      <div class="ll-board-item-side">
-        ${is86 ? '<span class="ll-board-stamp">Sold Out</span>' : ''}
-        ${item?.price ? `<span class="ll-board-price menu-item-price">${escHtml(item.price)}</span>` : ''}
-        ${expandIcon}
-      </div>
-    </div>
-    ${hasDesc ? `<div class="item-detail-panel ll-board-detail"><p class="ll-board-item-desc menu-item-desc">${escHtml(desc)}</p></div>` : ''}
-  </article>`;
-}
-
-function _buildLeroyRouteFeaturedItemsHtml() {
-  const featuredSlots = _featuredGroups.flatMap(group => group.slots || []).filter(slot => slot.item);
-  if (!featuredSlots.length) {
-    const fallbackItems = _getVisiblePublicItemsForRoute('special').slice(0, 3);
-    if (!fallbackItems.length) return '<p class="ll-route-empty">Nothing featured right now.</p>';
-    return fallbackItems.map((item, index) => _buildLeroyRouteItemHtml(item, {
-      badgeText: index === 0 ? 'Chef\'s Choice' : '',
-    })).join('');
-  }
-
-  return featuredSlots.slice(0, 3).map((slot, index) => _buildLeroyRouteItemHtml(slot.item, {
-    badgeText: index === 0 ? 'Chef\'s Choice' : '',
-  })).join('');
-}
-
-function _buildLeroyRouteCategoryHtml(cat) {
-  const items = _getVisiblePublicItemsForRoute(cat.id);
-  if (!items.length) return '';
-  return `<section class="ll-board-section menu-category" data-category="${escHtml(cat.id)}">
-    <div class="ll-board-section-head">
-      <h2 class="ll-board-section-title">${escHtml(cat.title)}</h2>
-    </div>
-    <div class="ll-board-rows">${items.map(item => _buildLeroyRouteItemHtml(item)).join('')}</div>
-  </section>`;
-}
-
-function _getLeroyRouteMenus() {
-  return sortKnownMenus(
-    knownMenuList()
-      .filter(menu => menu.restaurantId === RESTAURANTS.LEROYS.id)
-      .map(menu => ({
-        id: menu.id,
-        name: menu.name,
-        slug: menu.slug,
-        type: menu.type,
-        restaurant_id: menu.restaurantId,
-      }))
-  );
-}
-
-function _renderLeroyRouteSettingsDropdown() {
-  const wrapper = document.querySelector('[data-route-settings]');
-  const dropdown = document.getElementById('ll-route-settings-dropdown');
-  if (!wrapper || !dropdown) return;
-
-  const role = currentUser?.role || 'none';
-  const accessibleIds = currentUser?.accessibleMenuIds || [];
-  const options = [];
-
-  if (role === 'admin' || accessibleIds.length > 0) {
-    options.push({ label: 'Manager', icon: 'tune', onClick: () => onActionBtnClick() });
-  }
-  if (role === 'admin') {
-    options.push({ label: 'Admin', icon: 'shield_person', onClick: () => onAdminBtnClick() });
-  }
-
-  wrapper.style.display = options.length ? '' : 'none';
-  dropdown.innerHTML = options.map(option => `
-    <button class="ll-board-route-option" type="button" data-route-settings-option="${escHtml(option.label)}">
-      <span class="ll-board-route-option-label">${escHtml(option.label)}</span>
-      <span class="material-symbols-outlined ll-board-route-option-icon" aria-hidden="true">${escHtml(option.icon)}</span>
-    </button>
-  `).join('');
-
-  dropdown.querySelectorAll('[data-route-settings-option]').forEach((button, index) => {
-    button.onclick = () => {
-      closeRouteDropdowns();
-      options[index]?.onClick?.();
-    };
-  });
-}
-
-async function onLeroyRouteMenuSelect(menuId) {
-  const menu = _getLeroyRouteMenus().find(entry => entry.id === menuId);
-  if (!menu) return;
-
-  closeRouteDropdowns();
-  selectMenu(menu.id, menu.slug, menu.name, menu.type, menu.restaurant_id);
-
-  const targetHref = getPublicHrefForCurrentMenu();
-  const currentHref = `${window.location.pathname}${window.location.search}`;
-  if (targetHref && targetHref !== currentHref) {
-    navigateToPage(targetHref);
-    return;
-  }
-
-  await loadActiveMenuState();
-  applyDesign(currentDesign);
-  renderPublicViews();
-}
-
-function _renderLeroyRouteSwapDropdown() {
-  const dropdown = document.getElementById('ll-route-swap-dropdown');
-  const trigger = document.getElementById('ll-route-swap-trigger');
-  if (!dropdown || !trigger) return;
-
-  const menus = _getLeroyRouteMenus();
-  trigger.style.display = menus.length > 1 ? '' : 'none';
-  dropdown.innerHTML = menus.map(menu => {
-    const isActive = menu.id === MENU_ID;
-    return `
-      <button class="ll-board-route-option${isActive ? ' is-active' : ''}" type="button" data-route-menu-option="${escHtml(menu.id)}">
-        <span class="ll-board-route-option-label">${escHtml(getMenuTypeLabel(menu.type))}</span>
-        <span class="material-symbols-outlined ll-board-route-option-icon" aria-hidden="true">${menu.type === 'food' ? 'restaurant_menu' : 'sports_bar'}</span>
-      </button>
-    `;
-  }).join('');
-
-  dropdown.querySelectorAll('[data-route-menu-option]').forEach(button => {
-    button.onclick = async () => {
-      await onLeroyRouteMenuSelect(button.getAttribute('data-route-menu-option') || '');
-    };
-  });
-}
-
-function _renderLeroyRoutePage(container) {
-  const template = document.getElementById('leroy-route-template');
-  if (!template) return false;
-  container.innerHTML = '';
-  container.appendChild(template.content.cloneNode(true));
-
-  const timestamp = getLastUpdatedTs();
-  const timestampText = timestamp ? formatUpdatedAt(timestamp, '') : 'Awaiting first update';
-  const menuNameEl = document.getElementById('ll-route-menu-name');
-  if (menuNameEl) menuNameEl.textContent = _activeMenuName || "Leroy's Lounge";
-  const statusTsEl = document.getElementById('ll-route-status-timestamp');
-  if (statusTsEl) statusTsEl.textContent = timestampText;
-  const footerTsEl = document.getElementById('ll-route-footer-timestamp');
-  if (footerTsEl) footerTsEl.textContent = timestampText;
-  const footerVersionEl = document.getElementById('ll-route-footer-version');
-  if (footerVersionEl) footerVersionEl.innerHTML = APP_VERSION + (IS_PREVIEW ? ' <span class="footer-preview-badge">PREVIEW</span>' : '');
-
-  const featuredWrap = document.getElementById('ll-route-specials');
-  if (featuredWrap) featuredWrap.innerHTML = _buildLeroyRouteFeaturedItemsHtml();
-
-  const categoryWrap = document.getElementById('ll-route-sections');
-  if (categoryWrap) {
-    const categoriesHtml = CATEGORY_DEFS
-      .filter(cat => cat.id !== 'special')
-      .map(_buildLeroyRouteCategoryHtml)
-      .filter(Boolean)
-      .join('');
-    categoryWrap.innerHTML = categoriesHtml || '<p class="ll-route-empty">Nothing on the menu yet.</p>';
-  }
-
-  _renderLeroyRouteSwapDropdown();
-  _renderLeroyRouteSettingsDropdown();
-
-  return true;
-}
-
 async function _renderCustomDesignView() {
   const fallbackContainer = document.getElementById('public-categories');
   const siteWrapper = document.getElementById('restaurant-site-wrapper');
@@ -2166,11 +2016,6 @@ async function _renderCustomDesignView() {
       _togglePublicShellMode('site');
       return;
     }
-  }
-
-  if (renderIntoSiteWrapper && _siteRestaurant?.id === RESTAURANTS.LEROYS.id && _renderLeroyRoutePage(container)) {
-    _togglePublicShellMode('site');
-    return;
   }
 
   _togglePublicShellMode('default');
@@ -2401,8 +2246,6 @@ function renderUserHeader() {
   if (isDedicatedRestaurantPage() && !isManagerMode && !isAdminMode && publicView?.style.display !== 'none') {
     renderPublicView();
   }
-
-  _renderLeroyRouteSettingsDropdown();
 }
 
 function applyRole(role) {

--- a/app.js
+++ b/app.js
@@ -2316,12 +2316,22 @@ function toggleUserDropdown(chipId = 'user-chip') {
   const chip = document.getElementById(chipId);
   if (!chip) return;
   closeRouteDropdowns();
+  closeUserChips(chipId);
   const isOpen = chip.classList.toggle('open');
   chip.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
   if (isOpen) {
     const firstFocusable = chip.querySelector('button, a');
     if (firstFocusable) firstFocusable.focus();
   }
+}
+
+function closeUserChips(exceptChipId = '', target = null) {
+  document.querySelectorAll('.user-chip, .ll-site-userchip, .erc-userchip, [data-route-user-chip]').forEach(chip => {
+    if (exceptChipId && chip.id === exceptChipId) return;
+    if (target && chip.contains(target)) return;
+    chip.classList.remove('open');
+    chip.setAttribute('aria-expanded', 'false');
+  });
 }
 
 function closeRouteDropdowns(exceptDropdownId = '') {
@@ -2342,6 +2352,7 @@ function toggleRouteDropdown(triggerId, dropdownId) {
   if (!trigger || !dropdown) return;
   const wrapper = trigger.closest('[data-route-dropdown]');
   const shouldOpen = dropdown.hidden;
+  closeUserChips();
   closeRouteDropdowns(shouldOpen ? dropdownId : '');
   if (!wrapper) return;
   wrapper.classList.toggle('open', shouldOpen);
@@ -2355,12 +2366,7 @@ function toggleRouteDropdown(triggerId, dropdownId) {
 
 // Close dropdown when clicking outside
 document.addEventListener('click', function(e) {
-  document.querySelectorAll('.user-chip, .ll-site-userchip').forEach(chip => {
-    if (!chip.contains(e.target)) {
-      chip.classList.remove('open');
-      chip.setAttribute('aria-expanded', 'false');
-    }
-  });
+  closeUserChips('', e.target);
   document.querySelectorAll('[data-route-dropdown]').forEach(wrapper => {
     if (!wrapper.contains(e.target)) {
       wrapper.classList.remove('open');
@@ -2375,7 +2381,7 @@ document.addEventListener('click', function(e) {
 // Close dropdown on Escape
 document.addEventListener('keydown', function(e) {
   if (e.key !== 'Escape') return;
-  document.querySelectorAll('.user-chip, .ll-site-userchip').forEach(chip => {
+  document.querySelectorAll('.user-chip, .ll-site-userchip, .erc-userchip, [data-route-user-chip]').forEach(chip => {
     if (chip.classList.contains('open')) {
       chip.classList.remove('open');
       chip.setAttribute('aria-expanded', 'false');

--- a/app.js
+++ b/app.js
@@ -212,6 +212,35 @@ function getRestaurantById(id) {
   return knownRestaurantList().find(restaurant => restaurant.id === id) || null;
 }
 
+function getMenuById(menuId) {
+  return knownMenuList().find(menu => menu.id === menuId) || null;
+}
+
+function getMenuBySlug(slug) {
+  const normalizedSlug = normalizeKnownMenuSlug(slug || '');
+  return knownMenuList().find(menu => menu.slug === normalizedSlug) || null;
+}
+
+function getRequestedMenuForSettingsPage() {
+  const requestedSlug = new URLSearchParams(location.search).get('menu') || '';
+  if (requestedSlug) return getMenuBySlug(requestedSlug);
+  if (MENU_ID) return getMenuById(MENU_ID);
+  return null;
+}
+
+function getFirstAccessibleManagerMenuId(user = currentUser) {
+  if (user?.role === 'admin') return KNOWN_MENU_ORDER[0] || '';
+  const allowedIds = new Set(normalizeAccessibleMenuIds(user?.accessibleMenuIds));
+  return KNOWN_MENU_ORDER.find(menuId => allowedIds.has(menuId)) || '';
+}
+
+function currentUserCanManageMenu(menuId = MENU_ID, user = currentUser) {
+  if (!menuId || !KNOWN_MENU_ORDER.includes(menuId) || !user) return false;
+  if (user.role === 'admin') return true;
+  if (user.role !== 'manager') return false;
+  return normalizeAccessibleMenuIds(user.accessibleMenuIds).includes(menuId);
+}
+
 function getMenuTypeLabel(menuType) {
   return (menuType || '').toLowerCase() === 'food' ? 'Food' : 'Drinks';
 }
@@ -315,13 +344,25 @@ function getDefaultPublicPath() {
   return '/';
 }
 
-function getPublicHrefForCurrentMenu() {
-  const menu = knownMenuList().find(entry => entry.id === MENU_ID) || null;
+function getPublicHrefForMenuId(menuId) {
+  const menu = getMenuById(menuId);
   const basePath = menu?.restaurantId && SITE_PATHS[menu.restaurantId]
     ? SITE_PATHS[menu.restaurantId]
     : getDefaultPublicPath();
   if (!menu?.slug) return basePath;
   const url = new URL(basePath, window.location.origin);
+  url.searchParams.set('menu', menu.slug);
+  return `${url.pathname}${url.search}`;
+}
+
+function getPublicHrefForCurrentMenu() {
+  return getPublicHrefForMenuId(MENU_ID);
+}
+
+function getManagerHrefForMenuId(menuId) {
+  const menu = getMenuById(menuId);
+  if (!menu?.slug) return SHARED_PAGE_PATHS.manager;
+  const url = new URL(SHARED_PAGE_PATHS.manager, window.location.origin);
   url.searchParams.set('menu', menu.slug);
   return `${url.pathname}${url.search}`;
 }
@@ -1615,7 +1656,10 @@ function _clearSettingsRedirectPrompt() {
   }
 }
 
-function _showSettingsRedirectMessage(message) {
+function _showSettingsRedirectMessage(message, opts = {}) {
+  const targetPath = opts.targetPath || '/';
+  const redirectLabel = opts.redirectLabel || 'the menu selector';
+  const actionLabel = opts.actionLabel || 'Return to the restaurant selector';
   _clearSettingsRedirectPrompt();
   isManagerMode = false;
   isAdminMode = false;
@@ -1628,12 +1672,12 @@ function _showSettingsRedirectMessage(message) {
   if (managerView) managerView.style.display = 'none';
 
   closeMenuPicker({ skipOnClose: true });
-  _setLoadingMessage(`${message} Redirecting to the menu selector…`, { hideSpinner: true });
+  _setLoadingMessage(`${message} Redirecting to ${redirectLabel}…`, { hideSpinner: true });
 
   const loadingView = document.getElementById('loading-view');
   const redirectNow = () => {
     _clearSettingsRedirectPrompt();
-    navigateToPage('/');
+    navigateToPage(targetPath);
   };
 
   if (loadingView) {
@@ -1646,7 +1690,7 @@ function _showSettingsRedirectMessage(message) {
     loadingView.classList.add('loading-view-actionable');
     loadingView.tabIndex = 0;
     loadingView.setAttribute('role', 'button');
-    loadingView.setAttribute('aria-label', 'Return to the restaurant selector');
+    loadingView.setAttribute('aria-label', actionLabel);
     loadingView.addEventListener('click', onClick);
     loadingView.addEventListener('keydown', onKeyDown);
     _settingsRedirectCleanup = () => {
@@ -1666,31 +1710,8 @@ function showAdminAccessDenied(message = 'Admin access required for this page.')
   _showSettingsRedirectMessage(message);
 }
 
-function showManagerAccessDenied(message = 'Manager access required for this page.') {
-  _showSettingsRedirectMessage(message);
-}
-
-async function showManagerMenuSelector(menuIds) {
-  const accessibleMenuIds = normalizeAccessibleMenuIds(menuIds);
-  const entryMenuIds = accessibleMenuIds.length ? accessibleMenuIds : getAccessibleManagerMenuIds();
-  _setSettingsShellPending(false);
-  showMenuPicker(async () => {
-    _managerMenuPicked = true;
-    _setLoadingMessage('Loading settings…');
-    const hasMenuContext = await _loadSettingsPageMenuContext(MENU_ID);
-    if (!hasMenuContext) {
-      showManagerAccessDenied('Selected menu is no longer available for this account.');
-      return;
-    }
-    enterManager();
-  }, {
-    menuIds: entryMenuIds,
-    title: 'CHOOSE MENU TO EDIT',
-    subtitle: 'Select the menu you want to manage.',
-    closeLabel: 'Back to menu selector',
-    emptyMessage: 'No accessible menus found.',
-    onClose: () => navigateToPage('/'),
-  });
+function showManagerAccessDenied(message = 'Manager access required for this page.', opts = {}) {
+  _showSettingsRedirectMessage(message, opts);
 }
 
 async function _syncRequestedPageMode() {
@@ -1715,8 +1736,6 @@ async function _syncRequestedPageMode() {
   }
 
   const isAdmin = currentUser.role === 'admin';
-  const isManager = currentUser.role === 'manager';
-
   if (_appPageMode === 'admin') {
     if (!isAdmin) {
       showAdminAccessDenied();
@@ -1734,36 +1753,44 @@ async function _syncRequestedPageMode() {
     return;
   }
 
-  if (!isAdmin && !isManager) {
-    showManagerAccessDenied();
+  _setLoadingMessage('Checking manager access…');
+  await refreshCurrentUserProfile();
+
+  const requestedMenu = getRequestedMenuForSettingsPage();
+  if (!requestedMenu) {
+    showManagerAccessDenied('No menu context available for this page.');
     return;
   }
 
-  const accessibleMenuIds = getAccessibleManagerMenuIds();
-  if (!accessibleMenuIds.length) {
-    showManagerAccessDenied('No accessible menu found for this account.');
-    return;
-  }
-
-  if (accessibleMenuIds.length === 1) {
-    _managerMenuPicked = false;
-    _setLoadingMessage('Loading settings…');
-    const hasMenuContext = await _loadSettingsPageMenuContext(accessibleMenuIds[0]);
-    if (!hasMenuContext) {
-      showManagerAccessDenied('Selected menu is no longer available for this account.');
-      return;
+  if (!currentUserCanManageMenu(requestedMenu.id)) {
+    const fallbackMenuId = getFirstAccessibleManagerMenuId();
+    if (fallbackMenuId) {
+      const targetPath = getManagerHrefForMenuId(fallbackMenuId);
+      if (targetPath) {
+        navigateToPage(targetPath);
+        return;
+      }
     }
-    enterManager();
+    showManagerAccessDenied('You don\'t have manager access to this menu.', {
+      targetPath: getPublicHrefForMenuId(requestedMenu.id),
+      redirectLabel: 'the public menu',
+      actionLabel: 'Return to the public menu',
+    });
     return;
   }
 
-  isManagerMode = false;
-  isAdminMode = false;
-  document.body.classList.remove('manager-mode');
-  publicView.style.display = 'none';
-  managerView.style.display = 'none';
-  _setLoadingMessage('Select a menu to manage.', { hideSpinner: true });
-  showManagerMenuSelector(accessibleMenuIds);
+  _managerMenuPicked = true;
+  _setLoadingMessage('Loading settings…');
+  const hasMenuContext = await _loadSettingsPageMenuContext(requestedMenu.id);
+  if (!hasMenuContext) {
+    showManagerAccessDenied('Selected menu is no longer available for this account.', {
+      targetPath: getPublicHrefForMenuId(requestedMenu.id),
+      redirectLabel: 'the public menu',
+      actionLabel: 'Return to the public menu',
+    });
+    return;
+  }
+  enterManager();
 }
 
 // ─── AUTO-REFRESH POLLING ────────────────────────────────────────────────────
@@ -2115,6 +2142,25 @@ async function sbGetProfile(accessToken) {
   return { role: role || 'none', name: name || '', accessibleMenuIds: normalizeAccessibleMenuIds(accessibleMenuIds) };
 }
 
+function updateCurrentUserProfile(profile = {}) {
+  if (!currentUser) return profile;
+  currentUser.name = profile.name || '';
+  currentUser.role = profile.role || 'none';
+  currentUser.accessibleMenuIds = normalizeAccessibleMenuIds(profile.accessibleMenuIds);
+  applyRole(currentUser.role);
+  return profile;
+}
+
+async function refreshCurrentUserProfile() {
+  if (!currentUser?.accessToken) return { role: 'none', name: '', accessibleMenuIds: [] };
+  try {
+    const profile = await sbGetProfile(currentUser.accessToken);
+    return updateCurrentUserProfile(profile);
+  } catch (_) {
+    return updateCurrentUserProfile({ role: 'none', name: currentUser?.name || '', accessibleMenuIds: [] });
+  }
+}
+
 async function sbResetPasswordForEmail(email) {
   const redirectTo = window.location.origin + window.location.pathname;
   const r = await fetch(`${SUPABASE_URL}/auth/v1/recover`, {
@@ -2205,10 +2251,7 @@ function renderUserHeader() {
     : (parts[0]?.[0] || '?').toUpperCase();
   const roleLabel = { none: 'User', manager: 'Manager', admin: 'Admin' }[role] || 'User';
 
-  // Access to the manager panel requires either admin role or explicit menu access.
-  // Show the button if the manager has access to ANY menu (MENU_ID may not be set yet).
-  const accessibleIds = currentUser?.accessibleMenuIds || [];
-  const hasMenuAccess = isAdmin || accessibleIds.length > 0;
+  const canManageCurrentMenu = currentUserCanManageMenu();
 
   _setDisplayById('signin-btn', signedIn ? 'none' : '');
   _setDisplayById('user-chip', signedIn ? '' : 'none');
@@ -2220,7 +2263,7 @@ function renderUserHeader() {
   const adminBtn  = document.getElementById('admin-btn');
 
   if (actionBtn) {
-    actionBtn.style.display = (signedIn && hasMenuAccess) ? '' : 'none';
+    actionBtn.style.display = (signedIn && canManageCurrentMenu) ? '' : 'none';
     actionBtn.textContent   = (isManagerMode && !isSettingsRoute) ? '✕ Exit' : '⚙ Manager';
     actionBtn.classList.toggle('active', isManagerMode);
   }
@@ -2229,7 +2272,7 @@ function renderUserHeader() {
     adminBtn.classList.toggle('active', isAdminMode);
   }
 
-  _setDisplayBySelector('[data-route-manager]', (signedIn && hasMenuAccess) ? '' : 'none');
+  _setDisplayBySelector('[data-route-manager]', (signedIn && canManageCurrentMenu) ? '' : 'none');
   _setDisplayBySelector('[data-route-admin]', (signedIn && isAdmin) ? '' : 'none');
   document.querySelectorAll('[data-route-manager]').forEach(el => {
     el.textContent = isManagerMode ? 'Exit' : 'Manager';
@@ -2274,8 +2317,13 @@ function applyRole(role) {
 
 // ─── AUTH OVERLAY ─────────────────────────────────────────────────────────────
 function onActionBtnClick() {
-  if (_appPageMode !== 'manager') {
-    navigateToPage(SHARED_PAGE_PATHS.manager);
+  const targetPath = getManagerHrefForMenuId(MENU_ID);
+  if (!MENU_ID || targetPath === SHARED_PAGE_PATHS.manager) {
+    showToast('Select a menu from the public view first.', 'info');
+    return;
+  }
+  if (_appPageMode !== 'manager' || `${window.location.pathname}${window.location.search}` !== targetPath) {
+    navigateToPage(targetPath);
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -1366,6 +1366,7 @@ async function init() {
   const detectedSiteRestaurant = getSiteRestaurantFromPath();
   _siteRestaurant = isValidRestaurant(detectedSiteRestaurant?.id) ? detectedSiteRestaurant : null;
   const isDedicatedRoute = isDedicatedRestaurantPage();
+  const isSettingsRoute = isSettingsPage();
   if (_appPageMode === 'picker') {
     showPickerPage();
     return;
@@ -1373,7 +1374,7 @@ async function init() {
   showAppShell();
   migrateLocalStorage();
   if (MENU_ID && !KNOWN_MENU_ORDER.includes(MENU_ID)) _clearActiveMenuContext({ clearCache: true });
-  document.getElementById('loading-view').style.display = isDedicatedRoute ? 'none' : 'block';
+  document.getElementById('loading-view').style.display = (isDedicatedRoute || isSettingsRoute) ? 'none' : 'block';
   document.getElementById('public-view').style.display = isDedicatedRoute ? 'block' : 'none';
 
   if (_siteRestaurant && !new URLSearchParams(location.search).get('menu')) {
@@ -1386,6 +1387,15 @@ async function init() {
 
   loadLocalConfig();
   await loadSupabaseConfig();
+
+  if (isSettingsRoute) {
+    const handledRecovery = await _tryHandleRecoveryCallback();
+    if (!handledRecovery) await _tryRestoreSession();
+    await _syncRequestedPageMode();
+    const redirectNotice = consumeRedirectNotice();
+    if (redirectNotice) showToast(redirectNotice, 'error');
+    return;
+  }
 
   if (SUPABASE_URL) await sbResolveMenu();
 
@@ -1555,9 +1565,15 @@ function showRouteLoadError(message) {
   return true;
 }
 
+function _setSettingsShellPending(isPending) {
+  if (!isSettingsPage()) return;
+  document.body.classList.toggle('settings-shell-pending', !!isPending);
+}
+
 function _setLoadingMessage(message, opts = {}) {
   const loadingView = document.getElementById('loading-view');
   if (!loadingView) return;
+  _setSettingsShellPending(false);
   const spinner = loadingView.querySelector('.spinner');
   const textEl = loadingView.querySelector('p');
   loadingView.style.display = 'block';
@@ -1657,6 +1673,7 @@ function showManagerAccessDenied(message = 'Manager access required for this pag
 async function showManagerMenuSelector(menuIds) {
   const accessibleMenuIds = normalizeAccessibleMenuIds(menuIds);
   const entryMenuIds = accessibleMenuIds.length ? accessibleMenuIds : getAccessibleManagerMenuIds();
+  _setSettingsShellPending(false);
   showMenuPicker(async () => {
     _managerMenuPicked = true;
     _setLoadingMessage('Loading settings…');
@@ -2277,6 +2294,7 @@ function enterAdmin() {
     return;
   }
   document.getElementById('custom-design-style')?.remove();
+  _setSettingsShellPending(false);
   _togglePublicShellMode('default');
   if (isManagerMode) { isManagerMode = false; document.body.classList.remove('manager-mode'); }
   isAdminMode = true;
@@ -2627,6 +2645,7 @@ function _authFocusTrap(e) {
 }
 
 function openAuthOverlay(screen) {
+  _setSettingsShellPending(false);
   _authFocusBefore = document.activeElement;
   const overlay = document.getElementById('auth-overlay');
   overlay.classList.add('open');
@@ -2786,6 +2805,7 @@ function enterManager() {
     return;
   }
   document.getElementById('custom-design-style')?.remove();
+  _setSettingsShellPending(false);
   _togglePublicShellMode('default');
   if (!MENU_ID) {
     showToast('Select a menu from the public view first.', 'info');

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 // ─── CONFIG ───────────────────────────────────────────────────────────────────
-const APP_VERSION = 'v0.8.2';
+const APP_VERSION = 'v0.8.3';
 const RESTAURANTS = {
   LEROYS: { id: '00000000-0000-0000-0000-000000000010', name: "Leroy's Lounge", slug: 'leroys-lounge' },
   ELROYS: { id: '00000000-0000-0000-0000-000000000001', name: "El Roy's Cantina", slug: 'el-roys-cantina' },

--- a/elroyscantina/app.js
+++ b/elroyscantina/app.js
@@ -81,10 +81,12 @@
     if (!wrapper || !dropdown) return;
 
     const role = sharedState.currentUser?.role || 'none';
-    const accessibleIds = sharedState.currentUser?.accessibleMenuIds || [];
+    const canManageCurrentMenu = typeof window.currentUserCanManageMenu === 'function'
+      ? window.currentUserCanManageMenu(sharedState.menuId, sharedState.currentUser)
+      : (role === 'admin');
     const options = [];
 
-    if (role === 'admin' || accessibleIds.length > 0) {
+    if (canManageCurrentMenu) {
       options.push({ label: 'Manager', icon: 'tune', onClick: () => window.onActionBtnClick?.() });
     }
     if (role === 'admin') {

--- a/elroyscantina/app.js
+++ b/elroyscantina/app.js
@@ -141,6 +141,47 @@
     if (userChip) userChip.style.display = isAuthed ? '' : 'none';
   }
 
+  function renderBootShell() {
+    const template = document.getElementById('elroy-route-template');
+    const container = document.getElementById('restaurant-site-wrapper');
+    if (!template || !container) return false;
+
+    container.innerHTML = '';
+    container.appendChild(template.content.cloneNode(true));
+
+    const statusTsEl = document.getElementById('erc-route-status-timestamp');
+    if (statusTsEl) statusTsEl.textContent = 'Loading live menu...';
+
+    const footerTsEl = document.getElementById('erc-route-footer-timestamp');
+    if (footerTsEl) footerTsEl.textContent = 'Loading live menu...';
+
+    const featuredWrap = document.getElementById('erc-route-specials');
+    if (featuredWrap) {
+      featuredWrap.innerHTML = '<p class="erc-route-boot-copy">Loading specials...</p>';
+    }
+
+    const categoryWrap = document.getElementById('erc-route-sections');
+    if (categoryWrap) {
+      categoryWrap.innerHTML = `
+        <section class="erc-section erc-route-boot-section" aria-hidden="true">
+          <div class="erc-section-head">
+            <h3 class="erc-section-title">Preparing The Menu</h3>
+            <div class="erc-section-line"></div>
+          </div>
+          <div class="erc-route-boot-rows">
+            <span class="erc-route-boot-line erc-route-boot-line--wide"></span>
+            <span class="erc-route-boot-line erc-route-boot-line--mid"></span>
+            <span class="erc-route-boot-line erc-route-boot-line--narrow"></span>
+          </div>
+        </section>
+      `;
+    }
+
+    return true;
+  }
+
+  window.renderRouteBootShell = renderBootShell;
+
   window.initializeRoute = function initializeRoute(menuState, authState) {
     const template = document.getElementById('elroy-route-template');
     const container = document.getElementById('restaurant-site-wrapper');

--- a/elroyscantina/index.html
+++ b/elroyscantina/index.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/elroyscantina/style.css">
 </head>
-<body class="route-restaurant">
+<body class="route-restaurant route-shell-pending">
 <main id="site-picker-view" class="site-picker-view" hidden>
   <div class="site-picker-card">
     <p class="site-picker-kicker">Current Menu</p>
@@ -329,8 +329,8 @@
 <!-- MENU PICKER OVERLAY -->
 <div id="menu-picker-overlay">
   <div class="picker-box" role="dialog" aria-modal="true" aria-label="Select a Menu">
-    <h2 class="picker-title">SELECT A MENU</h2>
-    <p class="picker-subtitle">Choose which menu to view</p>
+    <h2 class="picker-title" id="picker-title">SELECT A MENU</h2>
+    <p class="picker-subtitle" id="picker-subtitle">Choose which menu to view</p>
     <div id="picker-menu-list" class="picker-menu-list"></div>
   </div>
 </div>

--- a/elroyscantina/style.css
+++ b/elroyscantina/style.css
@@ -188,13 +188,22 @@
 }
 
 #restaurant-site-wrapper .erc-userdropdown {
+  display: none;
+  position: absolute;
   right: 0;
   top: calc(100% + 10px);
   min-width: 188px;
+  padding: 12px 16px;
+  border: 1px solid rgb(178 173 160 / 0.4);
   border-radius: 12px;
-  border-color: rgb(178 173 160 / 0.4);
   background: rgb(255 255 255 / 0.94);
   box-shadow: 0 18px 36px rgb(49 47 38 / 0.16);
+  z-index: 25;
+  text-align: left;
+}
+
+#restaurant-site-wrapper .erc-userchip.open .erc-userdropdown {
+  display: block;
 }
 
 #restaurant-site-wrapper .erc-dropdown {

--- a/elroyscantina/style.css
+++ b/elroyscantina/style.css
@@ -413,6 +413,42 @@
   font-size: 1rem;
 }
 
+#restaurant-site-wrapper .erc-route-boot-copy {
+  margin: 0;
+  color: var(--erc-muted);
+  font-size: 0.85rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+#restaurant-site-wrapper .erc-route-boot-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.85rem;
+}
+
+#restaurant-site-wrapper .erc-route-boot-line {
+  display: block;
+  height: 18px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgb(227 221 203 / 0.6), rgb(255 255 255 / 0.92), rgb(227 221 203 / 0.6));
+  background-size: 200% 100%;
+  animation: erc-route-boot-sheen 1.4s linear infinite;
+}
+
+#restaurant-site-wrapper .erc-route-boot-line--wide {
+  width: min(100%, 26rem);
+}
+
+#restaurant-site-wrapper .erc-route-boot-line--mid {
+  width: min(82%, 19rem);
+}
+
+#restaurant-site-wrapper .erc-route-boot-line--narrow {
+  width: min(68%, 14rem);
+}
+
 #restaurant-site-wrapper .erc-footer {
   background: var(--erc-surface-low);
   padding: 3rem 2rem;
@@ -468,6 +504,16 @@
   border-color: rgb(122 119 107 / 0.3);
 }
 
+@keyframes erc-route-boot-sheen {
+  from {
+    background-position: 200% 0;
+  }
+
+  to {
+    background-position: -200% 0;
+  }
+}
+
 @media (max-width: 980px) {
   #restaurant-site-wrapper .erc-topbar-inner,
   #restaurant-site-wrapper .erc-hero,
@@ -521,5 +567,36 @@
     flex-direction: column;
     align-items: flex-start;
     gap: 0.25rem;
+  }
+
+  #restaurant-site-wrapper .erc-topbar-inner {
+    gap: 0.75rem;
+  }
+
+  #restaurant-site-wrapper .erc-menu-toggle,
+  #restaurant-site-wrapper .erc-actions {
+    width: 100%;
+  }
+
+  #restaurant-site-wrapper .erc-actions {
+    justify-content: space-between;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  #restaurant-site-wrapper .erc-login-btn {
+    padding: 0.55rem 0.85rem;
+  }
+
+  #restaurant-site-wrapper .erc-title {
+    font-size: clamp(3rem, 18vw, 4.75rem);
+  }
+
+  #restaurant-site-wrapper .erc-section {
+    margin-bottom: 3rem;
+  }
+
+  #restaurant-site-wrapper .erc-footer-main {
+    gap: 1rem;
   }
 }

--- a/leroyslounge/app.js
+++ b/leroyslounge/app.js
@@ -90,10 +90,12 @@
     if (!wrapper || !dropdown) return;
 
     const role = sharedState.currentUser?.role || 'none';
-    const accessibleIds = sharedState.currentUser?.accessibleMenuIds || [];
+    const canManageCurrentMenu = typeof window.currentUserCanManageMenu === 'function'
+      ? window.currentUserCanManageMenu(sharedState.menuId, sharedState.currentUser)
+      : (role === 'admin');
     const options = [];
 
-    if (role === 'admin' || accessibleIds.length > 0) {
+    if (canManageCurrentMenu) {
       options.push({ label: 'Manager', icon: 'tune', onClick: () => window.onActionBtnClick?.() });
     }
     if (role === 'admin') {

--- a/leroyslounge/app.js
+++ b/leroyslounge/app.js
@@ -194,6 +194,44 @@
     if (userChip) userChip.style.display = isAuthed ? '' : 'none';
   }
 
+  function renderBootShell() {
+    const template = document.getElementById('leroy-route-template');
+    const container = document.getElementById('restaurant-site-wrapper');
+    if (!template || !container) return false;
+
+    container.innerHTML = '';
+    container.appendChild(template.content.cloneNode(true));
+
+    const statusTsEl = document.getElementById('ll-route-status-timestamp');
+    if (statusTsEl) statusTsEl.textContent = 'Loading live menu...';
+
+    const footerTsEl = document.getElementById('ll-route-footer-timestamp');
+    if (footerTsEl) footerTsEl.textContent = 'Loading live menu...';
+
+    const featuredWrap = document.getElementById('ll-route-specials');
+    if (featuredWrap) {
+      featuredWrap.innerHTML = '<p class="ll-route-boot-copy">Loading specials...</p>';
+    }
+
+    const categoryWrap = document.getElementById('ll-route-sections');
+    if (categoryWrap) {
+      categoryWrap.innerHTML = `
+        <section class="ll-slat-section ll-route-boot-section" aria-hidden="true">
+          <div class="ll-slat-section-head"><h2 class="ll-slat-section-title">On The Board</h2></div>
+          <div class="ll-route-boot-rows">
+            <span class="ll-route-boot-line ll-route-boot-line--wide"></span>
+            <span class="ll-route-boot-line ll-route-boot-line--mid"></span>
+            <span class="ll-route-boot-line ll-route-boot-line--narrow"></span>
+          </div>
+        </section>
+      `;
+    }
+
+    return true;
+  }
+
+  window.renderRouteBootShell = renderBootShell;
+
   window.initializeRoute = function initializeRoute(menuState, authState) {
     const template = document.getElementById('leroy-route-template');
     const container = document.getElementById('restaurant-site-wrapper');

--- a/leroyslounge/index.html
+++ b/leroyslounge/index.html
@@ -12,7 +12,7 @@
 <link rel="stylesheet" href="/style.css">
 <link rel="stylesheet" href="/leroyslounge/style.css">
 </head>
-<body class="route-restaurant route-restaurant--leroy">
+<body class="route-restaurant route-restaurant--leroy route-shell-pending">
 <main id="site-picker-view" class="site-picker-view" hidden>
   <div class="site-picker-card">
     <p class="site-picker-kicker">Current Menu</p>
@@ -606,8 +606,8 @@
 <!-- MENU PICKER OVERLAY -->
 <div id="menu-picker-overlay">
   <div class="picker-box" role="dialog" aria-modal="true" aria-label="Select a Menu">
-    <h2 class="picker-title">SELECT A MENU</h2>
-    <p class="picker-subtitle">Choose which menu to view</p>
+    <h2 class="picker-title" id="picker-title">SELECT A MENU</h2>
+    <p class="picker-subtitle" id="picker-subtitle">Choose which menu to view</p>
     <div id="picker-menu-list" class="picker-menu-list"></div>
   </div>
 </div>

--- a/leroyslounge/style.css
+++ b/leroyslounge/style.css
@@ -65,6 +65,18 @@
   min-width: 0;
 }
 
+#restaurant-site-wrapper .ll-board-topbar-left {
+  justify-content: flex-start;
+}
+
+#restaurant-site-wrapper .ll-board-topbar-left::before {
+  content: '';
+  display: block;
+  width: clamp(11rem, 16vw, 15rem);
+  height: 1px;
+  pointer-events: none;
+}
+
 #restaurant-site-wrapper .ll-board-topbar-center {
   justify-content: center;
 }

--- a/leroyslounge/style.css
+++ b/leroyslounge/style.css
@@ -595,6 +595,43 @@
   text-transform: uppercase;
 }
 
+#restaurant-site-wrapper .ll-route-boot-copy {
+  margin: 0;
+  color: rgb(17 24 39 / 0.88);
+  font-family: 'Space Grotesk', sans-serif;
+  font-size: 0.85rem;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+#restaurant-site-wrapper .ll-route-boot-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+#restaurant-site-wrapper .ll-route-boot-line {
+  display: block;
+  height: 18px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgb(17 24 39 / 0.1), rgb(255 255 255 / 0.5), rgb(17 24 39 / 0.1));
+  background-size: 200% 100%;
+  animation: ll-route-boot-sheen 1.4s linear infinite;
+}
+
+#restaurant-site-wrapper .ll-route-boot-line--wide {
+  width: min(100%, 24rem);
+}
+
+#restaurant-site-wrapper .ll-route-boot-line--mid {
+  width: min(82%, 18rem);
+}
+
+#restaurant-site-wrapper .ll-route-boot-line--narrow {
+  width: min(68%, 14rem);
+}
+
 #restaurant-site-wrapper .ll-board-footer {
   padding: 0 2rem 1.5rem;
   text-align: right;
@@ -626,6 +663,16 @@
   55% {
     opacity: 0.95;
     filter: brightness(1.05) drop-shadow(0 0 12px rgb(255 68 68 / 1));
+  }
+}
+
+@keyframes ll-route-boot-sheen {
+  from {
+    background-position: 200% 0;
+  }
+
+  to {
+    background-position: -200% 0;
   }
 }
 
@@ -701,5 +748,59 @@
   #restaurant-site-wrapper .ll-board-footer {
     padding-inline: 0.75rem;
     text-align: left;
+  }
+}
+
+@media (max-width: 640px) {
+  #restaurant-site-wrapper .ll-board-topbar {
+    grid-template-columns: 1fr auto;
+    gap: 0.75rem;
+    padding: 0.75rem;
+  }
+
+  #restaurant-site-wrapper .ll-board-topbar-left {
+    display: none;
+  }
+
+  #restaurant-site-wrapper .ll-board-topbar-center,
+  #restaurant-site-wrapper .ll-board-topbar-right {
+    grid-column: 1 / -1;
+    justify-content: center;
+  }
+
+  #restaurant-site-wrapper .ll-board-topbar-right {
+    gap: 0.625rem;
+  }
+
+  #restaurant-site-wrapper .ll-menu-toggle,
+  #restaurant-site-wrapper .ll-board-action-cluster {
+    width: 100%;
+    justify-content: center;
+  }
+
+  #restaurant-site-wrapper .ll-board-jump-link,
+  #restaurant-site-wrapper .ll-board-swap-trigger {
+    min-height: 32px;
+    padding-inline: 10px;
+  }
+
+  #restaurant-site-wrapper .ll-board-route-dropdown {
+    right: 50%;
+    transform: translateX(50%);
+  }
+
+  #restaurant-site-wrapper .ll-board-main {
+    width: calc(100% - 0.5rem);
+    padding: 0.875rem 0.25rem 1.5rem;
+  }
+
+  #restaurant-site-wrapper .ll-board-row {
+    align-items: flex-start;
+  }
+
+  #restaurant-site-wrapper .ll-board-item-side {
+    flex-wrap: wrap;
+    justify-content: flex-end;
+    max-width: 42%;
   }
 }

--- a/manager/index.html
+++ b/manager/index.html
@@ -8,7 +8,7 @@
 <link rel="stylesheet" href="/lib/fonts/fonts.css">
 <link rel="stylesheet" href="/style.css">
 </head>
-<body>
+<body class="settings-shell-pending">
 <main id="site-picker-view" class="site-picker-view" hidden>
   <div class="site-picker-card">
     <p class="site-picker-kicker">Current Menu</p>

--- a/style.css
+++ b/style.css
@@ -72,8 +72,17 @@
   body.route-restaurant .wrapper { max-width: none; }
   body.route-restaurant #public-view { width: 100%; }
   body.route-restaurant #restaurant-site-wrapper { width: 100%; min-height: 100vh; }
+  body.route-restaurant.route-shell-pending { padding: 0; }
+  body.route-restaurant.route-shell-pending #app-shell > header,
+  body.route-restaurant.route-shell-pending #loading-view,
+  body.route-restaurant.route-shell-pending #public-default-shell { display: none !important; }
   body.route-restaurant.restaurant-public-site { padding: 0; }
   body.route-restaurant.restaurant-public-site #app-shell > header { display: none !important; }
+  body.route-restaurant #restaurant-site-wrapper > .route-load-error {
+    display: block;
+    width: min(48rem, calc(100% - 24px));
+    margin: 16px auto 0;
+  }
   #restaurant-site-wrapper .material-symbols-outlined { font-family: 'Material Symbols Outlined'; font-variation-settings: "FILL" 0, "wght" 400, "GRAD" 0, "opsz" 24; }
   #restaurant-site-wrapper .ll-site-page {
     --ll-surface: #131313;
@@ -1173,3 +1182,106 @@
 .featured-admin-group { border: 1px solid var(--border); border-radius: 8px; padding: 10px; margin-bottom: 8px; }
 .featured-admin-group-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
 .featured-admin-menu-label { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: var(--text); margin-right: 10px; }
+
+@media (max-width: 640px) {
+  body { padding: 0 12px 64px; }
+  header {
+    margin: 0 -12px 18px;
+    padding: 68px 16px 18px;
+    border-radius: 0 0 18px 18px;
+  }
+  header h1 {
+    font-size: 32px;
+    letter-spacing: 1px;
+  }
+  .header-sub {
+    font-size: 11px;
+    line-height: 1.4;
+  }
+  .header-action-group {
+    top: 12px;
+    left: 12px;
+    right: 88px;
+    flex-wrap: wrap;
+    gap: 5px;
+  }
+  .manager-btn,
+  .header-signin-btn {
+    padding: 6px 9px;
+    font-size: 11px;
+    letter-spacing: 0.08em;
+  }
+  .header-signin-btn,
+  .user-chip {
+    top: 12px;
+    right: 12px;
+  }
+  .user-chip {
+    max-width: calc(100% - 24px);
+  }
+  .user-dropdown {
+    right: -2px;
+    max-width: min(18rem, calc(100vw - 24px));
+  }
+  .menu-section,
+  .config-card,
+  .cat-card {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+  .cat-header,
+  .current-section {
+    padding-left: 16px;
+    padding-right: 16px;
+  }
+  .current-item,
+  .notif-cred-row,
+  .design-row,
+  .input-row,
+  .add-item-area {
+    flex-wrap: wrap;
+  }
+  .notif-cred-label,
+  .design-label {
+    width: 100%;
+    min-width: 0;
+    padding-top: 0;
+  }
+  .design-color-row {
+    flex-wrap: wrap;
+  }
+  .btn-row {
+    flex-direction: column;
+  }
+  .save-btn,
+  .send-btn,
+  .btn-small {
+    width: 100%;
+  }
+  #active-menu-bar,
+  .featured-mgr-group-header,
+  .featured-admin-group-header {
+    flex-wrap: wrap;
+  }
+  #menu-footer {
+    flex-wrap: wrap;
+    align-items: flex-start;
+  }
+  #footer-last-updated {
+    text-align: left;
+    width: 100%;
+  }
+  .picker-box,
+  .auth-box,
+  .modal {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+  .modal-actions {
+    flex-direction: column;
+  }
+  .picker-menu-card {
+    flex-wrap: wrap;
+    gap: 8px;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -76,6 +76,9 @@
   body.route-restaurant.route-shell-pending #app-shell > header,
   body.route-restaurant.route-shell-pending #loading-view,
   body.route-restaurant.route-shell-pending #public-default-shell { display: none !important; }
+  body.settings-shell-pending #app-shell > header,
+  body.settings-shell-pending #loading-view,
+  body.settings-shell-pending #public-default-shell { display: none !important; }
   body.route-restaurant.restaurant-public-site { padding: 0; }
   body.route-restaurant.restaurant-public-site #app-shell > header { display: none !important; }
   body.route-restaurant #restaurant-site-wrapper > .route-load-error {
@@ -592,10 +595,10 @@
   }
 
   /* ── HEADER ── */
-  header { background: var(--teal); margin: 0 -16px; padding: 24px 24px 20px; text-align: center; margin-bottom: 22px; position: relative; border-radius: 0 0 22px 22px; box-shadow: 0 6px 24px rgba(18,133,120,0.28); }
+  #app-shell > header { background: var(--teal); margin: 0 -16px; padding: 24px 24px 20px; text-align: center; margin-bottom: 22px; position: relative; border-radius: 0 0 22px 22px; box-shadow: 0 6px 24px rgba(18,133,120,0.28); }
   .hf-logo { display: block; width: 88px; height: 88px; object-fit: contain; margin: 0 auto 8px; filter: drop-shadow(0 2px 10px rgba(0,0,0,0.35)); }
   .logo-mark { font-family: var(--font-accent); font-size: 12px; letter-spacing: 3px; color: var(--yellow); display: block; margin-bottom: 4px; text-shadow: 0 1px 4px rgba(0,0,0,0.3); }
-  header h1 { font-family: var(--font-heading); font-size: 40px; letter-spacing: 2px; line-height: 1; color: var(--cream); text-shadow: 0 2px 10px rgba(0,0,0,0.3); }
+  #app-shell > header h1 { font-family: var(--font-heading); font-size: 40px; letter-spacing: 2px; line-height: 1; color: var(--cream); text-shadow: 0 2px 10px rgba(0,0,0,0.3); }
   .header-sub { margin-top: 5px; color: rgba(253,244,236,0.72); font-family: var(--font-accent); font-size: 12px; letter-spacing: 0.5px; }
   .header-action-group { position: absolute; top: 18px; left: 14px; display: flex; gap: 6px; }
   .manager-btn { background: rgba(253,244,236,0.15); border: 1px solid rgba(253,244,236,0.38); border-radius: 8px; color: var(--cream); font-family: var(--font-body); font-size: 12px; letter-spacing: 1px; text-transform: uppercase; padding: 7px 11px; cursor: pointer; transition: all 0.15s; backdrop-filter: blur(4px); }
@@ -617,8 +620,8 @@
   .user-dropdown-divider { height: 1px; background: var(--border); margin: 10px 0; }
   .user-dropdown-signout { background: none; border: none; color: var(--red); font-size: 13px; cursor: pointer; padding: 0; font-family: var(--font-body); }
   /* Manager mode header */
-  body.manager-mode header { background: #111; box-shadow: none; border-radius: 0; border-bottom: 1px solid var(--border); }
-  body.manager-mode header h1 { color: var(--text); }
+  body.manager-mode #app-shell > header { background: #111; box-shadow: none; border-radius: 0; border-bottom: 1px solid var(--border); }
+  body.manager-mode #app-shell > header h1 { color: var(--text); }
   body.manager-mode .header-sub { color: var(--muted); font-family: var(--font-body); }
   body.manager-mode .hf-logo { filter: brightness(0.85); }
   body.manager-mode .logo-mark { color: var(--terra); }
@@ -1185,12 +1188,12 @@
 
 @media (max-width: 640px) {
   body { padding: 0 12px 64px; }
-  header {
+  #app-shell > header {
     margin: 0 -12px 18px;
     padding: 68px 16px 18px;
     border-radius: 0 0 18px 18px;
   }
-  header h1 {
+  #app-shell > header h1 {
     font-size: 32px;
     letter-spacing: 1px;
   }


### PR DESCRIPTION
## Summary
- remove the manager-entry menu picker and open `/manager` for the currently viewed menu
- show manager actions only when the signed-in user can manage the active menu, while preserving admin access
- re-check menu permissions on manager-route entry and redirect unauthorized users to an allowed menu or back to the public menu
- align Leroy's Lounge and El Roy's Cantina route settings dropdowns with the same current-menu access rules

## Testing
- `node --check app.js`
- `node --check leroyslounge/app.js`
- `node --check elroyscantina/app.js`
- Not run (not requested)