### PR TITLE
Improved manager and admin settings screens

### DIFF
--- a/.agents/skills/stitch4settings/SKILL.md
+++ b/.agents/skills/stitch4settings/SKILL.md
@@ -1,0 +1,269 @@
+---
+name: stitch4settings
+description: >
+  Import or refresh a Google Stitch design for the shared `/manager` or `/admin`
+  settings routes. Treat Stitch as the visual source of truth for the selected
+  settings page, rebuild the route shell in `manager/index.html` or
+  `admin/index.html`, and integrate it into the shared `app.js` and `style.css`
+  runtime without breaking auth, role gating, or save-vs-send behavior.
+---
+
+# Stitch4Settings
+
+Use this skill when the user wants Google Stitch to generate or refresh the
+manager or admin settings experience, or when they explicitly mention
+`Stitch4Settings`.
+
+## Core rule
+
+Stitch owns the shell design.
+
+Treat the imported Stitch screen as the visual source material for the selected
+settings route. Preserve its layout, spacing, hierarchy, and general tone as
+closely as possible while wiring it into the existing app behavior.
+
+Required posture:
+- preserve Stitch structure unless a runtime hook requires a small change
+- keep shared app behavior in root `app.js`; do not fork manager/admin logic into route-local scripts
+- keep settings-route auth, role gating, save-vs-send, notifications, featured management, and menu switching intact
+- only add controls Stitch omitted when the app truly requires them
+
+## Expected inputs
+
+- `target`
+  - valid values: `manager`, `admin`
+- `stitch_project_id`
+- optional `screen_id`
+- optional trailing implementation notes from the user
+
+Interpret examples like these as valid:
+- `Use Stitch4Settings for manager 4044680601076201931`
+- `Refresh admin from Stitch project 4044680601076201931 screen abc123`
+
+If the target route is missing or ambiguous, ask a concise follow-up.
+
+## Valid targets
+
+Only these routes are valid:
+- `manager`
+  - `manager/index.html`
+- `admin`
+  - `admin/index.html`
+
+Supporting shared files:
+- `app.js`
+- `style.css`
+
+Do not use this skill for:
+- `leroyslounge/`
+- `elroyscantina/`
+- route-owned public menu imports
+
+Use the separate `stitch` skill for those public restaurant pages.
+
+## Required behaviors to preserve
+
+### Manager
+
+The manager route must continue to support:
+- active menu context and menu switching
+- `Save`
+- `Send Update`
+- unsent-diff preview modal for `Send Update`
+- featured confirmation banner
+- featured manager controls
+- editable categories and items
+- `Recent Changes` for the last 7 days of sent updates
+- database search/filter/prune tools
+- off-menu items tray
+- auth overlay and back-to-menu exit
+
+### Admin
+
+The admin route must continue to support:
+- restaurants overview
+- notifications configuration
+- credential key inputs
+- menu URL save
+- users list and invite flow
+- featured groups management
+- auth overlay and back-to-menu exit
+
+The admin route must not regress into a manager editor and must not reintroduce
+the removed History tab unless the user explicitly asks for it.
+
+## Output contract
+
+Every successful run must update the selected settings route and any shared
+files needed to integrate it:
+- `manager/index.html` or `admin/index.html`
+- `style.css` when new shared settings-shell styles are needed
+- `app.js` when DOM hooks, section targeting, or route-specific guards need adjustment
+
+Do not add dependencies, a build step, or generated framework output.
+
+## Workflow
+
+1. Parse the request.
+
+Extract:
+- target route
+- numeric Stitch project ID
+- optional screen ID
+- optional trailing instructions
+
+2. Verify the target route before editing.
+
+Accept only:
+- `manager`
+- `admin`
+
+If the target is invalid, stop and say so clearly.
+
+3. Read the Stitch project with Stitch MCP tools.
+
+Use this sequence:
+- `mcp__stitch__get_project`
+- `mcp__stitch__list_screens`
+- `mcp__stitch__get_screen`
+
+Selection rules:
+- if `screen_id` was provided, confirm it exists and use it
+- if exactly one screen exists, use it
+- if multiple screens exist and none was specified, ask the user which screen to use
+
+4. Extract the design source.
+
+From the selected Stitch screen, extract:
+- shell structure
+- visual grouping and layout hierarchy
+- button placement and section rhythm
+- any embedded CSS or asset references needed for fidelity
+
+Transformation rules:
+- remove imported scripts
+- keep semantic structure whenever practical
+- move inline style into `style.css`
+- preserve Stitch class names only when they help; otherwise translate into the existing settings-shell conventions
+
+5. Map the design to the app's required controls.
+
+Before editing, lock the required controls for the chosen route.
+
+### Required manager controls
+
+Ensure the final shell has visible homes for:
+- `Overview`
+- `Edit Menu`
+- `Recent Changes`
+- `Categories`
+- `Database`
+- `Switch Menu`
+- `Keep Today's Featured`
+- `Update Featured`
+- `Save`
+- `Send Update`
+
+Required manager hooks that should remain usable:
+- `#manager-panel`
+- `#manager-categories`
+- `#featured-mgr-wrap`
+- `#recent-changes-wrap`
+- `#catmgr-list`
+- `#db-table-wrap`
+- `#off-menu-items-wrap`
+- `#featured-confirm-banner`
+- `#switch-menu-btn`
+- `#save-btn`
+- `#send-btn`
+
+### Required admin controls
+
+Ensure the final shell has visible homes for:
+- `Overview`
+- `Restaurants`
+- `Notifications`
+- `Users`
+- `Featured`
+- `Refresh`
+- `Save Notifications`
+- `Save Credential Keys`
+- `Save`
+- `Invite Staff`
+- `Add Group`
+
+Required admin hooks that should remain usable:
+- `#admin-panel`
+- `#menus-mgmt-list`
+- `#notif-restaurant-select`
+- `#notif-menu-select`
+- `#users-list`
+- `#featured-admin-wrap`
+- `#new-featured-group-name`
+
+If Stitch does not include enough structure for a required control, add the
+minimum missing UI in the same design language.
+
+6. Rebuild the selected route shell.
+
+### `manager/index.html`
+
+Requirements:
+- manager-only shell; no admin-only sections
+- include auth overlay and send-preview modal
+- keep public/menu-view handoff elements required by shared runtime
+- prefer section-based or rail-based workspace navigation over generic tab markup
+
+### `admin/index.html`
+
+Requirements:
+- admin-only shell; no manager-editing sections
+- include auth overlay and invite modal
+- keep public/menu-view handoff elements required by shared runtime
+- preserve restaurants, notifications, users, and featured sections only
+
+7. Integrate into shared runtime.
+
+Update `app.js` only as needed to support the new Stitch shell:
+- route-aware DOM queries
+- section focus helpers
+- missing-element guards
+- event wiring that depends on moved controls
+
+Do not change business behavior unless the user asked for it.
+
+8. Integrate into shared styles.
+
+Update `style.css` only as needed to support the imported shell:
+- use CSS custom properties for any new colors
+- keep changes scoped to settings-route UI
+- avoid leaking route-specific public-menu styling into the settings shell
+
+9. Validate before finishing.
+
+At minimum:
+- `node --check app.js`
+- `git diff --check`
+
+If practical, also sanity-check that the selected route still has the controls
+and IDs the shared runtime expects.
+
+## Implementation rules
+
+- no dependencies
+- no build tools
+- preserve Supabase auth and role flows
+- preserve save vs send behavior exactly
+- `Recent Changes` stays distinct from the unsent `Send Update` preview
+- preserve accessibility attributes and keyboard behavior when moving controls
+- keep the two-restaurant, four-menu model intact
+
+## Reporting
+
+At the end, report:
+- target route
+- Stitch project ID
+- Stitch screen ID used
+- files updated
+- any required DOM hook adjustments
+- any visual compromises made to preserve app behavior

--- a/admin/index.html
+++ b/admin/index.html
@@ -5,10 +5,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>Admin | Current Menu</title>
 <link rel="icon" type="image/png" href="/HFLOGO.png">
-<link rel="stylesheet" href="/lib/fonts/fonts.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@300;400;500;600;700;800&family=Public+Sans:wght@500;700;800;900&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/style.css">
 </head>
-<body class="settings-shell-pending">
+<body class="settings-shell-pending admin-console-page">
 <main id="site-picker-view" class="site-picker-view" hidden>
   <div class="site-picker-card">
     <p class="site-picker-kicker">Current Menu</p>
@@ -20,37 +22,8 @@
   </div>
 </main>
 
-<div class="wrapper" id="app-shell">
-  <header>
-    <img class="hf-logo" src="" alt="Logo" style="display:none"/>
-    <span class="logo-mark" style="display:none"></span>
-    <h1>ADMIN CONSOLE</h1>
-    <div class="header-sub" id="last-updated-label">Last Updated: —</div>
-    <div class="header-action-group">
-      <button class="manager-btn" id="action-btn" onclick="onActionBtnClick()" style="display:none">⚙ Manager</button>
-      <button class="manager-btn admin-btn" id="admin-btn" onclick="onAdminBtnClick()" style="display:none">⚙ Admin</button>
-    </div>
-    <button class="header-signin-btn" id="signin-btn" onclick="openAuthOverlay()">Sign In</button>
-    <div class="user-chip" id="user-chip" style="display:none"
-         onclick="toggleUserDropdown()"
-         onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleUserDropdown()}"
-         tabindex="0"
-         role="button"
-         aria-haspopup="true"
-         aria-expanded="false"
-         aria-label="User menu">
-      <span id="user-initials">?</span>
-      <span>▾</span>
-      <div class="user-dropdown" id="user-dropdown">
-        <div class="user-dropdown-name" id="user-dropdown-name"></div>
-        <div class="user-dropdown-role" id="user-dropdown-role"></div>
-        <div class="user-dropdown-divider"></div>
-        <button class="user-dropdown-signout" onclick="signOut()">Sign Out</button>
-      </div>
-    </div>
-  </header>
-
-  <div id="loading-view">
+<div class="wrapper admin-console-wrapper" id="app-shell">
+  <div id="loading-view" class="admin-console-loading">
     <div class="spinner"></div>
     <p>Loading admin console...</p>
   </div>
@@ -72,68 +45,148 @@
     </div>
   </div>
 
-  <div id="manager-view">
-    <div class="settings-workspace settings-workspace--admin">
-      <aside class="settings-rail" aria-label="Admin console sections">
-        <p class="settings-rail-kicker">Admin</p>
+  <div id="manager-view" class="admin-console-shell" style="display:none">
+    <aside class="admin-console-rail" aria-label="Admin console sections">
+      <div class="admin-console-rail-brand">
+        <p class="admin-console-rail-kicker">The Gallery</p>
+        <h1 class="admin-console-rail-title">Command Center</h1>
+      </div>
+
+      <nav class="admin-console-rail-nav">
         <button class="settings-rail-btn active" type="button" data-target="admin-overview-section" onclick="focusSettingsSection('admin-overview-section', this)">Overview</button>
         <button class="settings-rail-btn" type="button" data-target="admin-restaurants-section" onclick="focusSettingsSection('admin-restaurants-section', this)">Restaurants</button>
         <button class="settings-rail-btn" type="button" data-target="admin-notifications-section" onclick="focusSettingsSection('admin-notifications-section', this)">Notifications</button>
         <button class="settings-rail-btn" type="button" data-target="admin-users-section" onclick="focusSettingsSection('admin-users-section', this)">Users</button>
-        <button class="settings-rail-btn" type="button" data-target="admin-featured-section" onclick="focusSettingsSection('admin-featured-section', this)">Featured</button>
-      </aside>
+      </nav>
 
-      <div class="settings-stage">
-        <section class="settings-hero settings-hero--admin" id="admin-overview-section">
-          <div class="settings-hero-copy">
-            <p class="settings-kicker">System Control</p>
-            <h2>Manage the four fixed menus without the old shared shell baggage.</h2>
-            <p>Restaurants, notifications, staff access, and featured groups all live here now in one focused admin console.</p>
-          </div>
+      <div class="admin-console-rail-footer">
+        <p class="admin-console-rail-note">Fixed to Leroy's Lounge and El Roy's Cantina with four live menus.</p>
+        <button class="logout-link admin-console-back-link" onclick="exitView()">Return to menu view</button>
+      </div>
+    </aside>
 
-          <div class="workspace-status-card">
-            <div id="admin-status-bar" class="admin-status-bar">
-              <span id="admin-supabase-status" class="db-status">Checking…</span>
-              <button class="btn-small btn-tiny" onclick="checkAdminSupabaseStatus()">↺</button>
+    <div class="admin-console-stage">
+      <header class="admin-console-topbar">
+        <div class="admin-console-topbar-copy">
+          <p class="admin-console-kicker">System Admin Console</p>
+          <div class="admin-console-title-row">
+            <h2>Architectural control room for live menu operations.</h2>
+            <div class="admin-console-status-pill">
+              <span class="admin-console-status-dot" aria-hidden="true"></span>
+              <span id="admin-supabase-status" class="db-status">Checking...</span>
             </div>
-            <p class="config-hint">This build stays locked to Leroy's Lounge and El Roy's Cantina. Managers are assigned per menu across the four known menus.</p>
           </div>
+          <p class="admin-console-topbar-sub" id="admin-overview-summary">Live summaries will populate as admin data loads.</p>
+          <div class="header-sub admin-console-last-updated" id="last-updated-label">Last Updated: —</div>
+        </div>
+
+        <div class="admin-console-topbar-actions">
+          <div class="header-action-group admin-console-action-group">
+            <button class="manager-btn" id="action-btn" onclick="onActionBtnClick()" style="display:none">Manager</button>
+            <button class="manager-btn admin-btn" id="admin-btn" onclick="onAdminBtnClick()" style="display:none">Admin</button>
+          </div>
+          <button class="header-signin-btn admin-console-signin" id="signin-btn" onclick="openAuthOverlay()">Sign In</button>
+          <div class="user-chip admin-console-userchip" id="user-chip" style="display:none"
+               onclick="toggleUserDropdown()"
+               onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleUserDropdown()}"
+               tabindex="0"
+               role="button"
+               aria-haspopup="true"
+               aria-expanded="false"
+               aria-label="User menu">
+            <span id="user-initials">?</span>
+            <span>▾</span>
+            <div class="user-dropdown" id="user-dropdown">
+              <div class="user-dropdown-name" id="user-dropdown-name"></div>
+              <div class="user-dropdown-role" id="user-dropdown-role"></div>
+              <div class="user-dropdown-divider"></div>
+              <button class="user-dropdown-signout" onclick="signOut()">Sign Out</button>
+            </div>
+          </div>
+        </div>
+      </header>
+
+      <section class="admin-console-overview" id="admin-overview-section">
+        <div class="admin-console-overview-grid">
+          <article class="admin-console-summary-card">
+            <div class="admin-console-card-head">
+              <p class="admin-console-card-kicker">System Summary</p>
+              <p class="admin-console-card-caption">Live counts driven by the current admin runtime.</p>
+            </div>
+            <div class="admin-console-summary-metrics">
+              <div>
+                <span class="admin-console-summary-value" id="admin-overview-restaurants">--</span>
+                <p class="admin-console-summary-label">Restaurants</p>
+              </div>
+              <div>
+                <span class="admin-console-summary-value" id="admin-overview-menus">--</span>
+                <p class="admin-console-summary-label">Menus</p>
+              </div>
+            </div>
+            <div class="admin-console-summary-foot">
+              <span class="admin-console-summary-pill">Locked model, live data</span>
+            </div>
+          </article>
+
+          <div class="admin-console-metric-stack">
+            <article class="admin-console-metric-card">
+              <span class="admin-console-metric-value" id="admin-overview-staff">--</span>
+              <p class="admin-console-metric-label">Staff Accounts</p>
+            </article>
+            <article class="admin-console-metric-card admin-console-metric-card--alert">
+              <span class="admin-console-metric-value" id="admin-overview-pending">--</span>
+              <p class="admin-console-metric-label">Pending Approvals</p>
+            </article>
+          </div>
+        </div>
+
+        <article class="admin-console-activity-card">
+          <div class="admin-console-card-head">
+            <p class="admin-console-card-kicker">Recent Admin Activity</p>
+            <p class="admin-console-card-caption">Latest sent updates across the four fixed menus.</p>
+          </div>
+          <div id="admin-activity-feed" class="admin-console-activity-feed">
+            <p class="db-empty">Loading recent activity...</p>
+          </div>
+        </article>
+      </section>
+
+      <div id="admin-panel" class="admin-console-panels" style="display:none">
+        <section class="settings-section admin-console-section" id="admin-restaurants-section">
+          <div class="settings-section-head admin-console-section-head">
+            <div>
+              <p class="settings-section-kicker">Instance Management</p>
+              <h3>Restaurants &amp; Menus</h3>
+            </div>
+            <p class="settings-section-copy">A Stitch-inspired overview of the fixed restaurant model, without the generated placeholder imagery.</p>
+          </div>
+          <div id="menus-mgmt-list" class="admin-console-instance-grid"></div>
         </section>
 
-        <div id="admin-panel" class="settings-panel" style="display:none">
-          <section class="settings-section" id="admin-restaurants-section">
-            <div class="settings-section-head">
-              <div>
-                <p class="settings-section-kicker">Structure</p>
-                <h3>Restaurants &amp; Menus</h3>
+        <section class="settings-section admin-console-section" id="admin-notifications-section">
+          <div class="settings-section-head admin-console-section-head">
+            <div>
+              <p class="settings-section-kicker">Integration Protocols</p>
+              <h3>Notifications</h3>
+            </div>
+            <p class="settings-section-copy">Preserve the Stitch composition up front, then tuck the runtime-specific credential and menu-url controls into secondary folds.</p>
+          </div>
+
+          <div class="admin-console-split">
+            <div class="config-card admin-console-protocol-card">
+              <div class="admin-context-switcher admin-context-switcher--admin">
+                <label class="switcher-label" for="notif-restaurant-select">Restaurant</label>
+                <select id="notif-restaurant-select" class="switcher-select" onchange="onAdminSwitcherRestaurantChange('notif')"></select>
+                <label class="switcher-label" for="notif-menu-select">Menu</label>
+                <select id="notif-menu-select" class="switcher-select" onchange="onAdminSwitcherMenuChange('notif')"></select>
               </div>
-              <p class="settings-section-copy">Reference the locked restaurant and menu model exactly as it exists in the database.</p>
-            </div>
-            <div id="menus-mgmt-list"></div>
-          </section>
 
-          <section class="settings-section" id="admin-notifications-section">
-            <div class="settings-section-head">
-              <div>
-                <p class="settings-section-kicker">Delivery</p>
-                <h3>Notifications</h3>
-              </div>
-              <p class="settings-section-copy">Choose the menu, then control which channels fire on Send Update and which env-var keys each restaurant should use.</p>
-            </div>
-
-            <div class="admin-context-switcher">
-              <label class="switcher-label" for="notif-restaurant-select">Restaurant</label>
-              <select id="notif-restaurant-select" class="switcher-select" onchange="onAdminSwitcherRestaurantChange('notif')"></select>
-              <label class="switcher-label" for="notif-menu-select">Menu</label>
-              <select id="notif-menu-select" class="switcher-select" onchange="onAdminSwitcherMenuChange('notif')"></select>
-            </div>
-
-            <div class="config-card">
               <p class="config-hint">Toggle which channels fire when you send a menu update for the selected menu.</p>
+
               <div class="notif-channel" id="notif-groupme">
                 <div class="notif-channel-header">
                   <label class="notif-toggle-label" for="notif-groupme-enabled">
-                    <input type="checkbox" id="notif-groupme-enabled" class="notif-toggle" onchange="onNotifToggle('groupme')"/>
+                    <input type="checkbox" id="notif-groupme-enabled" class="notif-toggle" onchange="onNotifToggle('groupme')">
                     <span class="notif-channel-name">GroupMe</span>
                   </label>
                 </div>
@@ -144,10 +197,11 @@
                   </div>
                 </div>
               </div>
+
               <div class="notif-channel" id="notif-sms">
                 <div class="notif-channel-header">
                   <label class="notif-toggle-label" for="notif-sms-enabled">
-                    <input type="checkbox" id="notif-sms-enabled" class="notif-toggle" onchange="onNotifToggle('sms')"/>
+                    <input type="checkbox" id="notif-sms-enabled" class="notif-toggle" onchange="onNotifToggle('sms')">
                     <span class="notif-channel-name">Twilio SMS</span>
                   </label>
                 </div>
@@ -158,10 +212,11 @@
                   </div>
                 </div>
               </div>
+
               <div class="notif-channel" id="notif-discord">
                 <div class="notif-channel-header">
                   <label class="notif-toggle-label" for="notif-discord-enabled">
-                    <input type="checkbox" id="notif-discord-enabled" class="notif-toggle" onchange="onNotifToggle('discord')"/>
+                    <input type="checkbox" id="notif-discord-enabled" class="notif-toggle" onchange="onNotifToggle('discord')">
                     <span class="notif-channel-name">Discord</span>
                   </label>
                 </div>
@@ -172,10 +227,11 @@
                   </div>
                 </div>
               </div>
+
               <div class="notif-channel" id="notif-webhook">
                 <div class="notif-channel-header">
                   <label class="notif-toggle-label" for="notif-webhook-enabled">
-                    <input type="checkbox" id="notif-webhook-enabled" class="notif-toggle" onchange="onNotifToggle('webhook')"/>
+                    <input type="checkbox" id="notif-webhook-enabled" class="notif-toggle" onchange="onNotifToggle('webhook')">
                     <span class="notif-channel-name">Generic Webhook</span>
                   </label>
                 </div>
@@ -186,91 +242,84 @@
                   </div>
                 </div>
               </div>
-              <div class="btn-row" style="margin-top:14px">
-                <button class="btn-small" onclick="saveNotifications()">Save Notifications</button>
+
+              <div class="btn-row admin-console-button-row">
+                <button class="btn-small admin-console-primary-btn" onclick="saveNotifications()">Save Notifications</button>
               </div>
             </div>
 
-            <div class="config-card">
-              <h3>Credential Keys <span style="font-weight:300;color:var(--muted)">(per restaurant)</span></h3>
-              <p class="config-hint">Map each channel to a Vercel env var name. Leave blank to use the global defaults. Actual secrets stay in Vercel.</p>
-              <div class="notif-cred-row">
-                <label class="notif-cred-label">GroupMe Bot ID</label>
-                <input type="text" id="notif-cred-groupme" class="notif-cred-input" placeholder="GROUPME_BOT_ID"/>
-              </div>
-              <div class="notif-cred-row">
-                <label class="notif-cred-label">Discord Webhook URL</label>
-                <input type="text" id="notif-cred-discord" class="notif-cred-input" placeholder="DISCORD_WEBHOOK_URL"/>
-              </div>
-              <div class="notif-cred-row">
-                <label class="notif-cred-label">Twilio SID</label>
-                <input type="text" id="notif-cred-sms-sid" class="notif-cred-input" placeholder="TWILIO_ACCOUNT_SID"/>
-              </div>
-              <div class="notif-cred-row">
-                <label class="notif-cred-label">Twilio Auth Token</label>
-                <input type="text" id="notif-cred-sms-token" class="notif-cred-input" placeholder="TWILIO_AUTH_TOKEN"/>
-              </div>
-              <div class="notif-cred-row">
-                <label class="notif-cred-label">Twilio From Number</label>
-                <input type="text" id="notif-cred-sms-from" class="notif-cred-input" placeholder="TWILIO_FROM_NUMBER"/>
-              </div>
-              <div class="notif-cred-row">
-                <label class="notif-cred-label">Twilio To Numbers</label>
-                <input type="text" id="notif-cred-sms-to" class="notif-cred-input" placeholder="TWILIO_TO_NUMBERS"/>
-              </div>
-              <div class="notif-cred-row">
-                <label class="notif-cred-label">Webhook URL</label>
-                <input type="text" id="notif-cred-webhook-url" class="notif-cred-input" placeholder="GENERIC_WEBHOOK_URL"/>
-              </div>
-              <div class="notif-cred-row">
-                <label class="notif-cred-label">Webhook Secret</label>
-                <input type="text" id="notif-cred-webhook-secret" class="notif-cred-input" placeholder="GENERIC_WEBHOOK_SECRET"/>
-              </div>
-              <div class="btn-row" style="margin-top:10px">
-                <button class="btn-small" onclick="saveNotifCredKeys()">Save Credential Keys</button>
-              </div>
-            </div>
+            <div class="admin-console-side-stack">
+              <details class="config-card admin-console-fold" open>
+                <summary class="admin-console-fold-summary">
+                  <span>Credential Keys</span>
+                  <span class="admin-console-fold-note">Per restaurant</span>
+                </summary>
+                <p class="config-hint">Map each channel to a Vercel env var name. Leave blank to use the global defaults. Actual secrets stay in Vercel.</p>
+                <div class="notif-cred-row">
+                  <label class="notif-cred-label" for="notif-cred-groupme">GroupMe Bot ID</label>
+                  <input type="text" id="notif-cred-groupme" class="notif-cred-input" placeholder="GROUPME_BOT_ID">
+                </div>
+                <div class="notif-cred-row">
+                  <label class="notif-cred-label" for="notif-cred-discord">Discord Webhook URL</label>
+                  <input type="text" id="notif-cred-discord" class="notif-cred-input" placeholder="DISCORD_WEBHOOK_URL">
+                </div>
+                <div class="notif-cred-row">
+                  <label class="notif-cred-label" for="notif-cred-sms-sid">Twilio SID</label>
+                  <input type="text" id="notif-cred-sms-sid" class="notif-cred-input" placeholder="TWILIO_ACCOUNT_SID">
+                </div>
+                <div class="notif-cred-row">
+                  <label class="notif-cred-label" for="notif-cred-sms-token">Twilio Auth Token</label>
+                  <input type="text" id="notif-cred-sms-token" class="notif-cred-input" placeholder="TWILIO_AUTH_TOKEN">
+                </div>
+                <div class="notif-cred-row">
+                  <label class="notif-cred-label" for="notif-cred-sms-from">Twilio From Number</label>
+                  <input type="text" id="notif-cred-sms-from" class="notif-cred-input" placeholder="TWILIO_FROM_NUMBER">
+                </div>
+                <div class="notif-cred-row">
+                  <label class="notif-cred-label" for="notif-cred-sms-to">Twilio To Numbers</label>
+                  <input type="text" id="notif-cred-sms-to" class="notif-cred-input" placeholder="TWILIO_TO_NUMBERS">
+                </div>
+                <div class="notif-cred-row">
+                  <label class="notif-cred-label" for="notif-cred-webhook-url">Webhook URL</label>
+                  <input type="text" id="notif-cred-webhook-url" class="notif-cred-input" placeholder="GENERIC_WEBHOOK_URL">
+                </div>
+                <div class="notif-cred-row">
+                  <label class="notif-cred-label" for="notif-cred-webhook-secret">Webhook Secret</label>
+                  <input type="text" id="notif-cred-webhook-secret" class="notif-cred-input" placeholder="GENERIC_WEBHOOK_SECRET">
+                </div>
+                <div class="btn-row admin-console-button-row">
+                  <button class="btn-small" onclick="saveNotifCredKeys()">Save Credential Keys</button>
+                </div>
+              </details>
 
-            <div class="config-card">
-              <h3>Menu Page URL <span style="font-weight:300;color:var(--muted)">(included in notifications)</span></h3>
-              <div class="input-row">
-                <input type="text" id="menu-url-input" placeholder="e.g. https://el-roys-drink-menu.vercel.app"/>
-                <button class="btn-small" onclick="saveMenuUrl()">Save</button>
-              </div>
+              <details class="config-card admin-console-fold">
+                <summary class="admin-console-fold-summary">
+                  <span>Menu Page URL</span>
+                  <span class="admin-console-fold-note">Used in notifications</span>
+                </summary>
+                <div class="input-row admin-console-url-row">
+                  <input type="text" id="menu-url-input" placeholder="https://el-roys-drink-menu.vercel.app">
+                  <button class="btn-small" onclick="saveMenuUrl()">Save</button>
+                </div>
+              </details>
             </div>
-          </section>
+          </div>
+        </section>
 
-          <section class="settings-section" id="admin-users-section">
-            <div class="settings-section-head">
-              <div>
-                <p class="settings-section-kicker">Access</p>
-                <h3>Staff Accounts</h3>
-              </div>
-              <p class="settings-section-copy">Invite staff, promote admins, and assign managers to the menus they can actually touch.</p>
+        <section class="settings-section admin-console-section" id="admin-users-section">
+          <div class="settings-section-head admin-console-section-head">
+            <div>
+              <p class="settings-section-kicker">Staff Directory</p>
+              <h3>Users &amp; Access</h3>
             </div>
-            <div class="users-invite-row">
-              <button class="btn-small" onclick="openInviteModal()">+ Invite Staff</button>
-            </div>
-            <div id="users-list"></div>
-          </section>
+            <p class="settings-section-copy">Keep the denser live management table, but restyle it so it still feels like the imported Stitch console.</p>
+          </div>
 
-          <section class="settings-section" id="admin-featured-section">
-            <div class="settings-section-head">
-              <div>
-                <p class="settings-section-kicker">Highlights</p>
-                <h3>Featured Groups</h3>
-              </div>
-              <p class="settings-section-copy">Link featured groups to menus so managers can curate the slots without needing admin access.</p>
-            </div>
-            <div id="featured-admin-wrap"></div>
-            <div class="input-row" style="margin-top:6px">
-              <input type="text" id="new-featured-group-name" placeholder="New group name…"/>
-              <button class="btn-small" onclick="addFeaturedGroup()">+ Add Group</button>
-            </div>
-          </section>
-        </div>
-
-        <button class="logout-link" onclick="exitView()">← Back to menu view</button>
+          <div class="users-invite-row admin-console-users-toolbar">
+            <button class="btn-small admin-console-primary-btn" onclick="openInviteModal()">Invite Staff</button>
+          </div>
+          <div id="users-list" class="admin-console-users-wrap"></div>
+        </section>
       </div>
     </div>
   </div>
@@ -284,10 +333,10 @@
         <h2 class="auth-screen-title">SIGN IN</h2>
         <p class="auth-screen-subtitle">Sign in to your account</p>
         <div class="auth-field">
-          <input type="email" id="signin-email" placeholder="Email address" autocomplete="email" aria-describedby="signin-error"/>
+          <input type="email" id="signin-email" placeholder="Email address" autocomplete="email" aria-describedby="signin-error">
         </div>
         <div class="auth-field">
-          <input type="password" id="signin-password" placeholder="Password" autocomplete="current-password" aria-describedby="signin-error"/>
+          <input type="password" id="signin-password" placeholder="Password" autocomplete="current-password" aria-describedby="signin-error">
         </div>
         <div class="auth-error" id="signin-error"></div>
         <button class="auth-submit-btn" id="signin-submit-btn" onclick="handleSignIn()">Sign In</button>
@@ -304,22 +353,22 @@
         <div class="auth-field">
           <input type="text" id="signup-firstname" placeholder="First name" autocomplete="given-name"
                  aria-describedby="signup-error"
-                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-lastname').focus();}"/>
+                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-lastname').focus();}">
         </div>
         <div class="auth-field">
           <input type="text" id="signup-lastname" placeholder="Last name" autocomplete="family-name"
                  aria-describedby="signup-error"
-                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-email').focus();}"/>
+                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-email').focus();}">
         </div>
         <div class="auth-field">
           <input type="email" id="signup-email" placeholder="Email address" autocomplete="email"
                  aria-describedby="signup-error"
-                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-password').focus();}"/>
+                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-password').focus();}">
         </div>
         <div class="auth-field">
           <input type="password" id="signup-password" placeholder="Password" autocomplete="new-password"
                  aria-describedby="signup-error"
-                 onkeydown="if(event.key==='Enter'){event.preventDefault();handleSignUp();}"/>
+                 onkeydown="if(event.key==='Enter'){event.preventDefault();handleSignUp();}">
         </div>
         <div class="auth-error" id="signup-error"></div>
         <button class="auth-submit-btn" id="signup-submit-btn" onclick="handleSignUp()">Create Account</button>
@@ -331,7 +380,7 @@
         <h2 class="auth-screen-title">RESET PASSWORD</h2>
         <p class="auth-screen-subtitle">Enter your email and we'll send a reset link</p>
         <div class="auth-field">
-          <input type="email" id="forgot-email" placeholder="Email address" autocomplete="email" aria-describedby="forgot-error"/>
+          <input type="email" id="forgot-email" placeholder="Email address" autocomplete="email" aria-describedby="forgot-error">
         </div>
         <div class="auth-error" id="forgot-error"></div>
         <button class="auth-submit-btn" id="forgot-submit-btn" onclick="handleForgotPassword()">Send Reset Link</button>
@@ -342,10 +391,10 @@
         <h2 class="auth-screen-title">SET NEW PASSWORD</h2>
         <p class="auth-screen-subtitle">Choose a new password for your account</p>
         <div class="auth-field">
-          <input type="password" id="reset-password" placeholder="New password" autocomplete="new-password" aria-describedby="reset-error"/>
+          <input type="password" id="reset-password" placeholder="New password" autocomplete="new-password" aria-describedby="reset-error">
         </div>
         <div class="auth-field">
-          <input type="password" id="reset-confirm" placeholder="Confirm new password" autocomplete="new-password" aria-describedby="reset-error"/>
+          <input type="password" id="reset-confirm" placeholder="Confirm new password" autocomplete="new-password" aria-describedby="reset-error">
         </div>
         <div class="auth-error" id="reset-error"></div>
         <button class="auth-submit-btn" id="reset-submit-btn" onclick="handleResetPassword()">Set Password</button>

--- a/admin/index.html
+++ b/admin/index.html
@@ -11,7 +11,8 @@
 <link rel="stylesheet" href="/style.css">
 </head>
 <body class="settings-shell-pending admin-console-page">
-<main id="site-picker-view" class="site-picker-view" hidden>
+<a class="admin-skip-link" href="#admin-main-content">Skip to Content</a>
+<section id="site-picker-view" class="site-picker-view" hidden>
   <div class="site-picker-card">
     <p class="site-picker-kicker">Current Menu</p>
     <h1 class="site-picker-title">Choose a restaurant</h1>
@@ -20,7 +21,7 @@
       <a class="site-picker-link" href="/elroyscantina">El Roy's Cantina</a>
     </div>
   </div>
-</main>
+</section>
 
 <div class="wrapper admin-console-wrapper" id="app-shell">
   <div id="loading-view" class="admin-console-loading">
@@ -65,7 +66,7 @@
       </div>
     </aside>
 
-    <div class="admin-console-stage">
+    <main class="admin-console-stage" id="admin-main-content">
       <header class="admin-console-topbar">
         <div class="admin-console-topbar-copy">
           <p class="admin-console-kicker">System Admin Console</p>
@@ -321,7 +322,7 @@
           <div id="users-list" class="admin-console-users-wrap"></div>
         </section>
       </div>
-    </div>
+    </main>
   </div>
 </div>
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -49,13 +49,12 @@
   <div id="manager-view" class="admin-console-shell" style="display:none">
     <aside class="admin-console-rail" aria-label="Admin console sections">
       <div class="admin-console-rail-brand">
-        <p class="admin-console-rail-kicker">The Gallery</p>
-        <h1 class="admin-console-rail-title">Command Center</h1>
+        <p class="admin-console-rail-kicker">Admin</p>
+        <h1 class="admin-console-rail-title">Console</h1>
       </div>
 
       <nav class="admin-console-rail-nav">
-        <button class="settings-rail-btn active" type="button" data-target="admin-overview-section" onclick="focusSettingsSection('admin-overview-section', this)">Overview</button>
-        <button class="settings-rail-btn" type="button" data-target="admin-restaurants-section" onclick="focusSettingsSection('admin-restaurants-section', this)">Restaurants</button>
+        <button class="settings-rail-btn active" type="button" data-target="admin-restaurants-section" onclick="focusSettingsSection('admin-restaurants-section', this)">Restaurants</button>
         <button class="settings-rail-btn" type="button" data-target="admin-notifications-section" onclick="focusSettingsSection('admin-notifications-section', this)">Notifications</button>
         <button class="settings-rail-btn" type="button" data-target="admin-users-section" onclick="focusSettingsSection('admin-users-section', this)">Users</button>
       </nav>
@@ -69,16 +68,8 @@
     <main class="admin-console-stage" id="admin-main-content">
       <header class="admin-console-topbar">
         <div class="admin-console-topbar-copy">
-          <p class="admin-console-kicker">System Admin Console</p>
-          <div class="admin-console-title-row">
-            <h2>Architectural control room for live menu operations.</h2>
-            <div class="admin-console-status-pill">
-              <span class="admin-console-status-dot" aria-hidden="true"></span>
-              <span id="admin-supabase-status" class="db-status">Checking...</span>
-            </div>
-          </div>
-          <p class="admin-console-topbar-sub" id="admin-overview-summary">Live summaries will populate as admin data loads.</p>
-          <div class="header-sub admin-console-last-updated" id="last-updated-label">Last Updated: —</div>
+          <p class="admin-console-kicker">Admin Console</p>
+          <h2>Edit restaurants, notification settings, and staff access.</h2>
         </div>
 
         <div class="admin-console-topbar-actions">
@@ -106,51 +97,6 @@
           </div>
         </div>
       </header>
-
-      <section class="admin-console-overview" id="admin-overview-section">
-        <div class="admin-console-overview-grid">
-          <article class="admin-console-summary-card">
-            <div class="admin-console-card-head">
-              <p class="admin-console-card-kicker">System Summary</p>
-              <p class="admin-console-card-caption">Live counts driven by the current admin runtime.</p>
-            </div>
-            <div class="admin-console-summary-metrics">
-              <div>
-                <span class="admin-console-summary-value" id="admin-overview-restaurants">--</span>
-                <p class="admin-console-summary-label">Restaurants</p>
-              </div>
-              <div>
-                <span class="admin-console-summary-value" id="admin-overview-menus">--</span>
-                <p class="admin-console-summary-label">Menus</p>
-              </div>
-            </div>
-            <div class="admin-console-summary-foot">
-              <span class="admin-console-summary-pill">Locked model, live data</span>
-            </div>
-          </article>
-
-          <div class="admin-console-metric-stack">
-            <article class="admin-console-metric-card">
-              <span class="admin-console-metric-value" id="admin-overview-staff">--</span>
-              <p class="admin-console-metric-label">Staff Accounts</p>
-            </article>
-            <article class="admin-console-metric-card admin-console-metric-card--alert">
-              <span class="admin-console-metric-value" id="admin-overview-pending">--</span>
-              <p class="admin-console-metric-label">Pending Approvals</p>
-            </article>
-          </div>
-        </div>
-
-        <article class="admin-console-activity-card">
-          <div class="admin-console-card-head">
-            <p class="admin-console-card-kicker">Recent Admin Activity</p>
-            <p class="admin-console-card-caption">Latest sent updates across the four fixed menus.</p>
-          </div>
-          <div id="admin-activity-feed" class="admin-console-activity-feed">
-            <p class="db-empty">Loading recent activity...</p>
-          </div>
-        </article>
-      </section>
 
       <div id="admin-panel" class="admin-console-panels" style="display:none">
         <section class="settings-section admin-console-section" id="admin-restaurants-section">

--- a/admin/index.html
+++ b/admin/index.html
@@ -24,7 +24,7 @@
   <header>
     <img class="hf-logo" src="" alt="Logo" style="display:none"/>
     <span class="logo-mark" style="display:none"></span>
-    <h1>CURRENT MENU</h1>
+    <h1>ADMIN CONSOLE</h1>
     <div class="header-sub" id="last-updated-label">Last Updated: —</div>
     <div class="header-action-group">
       <button class="manager-btn" id="action-btn" onclick="onActionBtnClick()" style="display:none">⚙ Manager</button>
@@ -50,13 +50,11 @@
     </div>
   </header>
 
-  <!-- LOADING -->
   <div id="loading-view">
     <div class="spinner"></div>
-    <p>Loading menu...</p>
+    <p>Loading admin console...</p>
   </div>
 
-  <!-- PUBLIC VIEW -->
   <div id="public-view" style="display:none;">
     <div id="restaurant-site-wrapper" hidden></div>
     <div id="public-default-shell">
@@ -74,293 +72,214 @@
     </div>
   </div>
 
-  <!-- MANAGER VIEW -->
   <div id="manager-view">
-    <div id="setup-banner">
-      <h3>⚙️ One-Time Setup</h3>
-      <p>Click <strong style="color:var(--ember)">⚙ Admin</strong> in the header to configure notification channels. Everything syncs to the cloud from this point on.</p>
+    <div class="settings-workspace settings-workspace--admin">
+      <aside class="settings-rail" aria-label="Admin console sections">
+        <p class="settings-rail-kicker">Admin</p>
+        <button class="settings-rail-btn active" type="button" data-target="admin-overview-section" onclick="focusSettingsSection('admin-overview-section', this)">Overview</button>
+        <button class="settings-rail-btn" type="button" data-target="admin-restaurants-section" onclick="focusSettingsSection('admin-restaurants-section', this)">Restaurants</button>
+        <button class="settings-rail-btn" type="button" data-target="admin-notifications-section" onclick="focusSettingsSection('admin-notifications-section', this)">Notifications</button>
+        <button class="settings-rail-btn" type="button" data-target="admin-users-section" onclick="focusSettingsSection('admin-users-section', this)">Users</button>
+        <button class="settings-rail-btn" type="button" data-target="admin-featured-section" onclick="focusSettingsSection('admin-featured-section', this)">Featured</button>
+      </aside>
+
+      <div class="settings-stage">
+        <section class="settings-hero settings-hero--admin" id="admin-overview-section">
+          <div class="settings-hero-copy">
+            <p class="settings-kicker">System Control</p>
+            <h2>Manage the four fixed menus without the old shared shell baggage.</h2>
+            <p>Restaurants, notifications, staff access, and featured groups all live here now in one focused admin console.</p>
+          </div>
+
+          <div class="workspace-status-card">
+            <div id="admin-status-bar" class="admin-status-bar">
+              <span id="admin-supabase-status" class="db-status">Checking…</span>
+              <button class="btn-small btn-tiny" onclick="checkAdminSupabaseStatus()">↺</button>
+            </div>
+            <p class="config-hint">This build stays locked to Leroy's Lounge and El Roy's Cantina. Managers are assigned per menu across the four known menus.</p>
+          </div>
+        </section>
+
+        <div id="admin-panel" class="settings-panel" style="display:none">
+          <section class="settings-section" id="admin-restaurants-section">
+            <div class="settings-section-head">
+              <div>
+                <p class="settings-section-kicker">Structure</p>
+                <h3>Restaurants &amp; Menus</h3>
+              </div>
+              <p class="settings-section-copy">Reference the locked restaurant and menu model exactly as it exists in the database.</p>
+            </div>
+            <div id="menus-mgmt-list"></div>
+          </section>
+
+          <section class="settings-section" id="admin-notifications-section">
+            <div class="settings-section-head">
+              <div>
+                <p class="settings-section-kicker">Delivery</p>
+                <h3>Notifications</h3>
+              </div>
+              <p class="settings-section-copy">Choose the menu, then control which channels fire on Send Update and which env-var keys each restaurant should use.</p>
+            </div>
+
+            <div class="admin-context-switcher">
+              <label class="switcher-label" for="notif-restaurant-select">Restaurant</label>
+              <select id="notif-restaurant-select" class="switcher-select" onchange="onAdminSwitcherRestaurantChange('notif')"></select>
+              <label class="switcher-label" for="notif-menu-select">Menu</label>
+              <select id="notif-menu-select" class="switcher-select" onchange="onAdminSwitcherMenuChange('notif')"></select>
+            </div>
+
+            <div class="config-card">
+              <p class="config-hint">Toggle which channels fire when you send a menu update for the selected menu.</p>
+              <div class="notif-channel" id="notif-groupme">
+                <div class="notif-channel-header">
+                  <label class="notif-toggle-label" for="notif-groupme-enabled">
+                    <input type="checkbox" id="notif-groupme-enabled" class="notif-toggle" onchange="onNotifToggle('groupme')"/>
+                    <span class="notif-channel-name">GroupMe</span>
+                  </label>
+                </div>
+                <div class="notif-channel-body" id="notif-groupme-body" style="display:none">
+                  <div class="notif-help">
+                    <p>Go to <strong>dev.groupme.com → Bots → Create Bot</strong>. Set the callback URL to your Vercel deployment URL. Copy the Bot ID and add it as a Vercel environment variable:</p>
+                    <p><code>GROUPME_BOT_ID</code></p>
+                  </div>
+                </div>
+              </div>
+              <div class="notif-channel" id="notif-sms">
+                <div class="notif-channel-header">
+                  <label class="notif-toggle-label" for="notif-sms-enabled">
+                    <input type="checkbox" id="notif-sms-enabled" class="notif-toggle" onchange="onNotifToggle('sms')"/>
+                    <span class="notif-channel-name">Twilio SMS</span>
+                  </label>
+                </div>
+                <div class="notif-channel-body" id="notif-sms-body" style="display:none">
+                  <div class="notif-help">
+                    <p>Sign up at <strong>twilio.com</strong> and buy a phone number. Add these Vercel environment variables:</p>
+                    <p><code>TWILIO_ACCOUNT_SID</code><br><code>TWILIO_AUTH_TOKEN</code><br><code>TWILIO_FROM_NUMBER</code><br><code>TWILIO_TO_NUMBERS</code> <span class="notif-help-note">(comma-separated E.164 numbers, e.g. +15551234567,+15559876543)</span></p>
+                  </div>
+                </div>
+              </div>
+              <div class="notif-channel" id="notif-discord">
+                <div class="notif-channel-header">
+                  <label class="notif-toggle-label" for="notif-discord-enabled">
+                    <input type="checkbox" id="notif-discord-enabled" class="notif-toggle" onchange="onNotifToggle('discord')"/>
+                    <span class="notif-channel-name">Discord</span>
+                  </label>
+                </div>
+                <div class="notif-channel-body" id="notif-discord-body" style="display:none">
+                  <div class="notif-help">
+                    <p>In Discord, open a channel's <strong>Settings → Integrations → Webhooks → New Webhook</strong>. Copy the webhook URL and add it as a Vercel environment variable:</p>
+                    <p><code>DISCORD_WEBHOOK_URL</code></p>
+                  </div>
+                </div>
+              </div>
+              <div class="notif-channel" id="notif-webhook">
+                <div class="notif-channel-header">
+                  <label class="notif-toggle-label" for="notif-webhook-enabled">
+                    <input type="checkbox" id="notif-webhook-enabled" class="notif-toggle" onchange="onNotifToggle('webhook')"/>
+                    <span class="notif-channel-name">Generic Webhook</span>
+                  </label>
+                </div>
+                <div class="notif-channel-body" id="notif-webhook-body" style="display:none">
+                  <div class="notif-help">
+                    <p>The full update payload will be POSTed as JSON to your endpoint. Add these Vercel environment variables:</p>
+                    <p><code>GENERIC_WEBHOOK_URL</code><br><code>GENERIC_WEBHOOK_SECRET</code> <span class="notif-help-note">(optional — sent as <code>X-Webhook-Secret</code> header)</span></p>
+                  </div>
+                </div>
+              </div>
+              <div class="btn-row" style="margin-top:14px">
+                <button class="btn-small" onclick="saveNotifications()">Save Notifications</button>
+              </div>
+            </div>
+
+            <div class="config-card">
+              <h3>Credential Keys <span style="font-weight:300;color:var(--muted)">(per restaurant)</span></h3>
+              <p class="config-hint">Map each channel to a Vercel env var name. Leave blank to use the global defaults. Actual secrets stay in Vercel.</p>
+              <div class="notif-cred-row">
+                <label class="notif-cred-label">GroupMe Bot ID</label>
+                <input type="text" id="notif-cred-groupme" class="notif-cred-input" placeholder="GROUPME_BOT_ID"/>
+              </div>
+              <div class="notif-cred-row">
+                <label class="notif-cred-label">Discord Webhook URL</label>
+                <input type="text" id="notif-cred-discord" class="notif-cred-input" placeholder="DISCORD_WEBHOOK_URL"/>
+              </div>
+              <div class="notif-cred-row">
+                <label class="notif-cred-label">Twilio SID</label>
+                <input type="text" id="notif-cred-sms-sid" class="notif-cred-input" placeholder="TWILIO_ACCOUNT_SID"/>
+              </div>
+              <div class="notif-cred-row">
+                <label class="notif-cred-label">Twilio Auth Token</label>
+                <input type="text" id="notif-cred-sms-token" class="notif-cred-input" placeholder="TWILIO_AUTH_TOKEN"/>
+              </div>
+              <div class="notif-cred-row">
+                <label class="notif-cred-label">Twilio From Number</label>
+                <input type="text" id="notif-cred-sms-from" class="notif-cred-input" placeholder="TWILIO_FROM_NUMBER"/>
+              </div>
+              <div class="notif-cred-row">
+                <label class="notif-cred-label">Twilio To Numbers</label>
+                <input type="text" id="notif-cred-sms-to" class="notif-cred-input" placeholder="TWILIO_TO_NUMBERS"/>
+              </div>
+              <div class="notif-cred-row">
+                <label class="notif-cred-label">Webhook URL</label>
+                <input type="text" id="notif-cred-webhook-url" class="notif-cred-input" placeholder="GENERIC_WEBHOOK_URL"/>
+              </div>
+              <div class="notif-cred-row">
+                <label class="notif-cred-label">Webhook Secret</label>
+                <input type="text" id="notif-cred-webhook-secret" class="notif-cred-input" placeholder="GENERIC_WEBHOOK_SECRET"/>
+              </div>
+              <div class="btn-row" style="margin-top:10px">
+                <button class="btn-small" onclick="saveNotifCredKeys()">Save Credential Keys</button>
+              </div>
+            </div>
+
+            <div class="config-card">
+              <h3>Menu Page URL <span style="font-weight:300;color:var(--muted)">(included in notifications)</span></h3>
+              <div class="input-row">
+                <input type="text" id="menu-url-input" placeholder="e.g. https://el-roys-drink-menu.vercel.app"/>
+                <button class="btn-small" onclick="saveMenuUrl()">Save</button>
+              </div>
+            </div>
+          </section>
+
+          <section class="settings-section" id="admin-users-section">
+            <div class="settings-section-head">
+              <div>
+                <p class="settings-section-kicker">Access</p>
+                <h3>Staff Accounts</h3>
+              </div>
+              <p class="settings-section-copy">Invite staff, promote admins, and assign managers to the menus they can actually touch.</p>
+            </div>
+            <div class="users-invite-row">
+              <button class="btn-small" onclick="openInviteModal()">+ Invite Staff</button>
+            </div>
+            <div id="users-list"></div>
+          </section>
+
+          <section class="settings-section" id="admin-featured-section">
+            <div class="settings-section-head">
+              <div>
+                <p class="settings-section-kicker">Highlights</p>
+                <h3>Featured Groups</h3>
+              </div>
+              <p class="settings-section-copy">Link featured groups to menus so managers can curate the slots without needing admin access.</p>
+            </div>
+            <div id="featured-admin-wrap"></div>
+            <div class="input-row" style="margin-top:6px">
+              <input type="text" id="new-featured-group-name" placeholder="New group name…"/>
+              <button class="btn-small" onclick="addFeaturedGroup()">+ Add Group</button>
+            </div>
+          </section>
+        </div>
+
+        <button class="logout-link" onclick="exitView()">← Back to menu view</button>
+      </div>
     </div>
-
-    <!-- ACTIVE MENU BAR -->
-    <div id="active-menu-bar" style="display:none;" aria-live="polite">
-      <span class="active-menu-label">MENU</span>
-      <span id="active-menu-name" class="active-menu-name-text"></span>
-      <button class="btn-small" id="switch-menu-btn" onclick="onSwitchMenuClick()" style="display:none" aria-label="Switch to a different menu">⇄ Switch</button>
-    </div>
-
-    <div id="featured-confirm-banner" class="featured-confirm-banner" style="display:none;">
-      <span>Today's featured items haven't been confirmed yet.</span>
-      <button class="btn-small" onclick="confirmFeaturedToday()">Keep Today's Featured</button>
-      <button class="btn-small" onclick="editFeaturedFromBanner()">Update Featured</button>
-    </div>
-
-    <!-- MANAGER PANEL: Edit Menu, Categories, Database -->
-    <div id="manager-panel" style="display:none">
-      <div class="tab-bar" role="tablist" id="manager-tab-bar">
-        <button class="tab-btn active" id="tab-btn-edit-menu"  role="tab" aria-selected="true"  aria-controls="tab-panel-edit-menu"  onclick="switchManagerTab('edit-menu')">MANAGER</button>
-        <button class="tab-btn"        id="tab-btn-categories" role="tab" aria-selected="false" aria-controls="tab-panel-categories" onclick="switchManagerTab('categories')">CATEGORIES</button>
-        <button class="tab-btn"        id="tab-btn-database"   role="tab" aria-selected="false" aria-controls="tab-panel-database"   onclick="switchManagerTab('database')">DATABASE</button>
-      </div>
-
-      <!-- EDIT MENU TAB -->
-      <div class="tab-panel active" id="tab-panel-edit-menu" role="tabpanel" aria-labelledby="tab-btn-edit-menu">
-        <div class="section-label">Edit Menu</div>
-        <div id="featured-mgr-wrap"></div>
-        <div id="manager-categories"></div>
-        <div class="btn-row">
-          <button class="save-btn" id="save-btn" onclick="saveMenu()">💾 SAVE</button>
-          <button class="send-btn" id="send-btn" onclick="openPreview()">🔥 SEND UPDATE</button>
-        </div>
-        <div id="sync-status"></div>
-        <div id="off-menu-section" class="prune-section" style="display:none;">
-          <div class="prune-section-header">
-            <div class="section-label prune-section-label">Off Menu Items</div>
-          </div>
-          <p class="hint">Staff-only items hidden from the public menu. Visible to managers and admins.</p>
-          <div id="off-menu-items-wrap"></div>
-        </div>
-      </div>
-
-      <!-- CATEGORIES TAB -->
-      <div class="tab-panel" id="tab-panel-categories" role="tabpanel" aria-labelledby="tab-btn-categories">
-        <div class="section-label">Menu Categories</div>
-        <div class="active-menu-context" id="categories-menu-context"></div>
-        <div id="catmgr-list"></div>
-        <div class="catmgr-add-form" id="catmgr-add-form" style="display:none">
-          <h3>New Category</h3>
-          <div class="catmgr-field-row">
-            <label>Icon</label>
-            <input type="text" id="new-cat-icon" class="catmgr-input catmgr-icon-input" value="🍸" maxlength="4" placeholder="Emoji"/>
-          </div>
-          <div class="catmgr-field-row">
-            <label>Title</label>
-            <input type="text" id="new-cat-title" class="catmgr-input" placeholder="Category name (required)"/>
-          </div>
-          <div class="catmgr-field-row">
-            <label>Subtitle</label>
-            <input type="text" id="new-cat-sub" class="catmgr-input" placeholder="Short description (optional)"/>
-          </div>
-          <div class="catmgr-field-row">
-            <label>Hint text</label>
-            <input type="text" id="new-cat-placeholder" class="catmgr-input" placeholder="Add item input hint (optional)"/>
-          </div>
-          <div class="catmgr-add-btn-row">
-            <button class="btn-small" onclick="confirmAddCategory()">Add Category</button>
-            <button class="btn-small" onclick="document.getElementById('catmgr-add-form').style.display='none'">Cancel</button>
-          </div>
-        </div>
-        <button class="btn-small" id="show-add-cat-btn" onclick="toggleAddCategoryForm()" style="margin-top:4px">+ Add Category</button>
-      </div>
-
-      <!-- DATABASE TAB -->
-      <div class="tab-panel" id="tab-panel-database" role="tabpanel" aria-labelledby="tab-btn-database">
-        <div class="section-label">Recipe Database</div>
-        <div class="db-search-row">
-          <input type="text" id="db-search" placeholder="Search drinks or ingredients…" oninput="filterDatabase()" />
-        </div>
-        <div class="db-filter-row">
-          <span class="db-filter-label">Recipe:</span>
-          <div class="db-filter-group" id="db-filter-recipe">
-            <button class="db-filter-btn active" data-value="all"  onclick="setDbFilter('recipe','all')">All</button>
-            <button class="db-filter-btn"        data-value="yes"  onclick="setDbFilter('recipe','yes')">With Recipe</button>
-            <button class="db-filter-btn"        data-value="no"   onclick="setDbFilter('recipe','no')">No Recipe</button>
-          </div>
-          <span class="db-filter-label">Status:</span>
-          <div class="db-filter-group" id="db-filter-status">
-            <button class="db-filter-btn active" data-value="all"  onclick="setDbFilter('status','all')">All</button>
-            <button class="db-filter-btn"        data-value="on"   onclick="setDbFilter('status','on')">On Menu</button>
-            <button class="db-filter-btn"        data-value="off"  onclick="setDbFilter('status','off')">Off Menu</button>
-          </div>
-        </div>
-        <div id="db-table-wrap"></div>
-        <div id="prune-section" class="prune-section" style="display:none;">
-          <div class="prune-section-header">
-            <div class="section-label prune-section-label">Prune Database</div>
-            <button id="prune-all-btn" class="btn-small btn-danger">Clear All</button>
-          </div>
-          <p class="hint">Permanently removes off-menu items from Supabase (autocomplete trash). Live menu items are unaffected.</p>
-          <div id="prune-items-wrap"></div>
-        </div>
-      </div>
-
-    </div><!-- /manager-panel -->
-
-    <!-- ADMIN PANEL: Restaurants, Notifications, Design, Users -->
-    <div id="admin-panel" style="display:none">
-      <div id="admin-status-bar" class="admin-status-bar">
-        <span id="admin-supabase-status" class="db-status">Checking…</span>
-        <button class="btn-small btn-tiny" onclick="checkAdminSupabaseStatus()">↺</button>
-      </div>
-      <div class="tab-bar" role="tablist" id="admin-tab-bar">
-        <button class="tab-btn active" id="tab-btn-admin-restaurants"   role="tab" aria-selected="true"  aria-controls="tab-panel-admin-restaurants"   onclick="switchAdminTab('admin-restaurants')">RESTAURANTS</button>
-        <button class="tab-btn"        id="tab-btn-admin-notifications" role="tab" aria-selected="false" aria-controls="tab-panel-admin-notifications" onclick="switchAdminTab('admin-notifications')">NOTIFICATIONS</button>
-        <button class="tab-btn"        id="tab-btn-admin-users"         role="tab" aria-selected="false" aria-controls="tab-panel-admin-users"         onclick="switchAdminTab('admin-users')">USERS</button>
-        <button class="tab-btn"        id="tab-btn-admin-featured"      role="tab" aria-selected="false" aria-controls="tab-panel-admin-featured"      onclick="switchAdminTab('admin-featured')">FEATURED</button>
-        <button class="tab-btn"        id="tab-btn-admin-history"       role="tab" aria-selected="false" aria-controls="tab-panel-admin-history"       onclick="switchAdminTab('admin-history')">HISTORY</button>
-      </div>
-
-      <!-- RESTAURANTS SUB-PANEL -->
-      <div class="tab-panel active" id="tab-panel-admin-restaurants" role="tabpanel" aria-labelledby="tab-btn-admin-restaurants">
-        <div class="section-label">Restaurants &amp; Menus</div>
-        <p class="config-hint">This build is locked to Leroy's Lounge and El Roy's Cantina. Managers are assigned at the menu level across the four fixed menus.</p>
-        <div id="menus-mgmt-list"></div>
-      </div>
-
-      <!-- NOTIFICATIONS SUB-PANEL -->
-      <div class="tab-panel" id="tab-panel-admin-notifications" role="tabpanel" aria-labelledby="tab-btn-admin-notifications">
-        <div class="section-label">Notifications</div>
-        <div class="admin-context-switcher">
-          <label class="switcher-label" for="notif-restaurant-select">Restaurant</label>
-          <select id="notif-restaurant-select" class="switcher-select" onchange="onAdminSwitcherRestaurantChange('notif')"></select>
-          <label class="switcher-label" for="notif-menu-select">Menu</label>
-          <select id="notif-menu-select" class="switcher-select" onchange="onAdminSwitcherMenuChange('notif')"></select>
-        </div>
-        <div class="config-card">
-          <p class="config-hint">Toggle which channels fire when you send a menu update for the selected menu.</p>
-          <div class="notif-channel" id="notif-groupme">
-            <div class="notif-channel-header">
-              <label class="notif-toggle-label" for="notif-groupme-enabled">
-                <input type="checkbox" id="notif-groupme-enabled" class="notif-toggle" onchange="onNotifToggle('groupme')"/>
-                <span class="notif-channel-name">GroupMe</span>
-              </label>
-            </div>
-            <div class="notif-channel-body" id="notif-groupme-body" style="display:none">
-              <div class="notif-help">
-                <p>Go to <strong>dev.groupme.com → Bots → Create Bot</strong>. Set the callback URL to your Vercel deployment URL. Copy the Bot ID and add it as a Vercel environment variable:</p>
-                <p><code>GROUPME_BOT_ID</code></p>
-              </div>
-            </div>
-          </div>
-          <div class="notif-channel" id="notif-sms">
-            <div class="notif-channel-header">
-              <label class="notif-toggle-label" for="notif-sms-enabled">
-                <input type="checkbox" id="notif-sms-enabled" class="notif-toggle" onchange="onNotifToggle('sms')"/>
-                <span class="notif-channel-name">Twilio SMS</span>
-              </label>
-            </div>
-            <div class="notif-channel-body" id="notif-sms-body" style="display:none">
-              <div class="notif-help">
-                <p>Sign up at <strong>twilio.com</strong> and buy a phone number. Add these Vercel environment variables:</p>
-                <p><code>TWILIO_ACCOUNT_SID</code><br><code>TWILIO_AUTH_TOKEN</code><br><code>TWILIO_FROM_NUMBER</code><br><code>TWILIO_TO_NUMBERS</code> <span class="notif-help-note">(comma-separated E.164 numbers, e.g. +15551234567,+15559876543)</span></p>
-              </div>
-            </div>
-          </div>
-          <div class="notif-channel" id="notif-discord">
-            <div class="notif-channel-header">
-              <label class="notif-toggle-label" for="notif-discord-enabled">
-                <input type="checkbox" id="notif-discord-enabled" class="notif-toggle" onchange="onNotifToggle('discord')"/>
-                <span class="notif-channel-name">Discord</span>
-              </label>
-            </div>
-            <div class="notif-channel-body" id="notif-discord-body" style="display:none">
-              <div class="notif-help">
-                <p>In Discord, open a channel's <strong>Settings → Integrations → Webhooks → New Webhook</strong>. Copy the webhook URL and add it as a Vercel environment variable:</p>
-                <p><code>DISCORD_WEBHOOK_URL</code></p>
-              </div>
-            </div>
-          </div>
-          <div class="notif-channel" id="notif-webhook">
-            <div class="notif-channel-header">
-              <label class="notif-toggle-label" for="notif-webhook-enabled">
-                <input type="checkbox" id="notif-webhook-enabled" class="notif-toggle" onchange="onNotifToggle('webhook')"/>
-                <span class="notif-channel-name">Generic Webhook</span>
-              </label>
-            </div>
-            <div class="notif-channel-body" id="notif-webhook-body" style="display:none">
-              <div class="notif-help">
-                <p>The full update payload will be POSTed as JSON to your endpoint. Add these Vercel environment variables:</p>
-                <p><code>GENERIC_WEBHOOK_URL</code><br><code>GENERIC_WEBHOOK_SECRET</code> <span class="notif-help-note">(optional — sent as <code>X-Webhook-Secret</code> header)</span></p>
-              </div>
-            </div>
-          </div>
-          <div class="btn-row" style="margin-top:14px">
-            <button class="btn-small" onclick="saveNotifications()">Save Notifications</button>
-          </div>
-        </div>
-        <div class="config-card" style="margin-top:10px">
-          <h3>Credential Keys <span style="font-weight:300;color:var(--muted)">(per restaurant)</span></h3>
-          <p class="config-hint">Map each channel to a Vercel env var name. Leave blank to use the global defaults. Actual secrets stay in Vercel — only the key names are stored here.</p>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">GroupMe Bot ID</label>
-            <input type="text" id="notif-cred-groupme" class="notif-cred-input" placeholder="GROUPME_BOT_ID"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Discord Webhook URL</label>
-            <input type="text" id="notif-cred-discord" class="notif-cred-input" placeholder="DISCORD_WEBHOOK_URL"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Twilio SID</label>
-            <input type="text" id="notif-cred-sms-sid" class="notif-cred-input" placeholder="TWILIO_ACCOUNT_SID"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Twilio Auth Token</label>
-            <input type="text" id="notif-cred-sms-token" class="notif-cred-input" placeholder="TWILIO_AUTH_TOKEN"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Twilio From Number</label>
-            <input type="text" id="notif-cred-sms-from" class="notif-cred-input" placeholder="TWILIO_FROM_NUMBER"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Twilio To Numbers</label>
-            <input type="text" id="notif-cred-sms-to" class="notif-cred-input" placeholder="TWILIO_TO_NUMBERS"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Webhook URL</label>
-            <input type="text" id="notif-cred-webhook-url" class="notif-cred-input" placeholder="GENERIC_WEBHOOK_URL"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Webhook Secret</label>
-            <input type="text" id="notif-cred-webhook-secret" class="notif-cred-input" placeholder="GENERIC_WEBHOOK_SECRET"/>
-          </div>
-          <div class="btn-row" style="margin-top:10px">
-            <button class="btn-small" onclick="saveNotifCredKeys()">Save Credential Keys</button>
-          </div>
-        </div>
-        <div class="config-card" style="margin-top:10px">
-          <h3>Menu Page URL <span style="font-weight:300;color:var(--muted)">(included in notifications)</span></h3>
-          <div class="input-row">
-            <input type="text" id="menu-url-input" placeholder="e.g. https://el-roys-drink-menu.vercel.app"/>
-            <button class="btn-small" onclick="saveMenuUrl()">Save</button>
-          </div>
-        </div>
-      </div>
-
-      <!-- USERS SUB-PANEL -->
-      <div class="tab-panel" id="tab-panel-admin-users" role="tabpanel" aria-labelledby="tab-btn-admin-users">
-        <div class="section-label">Staff Accounts</div>
-        <div class="users-invite-row">
-          <button class="btn-small" onclick="openInviteModal()">+ Invite Staff</button>
-        </div>
-        <div id="users-list"></div>
-      </div>
-      <!-- FEATURED SUB-PANEL -->
-      <div class="tab-panel" id="tab-panel-admin-featured" role="tabpanel" aria-labelledby="tab-btn-admin-featured">
-        <div class="section-label">Featured Groups</div>
-        <div id="featured-admin-wrap"></div>
-        <div class="input-row" style="margin-top:6px">
-          <input type="text" id="new-featured-group-name" placeholder="New group name…"/>
-          <button class="btn-small" onclick="addFeaturedGroup()">+ Add Group</button>
-        </div>
-      </div>
-
-      <!-- HISTORY SUB-PANEL -->
-      <div class="tab-panel" id="tab-panel-admin-history" role="tabpanel" aria-labelledby="tab-btn-admin-history">
-        <div class="section-label">Update History</div>
-        <div id="update-history-wrap"></div>
-      </div>
-    </div><!-- /admin-panel -->
-
-    <button class="logout-link" onclick="exitView()">← Back to menu view</button>
   </div>
 </div>
 
-<!-- AUTH OVERLAY -->
 <div id="auth-overlay">
   <div class="auth-box" id="auth-box" role="dialog" aria-modal="true" aria-label="Sign In">
     <div id="auth-no-config" style="display:none" class="auth-hint-msg">Supabase is not configured. Check server environment variables.</div>
     <div id="auth-form-wrap">
-
-      <!-- SIGN IN -->
       <div id="auth-screen-signin" class="auth-screen">
         <h2 class="auth-screen-title">SIGN IN</h2>
         <p class="auth-screen-subtitle">Sign in to your account</p>
@@ -379,7 +298,6 @@
         </div>
       </div>
 
-      <!-- SIGN UP -->
       <div id="auth-screen-signup" class="auth-screen" style="display:none">
         <h2 class="auth-screen-title">CREATE ACCOUNT</h2>
         <p class="auth-screen-subtitle">Sign up with your work email</p>
@@ -409,7 +327,6 @@
         <button class="auth-back-btn" onclick="renderAuthScreen('signin')">← Back to Sign In</button>
       </div>
 
-      <!-- FORGOT PASSWORD -->
       <div id="auth-screen-forgot" class="auth-screen" style="display:none">
         <h2 class="auth-screen-title">RESET PASSWORD</h2>
         <p class="auth-screen-subtitle">Enter your email and we'll send a reset link</p>
@@ -421,7 +338,6 @@
         <button class="auth-back-btn" onclick="renderAuthScreen('signin')">← Back to Sign In</button>
       </div>
 
-      <!-- RESET PASSWORD -->
       <div id="auth-screen-reset" class="auth-screen" style="display:none">
         <h2 class="auth-screen-title">SET NEW PASSWORD</h2>
         <p class="auth-screen-subtitle">Choose a new password for your account</p>
@@ -434,39 +350,11 @@
         <div class="auth-error" id="reset-error"></div>
         <button class="auth-submit-btn" id="reset-submit-btn" onclick="handleResetPassword()">Set Password</button>
       </div>
-
     </div>
     <button class="pin-cancel" onclick="closeAuthOverlay()">Cancel</button>
   </div>
 </div>
 
-<!-- CONFIG JSON MODAL -->
-<div class="modal-bg" id="config-modal-bg">
-  <div class="modal">
-    <h2>UPDATE CONFIG FILE</h2>
-    <div class="modal-sub">Copy this into <code>lib/config/notifications.json</code> and reload the page.</div>
-    <textarea id="config-json-output" class="config-json-textarea" readonly spellcheck="false"></textarea>
-    <div class="modal-actions">
-      <button class="btn-cancel" onclick="closeConfigModal()">Done</button>
-      <button class="btn-confirm" onclick="copyConfigJson()">COPY JSON</button>
-    </div>
-  </div>
-</div>
-
-<!-- PREVIEW MODAL -->
-<div class="modal-bg" id="modal-bg">
-  <div class="modal">
-    <h2>PATCH NOTES PREVIEW</h2>
-    <div class="modal-sub">Only changes since the last update will be sent.</div>
-    <div id="preview-content"></div>
-    <div class="modal-actions">
-      <button class="btn-cancel" onclick="closeModal()">Cancel</button>
-      <button class="btn-confirm" id="confirm-btn" onclick="sendUpdate()">SEND UPDATE</button>
-    </div>
-  </div>
-</div>
-
-<!-- INVITE MODAL -->
 <div class="modal-bg" id="invite-modal-bg">
   <div class="modal">
     <h2>INVITE STAFF</h2>
@@ -479,7 +367,6 @@
   </div>
 </div>
 
-<!-- MENU PICKER OVERLAY -->
 <div id="menu-picker-overlay">
   <div class="picker-box" role="dialog" aria-modal="true" aria-label="Select a Menu">
     <h2 class="picker-title" id="picker-title">SELECT A MENU</h2>

--- a/app.js
+++ b/app.js
@@ -169,8 +169,14 @@ let _dirty = false;
 let _pollFailCount = 0;
 let _deletedItemIds    = new Set();  // item UUIDs to DELETE on next persistState()
 let _uncatCategoryUuid = '';         // DB UUID of the __uncategorized__ category row
+let _managerDraggedItemId = '';
+let _managerDraggedCatId = '';
 function invalidateDiff() { _diffDirty = true; _dirty = true; updateSaveBtn(); }
-function updateSaveBtn() { const btn = document.getElementById('save-btn'); if (btn) btn.disabled = !_dirty; }
+function updateSaveBtn() {
+  const btn = document.getElementById('save-btn');
+  if (btn) btn.disabled = !_dirty;
+  updateManagerActionBar();
+}
 function getCachedDiff() {
   if (_diffDirty) { _diffCache = computeDiff(); _diffDirty = false; }
   return _diffCache;
@@ -1003,6 +1009,60 @@ function updateManagerToolsContext() {
   if (ctx) ctx.textContent = _activeMenuName ? `Editing: ${_activeMenuName}` : '';
 }
 
+function renderManagerOverviewStats() {
+  const activeItems = CATEGORY_DEFS.reduce((total, cat) => (
+    total + (menuState[cat.id]?.items || []).filter(item => item.onMenu !== false).length
+  ), 0);
+  const eightySixed = CATEGORY_DEFS.reduce((total, cat) => (
+    total + (menuState[cat.id]?.items || []).filter(item => item.onMenu !== false && item.eightySixed).length
+  ), 0);
+  const draftCount = getCachedDiff().reduce((count, section) => (
+    count + section.added.length + section.removed.length + section.eightySixed.length + section.restored.length
+  ), 0);
+  const statusValue = document.getElementById('manager-overview-status-value');
+  const statusMeta = document.getElementById('manager-overview-status-meta');
+  const activeValue = document.getElementById('manager-overview-active-value');
+  const activeMeta = document.getElementById('manager-overview-active-meta');
+  const eightysixValue = document.getElementById('manager-overview-86-value');
+  const eightysixMeta = document.getElementById('manager-overview-86-meta');
+
+  if (statusValue) statusValue.textContent = draftCount > 0 ? 'Drafting' : 'Live';
+  if (statusMeta) statusMeta.textContent = draftCount > 0
+    ? `${draftCount} unsent change${draftCount === 1 ? '' : 's'}`
+    : 'No unsent changes';
+  if (activeValue) activeValue.textContent = String(activeItems);
+  if (activeMeta) activeMeta.textContent = activeItems === 1 ? 'active item' : 'active items';
+  if (eightysixValue) eightysixValue.textContent = String(eightySixed);
+  if (eightysixMeta) eightysixMeta.textContent = eightySixed === 1 ? "item 86'd" : "items 86'd";
+}
+
+function updateManagerActionBar() {
+  const bar = document.getElementById('manager-action-bar');
+  if (!bar) return;
+  const primaryGroup = document.getElementById('manager-primary-action-group');
+  const featuredGroup = document.getElementById('manager-featured-action-group');
+  const summary = document.getElementById('manager-action-bar-summary');
+  const featuredBanner = document.getElementById('featured-confirm-banner');
+  const hasFeaturedPrompt = !!featuredBanner && featuredBanner.style.display !== 'none';
+  const hasDraftChanges = !!_dirty;
+
+  if (primaryGroup) primaryGroup.hidden = !hasDraftChanges;
+  if (featuredGroup) featuredGroup.hidden = !hasFeaturedPrompt;
+  bar.hidden = !(hasDraftChanges || hasFeaturedPrompt);
+
+  if (summary) {
+    if (hasDraftChanges && hasFeaturedPrompt) {
+      summary.textContent = 'Draft changes are ready to review, and featured items still need confirmation.';
+    } else if (hasDraftChanges) {
+      summary.textContent = 'Draft changes are ready to save quietly or review before sending.';
+    } else if (hasFeaturedPrompt) {
+      summary.textContent = "Today's featured lineup still needs confirmation.";
+    } else {
+      summary.textContent = '';
+    }
+  }
+}
+
 function renderManagerWorkspace(options = {}) {
   renderManagerCategories();
   renderFeaturedTab();
@@ -1012,7 +1072,9 @@ function renderManagerWorkspace(options = {}) {
   renderDatabaseTab();
   renderPruneSection();
   updateActiveMenuBar();
+  renderManagerOverviewStats();
   if (options.includeRecentChanges !== false) renderRecentChanges();
+  updateManagerActionBar();
 }
 
 function renderAdminWorkspace() {
@@ -2348,11 +2410,33 @@ function setActiveSettingsSection(sectionId) {
   });
 }
 
+function setSettingsDrawerOpen(isOpen) {
+  const drawer = document.getElementById('manager-settings-rail');
+  const backdrop = document.getElementById('settings-drawer-backdrop');
+  const toggle = document.getElementById('settings-drawer-toggle');
+  if (!drawer || !backdrop) return;
+  drawer.classList.toggle('is-open', !!isOpen);
+  backdrop.hidden = !isOpen;
+  document.body.classList.toggle('settings-drawer-open', !!isOpen);
+  if (toggle) toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+}
+
+function toggleSettingsDrawer() {
+  const drawer = document.getElementById('manager-settings-rail');
+  if (!drawer) return;
+  setSettingsDrawerOpen(!drawer.classList.contains('is-open'));
+}
+
+function closeSettingsDrawer() {
+  setSettingsDrawerOpen(false);
+}
+
 function focusSettingsSection(sectionId, trigger) {
   const section = document.getElementById(sectionId);
   if (!section) return;
   if (trigger) setActiveSettingsSection(trigger.dataset.target || sectionId);
   else setActiveSettingsSection(sectionId);
+  closeSettingsDrawer();
   section.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
@@ -2392,6 +2476,7 @@ function enterAdmin() {
   _setDisplayById('public-view', 'none');
   _setDisplayById('loading-view', 'none');
   closeMenuPicker({ skipOnClose: true });
+  closeSettingsDrawer();
   settingsView.style.display = 'block';
   adminPanel.style.display = 'block';
   renderUserHeader();
@@ -2404,6 +2489,7 @@ function exitAdmin() {
   document.body.classList.remove('manager-mode');
   _setDisplayById('manager-view', 'none');
   _setRestaurantPublicMode(false);
+  closeSettingsDrawer();
   renderUserHeader();
   if (isSettingsPage()) {
     navigateToPage(getPublicHrefForCurrentMenu());
@@ -2910,6 +2996,7 @@ function enterManager() {
   _setDisplayById('public-view', 'none');
   _setDisplayById('loading-view', 'none');
   closeMenuPicker({ skipOnClose: true });
+  closeSettingsDrawer();
   settingsView.style.display = 'block';
   managerPanel.style.display = 'block';
   renderUserHeader();
@@ -2925,6 +3012,7 @@ function exitManager() {
   document.body.classList.remove('manager-mode');
   _setDisplayById('manager-view', 'none');
   _setRestaurantPublicMode(false);
+  closeSettingsDrawer();
   renderUserHeader();
   if (isSettingsPage()) {
     navigateToPage(getPublicHrefForCurrentMenu());
@@ -3305,6 +3393,11 @@ function buildManagerItemHtml(item, catId, lastSentNames) {
   const statusTitle = is86 ? "86'd" : isNew ? 'New — not yet announced' : 'On menu';
   const rowClass = ['current-item', isNew ? 'is-new' : '', is86 ? 'is-eighty-sixed' : '', item.visibility === 'off_menu' ? 'is-off-menu' : ''].filter(Boolean).join(' ');
   return `<div class="${rowClass}">
+      <span class="item-drag-handle" draggable="true"
+        ondragstart="startManagerItemDrag(event,'${catId}','${item.id}')"
+        ondragend="endManagerItemDrag(event)"
+        title="Drag to reorder"
+        aria-hidden="true">⋮⋮</span>
       <div class="item-status-dot" role="img" aria-label="${statusTitle}" title="${statusTitle}"></div>
       <div class="item-name"><input type="text" value="${escHtml(item.name)}"
         aria-label="Item name"
@@ -3340,9 +3433,68 @@ function renderManagerItems(catId) {
     const wrapper  = document.createElement('div');
     wrapper.className = 'item-wrapper';
     wrapper.id = 'wrapper-' + item.id;
+    wrapper.dataset.catId = catId;
+    wrapper.dataset.itemId = item.id;
     wrapper.innerHTML = buildManagerItemHtml(item, catId, lastSentNames);
+    const row = wrapper.querySelector('.current-item');
+    if (row) {
+      row.addEventListener('dragover', event => allowManagerItemDrop(event, catId, item.id));
+      row.addEventListener('drop', event => handleManagerItemDrop(event, catId, item.id));
+    }
     listEl.appendChild(wrapper);
   });
+}
+
+function startManagerItemDrag(event, catId, itemId) {
+  _managerDraggedCatId = catId;
+  _managerDraggedItemId = itemId;
+  if (event.dataTransfer) {
+    event.dataTransfer.effectAllowed = 'move';
+    event.dataTransfer.setData('text/plain', itemId);
+  }
+  document.getElementById(`wrapper-${itemId}`)?.classList.add('is-dragging');
+}
+
+function endManagerItemDrag(event) {
+  const wrapper = event?.target?.closest('.item-wrapper');
+  if (wrapper) wrapper.classList.remove('is-dragging');
+  document.querySelectorAll('.item-wrapper.is-drop-target').forEach(el => el.classList.remove('is-drop-target'));
+  _managerDraggedCatId = '';
+  _managerDraggedItemId = '';
+}
+
+function allowManagerItemDrop(event, catId, itemId) {
+  if (!_managerDraggedItemId || _managerDraggedCatId !== catId || _managerDraggedItemId === itemId) return;
+  event.preventDefault();
+  if (event.dataTransfer) event.dataTransfer.dropEffect = 'move';
+  document.querySelectorAll('.item-wrapper.is-drop-target').forEach(el => {
+    if (el.dataset.itemId !== itemId) el.classList.remove('is-drop-target');
+  });
+  document.getElementById(`wrapper-${itemId}`)?.classList.add('is-drop-target');
+}
+
+function handleManagerItemDrop(event, catId, targetItemId) {
+  if (!_managerDraggedItemId || _managerDraggedCatId !== catId || _managerDraggedItemId === targetItemId) return;
+  event.preventDefault();
+  const items = menuState[catId]?.items || [];
+  const visibleItems = items.filter(item => item.onMenu !== false);
+  const fromIndex = visibleItems.findIndex(item => item.id === _managerDraggedItemId);
+  const toIndex = visibleItems.findIndex(item => item.id === targetItemId);
+  if (fromIndex < 0 || toIndex < 0) return;
+
+  const reorderedVisible = [...visibleItems];
+  const [movedItem] = reorderedVisible.splice(fromIndex, 1);
+  reorderedVisible.splice(toIndex, 0, movedItem);
+  menuState[catId].items = [
+    ...reorderedVisible,
+    ...items.filter(item => item.onMenu === false),
+  ];
+
+  invalidateDiff();
+  renderManagerItems(catId);
+  updateDraftIndicator();
+  renderManagerOverviewStats();
+  showToast('Item order updated.', 'success');
 }
 
 function buildCategoryUpsertRows() {
@@ -3846,6 +3998,8 @@ function updateDraftIndicator() {
     btn.innerHTML = '🔥 SEND UPDATE';
     btn.style.boxShadow = '';
   }
+  renderManagerOverviewStats();
+  updateManagerActionBar();
 }
 
 // ─── DIFF ─────────────────────────────────────────────────────────────────────
@@ -4077,6 +4231,8 @@ async function sendUpdate() {
           last_sent_categories: diff.map(d => d.id),
           last_sent_featured:   currentFeaturedIds,
         });
+        _dirty = false;
+        updateSaveBtn();
         updateLastUpdatedLabel();
         renderManagerWorkspace({ includeRecentChanges: false });
         updateDraftIndicator();
@@ -4555,6 +4711,7 @@ function checkFeaturedConfirmation() {
   if (!hasStaleSlots || !_featuredGroups.some(g => g.slots.length)) return;
 
   if (banner) banner.style.display = '';
+  updateManagerActionBar();
 }
 
 async function confirmFeaturedToday() {
@@ -4574,6 +4731,7 @@ async function confirmFeaturedToday() {
     sessionStorage.setItem('featured_confirmed', '1');
     const banner = document.getElementById('featured-confirm-banner');
     if (banner) banner.style.display = 'none';
+    updateManagerActionBar();
     showToast('Featured items confirmed for today!', 'success');
   } catch(e) { showToast('Failed to confirm.', 'error'); }
 }
@@ -4582,6 +4740,7 @@ function editFeaturedFromBanner() {
   const banner = document.getElementById('featured-confirm-banner');
   if (banner) banner.style.display = 'none';
   sessionStorage.setItem('featured_confirmed', '1');
+  updateManagerActionBar();
   focusSettingsSection('manager-edit-section');
 }
 

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 // ─── CONFIG ───────────────────────────────────────────────────────────────────
-const APP_VERSION = 'v0.8.3';
+const APP_VERSION = 'v0.8.4';
 const RESTAURANTS = {
   LEROYS: { id: '00000000-0000-0000-0000-000000000010', name: "Leroy's Lounge", slug: 'leroys-lounge' },
   ELROYS: { id: '00000000-0000-0000-0000-000000000001', name: "El Roy's Cantina", slug: 'el-roys-cantina' },
@@ -878,15 +878,20 @@ async function loadLocalConfig() {
 }
 
 function showConfigModal() {
+  const output = document.getElementById('config-json-output');
+  const modal = document.getElementById('config-modal-bg');
+  if (!output || !modal) return;
   const json = JSON.stringify({ groupme: { botId: BOT_ID } }, null, 2);
-  document.getElementById('config-json-output').value = json;
-  document.getElementById('config-modal-bg').classList.add('open');
+  output.value = json;
+  modal.classList.add('open');
 }
 function closeConfigModal() {
-  document.getElementById('config-modal-bg').classList.remove('open');
+  document.getElementById('config-modal-bg')?.classList.remove('open');
 }
 async function copyConfigJson() {
-  await navigator.clipboard.writeText(document.getElementById('config-json-output').value);
+  const output = document.getElementById('config-json-output');
+  if (!output) return;
+  await navigator.clipboard.writeText(output.value);
   showToast('Copied!', 'success');
 }
 
@@ -993,14 +998,36 @@ async function renderPublicViews() {
   updateLastUpdatedLabel();
 }
 
-function refreshManagerViews() {
+function updateManagerToolsContext() {
+  const ctx = document.getElementById('categories-menu-context');
+  if (ctx) ctx.textContent = _activeMenuName ? `Editing: ${_activeMenuName}` : '';
+}
+
+function renderManagerWorkspace(options = {}) {
   renderManagerCategories();
   renderFeaturedTab();
   renderOffMenuSection();
+  renderCategoriesTab();
+  updateManagerToolsContext();
+  renderDatabaseTab();
+  renderPruneSection();
+  updateActiveMenuBar();
+  if (options.includeRecentChanges !== false) renderRecentChanges();
+}
+
+function renderAdminWorkspace() {
+  checkAdminSupabaseStatus();
+  renderMenusPanel();
+  initAdminSwitcherTab('notif');
+  loadUsers();
+  renderFeaturedAdmin();
+}
+
+function refreshManagerViews() {
+  renderManagerWorkspace({ includeRecentChanges: false });
 }
 
 function refreshCategoryAdminViews() {
-  renderCategoriesTab();
   refreshManagerViews();
   renderPublicView();
 }
@@ -2315,6 +2342,20 @@ function applyRole(role) {
   renderUserHeader();
 }
 
+function setActiveSettingsSection(sectionId) {
+  document.querySelectorAll('.settings-rail-btn').forEach(btn => {
+    btn.classList.toggle('active', btn.dataset.target === sectionId);
+  });
+}
+
+function focusSettingsSection(sectionId, trigger) {
+  const section = document.getElementById(sectionId);
+  if (!section) return;
+  if (trigger) setActiveSettingsSection(trigger.dataset.target || sectionId);
+  else setActiveSettingsSection(sectionId);
+  section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+}
+
 // ─── AUTH OVERLAY ─────────────────────────────────────────────────────────────
 function onActionBtnClick() {
   const targetPath = getManagerHrefForMenuId(MENU_ID);
@@ -2334,10 +2375,9 @@ function onAdminBtnClick() {
 }
 
 function enterAdmin() {
-  const managerView = document.getElementById('manager-view');
-  const managerPanel = document.getElementById('manager-panel');
+  const settingsView = document.getElementById('manager-view');
   const adminPanel = document.getElementById('admin-panel');
-  if (!managerView || !managerPanel || !adminPanel) {
+  if (!settingsView || !adminPanel) {
     navigateToPage(SHARED_PAGE_PATHS.admin);
     return;
   }
@@ -2349,21 +2389,20 @@ function enterAdmin() {
   _clearSettingsRedirectPrompt();
   stopPolling();
   document.body.classList.add('manager-mode');
-  document.getElementById('public-view').style.display     = 'none';
-  document.getElementById('loading-view').style.display    = 'none';
+  _setDisplayById('public-view', 'none');
+  _setDisplayById('loading-view', 'none');
   closeMenuPicker({ skipOnClose: true });
-  managerView.style.display    = 'block';
-  managerPanel.style.display   = 'none';
-  adminPanel.style.display     = 'block';
+  settingsView.style.display = 'block';
+  adminPanel.style.display = 'block';
   renderUserHeader();
-  checkAdminSupabaseStatus();
-  switchAdminTab('admin-restaurants');
+  renderAdminWorkspace();
+  setActiveSettingsSection('admin-overview-section');
 }
 
 function exitAdmin() {
   isAdminMode = false;
   document.body.classList.remove('manager-mode');
-  document.getElementById('manager-view').style.display = 'none';
+  _setDisplayById('manager-view', 'none');
   _setRestaurantPublicMode(false);
   renderUserHeader();
   if (isSettingsPage()) {
@@ -2646,12 +2685,10 @@ async function onSwitchMenuClick() {
     await loadActiveMenuState();
     applyDesign(currentDesign);
     await sbEnsureUncategorized();
-    refreshManagerViews();
-    if (typeof renderCatManager  === 'function') renderCatManager();
-    if (typeof renderDatabase    === 'function') renderDatabase();
-    if (typeof renderUsersList   === 'function') renderUsersList();
+    renderManagerWorkspace();
     updateDraftIndicator();
     updateSaveBtn();
+    checkFeaturedConfirmation();
   }, { managerOnly: true });
 }
 
@@ -2845,10 +2882,9 @@ function signOut() {
 
 // ─── MANAGER MODE ─────────────────────────────────────────────────────────────
 function enterManager() {
-  const managerView = document.getElementById('manager-view');
+  const settingsView = document.getElementById('manager-view');
   const managerPanel = document.getElementById('manager-panel');
-  const adminPanel = document.getElementById('admin-panel');
-  if (!managerView || !managerPanel || !adminPanel) {
+  if (!settingsView || !managerPanel) {
     navigateToPage(SHARED_PAGE_PATHS.manager);
     return;
   }
@@ -2871,25 +2907,23 @@ function enterManager() {
   _clearSettingsRedirectPrompt();
   stopPolling();
   document.body.classList.add('manager-mode');
-  document.getElementById('public-view').style.display    = 'none';
-  document.getElementById('loading-view').style.display   = 'none';
+  _setDisplayById('public-view', 'none');
+  _setDisplayById('loading-view', 'none');
   closeMenuPicker({ skipOnClose: true });
-  managerView.style.display   = 'block';
-  managerPanel.style.display  = 'block';
-  adminPanel.style.display    = 'none';
+  settingsView.style.display = 'block';
+  managerPanel.style.display = 'block';
   renderUserHeader();
-  switchManagerTab('edit-menu');
+  renderManagerWorkspace();
+  setActiveSettingsSection('manager-overview-section');
   updateDraftIndicator();
   updateSaveBtn();
-  renderManagerCategories();
-  updateActiveMenuBar();
   checkFeaturedConfirmation();
 }
 
 function exitManager() {
   isManagerMode = false;
   document.body.classList.remove('manager-mode');
-  document.getElementById('manager-view').style.display = 'none';
+  _setDisplayById('manager-view', 'none');
   _setRestaurantPublicMode(false);
   renderUserHeader();
   if (isSettingsPage()) {
@@ -3707,9 +3741,11 @@ function removeItem(catId, itemId) {
 function renderPruneSection() {
   const isAdmin = currentUser?.role === 'admin';
   const section = document.getElementById('prune-section');
+  if (!section) return;
   section.style.display = isAdmin ? '' : 'none';
   if (!isAdmin) return;
   const wrap = document.getElementById('prune-items-wrap');
+  if (!wrap) return;
   const allOffMenu = [];
   CATEGORY_DEFS.forEach(cat => {
     (menuState[cat.id]?.items || []).filter(i => i.onMenu === false).forEach(item => {
@@ -3915,6 +3951,8 @@ function openPreview() {
   const diff = getCachedDiff();
   const content = document.getElementById('preview-content');
   const confirmBtn = document.getElementById('confirm-btn');
+  const modal = document.getElementById('modal-bg');
+  if (!content || !confirmBtn || !modal) return;
   content.innerHTML = '';
   if (!diff.length) {
     content.innerHTML = `<div class="no-changes">🎉 No changes since the last update.<br><span style="font-size:11px;color:#444;">Add, remove, or 86 items to generate an update.</span></div>`;
@@ -3928,9 +3966,9 @@ function openPreview() {
       content.appendChild(block);
     });
   }
-  document.getElementById('modal-bg').classList.add('open');
+  modal.classList.add('open');
 }
-function closeModal() { document.getElementById('modal-bg').classList.remove('open'); }
+function closeModal() { document.getElementById('modal-bg')?.classList.remove('open'); }
 
 // ─── SEND UPDATE ──────────────────────────────────────────────────────────────
 function buildPatchMessage(diff) {
@@ -3979,18 +4017,23 @@ function applySentState(diff, ts) {
 }
 
 async function logUpdate(diff, patchMessage) {
-  if (!SUPABASE_URL || !currentUser?.accessToken) return;
-  fetch(`${SUPABASE_URL}/rest/v1/update_log`, {
-    method: 'POST',
-    headers: sbHeaders({ 'Prefer': 'return=minimal' }),
-    body: JSON.stringify({
-      menu_id:   MENU_ID,
-      user_id:   currentUser.uid,
-      user_name: currentUser.name || currentUser.email || '',
-      diff:      diff,
-      message:   patchMessage,
-    }),
-  }).catch(() => {});
+  if (!SUPABASE_URL || !currentUser?.accessToken) return false;
+  try {
+    const response = await fetch(`${SUPABASE_URL}/rest/v1/update_log`, {
+      method: 'POST',
+      headers: sbHeaders({ 'Prefer': 'return=minimal' }),
+      body: JSON.stringify({
+        menu_id:   MENU_ID,
+        user_id:   currentUser.uid,
+        user_name: currentUser.name || currentUser.email || '',
+        diff:      diff,
+        message:   patchMessage,
+      }),
+    });
+    return response.ok;
+  } catch (_) {
+    return false;
+  }
 }
 
 async function sendUpdate() {
@@ -4035,9 +4078,10 @@ async function sendUpdate() {
           last_sent_featured:   currentFeaturedIds,
         });
         updateLastUpdatedLabel();
-        renderManagerCategories();
+        renderManagerWorkspace({ includeRecentChanges: false });
         updateDraftIndicator();
-        logUpdate(diff, patchMessage);
+        await logUpdate(diff, patchMessage);
+        renderRecentChanges();
       } catch (syncError) {
         console.warn('sendUpdate post-send sync failed:', syncError);
         showToast('⚠️  Update sent but local cache failed to sync', 'warning');
@@ -4054,7 +4098,7 @@ async function sendUpdate() {
   }
 
   confirmBtn.disabled = false;
-  confirmBtn.textContent = 'SEND TO GROUP';
+  confirmBtn.textContent = 'SEND UPDATE';
 }
 
 // ─── TOAST ───────────────────────────────────────────────────────────────────
@@ -4101,6 +4145,7 @@ document.getElementById('prune-items-wrap')?.addEventListener('click', e => {
 // ─── USER MANAGEMENT ─────────────────────────────────────────────────────────
 async function loadUsers() {
   const wrap = document.getElementById('users-list');
+  if (!wrap) return;
   wrap.innerHTML = '<div class="db-empty">Loading...</div>';
   try {
     // Fetch menus list for menu access checkboxes
@@ -4146,47 +4191,55 @@ function buildHistoryDetailHtml(diff) {
   ).join('');
 }
 
-async function renderUpdateHistory() {
-  const wrap = document.getElementById('update-history-wrap');
-  if (!wrap) return;
-  if (!SUPABASE_URL || !currentUser?.accessToken) { wrap.innerHTML = ''; return; }
+function buildChangeFeedHtml(logs) {
+  return logs.map(log => {
+    const d = new Date(log.created_at);
+    const dateStr = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
+    const timeStr = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+    const diff = log.diff || [];
+    const summary = summarizeHistoryDiff(diff);
+    const detailHtml = buildHistoryDetailHtml(diff);
 
-  // Determine which menu to show history for — use the admin switcher if available
-  const menuId = _adminSwitcherState.notif?.menuId || MENU_ID;
-  if (!menuId) { wrap.innerHTML = '<p class="db-empty">Select a menu to view history.</p>'; return; }
+    return `<div class="history-entry">
+      <div class="history-header" onclick="this.parentElement.classList.toggle('expanded')">
+        <span class="history-date">${escHtml(dateStr)} ${escHtml(timeStr)}</span>
+        <span class="history-user">${escHtml(log.user_name || 'Unknown')}</span>
+        <span class="history-summary">${escHtml(summary)}</span>
+        <span class="history-chevron">\u203A</span>
+      </div>
+      <div class="history-detail">${detailHtml}</div>
+    </div>`;
+  }).join('');
+}
+
+async function renderRecentChanges() {
+  const wrap = document.getElementById('recent-changes-wrap');
+  if (!wrap) return;
+  if (!SUPABASE_URL || !currentUser?.accessToken) {
+    wrap.innerHTML = '<p class="db-empty">Recent changes are unavailable until you are signed in.</p>';
+    return;
+  }
+  if (!MENU_ID) {
+    wrap.innerHTML = '<p class="db-empty">Select a menu to view recent changes.</p>';
+    return;
+  }
 
   wrap.innerHTML = '<p class="db-empty">Loading\u2026</p>';
   try {
+    const sinceIso = new Date(Date.now() - (7 * 24 * 60 * 60 * 1000)).toISOString();
     const r = await fetch(
-      `${SUPABASE_URL}/rest/v1/update_log?menu_id=eq.${menuId}&select=*&order=created_at.desc&limit=20`,
+      `${SUPABASE_URL}/rest/v1/update_log?menu_id=eq.${MENU_ID}&created_at=gte.${encodeURIComponent(sinceIso)}&select=*&order=created_at.desc&limit=25`,
       { headers: sbHeaders() }
     );
     if (!r.ok) throw new Error('fetch failed');
     const logs = await r.json();
     if (!logs.length) {
-      wrap.innerHTML = '<p class="db-empty">No updates sent yet for this menu.</p>';
+      wrap.innerHTML = '<p class="db-empty">No sent updates for this menu in the last 7 days.</p>';
       return;
     }
-    wrap.innerHTML = logs.map(log => {
-      const d = new Date(log.created_at);
-      const dateStr = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-      const timeStr = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
-      const diff = log.diff || [];
-      const summary = summarizeHistoryDiff(diff);
-      const detailHtml = buildHistoryDetailHtml(diff);
-
-      return `<div class="history-entry">
-        <div class="history-header" onclick="this.parentElement.classList.toggle('expanded')">
-          <span class="history-date">${escHtml(dateStr)} ${escHtml(timeStr)}</span>
-          <span class="history-user">${escHtml(log.user_name || 'Unknown')}</span>
-          <span class="history-summary">${escHtml(summary)}</span>
-          <span class="history-chevron">\u203A</span>
-        </div>
-        <div class="history-detail">${detailHtml}</div>
-      </div>`;
-    }).join('');
+    wrap.innerHTML = buildChangeFeedHtml(logs);
   } catch(e) {
-    wrap.innerHTML = `<p class="db-empty db-error">Failed to load history.</p>`;
+    wrap.innerHTML = '<p class="db-empty db-error">Failed to load recent changes.</p>';
   }
 }
 
@@ -4330,18 +4383,23 @@ async function saveUserName(userId) {
 
 function openInviteModal() {
   const url = MENU_URL || window.location.origin;
-  const brand = document.getElementById('design-brand-name')?.value?.trim() || 'the menu';
-  document.getElementById('invite-text-output').value =
+  const brand = formatMenuDisplayName(_activeMenuName, MENU_TYPE, RESTAURANT_ID) || _activeMenuName || 'the menu';
+  const output = document.getElementById('invite-text-output');
+  const modal = document.getElementById('invite-modal-bg');
+  if (!output || !modal) return;
+  output.value =
     `You've been invited to manage ${brand}!\n\nVisit ${url} and tap "Sign In" to create your account. Once you've signed up, ask an admin to approve your access.`;
-  document.getElementById('invite-modal-bg').classList.add('open');
+  modal.classList.add('open');
 }
 
 function closeInviteModal() {
-  document.getElementById('invite-modal-bg').classList.remove('open');
+  document.getElementById('invite-modal-bg')?.classList.remove('open');
 }
 
 async function copyInviteText() {
-  await navigator.clipboard.writeText(document.getElementById('invite-text-output').value);
+  const output = document.getElementById('invite-text-output');
+  if (!output) return;
+  await navigator.clipboard.writeText(output.value);
   showToast('Copied!', 'success');
 }
 
@@ -4484,6 +4542,8 @@ async function moveFeaturedSlot(groupId, slotId, direction) {
 // ─── FEATURED DAILY CONFIRMATION ─────────────────────────────────────────────
 
 function checkFeaturedConfirmation() {
+  const banner = document.getElementById('featured-confirm-banner');
+  if (banner) banner.style.display = 'none';
   if (sessionStorage.getItem('featured_confirmed')) return;
   const hasStaleSlots = _featuredGroups.some(g => g.slots.some(s => {
     if (!s.confirmedAt) return true;
@@ -4494,7 +4554,6 @@ function checkFeaturedConfirmation() {
   }));
   if (!hasStaleSlots || !_featuredGroups.some(g => g.slots.length)) return;
 
-  const banner = document.getElementById('featured-confirm-banner');
   if (banner) banner.style.display = '';
 }
 
@@ -4523,7 +4582,7 @@ function editFeaturedFromBanner() {
   const banner = document.getElementById('featured-confirm-banner');
   if (banner) banner.style.display = 'none';
   sessionStorage.setItem('featured_confirmed', '1');
-  switchManagerTab('edit-menu');
+  focusSettingsSection('manager-edit-section');
 }
 
 // ─── FEATURED ADMIN ──────────────────────────────────────────────────────────
@@ -4616,33 +4675,40 @@ async function toggleFeaturedGroupMenu(groupId, menuId, checked) {
 
 // ─── TAB SWITCHING ────────────────────────────────────────────────────────────
 function switchManagerTab(name) {
-  ['edit-menu', 'categories', 'database'].forEach(t => {
-    const btn   = document.getElementById('tab-btn-' + t);
-    const panel = document.getElementById('tab-panel-' + t);
-    if (btn)   { btn.classList.toggle('active', t === name); btn.setAttribute('aria-selected', t === name ? 'true' : 'false'); }
-    if (panel) panel.classList.toggle('active', t === name);
-  });
-  if (name === 'edit-menu')   { renderFeaturedTab(); renderOffMenuSection(); }
-  if (name === 'database')   { renderDatabaseTab(); renderPruneSection(); }
+  if (name === 'edit-menu') {
+    renderFeaturedTab();
+    renderOffMenuSection();
+    focusSettingsSection('manager-edit-section');
+  }
   if (name === 'categories') {
     renderCategoriesTab();
-    const ctx = document.getElementById('categories-menu-context');
-    if (ctx) ctx.textContent = _activeMenuName ? `Editing: ${_activeMenuName}` : '';
+    updateManagerToolsContext();
+    focusSettingsSection('manager-categories-section');
+  }
+  if (name === 'database') {
+    renderDatabaseTab();
+    renderPruneSection();
+    focusSettingsSection('manager-database-section');
   }
 }
 
 function switchAdminTab(name) {
-  ['admin-restaurants', 'admin-notifications', 'admin-users', 'admin-featured', 'admin-history'].forEach(t => {
-    const btn   = document.getElementById('tab-btn-' + t);
-    const panel = document.getElementById('tab-panel-' + t);
-    if (btn)   { btn.classList.toggle('active', t === name); btn.setAttribute('aria-selected', t === name ? 'true' : 'false'); }
-    if (panel) panel.classList.toggle('active', t === name);
-  });
-  if (name === 'admin-restaurants')   { renderMenusPanel(); }
-  if (name === 'admin-notifications') { initAdminSwitcherTab('notif'); }
-  if (name === 'admin-users')         { loadUsers(); }
-  if (name === 'admin-featured')      { renderFeaturedAdmin(); }
-  if (name === 'admin-history')       { renderUpdateHistory(); }
+  if (name === 'admin-restaurants') {
+    renderMenusPanel();
+    focusSettingsSection('admin-restaurants-section');
+  }
+  if (name === 'admin-notifications') {
+    initAdminSwitcherTab('notif');
+    focusSettingsSection('admin-notifications-section');
+  }
+  if (name === 'admin-users') {
+    loadUsers();
+    focusSettingsSection('admin-users-section');
+  }
+  if (name === 'admin-featured') {
+    renderFeaturedAdmin();
+    focusSettingsSection('admin-featured-section');
+  }
 }
 
 const dbFilters = { recipe: 'all', status: 'all' };

--- a/app.js
+++ b/app.js
@@ -1016,95 +1016,9 @@ function renderManagerWorkspace(options = {}) {
 }
 
 function renderAdminWorkspace() {
-  checkAdminSupabaseStatus();
   renderMenusPanel();
   initAdminSwitcherTab('notif');
   loadUsers();
-  renderAdminOverview();
-}
-
-function _setAdminOverviewValue(id, value) {
-  const el = document.getElementById(id);
-  if (el) el.textContent = value;
-}
-
-function _renderAdminOverviewMetrics() {
-  const restaurantsCount = _adminRestaurants.length || knownRestaurantList().length;
-  const menusCount = _adminAllMenus.length || knownMenuList().length;
-  const hasUserData = Array.isArray(window._adminUserList);
-  const users = hasUserData ? window._adminUserList : [];
-  const staffCount = users.length;
-  const pendingCount = users.filter(user => user.role === 'none').length;
-
-  _setAdminOverviewValue('admin-overview-restaurants', String(restaurantsCount).padStart(2, '0'));
-  _setAdminOverviewValue('admin-overview-menus', String(menusCount).padStart(2, '0'));
-  _setAdminOverviewValue('admin-overview-staff', hasUserData ? String(staffCount).padStart(2, '0') : '--');
-  _setAdminOverviewValue('admin-overview-pending', hasUserData ? String(pendingCount).padStart(2, '0') : '--');
-
-  const summary = document.getElementById('admin-overview-summary');
-  if (!summary) return;
-
-  if (!hasUserData) {
-    summary.textContent = `${restaurantsCount} restaurants and ${menusCount} menus are available. Staff summaries will populate after the users API responds.`;
-    return;
-  }
-
-  summary.textContent = `${restaurantsCount} restaurants, ${menusCount} live menus, ${staffCount} staff accounts, and ${pendingCount} pending approvals are currently in scope.`;
-}
-
-function _adminActivityLabelForMenu(menuId) {
-  const menu = (_adminAllMenus || []).find(entry => entry.id === menuId)
-    || knownMenuList().find(entry => entry.id === menuId);
-  if (!menu) return 'Unknown menu';
-  return formatMenuDisplayName(menu.name, menu.type, menu.restaurant_id);
-}
-
-async function renderAdminOverviewActivity() {
-  const feed = document.getElementById('admin-activity-feed');
-  if (!feed) return;
-
-  if (!SUPABASE_URL || !currentUser?.accessToken) {
-    feed.innerHTML = '<p class="db-empty">Recent admin activity is available once you are signed in.</p>';
-    return;
-  }
-
-  feed.innerHTML = '<p class="db-empty">Loading recent activity...</p>';
-  try {
-    const res = await fetch(
-      `${SUPABASE_URL}/rest/v1/update_log?select=menu_id,user_name,diff,created_at&order=created_at.desc&limit=4`,
-      { headers: sbHeaders() }
-    );
-    if (!res.ok) throw new Error(`activity fetch: ${res.status}`);
-    const logs = await res.json();
-    if (!logs.length) {
-      feed.innerHTML = '<p class="db-empty">No sent updates yet.</p>';
-      return;
-    }
-
-    feed.innerHTML = logs.map(log => {
-      const timestamp = new Date(log.created_at);
-      const timeLabel = timestamp.toLocaleString('en-US', {
-        month: 'short',
-        day: 'numeric',
-        hour: 'numeric',
-        minute: '2-digit',
-      });
-      return `<article class="admin-activity-row">
-        <div class="admin-activity-row-main">
-          <p class="admin-activity-title">${escHtml(_adminActivityLabelForMenu(log.menu_id))}</p>
-          <p class="admin-activity-copy">${escHtml(log.user_name || 'Unknown user')} sent an update. ${escHtml(summarizeHistoryDiff(log.diff || []))}.</p>
-        </div>
-        <time class="admin-activity-time">${escHtml(timeLabel)}</time>
-      </article>`;
-    }).join('');
-  } catch (e) {
-    feed.innerHTML = '<p class="db-empty db-error">Failed to load recent activity.</p>';
-  }
-}
-
-function renderAdminOverview() {
-  _renderAdminOverviewMetrics();
-  renderAdminOverviewActivity();
 }
 
 function refreshManagerViews() {
@@ -2500,7 +2414,7 @@ function enterAdmin() {
   adminPanel.style.display = 'block';
   renderUserHeader();
   renderAdminWorkspace();
-  _syncSettingsSectionFromLocation('admin-overview-section');
+  _syncSettingsSectionFromLocation('admin-restaurants-section');
 }
 
 function exitAdmin() {
@@ -4259,7 +4173,6 @@ async function loadUsers() {
   if (!wrap) return;
   wrap.innerHTML = '<div class="db-empty">Loading...</div>';
   window._adminUserList = null;
-  _renderAdminOverviewMetrics();
   try {
     // Fetch menus list for menu access checkboxes
     if (SUPABASE_URL) {
@@ -4276,10 +4189,8 @@ async function loadUsers() {
     const users = await r.json();
     window._adminUserList = users;
     renderUsersTab(users);
-    _renderAdminOverviewMetrics();
   } catch (e) {
     wrap.innerHTML = '<div class="db-empty db-error">Failed to load users.</div>';
-    _renderAdminOverviewMetrics();
   }
 }
 
@@ -5040,10 +4951,8 @@ async function renderMenusPanel() {
       row.innerHTML = buildRestaurantRowHtml(restaurant, menus);
       listEl.appendChild(row);
     });
-    _renderAdminOverviewMetrics();
   } catch(e) {
     listEl.innerHTML = `<p class="db-empty db-error">Failed to load restaurants: ${escHtml(String(e))}</p>`;
-    _renderAdminOverviewMetrics();
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -1020,7 +1020,91 @@ function renderAdminWorkspace() {
   renderMenusPanel();
   initAdminSwitcherTab('notif');
   loadUsers();
-  renderFeaturedAdmin();
+  renderAdminOverview();
+}
+
+function _setAdminOverviewValue(id, value) {
+  const el = document.getElementById(id);
+  if (el) el.textContent = value;
+}
+
+function _renderAdminOverviewMetrics() {
+  const restaurantsCount = _adminRestaurants.length || knownRestaurantList().length;
+  const menusCount = _adminAllMenus.length || knownMenuList().length;
+  const hasUserData = Array.isArray(window._adminUserList);
+  const users = hasUserData ? window._adminUserList : [];
+  const staffCount = users.length;
+  const pendingCount = users.filter(user => user.role === 'none').length;
+
+  _setAdminOverviewValue('admin-overview-restaurants', String(restaurantsCount).padStart(2, '0'));
+  _setAdminOverviewValue('admin-overview-menus', String(menusCount).padStart(2, '0'));
+  _setAdminOverviewValue('admin-overview-staff', hasUserData ? String(staffCount).padStart(2, '0') : '--');
+  _setAdminOverviewValue('admin-overview-pending', hasUserData ? String(pendingCount).padStart(2, '0') : '--');
+
+  const summary = document.getElementById('admin-overview-summary');
+  if (!summary) return;
+
+  if (!hasUserData) {
+    summary.textContent = `${restaurantsCount} restaurants and ${menusCount} menus are available. Staff summaries will populate after the users API responds.`;
+    return;
+  }
+
+  summary.textContent = `${restaurantsCount} restaurants, ${menusCount} live menus, ${staffCount} staff accounts, and ${pendingCount} pending approvals are currently in scope.`;
+}
+
+function _adminActivityLabelForMenu(menuId) {
+  const menu = (_adminAllMenus || []).find(entry => entry.id === menuId)
+    || knownMenuList().find(entry => entry.id === menuId);
+  if (!menu) return 'Unknown menu';
+  return formatMenuDisplayName(menu.name, menu.type, menu.restaurant_id);
+}
+
+async function renderAdminOverviewActivity() {
+  const feed = document.getElementById('admin-activity-feed');
+  if (!feed) return;
+
+  if (!SUPABASE_URL || !currentUser?.accessToken) {
+    feed.innerHTML = '<p class="db-empty">Recent admin activity is available once you are signed in.</p>';
+    return;
+  }
+
+  feed.innerHTML = '<p class="db-empty">Loading recent activity...</p>';
+  try {
+    const res = await fetch(
+      `${SUPABASE_URL}/rest/v1/update_log?select=menu_id,user_name,diff,created_at&order=created_at.desc&limit=6`,
+      { headers: sbHeaders() }
+    );
+    if (!res.ok) throw new Error(`activity fetch: ${res.status}`);
+    const logs = await res.json();
+    if (!logs.length) {
+      feed.innerHTML = '<p class="db-empty">No sent updates yet.</p>';
+      return;
+    }
+
+    feed.innerHTML = logs.map(log => {
+      const timestamp = new Date(log.created_at);
+      const timeLabel = timestamp.toLocaleString('en-US', {
+        month: 'short',
+        day: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      });
+      return `<article class="admin-activity-row">
+        <div class="admin-activity-row-main">
+          <p class="admin-activity-title">${escHtml(_adminActivityLabelForMenu(log.menu_id))}</p>
+          <p class="admin-activity-copy">${escHtml(log.user_name || 'Unknown user')} sent an update. ${escHtml(summarizeHistoryDiff(log.diff || []))}.</p>
+        </div>
+        <time class="admin-activity-time">${escHtml(timeLabel)}</time>
+      </article>`;
+    }).join('');
+  } catch (e) {
+    feed.innerHTML = '<p class="db-empty db-error">Failed to load recent activity.</p>';
+  }
+}
+
+function renderAdminOverview() {
+  _renderAdminOverviewMetrics();
+  renderAdminOverviewActivity();
 }
 
 function refreshManagerViews() {
@@ -2388,7 +2472,6 @@ function enterAdmin() {
   isAdminMode = true;
   _clearSettingsRedirectPrompt();
   stopPolling();
-  document.body.classList.add('manager-mode');
   _setDisplayById('public-view', 'none');
   _setDisplayById('loading-view', 'none');
   closeMenuPicker({ skipOnClose: true });
@@ -4147,11 +4230,13 @@ async function loadUsers() {
   const wrap = document.getElementById('users-list');
   if (!wrap) return;
   wrap.innerHTML = '<div class="db-empty">Loading...</div>';
+  window._adminUserList = null;
+  _renderAdminOverviewMetrics();
   try {
     // Fetch menus list for menu access checkboxes
     if (SUPABASE_URL) {
       const menusRes = await fetch(
-        `${SUPABASE_URL}/rest/v1/menus?id=in.(${KNOWN_MENU_ORDER.join(',')})&select=id,name&archived=eq.false&order=created_at.asc`,
+        `${SUPABASE_URL}/rest/v1/menus?id=in.(${KNOWN_MENU_ORDER.join(',')})&select=id,name,type,restaurant_id&archived=eq.false&order=created_at.asc`,
         { headers: sbHeaders() }
       );
       if (menusRes.ok) window._adminMenuList = await menusRes.json();
@@ -4163,8 +4248,10 @@ async function loadUsers() {
     const users = await r.json();
     window._adminUserList = users;
     renderUsersTab(users);
+    _renderAdminOverviewMetrics();
   } catch (e) {
     wrap.innerHTML = '<div class="db-empty db-error">Failed to load users.</div>';
+    _renderAdminOverviewMetrics();
   }
 }
 
@@ -4250,19 +4337,33 @@ function renderUsersTab(users) {
     return;
   }
   const roleLabel = { none: 'No Access', manager: 'Manager', admin: 'Admin' };
-  wrap.innerHTML = users.map(u => {
+  wrap.innerHTML = `
+    <div class="admin-users-table">
+      <div class="admin-users-head">
+        <span>Identity</span>
+        <span>Role</span>
+        <span>Menu Access</span>
+        <span>Status</span>
+      </div>
+      ${users.map(u => {
     const isSelf = u.id === currentUser?.uid;
+    const parts = (u.name || u.email || '?').trim().split(/\s+/).filter(Boolean);
+    const initials = parts.length >= 2
+      ? `${parts[0][0]}${parts[parts.length - 1][0]}`.toUpperCase()
+      : (parts[0]?.slice(0, 2) || '?').toUpperCase();
+    const statusLabel = isSelf ? 'Current Session' : (u.role === 'none' ? 'Pending Approval' : 'Active');
+    const statusClass = isSelf ? 'admin-user-status-pill--current' : (u.role === 'none' ? 'admin-user-status-pill--pending' : 'admin-user-status-pill--active');
 
     // Role controls
     const roleControls = isSelf
       ? `<span class="user-mgmt-self-note">(your account — role locked)</span>`
-      : `<select id="user-role-${escHtml(u.id)}" class="user-mgmt-role-select"
+      : `<div class="admin-user-role-editor"><select id="user-role-${escHtml(u.id)}" class="user-mgmt-role-select"
                  onchange="renderMenuAccessForUser('${escHtml(u.id)}')">
            <option value="none"    ${u.role === 'none'    ? 'selected' : ''}>No Access</option>
            <option value="manager" ${u.role === 'manager' ? 'selected' : ''}>Manager</option>
            <option value="admin"   ${u.role === 'admin'   ? 'selected' : ''}>Admin</option>
          </select>
-         <button class="btn-small" onclick="saveUserRole('${escHtml(u.id)}')">Save</button>`;
+         <button class="btn-small" onclick="saveUserRole('${escHtml(u.id)}')">Save</button></div>`;
 
     // Menu access section (only for non-self users)
     const menuAccessSection = isSelf ? '' : `
@@ -4271,32 +4372,41 @@ function renderUsersTab(users) {
       </div>`;
 
     return `
-      <div class="config-card">
-        <div class="user-mgmt-top">
+      <article class="admin-user-row">
+        <div class="admin-user-cell admin-user-cell--identity">
+          <div class="admin-user-avatar">${escHtml(initials)}</div>
           <div class="user-mgmt-identity">
-            <div class="input-row">
+            <div class="input-row admin-user-name-row">
               <input type="text" id="user-name-${escHtml(u.id)}" value="${escHtml(u.name)}" placeholder="Display name" />
               <button class="btn-small" onclick="saveUserName('${escHtml(u.id)}')">Save</button>
             </div>
             <div class="user-mgmt-email">${escHtml(u.email)}</div>
           </div>
-          <span class="user-role-badge user-role-badge--${escHtml(u.role)}">${escHtml(roleLabel[u.role] || u.role)}</span>
         </div>
-        <div class="input-row user-mgmt-role-row">${roleControls}</div>
-        ${menuAccessSection}
-      </div>`;
-  }).join('');
+        <div class="admin-user-cell admin-user-cell--role">
+          <span class="user-role-badge user-role-badge--${escHtml(u.role)}">${escHtml(roleLabel[u.role] || u.role)}</span>
+          <div class="input-row user-mgmt-role-row">${roleControls}</div>
+        </div>
+        <div class="admin-user-cell admin-user-cell--access">
+          ${menuAccessSection || '<p class="admin-user-access-note">This account always has access to the current session.</p>'}
+        </div>
+        <div class="admin-user-cell admin-user-cell--status">
+          <span class="admin-user-status-pill ${statusClass}">${escHtml(statusLabel)}</span>
+        </div>
+      </article>`;
+  }).join('')}
+    </div>`;
 }
 
 function buildMenuAccessHTML(u) {
   const role = document.getElementById(`user-role-${u.id}`)?.value ?? u.role;
   if (role === 'admin') {
-    return `<p class="hint" style="margin:6px 0 0">Admin — access to all menus.</p>`;
+    return '<p class="admin-user-access-note">Admin access automatically spans all four menus.</p>';
   }
-  if (role === 'none') return '';
+  if (role === 'none') return '<p class="admin-user-access-note">Approve this account and assign menus to activate manager access.</p>';
   // role === 'manager': show checkboxes for each menu
   const menus = window._adminMenuList || [];
-  if (!menus.length) return `<p class="hint" style="margin:6px 0 0">No menus found.</p>`;
+  if (!menus.length) return '<p class="admin-user-access-note">No menus found.</p>';
   const checkboxes = menus.map(m => {
     const checked = (u.menuAccess || []).includes(m.id) ? 'checked' : '';
     return `<label class="user-menu-access-label">
@@ -4306,8 +4416,7 @@ function buildMenuAccessHTML(u) {
     </label>`;
   }).join('');
   return `<div class="user-menu-access-row">
-    <span class="config-input-label" style="margin-bottom:4px">Menu Access</span>
-    ${checkboxes}
+    <div class="user-menu-access-grid">${checkboxes}</div>
     <button class="btn-small" onclick="saveMenuAccess('${escHtml(u.id)}')">Save Access</button>
   </div>`;
 }
@@ -4330,7 +4439,7 @@ async function patchUser(payload) {
 }
 
 function updateUserRoleBadge(select, role) {
-  const badge = select.closest('.config-card')?.querySelector('.user-role-badge');
+  const badge = select.closest('.config-card, .admin-user-row')?.querySelector('.user-role-badge');
   if (!badge) return;
   const label = { none: 'No Access', manager: 'Manager', admin: 'Admin' };
   badge.className = `user-role-badge user-role-badge--${role}`;
@@ -4870,8 +4979,13 @@ function buildRestaurantRowHtml(restaurant, menus) {
   const chipsHtml = menus.map(buildMenuChipHtml).join('');
   return `
     <div class="restaurant-header">
-      <span class="restaurant-name" id="restaurant-name-${escHtml(restaurant.id)}">${escHtml(restaurant.name)}</span>
+      <div>
+        <p class="restaurant-kicker">Fixed Instance</p>
+        <span class="restaurant-name" id="restaurant-name-${escHtml(restaurant.id)}">${escHtml(restaurant.name)}</span>
+      </div>
+      <span class="restaurant-summary-pill">${escHtml(String(menus.length).padStart(2, '0'))} Menu${menus.length === 1 ? '' : 's'}</span>
     </div>
+    <p class="restaurant-copy">These menu links are read directly from the known restaurant and menu IDs the admin console expects.</p>
     <div class="restaurant-menus" id="restaurant-menus-${escHtml(restaurant.id)}">
       ${chipsHtml || '<span style="font-size:12px;color:var(--muted)">Expected menus are missing from the database.</span>'}
     </div>`;
@@ -4898,8 +5012,10 @@ async function renderMenusPanel() {
       row.innerHTML = buildRestaurantRowHtml(restaurant, menus);
       listEl.appendChild(row);
     });
+    _renderAdminOverviewMetrics();
   } catch(e) {
     listEl.innerHTML = `<p class="db-empty db-error">Failed to load restaurants: ${escHtml(String(e))}</p>`;
+    _renderAdminOverviewMetrics();
   }
 }
 

--- a/app.js
+++ b/app.js
@@ -1071,7 +1071,7 @@ async function renderAdminOverviewActivity() {
   feed.innerHTML = '<p class="db-empty">Loading recent activity...</p>';
   try {
     const res = await fetch(
-      `${SUPABASE_URL}/rest/v1/update_log?select=menu_id,user_name,diff,created_at&order=created_at.desc&limit=6`,
+      `${SUPABASE_URL}/rest/v1/update_log?select=menu_id,user_name,diff,created_at&order=created_at.desc&limit=4`,
       { headers: sbHeaders() }
     );
     if (!res.ok) throw new Error(`activity fetch: ${res.status}`);
@@ -2432,12 +2432,33 @@ function setActiveSettingsSection(sectionId) {
   });
 }
 
-function focusSettingsSection(sectionId, trigger) {
+function _getSettingsSectionHashId() {
+  const hash = window.location.hash.replace(/^#/, '').trim();
+  if (!hash || hash.includes('=')) return '';
+  return document.getElementById(hash) ? hash : '';
+}
+
+function _syncSettingsSectionFromLocation(defaultSectionId) {
+  const targetSectionId = _getSettingsSectionHashId() || defaultSectionId;
+  if (!targetSectionId) return;
+  requestAnimationFrame(() => {
+    focusSettingsSection(targetSectionId, null, { behavior: 'auto', updateUrl: false });
+  });
+}
+
+function focusSettingsSection(sectionId, trigger, options = {}) {
   const section = document.getElementById(sectionId);
   if (!section) return;
+  const behavior = options.behavior || 'smooth';
+  const shouldUpdateUrl = options.updateUrl !== false;
   if (trigger) setActiveSettingsSection(trigger.dataset.target || sectionId);
   else setActiveSettingsSection(sectionId);
-  section.scrollIntoView({ behavior: 'smooth', block: 'start' });
+  if (shouldUpdateUrl && isSettingsPage()) {
+    const url = new URL(window.location.href);
+    url.hash = sectionId;
+    history.replaceState({}, '', url.toString());
+  }
+  section.scrollIntoView({ behavior, block: 'start' });
 }
 
 // ─── AUTH OVERLAY ─────────────────────────────────────────────────────────────
@@ -2479,7 +2500,7 @@ function enterAdmin() {
   adminPanel.style.display = 'block';
   renderUserHeader();
   renderAdminWorkspace();
-  setActiveSettingsSection('admin-overview-section');
+  _syncSettingsSectionFromLocation('admin-overview-section');
 }
 
 function exitAdmin() {
@@ -2586,6 +2607,13 @@ document.addEventListener('keydown', function(e) {
     }
     if (panel) panel.hidden = true;
   });
+});
+
+window.addEventListener('hashchange', () => {
+  if (!isSettingsPage()) return;
+  const sectionId = _getSettingsSectionHashId();
+  if (!sectionId) return;
+  focusSettingsSection(sectionId, null, { behavior: 'auto', updateUrl: false });
 });
 
 // ─── KEYBOARD SHORTCUTS ──────────────────────────────────────────────────────
@@ -2997,7 +3025,7 @@ function enterManager() {
   managerPanel.style.display = 'block';
   renderUserHeader();
   renderManagerWorkspace();
-  setActiveSettingsSection('manager-overview-section');
+  _syncSettingsSectionFromLocation('manager-overview-section');
   updateDraftIndicator();
   updateSaveBtn();
   checkFeaturedConfirmation();

--- a/app.js
+++ b/app.js
@@ -1287,28 +1287,28 @@ function renderCategoriesTab() {
           <div class="catmgr-sub">${escHtml(cat.sub || '')}</div>
         </div>
         <div class="catmgr-actions">
-          <button class="btn-small" onclick="moveCategoryUp('${escHtml(cat.id)}')" ${isFirst ? 'disabled' : ''} title="Move up">↑</button>
-          <button class="btn-small" onclick="moveCategoryDown('${escHtml(cat.id)}')" ${isLast ? 'disabled' : ''} title="Move down">↓</button>
-          <button class="btn-small" onclick="toggleCategoryEdit('${escHtml(cat.id)}')">✏️</button>
-          <button class="btn-small btn-danger" onclick="deleteCategory('${escHtml(cat.id)}')">×</button>
+          <button class="btn-small" onclick="moveCategoryUp('${escHtml(cat.id)}')" ${isFirst ? 'disabled' : ''} title="Move up" aria-label="Move ${escHtml(cat.title)} up">↑</button>
+          <button class="btn-small" onclick="moveCategoryDown('${escHtml(cat.id)}')" ${isLast ? 'disabled' : ''} title="Move down" aria-label="Move ${escHtml(cat.title)} down">↓</button>
+          <button class="btn-small" onclick="toggleCategoryEdit('${escHtml(cat.id)}')" aria-label="Edit ${escHtml(cat.title)}">✏️</button>
+          <button class="btn-small btn-danger" onclick="deleteCategory('${escHtml(cat.id)}')" aria-label="Delete ${escHtml(cat.title)}">×</button>
         </div>
       </div>
       <div class="catmgr-edit" id="catmgr-edit-${escHtml(cat.id)}" style="display:none">
         <div class="catmgr-field-row">
-          <label>Icon</label>
-          <input type="text" class="catmgr-input catmgr-icon-input" id="ce-icon-${escHtml(cat.id)}" value="${escHtml(cat.icon)}" maxlength="4" placeholder="Emoji"/>
+          <label for="ce-icon-${escHtml(cat.id)}">Icon</label>
+          <input type="text" class="catmgr-input catmgr-icon-input" id="ce-icon-${escHtml(cat.id)}" name="category-icon-${escHtml(cat.id)}" value="${escHtml(cat.icon)}" maxlength="4" placeholder="Emoji…" autocomplete="off" spellcheck="false"/>
         </div>
         <div class="catmgr-field-row">
-          <label>Title</label>
-          <input type="text" class="catmgr-input" id="ce-title-${escHtml(cat.id)}" value="${escHtml(cat.title)}" placeholder="Category title"/>
+          <label for="ce-title-${escHtml(cat.id)}">Title</label>
+          <input type="text" class="catmgr-input" id="ce-title-${escHtml(cat.id)}" name="category-title-${escHtml(cat.id)}" value="${escHtml(cat.title)}" placeholder="Category title…" autocomplete="off"/>
         </div>
         <div class="catmgr-field-row">
-          <label>Subtitle</label>
-          <input type="text" class="catmgr-input" id="ce-sub-${escHtml(cat.id)}" value="${escHtml(cat.sub || '')}" placeholder="Short description"/>
+          <label for="ce-sub-${escHtml(cat.id)}">Subtitle</label>
+          <input type="text" class="catmgr-input" id="ce-sub-${escHtml(cat.id)}" name="category-subtitle-${escHtml(cat.id)}" value="${escHtml(cat.sub || '')}" placeholder="Short description…" autocomplete="off"/>
         </div>
         <div class="catmgr-field-row">
-          <label>Hint text</label>
-          <input type="text" class="catmgr-input" id="ce-ph-${escHtml(cat.id)}" value="${escHtml(cat.placeholder || '')}" placeholder="Add item input hint"/>
+          <label for="ce-ph-${escHtml(cat.id)}">Hint text</label>
+          <input type="text" class="catmgr-input" id="ce-ph-${escHtml(cat.id)}" name="category-hint-${escHtml(cat.id)}" value="${escHtml(cat.placeholder || '')}" placeholder="Add item input hint…" autocomplete="off"/>
         </div>
         <div class="catmgr-save-row">
           <button class="btn-small" onclick="toggleCategoryEdit('${escHtml(cat.id)}')">Cancel</button>
@@ -1419,7 +1419,7 @@ async function confirmAddCategory() {
   const title = document.getElementById('new-cat-title')?.value.trim();
   if (!title) { showToast('Category title is required.', 'error'); return; }
   const sub = document.getElementById('new-cat-sub')?.value.trim() || '';
-  const ph  = document.getElementById('new-cat-placeholder')?.value.trim() || `e.g. Add ${title} item...`;
+  const ph  = document.getElementById('new-cat-placeholder')?.value.trim() || `e.g. Add ${title} item…`;
   const id  = 'cat_' + Date.now().toString(36);
   const color = getNextCategoryColor();
   // _uuid is left undefined; persistState() will INSERT and capture the generated UUID
@@ -2437,6 +2437,9 @@ function focusSettingsSection(sectionId, trigger) {
   if (trigger) setActiveSettingsSection(trigger.dataset.target || sectionId);
   else setActiveSettingsSection(sectionId);
   closeSettingsDrawer();
+  const url = new URL(window.location.href);
+  url.hash = sectionId;
+  history.replaceState({}, '', url.toString());
   section.scrollIntoView({ behavior: 'smooth', block: 'start' });
 }
 
@@ -3263,7 +3266,7 @@ function renderManagerCategories() {
         <div class="current-items" id="mgr-items-${escHtml(cat.id)}"></div>
         <div class="add-item-wrap">
           <div class="add-item-area">
-            <input class="add-item-input" id="new-input-${escHtml(cat.id)}" type="text" placeholder="${escHtml(cat.placeholder || 'Add item...')}"
+            <input class="add-item-input" id="new-input-${escHtml(cat.id)}" type="text" placeholder="${escHtml(cat.placeholder || 'Add item…')}" aria-label="Add item to ${escHtml(cat.title)}" autocomplete="off"
               oninput="showAutocomplete('${escHtml(cat.id)}')"
               onblur="setTimeout(()=>hideAutocomplete('${escHtml(cat.id)}'),150)"
               onkeydown="handleAddItemKeydown(event,'${escHtml(cat.id)}')"/>
@@ -3294,7 +3297,7 @@ function renderManagerCategories() {
       <div class="current-items" id="mgr-items-${UNCATEGORIZED_ID}"></div>
       <div class="add-item-wrap">
         <div class="add-item-area">
-          <input class="add-item-input" id="new-input-${UNCATEGORIZED_ID}" type="text" placeholder="Add to pool…"
+          <input class="add-item-input" id="new-input-${UNCATEGORIZED_ID}" type="text" placeholder="Add to pool…" aria-label="Add item to uncategorized pool" autocomplete="off"
             onkeydown="if(event.key==='Enter'){event.preventDefault();addUncategorizedItem()}"/>
           <button class="add-item-btn" onclick="addUncategorizedItem()" aria-label="Add item to uncategorized pool">+</button>
         </div>
@@ -3358,14 +3361,14 @@ function buildRecipeListHtml(catId, itemId, ingredients) {
 
 function buildManagerItemEditorHtml(item, catId, itemId, ingredients) {
   return `<div class="desc-row" id="desc-row-${itemId}">
-      <textarea class="desc-input" aria-label="Item description" placeholder="Ingredients, description, how to sell it..."
+      <textarea class="desc-input" aria-label="Item description" placeholder="Ingredients, description, how to sell it…"
         onblur="saveDesc('${catId}','${itemId}',this.value)">${escHtml(item.desc || '')}</textarea>
     </div>
     <div class="recipe-row" id="recipe-row-${itemId}">
       <div class="recipe-ingredient-list" id="recipe-list-${itemId}">${buildRecipeListHtml(catId, itemId, ingredients)}</div>
       <div class="add-ingredient-area">
         <input class="add-ingredient-input" id="ingredient-input-${itemId}" type="text"
-          placeholder="Add ingredient..."
+          placeholder="Add ingredient…"
           onkeydown="handleIngredientKeydown(event,'${catId}','${itemId}')"/>
         <button class="add-ingredient-btn" onclick="addIngredient('${catId}','${itemId}')">+</button>
       </div>
@@ -3378,8 +3381,8 @@ function buildUncategorizedItemHtml(item) {
   const hasRecipe = ingredients.length > 0;
   return `<div class="current-item">
       <div class="item-name"><span class="item-name-static">${escHtml(item.name)}</span></div>
-      <button class="desc-btn${hasDesc ? ' has-desc' : ''}" title="Edit description" onclick="toggleItemDesc('${item.id}')">📝</button>
-      <button class="recipe-btn${hasRecipe ? ' has-recipe' : ''}" title="Add recipe" onclick="toggleItemRecipe('${item.id}')">🧪</button>
+      <button class="desc-btn${hasDesc ? ' has-desc' : ''}" title="Edit description" aria-label="Edit description for ${escHtml(item.name)}" onclick="toggleItemDesc('${item.id}')">📝</button>
+      <button class="recipe-btn${hasRecipe ? ' has-recipe' : ''}" title="Add recipe" aria-label="Edit recipe for ${escHtml(item.name)}" onclick="toggleItemRecipe('${item.id}')">🧪</button>
     </div>
     ${buildManagerItemEditorHtml(item, UNCATEGORIZED_ID, item.id, ingredients)}`;
 }
@@ -3393,11 +3396,11 @@ function buildManagerItemHtml(item, catId, lastSentNames) {
   const statusTitle = is86 ? "86'd" : isNew ? 'New — not yet announced' : 'On menu';
   const rowClass = ['current-item', isNew ? 'is-new' : '', is86 ? 'is-eighty-sixed' : '', item.visibility === 'off_menu' ? 'is-off-menu' : ''].filter(Boolean).join(' ');
   return `<div class="${rowClass}">
-      <span class="item-drag-handle" draggable="true"
+      <button class="item-drag-handle" type="button" draggable="true"
         ondragstart="startManagerItemDrag(event,'${catId}','${item.id}')"
         ondragend="endManagerItemDrag(event)"
         title="Drag to reorder"
-        aria-hidden="true">⋮⋮</span>
+        aria-label="Drag to reorder ${escHtml(item.name)}">⋮⋮</button>
       <div class="item-status-dot" role="img" aria-label="${statusTitle}" title="${statusTitle}"></div>
       <div class="item-name"><input type="text" value="${escHtml(item.name)}"
         aria-label="Item name"
@@ -3406,11 +3409,11 @@ function buildManagerItemHtml(item, catId, lastSentNames) {
       <input class="price-input" type="text" placeholder="Price…" aria-label="Price"
         onblur="savePrice('${catId}','${item.id}',this.value)"
         value="${escHtml(item.price||'')}"/>
-      <button class="desc-btn${hasDesc ? ' has-desc' : ''}" title="Add description" onclick="toggleItemDesc('${item.id}')">📝</button>
-      <button class="recipe-btn${hasRecipe ? ' has-recipe' : ''}" title="Add recipe" onclick="toggleItemRecipe('${item.id}')"
+      <button class="desc-btn${hasDesc ? ' has-desc' : ''}" title="Add description" aria-label="Edit description for ${escHtml(item.name)}" onclick="toggleItemDesc('${item.id}')">📝</button>
+      <button class="recipe-btn${hasRecipe ? ' has-recipe' : ''}" title="Add recipe" aria-label="Edit recipe for ${escHtml(item.name)}" onclick="toggleItemRecipe('${item.id}')"
         style="${MENU_TYPE === 'food' ? 'display:none' : ''}">🧪</button>
-      <button class="eighty-six-btn${is86 ? ' restore' : ''}" title="${is86 ? 'Restore to menu' : "86 this item"}" onclick="toggle86('${catId}','${item.id}')">${is86 ? '↩' : '86'}</button>
-      <button class="visibility-btn${item.visibility === 'off_menu' ? ' is-off-menu' : ''}" title="${item.visibility === 'off_menu' ? 'Make public' : 'Move off menu'}" onclick="toggleVisibility('${catId}','${item.id}')">${item.visibility === 'off_menu' ? '👁‍🗨' : '👁'}</button>
+      <button class="eighty-six-btn${is86 ? ' restore' : ''}" title="${is86 ? 'Restore to menu' : "86 this item"}" aria-label="${is86 ? `Restore ${escHtml(item.name)}` : `Mark ${escHtml(item.name)} 86'd`}" onclick="toggle86('${catId}','${item.id}')">${is86 ? '↩' : '86'}</button>
+      <button class="visibility-btn${item.visibility === 'off_menu' ? ' is-off-menu' : ''}" title="${item.visibility === 'off_menu' ? 'Make public' : 'Move off menu'}" aria-label="${item.visibility === 'off_menu' ? `Make ${escHtml(item.name)} public` : `Move ${escHtml(item.name)} off menu`}" onclick="toggleVisibility('${catId}','${item.id}')">${item.visibility === 'off_menu' ? '👁‍🗨' : '👁'}</button>
       <button class="del-item" onclick="removeItem('${catId}','${item.id}')" aria-label="Remove ${escHtml(item.name)}">×</button>
     </div>
     ${buildManagerItemEditorHtml(item, catId, item.id, ingredients)}`;
@@ -3992,10 +3995,10 @@ function updateDraftIndicator() {
   const diff = getCachedDiff();
   const total = diff.reduce((n, s) => n + s.added.length + s.removed.length + s.eightySixed.length + s.restored.length, 0);
   if (total > 0) {
-    btn.innerHTML = `🔥 SEND UPDATE <span class="send-update-count">(${total} CHANGE${total > 1 ? 'S' : ''})</span>`;
+    btn.innerHTML = `Send Update <span class="send-update-count">(${total} Change${total > 1 ? 's' : ''})</span>`;
     btn.style.boxShadow = '0 4px 22px rgba(255,77,0,0.55)';
   } else {
-    btn.innerHTML = '🔥 SEND UPDATE';
+    btn.innerHTML = 'Send Update';
     btn.style.boxShadow = '';
   }
   renderManagerOverviewStats();
@@ -4201,7 +4204,7 @@ async function sendUpdate() {
 
   const confirmBtn = document.getElementById('confirm-btn');
   confirmBtn.disabled = true;
-  confirmBtn.textContent = 'SENDING...';
+  confirmBtn.textContent = 'SENDING…';
 
   try {
     const authHeaders = currentUser?.accessToken
@@ -4302,7 +4305,7 @@ document.getElementById('prune-items-wrap')?.addEventListener('click', e => {
 async function loadUsers() {
   const wrap = document.getElementById('users-list');
   if (!wrap) return;
-  wrap.innerHTML = '<div class="db-empty">Loading...</div>';
+  wrap.innerHTML = '<div class="db-empty">Loading…</div>';
   try {
     // Fetch menus list for menu access checkboxes
     if (SUPABASE_URL) {
@@ -4348,21 +4351,24 @@ function buildHistoryDetailHtml(diff) {
 }
 
 function buildChangeFeedHtml(logs) {
+  const locale = navigator.languages?.[0] || navigator.language || undefined;
+  const dateFormatter = new Intl.DateTimeFormat(locale, { month: 'short', day: 'numeric', year: 'numeric' });
+  const timeFormatter = new Intl.DateTimeFormat(locale, { hour: 'numeric', minute: '2-digit' });
   return logs.map(log => {
     const d = new Date(log.created_at);
-    const dateStr = d.toLocaleDateString('en-US', { month: 'short', day: 'numeric', year: 'numeric' });
-    const timeStr = d.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
+    const dateStr = dateFormatter.format(d);
+    const timeStr = timeFormatter.format(d);
     const diff = log.diff || [];
     const summary = summarizeHistoryDiff(diff);
     const detailHtml = buildHistoryDetailHtml(diff);
 
     return `<div class="history-entry">
-      <div class="history-header" onclick="this.parentElement.classList.toggle('expanded')">
+      <button class="history-header" type="button" aria-expanded="false" onclick="this.parentElement.classList.toggle('expanded'); this.setAttribute('aria-expanded', this.parentElement.classList.contains('expanded') ? 'true' : 'false');">
         <span class="history-date">${escHtml(dateStr)} ${escHtml(timeStr)}</span>
         <span class="history-user">${escHtml(log.user_name || 'Unknown')}</span>
         <span class="history-summary">${escHtml(summary)}</span>
         <span class="history-chevron">\u203A</span>
-      </div>
+      </button>
       <div class="history-detail">${detailHtml}</div>
     </div>`;
   }).join('');
@@ -4582,9 +4588,9 @@ function renderFeaturedTab() {
         <input class="featured-sell-note-input" type="text" placeholder="Sell note (staff only)…"
           value="${escHtml(slot.sellNote)}"
           onblur="saveFeaturedSellNote(${escAttrJs(slot.id)},this.value)"/>
-        <button class="btn-small" onclick="moveFeaturedSlot(${escAttrJs(group.id)},${escAttrJs(slot.id)},-1)" ${idx === 0 ? 'disabled' : ''}>&#8593;</button>
-        <button class="btn-small" onclick="moveFeaturedSlot(${escAttrJs(group.id)},${escAttrJs(slot.id)},1)" ${idx === slotCount - 1 ? 'disabled' : ''}>&#8595;</button>
-        <button class="btn-small btn-danger" onclick="removeFeaturedSlot(${escAttrJs(slot.id)},${escAttrJs(group.id)})">&#215;</button>
+        <button class="btn-small" onclick="moveFeaturedSlot(${escAttrJs(group.id)},${escAttrJs(slot.id)},-1)" ${idx === 0 ? 'disabled' : ''} aria-label="Move ${escHtml(slot.item?.name || 'featured item')} up">&#8593;</button>
+        <button class="btn-small" onclick="moveFeaturedSlot(${escAttrJs(group.id)},${escAttrJs(slot.id)},1)" ${idx === slotCount - 1 ? 'disabled' : ''} aria-label="Move ${escHtml(slot.item?.name || 'featured item')} down">&#8595;</button>
+        <button class="btn-small btn-danger" onclick="removeFeaturedSlot(${escAttrJs(slot.id)},${escAttrJs(group.id)})" aria-label="Remove ${escHtml(slot.item?.name || 'featured item')} from featured">&#215;</button>
       </div>`).join('');
 
     return `<div class="featured-mgr-group">
@@ -4929,13 +4935,13 @@ function filterDatabaseRows(rows, query) {
 function buildDatabaseTableHtml(rows) {
   return `
     <table class="db-table">
-      <thead><tr><th>Drink</th><th>Category</th><th>Recipe</th><th>Status</th></tr></thead>
+      <thead><tr><th>Item</th><th>Category</th><th>Recipe</th><th>Status</th></tr></thead>
       <tbody>${rows.map(r => `
         <tr>
-          <td class="db-name">${escHtml(r.name)}</td>
-          <td class="db-cat">${escHtml(r.category)}</td>
-          <td class="db-recipe">${r.recipe.length ? r.recipe.map(ing => `<span class="db-ing">${escHtml(ing)}</span>`).join('') : '<span class="db-no-recipe">—</span>'}</td>
-          <td>${r.eightySixed ? '<span class="db-badge db-badge--86">86\'d</span>' : r.onMenu ? '<span class="db-badge db-badge--on">On Menu</span>' : '<span class="db-badge db-badge--off">Off Menu</span>'}</td>
+          <td class="db-name" data-label="Item">${escHtml(r.name)}</td>
+          <td class="db-cat" data-label="Category">${escHtml(r.category)}</td>
+          <td class="db-recipe" data-label="Recipe">${r.recipe.length ? r.recipe.map(ing => `<span class="db-ing">${escHtml(ing)}</span>`).join('') : '<span class="db-no-recipe">—</span>'}</td>
+          <td data-label="Status">${r.eightySixed ? '<span class="db-badge db-badge--86">86\'d</span>' : r.onMenu ? '<span class="db-badge db-badge--on">On Menu</span>' : '<span class="db-badge db-badge--off">Off Menu</span>'}</td>
         </tr>`).join('')}
       </tbody>
     </table>`;

--- a/app.js
+++ b/app.js
@@ -65,6 +65,7 @@ let _settingsRedirectCleanup = null;
 let _featuredGroups     = []; // [{id, name, displayOrder, slots: [{id, itemId, sellNote, displayOrder, confirmedAt, confirmedBy, item: {…}}]}]
 let _lastSentFeaturedIds = new Set(); // item IDs that were featured at last Send Update
 let _featuredMenuGroups = []; // [{menu_id, featured_group_id, display_order}]
+let _menuMetaSupportsLastSentFeatured = null;
 
 // ─── CATEGORY DEFINITIONS ────────────────────────────────────────────────────
 const ICON_COLOR_PALETTE = [
@@ -156,9 +157,15 @@ function escHtml(s) { return String(s).replace(/&/g,'&amp;').replace(/"/g,'&quot
 // Escape a string for safe embedding inside an inline JS string within an HTML attribute.
 // Uses JSON.stringify (which handles quotes/backslashes) then HTML-escapes the result.
 function escAttrJs(s) { return escHtml(JSON.stringify(String(s))); }
-function lsSet(key, val) {
-  try { localStorage.setItem(key, val); }
-  catch(e) { showToast('⚠️ Storage full — data not saved locally.', 'error'); }
+function lsSet(key, val, options = {}) {
+  const { silent = false } = options;
+  try {
+    localStorage.setItem(key, val);
+    return true;
+  } catch(e) {
+    if (!silent) showToast('⚠️ Storage full — data not saved locally.', 'error');
+    return false;
+  }
 }
 function findItem(catId, itemId) {
   return menuState[catId]?.items.find(i => i.id === itemId) ?? null;
@@ -702,6 +709,7 @@ function hydrateState({ cats, meta, restaurant }) {
       lastSentTs:         meta.last_sent_ts?.toString()     || '',
       lastSentCategories: meta.last_sent_categories         || [],
     };
+    _menuMetaSupportsLastSentFeatured = Object.prototype.hasOwnProperty.call(meta, 'last_sent_featured');
     if (meta.bot_id) BOT_ID = meta.bot_id;
     if (meta.notifications) NOTIFICATIONS = meta.notifications;
     if (meta.last_updated_ts) lsSet(LS_KEYS.lastUpdated, meta.last_updated_ts.toString());
@@ -775,7 +783,119 @@ async function sbPatchMenuMeta(update) {
     headers: sbHeaders({ 'Prefer': 'return=minimal' }),
     body:    JSON.stringify(update),
   });
-  if (!r.ok) throw new Error(`menu_meta patch: ${r.status}`);
+  if (!r.ok) {
+    let detail = '';
+    try { detail = (await r.text()).trim(); } catch (_) { /* ignore */ }
+    throw new Error(detail ? `menu_meta patch: ${r.status} ${detail}` : `menu_meta patch: ${r.status}`);
+  }
+}
+
+function snapshotCurrentItemsAsLastSent() {
+  const lastSentState = {};
+  CATEGORY_DEFS.forEach(cat => {
+    lastSentState[cat.id] = (menuState[cat.id]?.items || []).map(item => ({ ...item }));
+  });
+  return lastSentState;
+}
+
+function buildMenuCacheSnapshot() {
+  const cats = CATEGORY_DEFS.map((cat, index) => ({
+    id: cat._uuid || `local-${cat.id}`,
+    key: cat.id,
+    label: cat.title,
+    icon: cat.icon || '',
+    color: cat.color || '',
+    sub: cat.sub || '',
+    placeholder: cat.placeholder || '',
+    display_order: index,
+    items: (menuState[cat.id]?.items || []).map((item, itemIndex) => ({
+      id: item.id,
+      name: item.name,
+      desc: item.desc || '',
+      recipe: Array.isArray(item.recipe) ? item.recipe : recipeArray(item.recipe),
+      price: item.price || '',
+      is_eighty_sixed: !!item.eightySixed,
+      on_menu: item.onMenu !== false,
+      visibility: item.visibility || 'public',
+      display_order: itemIndex,
+    })),
+  }));
+  const uncategorizedItems = menuState[UNCATEGORIZED_ID]?.items || [];
+  if (uncategorizedItems.length || _uncatCategoryUuid) {
+    cats.push({
+      id: _uncatCategoryUuid || `local-${UNCATEGORIZED_ID}`,
+      key: UNCATEGORIZED_ID,
+      label: 'Uncategorized',
+      icon: '',
+      color: '',
+      sub: '',
+      placeholder: '',
+      display_order: 9999,
+      items: uncategorizedItems.map((item, itemIndex) => ({
+        id: item.id,
+        name: item.name,
+        desc: item.desc || '',
+        recipe: Array.isArray(item.recipe) ? item.recipe : recipeArray(item.recipe),
+        price: item.price || '',
+        is_eighty_sixed: !!item.eightySixed,
+        on_menu: false,
+        visibility: item.visibility || 'public',
+        display_order: itemIndex,
+      })),
+    });
+  }
+  const meta = {
+    bot_id: BOT_ID || '',
+    notifications: NOTIFICATIONS || {},
+    last_updated_ts: menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null,
+    last_sent_ts: menuState._meta?.lastSentTs ? Number(menuState._meta.lastSentTs) : null,
+    last_sent_state: snapshotLastSentState(),
+    last_sent_categories: menuState._meta?.lastSentCategories || [],
+  };
+  if (_menuMetaSupportsLastSentFeatured !== false) {
+    meta.last_sent_featured = Array.from(_lastSentFeaturedIds);
+  }
+  const restaurant = isValidRestaurant(RESTAURANT_ID)
+    ? {
+        id: RESTAURANT_ID,
+        name: _activeRestaurantName || getRestaurantById(RESTAURANT_ID)?.name || '',
+        design: currentDesign,
+        use_custom_design: _restaurantCustomDesignEnabled,
+      }
+    : null;
+  return { cats, meta, restaurant };
+}
+
+function syncLocalMenuCache(options = {}) {
+  return lsSet(LS_KEYS.menuCache, JSON.stringify(buildMenuCacheSnapshot()), options);
+}
+
+function isMissingColumnError(error, columnName) {
+  const message = `${error?.message || error || ''}`.toLowerCase();
+  return message.includes(columnName.toLowerCase()) &&
+    (message.includes('column') || message.includes('schema cache'));
+}
+
+async function patchMenuMetaWithCompatibility(update) {
+  const payload = { ...update };
+  if (_menuMetaSupportsLastSentFeatured === false) {
+    delete payload.last_sent_featured;
+  }
+  try {
+    await sbPatchMenuMeta(payload);
+    if (Object.prototype.hasOwnProperty.call(payload, 'last_sent_featured')) {
+      _menuMetaSupportsLastSentFeatured = true;
+    }
+    return { downgradedFields: [] };
+  } catch (error) {
+    if (Object.prototype.hasOwnProperty.call(payload, 'last_sent_featured') && isMissingColumnError(error, 'last_sent_featured')) {
+      const { last_sent_featured, ...fallbackPayload } = payload;
+      await sbPatchMenuMeta(fallbackPayload);
+      _menuMetaSupportsLastSentFeatured = false;
+      return { downgradedFields: ['last_sent_featured'] };
+    }
+    throw error;
+  }
 }
 
 async function sbPatchRestaurantDesign(design) {
@@ -3643,12 +3763,13 @@ async function saveMenu() {
   try {
     const persisted = await persistState();
     if (!persisted) return;
-    await sbPatchMenuMeta({ last_updated_ts: ts });
+    await patchMenuMetaWithCompatibility({ last_updated_ts: ts });
     menuState._meta = { ...(menuState._meta || {}), lastUpdatedTs: ts.toString() };
     lsSet(LS_KEYS.lastUpdated, ts.toString());
     _dirty = false;
     updateSaveBtn();
     updateLastUpdatedLabel();
+    syncLocalMenuCache({ silent: true });
     showToast('✅ Menu saved!', 'success');
   } catch(e) {
     finalizePersistStatus(false);
@@ -4221,29 +4342,37 @@ async function sendUpdate() {
       const ts = Date.now();
       closeModal();
       try {
-        applySentState(diff, ts);
         const persisted = await persistState();
         if (!persisted) throw new Error('persist failed');
-        const lastSentState = snapshotLastSentState();
+        const lastSentState = snapshotCurrentItemsAsLastSent();
         const currentFeaturedIds = getCurrentFeaturedIds();
-        _lastSentFeaturedIds = new Set(currentFeaturedIds);
-        await sbPatchMenuMeta({
+        const compat = await patchMenuMetaWithCompatibility({
           last_updated_ts:      ts,
           last_sent_ts:         ts,
           last_sent_state:      lastSentState,
           last_sent_categories: diff.map(d => d.id),
           last_sent_featured:   currentFeaturedIds,
         });
+        if (compat.downgradedFields.length) {
+          console.warn('sendUpdate metadata compatibility fallback:', compat.downgradedFields.join(', '));
+        }
+        _lastSentFeaturedIds = new Set(currentFeaturedIds);
+        applySentState(diff, ts);
         _dirty = false;
         updateSaveBtn();
         updateLastUpdatedLabel();
         renderManagerWorkspace({ includeRecentChanges: false });
         updateDraftIndicator();
-        await logUpdate(diff, patchMessage);
+        const cacheSynced = syncLocalMenuCache({ silent: true });
+        if (!cacheSynced) {
+          showToast('⚠️ Update sent, but this device could not refresh its local cache.', 'warning');
+        }
+        const logged = await logUpdate(diff, patchMessage);
+        if (!logged) console.warn('sendUpdate audit log insert failed');
         renderRecentChanges();
       } catch (syncError) {
         console.warn('sendUpdate post-send sync failed:', syncError);
-        showToast('⚠️  Update sent but local cache failed to sync', 'warning');
+        showToast('⚠️ Update sent, but database sync needs attention. Refresh before sending again.', 'warning');
       }
     } else if (r1.status === 401) {
       showToast('❌ Not authorized. Please sign in.', 'error');

--- a/manager/index.html
+++ b/manager/index.html
@@ -24,7 +24,7 @@
   <header>
     <img class="hf-logo" src="" alt="Logo" style="display:none"/>
     <span class="logo-mark" style="display:none"></span>
-    <h1>CURRENT MENU</h1>
+    <h1>MANAGER WORKSPACE</h1>
     <div class="header-sub" id="last-updated-label">Last Updated: —</div>
     <div class="header-action-group">
       <button class="manager-btn" id="action-btn" onclick="onActionBtnClick()" style="display:none">⚙ Manager</button>
@@ -50,13 +50,11 @@
     </div>
   </header>
 
-  <!-- LOADING -->
   <div id="loading-view">
     <div class="spinner"></div>
-    <p>Loading menu...</p>
+    <p>Loading manager workspace...</p>
   </div>
 
-  <!-- PUBLIC VIEW -->
   <div id="public-view" style="display:none;">
     <div id="restaurant-site-wrapper" hidden></div>
     <div id="public-default-shell">
@@ -74,293 +72,173 @@
     </div>
   </div>
 
-  <!-- MANAGER VIEW -->
   <div id="manager-view">
-    <div id="setup-banner">
-      <h3>⚙️ One-Time Setup</h3>
-      <p>Click <strong style="color:var(--ember)">⚙ Admin</strong> in the header to configure notification channels. Everything syncs to the cloud from this point on.</p>
+    <div class="settings-workspace settings-workspace--manager">
+      <aside class="settings-rail" aria-label="Manager workspace sections">
+        <p class="settings-rail-kicker">Manager</p>
+        <button class="settings-rail-btn active" type="button" data-target="manager-overview-section" onclick="focusSettingsSection('manager-overview-section', this)">Overview</button>
+        <button class="settings-rail-btn" type="button" data-target="manager-edit-section" onclick="focusSettingsSection('manager-edit-section', this)">Edit Menu</button>
+        <button class="settings-rail-btn" type="button" data-target="manager-recent-section" onclick="focusSettingsSection('manager-recent-section', this)">Recent Changes</button>
+        <button class="settings-rail-btn" type="button" data-target="manager-categories-section" onclick="focusSettingsSection('manager-categories-section', this)">Categories</button>
+        <button class="settings-rail-btn" type="button" data-target="manager-database-section" onclick="focusSettingsSection('manager-database-section', this)">Database</button>
+      </aside>
+
+      <div class="settings-stage">
+        <section class="settings-hero settings-hero--manager" id="manager-overview-section">
+          <div class="settings-hero-copy">
+            <p class="settings-kicker">Live Service</p>
+            <h2>Run tonight's menu with confidence.</h2>
+            <p>Save quietly while you work, then use Send Update only when you are ready to notify staff and refresh the public timestamp.</p>
+          </div>
+
+          <div id="setup-banner">
+            <h3>⚙ One-Time Setup</h3>
+            <p>Click <strong style="color:var(--ember)">⚙ Admin</strong> in the header to configure notification channels. Everything syncs to the cloud from this point on.</p>
+          </div>
+
+          <div id="active-menu-bar" style="display:none;" aria-live="polite">
+            <span class="active-menu-label">MENU</span>
+            <span id="active-menu-name" class="active-menu-name-text"></span>
+            <button class="btn-small" id="switch-menu-btn" onclick="onSwitchMenuClick()" style="display:none" aria-label="Switch to a different menu">⇄ Switch</button>
+          </div>
+
+          <div id="featured-confirm-banner" class="featured-confirm-banner" style="display:none;">
+            <span>Today's featured items haven't been confirmed yet.</span>
+            <button class="btn-small" onclick="confirmFeaturedToday()">Keep Today's Featured</button>
+            <button class="btn-small" onclick="editFeaturedFromBanner()">Update Featured</button>
+          </div>
+        </section>
+
+        <div id="manager-panel" class="settings-panel" style="display:none">
+          <section class="settings-section settings-section--primary" id="manager-edit-section">
+            <div class="settings-section-head">
+              <div>
+                <p class="settings-section-kicker">Shift Control</p>
+                <h3>Edit Menu</h3>
+              </div>
+              <p class="settings-section-copy">Featured slots and live menu edits stay together here so the change you send matches the board your staff is staring at.</p>
+            </div>
+
+            <div class="workspace-actions workspace-actions--sticky">
+              <div class="workspace-actions-copy">
+                <p class="workspace-actions-title">Publishing</p>
+                <p class="workspace-actions-sub">Save is silent. Send Update previews unsent changes before anything goes out.</p>
+              </div>
+              <div class="btn-row workspace-btn-row">
+                <button class="save-btn" id="save-btn" onclick="saveMenu()">💾 SAVE</button>
+                <button class="send-btn" id="send-btn" onclick="openPreview()">🔥 SEND UPDATE</button>
+              </div>
+              <div id="sync-status"></div>
+            </div>
+
+            <div id="featured-mgr-wrap"></div>
+            <div id="manager-categories"></div>
+
+            <div id="off-menu-section" class="prune-section" style="display:none;">
+              <div class="prune-section-header">
+                <div class="section-label prune-section-label">Off Menu Items</div>
+              </div>
+              <p class="hint">Staff-only items hidden from the public menu. Visible to managers and admins.</p>
+              <div id="off-menu-items-wrap"></div>
+            </div>
+          </section>
+
+          <section class="settings-section" id="manager-recent-section">
+            <div class="settings-section-head">
+              <div>
+                <p class="settings-section-kicker">Last 7 Days</p>
+                <h3>Recent Changes</h3>
+              </div>
+              <p class="settings-section-copy">This feed shows sent updates for the active menu only. Draft edits still live in the Send Update preview.</p>
+            </div>
+            <div id="recent-changes-wrap"></div>
+          </section>
+
+          <section class="settings-section" id="manager-categories-section">
+            <div class="settings-section-head">
+              <div>
+                <p class="settings-section-kicker">Structure</p>
+                <h3>Category Tools</h3>
+              </div>
+              <p class="settings-section-copy">Reorder, rename, and add categories without leaving the manager workspace.</p>
+            </div>
+
+            <div class="active-menu-context" id="categories-menu-context"></div>
+            <div id="catmgr-list"></div>
+            <div class="catmgr-add-form" id="catmgr-add-form" style="display:none">
+              <h3>New Category</h3>
+              <div class="catmgr-field-row">
+                <label>Icon</label>
+                <input type="text" id="new-cat-icon" class="catmgr-input catmgr-icon-input" value="🍸" maxlength="4" placeholder="Emoji"/>
+              </div>
+              <div class="catmgr-field-row">
+                <label>Title</label>
+                <input type="text" id="new-cat-title" class="catmgr-input" placeholder="Category name (required)"/>
+              </div>
+              <div class="catmgr-field-row">
+                <label>Subtitle</label>
+                <input type="text" id="new-cat-sub" class="catmgr-input" placeholder="Short description (optional)"/>
+              </div>
+              <div class="catmgr-field-row">
+                <label>Hint text</label>
+                <input type="text" id="new-cat-placeholder" class="catmgr-input" placeholder="Add item input hint (optional)"/>
+              </div>
+              <div class="catmgr-add-btn-row">
+                <button class="btn-small" onclick="confirmAddCategory()">Add Category</button>
+                <button class="btn-small" onclick="document.getElementById('catmgr-add-form').style.display='none'">Cancel</button>
+              </div>
+            </div>
+            <button class="btn-small" id="show-add-cat-btn" onclick="toggleAddCategoryForm()">+ Add Category</button>
+          </section>
+
+          <section class="settings-section" id="manager-database-section">
+            <div class="settings-section-head">
+              <div>
+                <p class="settings-section-kicker">Maintenance</p>
+                <h3>Recipe Database</h3>
+              </div>
+              <p class="settings-section-copy">Search active and off-menu items, then prune hidden inventory when you need to clean up autocomplete noise.</p>
+            </div>
+
+            <div class="db-search-row">
+              <input type="text" id="db-search" placeholder="Search drinks or ingredients…" oninput="filterDatabase()" />
+            </div>
+            <div class="db-filter-row">
+              <span class="db-filter-label">Recipe:</span>
+              <div class="db-filter-group" id="db-filter-recipe">
+                <button class="db-filter-btn active" data-value="all" onclick="setDbFilter('recipe','all')">All</button>
+                <button class="db-filter-btn" data-value="yes" onclick="setDbFilter('recipe','yes')">With Recipe</button>
+                <button class="db-filter-btn" data-value="no" onclick="setDbFilter('recipe','no')">No Recipe</button>
+              </div>
+              <span class="db-filter-label">Status:</span>
+              <div class="db-filter-group" id="db-filter-status">
+                <button class="db-filter-btn active" data-value="all" onclick="setDbFilter('status','all')">All</button>
+                <button class="db-filter-btn" data-value="on" onclick="setDbFilter('status','on')">On Menu</button>
+                <button class="db-filter-btn" data-value="off" onclick="setDbFilter('status','off')">Off Menu</button>
+              </div>
+            </div>
+            <div id="db-table-wrap"></div>
+            <div id="prune-section" class="prune-section" style="display:none;">
+              <div class="prune-section-header">
+                <div class="section-label prune-section-label">Prune Database</div>
+                <button id="prune-all-btn" class="btn-small btn-danger">Clear All</button>
+              </div>
+              <p class="hint">Permanently removes off-menu items from Supabase. Live menu items are unaffected.</p>
+              <div id="prune-items-wrap"></div>
+            </div>
+          </section>
+        </div>
+
+        <button class="logout-link" onclick="exitView()">← Back to menu view</button>
+      </div>
     </div>
-
-    <!-- ACTIVE MENU BAR -->
-    <div id="active-menu-bar" style="display:none;" aria-live="polite">
-      <span class="active-menu-label">MENU</span>
-      <span id="active-menu-name" class="active-menu-name-text"></span>
-      <button class="btn-small" id="switch-menu-btn" onclick="onSwitchMenuClick()" style="display:none" aria-label="Switch to a different menu">⇄ Switch</button>
-    </div>
-
-    <div id="featured-confirm-banner" class="featured-confirm-banner" style="display:none;">
-      <span>Today's featured items haven't been confirmed yet.</span>
-      <button class="btn-small" onclick="confirmFeaturedToday()">Keep Today's Featured</button>
-      <button class="btn-small" onclick="editFeaturedFromBanner()">Update Featured</button>
-    </div>
-
-    <!-- MANAGER PANEL: Edit Menu, Categories, Database -->
-    <div id="manager-panel" style="display:none">
-      <div class="tab-bar" role="tablist" id="manager-tab-bar">
-        <button class="tab-btn active" id="tab-btn-edit-menu"  role="tab" aria-selected="true"  aria-controls="tab-panel-edit-menu"  onclick="switchManagerTab('edit-menu')">MANAGER</button>
-        <button class="tab-btn"        id="tab-btn-categories" role="tab" aria-selected="false" aria-controls="tab-panel-categories" onclick="switchManagerTab('categories')">CATEGORIES</button>
-        <button class="tab-btn"        id="tab-btn-database"   role="tab" aria-selected="false" aria-controls="tab-panel-database"   onclick="switchManagerTab('database')">DATABASE</button>
-      </div>
-
-      <!-- EDIT MENU TAB -->
-      <div class="tab-panel active" id="tab-panel-edit-menu" role="tabpanel" aria-labelledby="tab-btn-edit-menu">
-        <div class="section-label">Edit Menu</div>
-        <div id="featured-mgr-wrap"></div>
-        <div id="manager-categories"></div>
-        <div class="btn-row">
-          <button class="save-btn" id="save-btn" onclick="saveMenu()">💾 SAVE</button>
-          <button class="send-btn" id="send-btn" onclick="openPreview()">🔥 SEND UPDATE</button>
-        </div>
-        <div id="sync-status"></div>
-        <div id="off-menu-section" class="prune-section" style="display:none;">
-          <div class="prune-section-header">
-            <div class="section-label prune-section-label">Off Menu Items</div>
-          </div>
-          <p class="hint">Staff-only items hidden from the public menu. Visible to managers and admins.</p>
-          <div id="off-menu-items-wrap"></div>
-        </div>
-      </div>
-
-      <!-- CATEGORIES TAB -->
-      <div class="tab-panel" id="tab-panel-categories" role="tabpanel" aria-labelledby="tab-btn-categories">
-        <div class="section-label">Menu Categories</div>
-        <div class="active-menu-context" id="categories-menu-context"></div>
-        <div id="catmgr-list"></div>
-        <div class="catmgr-add-form" id="catmgr-add-form" style="display:none">
-          <h3>New Category</h3>
-          <div class="catmgr-field-row">
-            <label>Icon</label>
-            <input type="text" id="new-cat-icon" class="catmgr-input catmgr-icon-input" value="🍸" maxlength="4" placeholder="Emoji"/>
-          </div>
-          <div class="catmgr-field-row">
-            <label>Title</label>
-            <input type="text" id="new-cat-title" class="catmgr-input" placeholder="Category name (required)"/>
-          </div>
-          <div class="catmgr-field-row">
-            <label>Subtitle</label>
-            <input type="text" id="new-cat-sub" class="catmgr-input" placeholder="Short description (optional)"/>
-          </div>
-          <div class="catmgr-field-row">
-            <label>Hint text</label>
-            <input type="text" id="new-cat-placeholder" class="catmgr-input" placeholder="Add item input hint (optional)"/>
-          </div>
-          <div class="catmgr-add-btn-row">
-            <button class="btn-small" onclick="confirmAddCategory()">Add Category</button>
-            <button class="btn-small" onclick="document.getElementById('catmgr-add-form').style.display='none'">Cancel</button>
-          </div>
-        </div>
-        <button class="btn-small" id="show-add-cat-btn" onclick="toggleAddCategoryForm()" style="margin-top:4px">+ Add Category</button>
-      </div>
-
-      <!-- DATABASE TAB -->
-      <div class="tab-panel" id="tab-panel-database" role="tabpanel" aria-labelledby="tab-btn-database">
-        <div class="section-label">Recipe Database</div>
-        <div class="db-search-row">
-          <input type="text" id="db-search" placeholder="Search drinks or ingredients…" oninput="filterDatabase()" />
-        </div>
-        <div class="db-filter-row">
-          <span class="db-filter-label">Recipe:</span>
-          <div class="db-filter-group" id="db-filter-recipe">
-            <button class="db-filter-btn active" data-value="all"  onclick="setDbFilter('recipe','all')">All</button>
-            <button class="db-filter-btn"        data-value="yes"  onclick="setDbFilter('recipe','yes')">With Recipe</button>
-            <button class="db-filter-btn"        data-value="no"   onclick="setDbFilter('recipe','no')">No Recipe</button>
-          </div>
-          <span class="db-filter-label">Status:</span>
-          <div class="db-filter-group" id="db-filter-status">
-            <button class="db-filter-btn active" data-value="all"  onclick="setDbFilter('status','all')">All</button>
-            <button class="db-filter-btn"        data-value="on"   onclick="setDbFilter('status','on')">On Menu</button>
-            <button class="db-filter-btn"        data-value="off"  onclick="setDbFilter('status','off')">Off Menu</button>
-          </div>
-        </div>
-        <div id="db-table-wrap"></div>
-        <div id="prune-section" class="prune-section" style="display:none;">
-          <div class="prune-section-header">
-            <div class="section-label prune-section-label">Prune Database</div>
-            <button id="prune-all-btn" class="btn-small btn-danger">Clear All</button>
-          </div>
-          <p class="hint">Permanently removes off-menu items from Supabase (autocomplete trash). Live menu items are unaffected.</p>
-          <div id="prune-items-wrap"></div>
-        </div>
-      </div>
-
-    </div><!-- /manager-panel -->
-
-    <!-- ADMIN PANEL: Restaurants, Notifications, Design, Users -->
-    <div id="admin-panel" style="display:none">
-      <div id="admin-status-bar" class="admin-status-bar">
-        <span id="admin-supabase-status" class="db-status">Checking…</span>
-        <button class="btn-small btn-tiny" onclick="checkAdminSupabaseStatus()">↺</button>
-      </div>
-      <div class="tab-bar" role="tablist" id="admin-tab-bar">
-        <button class="tab-btn active" id="tab-btn-admin-restaurants"   role="tab" aria-selected="true"  aria-controls="tab-panel-admin-restaurants"   onclick="switchAdminTab('admin-restaurants')">RESTAURANTS</button>
-        <button class="tab-btn"        id="tab-btn-admin-notifications" role="tab" aria-selected="false" aria-controls="tab-panel-admin-notifications" onclick="switchAdminTab('admin-notifications')">NOTIFICATIONS</button>
-        <button class="tab-btn"        id="tab-btn-admin-users"         role="tab" aria-selected="false" aria-controls="tab-panel-admin-users"         onclick="switchAdminTab('admin-users')">USERS</button>
-        <button class="tab-btn"        id="tab-btn-admin-featured"      role="tab" aria-selected="false" aria-controls="tab-panel-admin-featured"      onclick="switchAdminTab('admin-featured')">FEATURED</button>
-        <button class="tab-btn"        id="tab-btn-admin-history"       role="tab" aria-selected="false" aria-controls="tab-panel-admin-history"       onclick="switchAdminTab('admin-history')">HISTORY</button>
-      </div>
-
-      <!-- RESTAURANTS SUB-PANEL -->
-      <div class="tab-panel active" id="tab-panel-admin-restaurants" role="tabpanel" aria-labelledby="tab-btn-admin-restaurants">
-        <div class="section-label">Restaurants &amp; Menus</div>
-        <p class="config-hint">This build is locked to Leroy's Lounge and El Roy's Cantina. Managers are assigned at the menu level across the four fixed menus.</p>
-        <div id="menus-mgmt-list"></div>
-      </div>
-
-      <!-- NOTIFICATIONS SUB-PANEL -->
-      <div class="tab-panel" id="tab-panel-admin-notifications" role="tabpanel" aria-labelledby="tab-btn-admin-notifications">
-        <div class="section-label">Notifications</div>
-        <div class="admin-context-switcher">
-          <label class="switcher-label" for="notif-restaurant-select">Restaurant</label>
-          <select id="notif-restaurant-select" class="switcher-select" onchange="onAdminSwitcherRestaurantChange('notif')"></select>
-          <label class="switcher-label" for="notif-menu-select">Menu</label>
-          <select id="notif-menu-select" class="switcher-select" onchange="onAdminSwitcherMenuChange('notif')"></select>
-        </div>
-        <div class="config-card">
-          <p class="config-hint">Toggle which channels fire when you send a menu update for the selected menu.</p>
-          <div class="notif-channel" id="notif-groupme">
-            <div class="notif-channel-header">
-              <label class="notif-toggle-label" for="notif-groupme-enabled">
-                <input type="checkbox" id="notif-groupme-enabled" class="notif-toggle" onchange="onNotifToggle('groupme')"/>
-                <span class="notif-channel-name">GroupMe</span>
-              </label>
-            </div>
-            <div class="notif-channel-body" id="notif-groupme-body" style="display:none">
-              <div class="notif-help">
-                <p>Go to <strong>dev.groupme.com → Bots → Create Bot</strong>. Set the callback URL to your Vercel deployment URL. Copy the Bot ID and add it as a Vercel environment variable:</p>
-                <p><code>GROUPME_BOT_ID</code></p>
-              </div>
-            </div>
-          </div>
-          <div class="notif-channel" id="notif-sms">
-            <div class="notif-channel-header">
-              <label class="notif-toggle-label" for="notif-sms-enabled">
-                <input type="checkbox" id="notif-sms-enabled" class="notif-toggle" onchange="onNotifToggle('sms')"/>
-                <span class="notif-channel-name">Twilio SMS</span>
-              </label>
-            </div>
-            <div class="notif-channel-body" id="notif-sms-body" style="display:none">
-              <div class="notif-help">
-                <p>Sign up at <strong>twilio.com</strong> and buy a phone number. Add these Vercel environment variables:</p>
-                <p><code>TWILIO_ACCOUNT_SID</code><br><code>TWILIO_AUTH_TOKEN</code><br><code>TWILIO_FROM_NUMBER</code><br><code>TWILIO_TO_NUMBERS</code> <span class="notif-help-note">(comma-separated E.164 numbers, e.g. +15551234567,+15559876543)</span></p>
-              </div>
-            </div>
-          </div>
-          <div class="notif-channel" id="notif-discord">
-            <div class="notif-channel-header">
-              <label class="notif-toggle-label" for="notif-discord-enabled">
-                <input type="checkbox" id="notif-discord-enabled" class="notif-toggle" onchange="onNotifToggle('discord')"/>
-                <span class="notif-channel-name">Discord</span>
-              </label>
-            </div>
-            <div class="notif-channel-body" id="notif-discord-body" style="display:none">
-              <div class="notif-help">
-                <p>In Discord, open a channel's <strong>Settings → Integrations → Webhooks → New Webhook</strong>. Copy the webhook URL and add it as a Vercel environment variable:</p>
-                <p><code>DISCORD_WEBHOOK_URL</code></p>
-              </div>
-            </div>
-          </div>
-          <div class="notif-channel" id="notif-webhook">
-            <div class="notif-channel-header">
-              <label class="notif-toggle-label" for="notif-webhook-enabled">
-                <input type="checkbox" id="notif-webhook-enabled" class="notif-toggle" onchange="onNotifToggle('webhook')"/>
-                <span class="notif-channel-name">Generic Webhook</span>
-              </label>
-            </div>
-            <div class="notif-channel-body" id="notif-webhook-body" style="display:none">
-              <div class="notif-help">
-                <p>The full update payload will be POSTed as JSON to your endpoint. Add these Vercel environment variables:</p>
-                <p><code>GENERIC_WEBHOOK_URL</code><br><code>GENERIC_WEBHOOK_SECRET</code> <span class="notif-help-note">(optional — sent as <code>X-Webhook-Secret</code> header)</span></p>
-              </div>
-            </div>
-          </div>
-          <div class="btn-row" style="margin-top:14px">
-            <button class="btn-small" onclick="saveNotifications()">Save Notifications</button>
-          </div>
-        </div>
-        <div class="config-card" style="margin-top:10px">
-          <h3>Credential Keys <span style="font-weight:300;color:var(--muted)">(per restaurant)</span></h3>
-          <p class="config-hint">Map each channel to a Vercel env var name. Leave blank to use the global defaults. Actual secrets stay in Vercel — only the key names are stored here.</p>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">GroupMe Bot ID</label>
-            <input type="text" id="notif-cred-groupme" class="notif-cred-input" placeholder="GROUPME_BOT_ID"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Discord Webhook URL</label>
-            <input type="text" id="notif-cred-discord" class="notif-cred-input" placeholder="DISCORD_WEBHOOK_URL"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Twilio SID</label>
-            <input type="text" id="notif-cred-sms-sid" class="notif-cred-input" placeholder="TWILIO_ACCOUNT_SID"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Twilio Auth Token</label>
-            <input type="text" id="notif-cred-sms-token" class="notif-cred-input" placeholder="TWILIO_AUTH_TOKEN"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Twilio From Number</label>
-            <input type="text" id="notif-cred-sms-from" class="notif-cred-input" placeholder="TWILIO_FROM_NUMBER"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Twilio To Numbers</label>
-            <input type="text" id="notif-cred-sms-to" class="notif-cred-input" placeholder="TWILIO_TO_NUMBERS"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Webhook URL</label>
-            <input type="text" id="notif-cred-webhook-url" class="notif-cred-input" placeholder="GENERIC_WEBHOOK_URL"/>
-          </div>
-          <div class="notif-cred-row">
-            <label class="notif-cred-label">Webhook Secret</label>
-            <input type="text" id="notif-cred-webhook-secret" class="notif-cred-input" placeholder="GENERIC_WEBHOOK_SECRET"/>
-          </div>
-          <div class="btn-row" style="margin-top:10px">
-            <button class="btn-small" onclick="saveNotifCredKeys()">Save Credential Keys</button>
-          </div>
-        </div>
-        <div class="config-card" style="margin-top:10px">
-          <h3>Menu Page URL <span style="font-weight:300;color:var(--muted)">(included in notifications)</span></h3>
-          <div class="input-row">
-            <input type="text" id="menu-url-input" placeholder="e.g. https://el-roys-drink-menu.vercel.app"/>
-            <button class="btn-small" onclick="saveMenuUrl()">Save</button>
-          </div>
-        </div>
-      </div>
-
-      <!-- USERS SUB-PANEL -->
-      <div class="tab-panel" id="tab-panel-admin-users" role="tabpanel" aria-labelledby="tab-btn-admin-users">
-        <div class="section-label">Staff Accounts</div>
-        <div class="users-invite-row">
-          <button class="btn-small" onclick="openInviteModal()">+ Invite Staff</button>
-        </div>
-        <div id="users-list"></div>
-      </div>
-      <!-- FEATURED SUB-PANEL -->
-      <div class="tab-panel" id="tab-panel-admin-featured" role="tabpanel" aria-labelledby="tab-btn-admin-featured">
-        <div class="section-label">Featured Groups</div>
-        <div id="featured-admin-wrap"></div>
-        <div class="input-row" style="margin-top:6px">
-          <input type="text" id="new-featured-group-name" placeholder="New group name…"/>
-          <button class="btn-small" onclick="addFeaturedGroup()">+ Add Group</button>
-        </div>
-      </div>
-
-      <!-- HISTORY SUB-PANEL -->
-      <div class="tab-panel" id="tab-panel-admin-history" role="tabpanel" aria-labelledby="tab-btn-admin-history">
-        <div class="section-label">Update History</div>
-        <div id="update-history-wrap"></div>
-      </div>
-    </div><!-- /admin-panel -->
-
-    <button class="logout-link" onclick="exitView()">← Back to menu view</button>
   </div>
 </div>
 
-<!-- AUTH OVERLAY -->
 <div id="auth-overlay">
   <div class="auth-box" id="auth-box" role="dialog" aria-modal="true" aria-label="Sign In">
     <div id="auth-no-config" style="display:none" class="auth-hint-msg">Supabase is not configured. Check server environment variables.</div>
     <div id="auth-form-wrap">
-
-      <!-- SIGN IN -->
       <div id="auth-screen-signin" class="auth-screen">
         <h2 class="auth-screen-title">SIGN IN</h2>
         <p class="auth-screen-subtitle">Sign in to your account</p>
@@ -379,7 +257,6 @@
         </div>
       </div>
 
-      <!-- SIGN UP -->
       <div id="auth-screen-signup" class="auth-screen" style="display:none">
         <h2 class="auth-screen-title">CREATE ACCOUNT</h2>
         <p class="auth-screen-subtitle">Sign up with your work email</p>
@@ -409,7 +286,6 @@
         <button class="auth-back-btn" onclick="renderAuthScreen('signin')">← Back to Sign In</button>
       </div>
 
-      <!-- FORGOT PASSWORD -->
       <div id="auth-screen-forgot" class="auth-screen" style="display:none">
         <h2 class="auth-screen-title">RESET PASSWORD</h2>
         <p class="auth-screen-subtitle">Enter your email and we'll send a reset link</p>
@@ -421,7 +297,6 @@
         <button class="auth-back-btn" onclick="renderAuthScreen('signin')">← Back to Sign In</button>
       </div>
 
-      <!-- RESET PASSWORD -->
       <div id="auth-screen-reset" class="auth-screen" style="display:none">
         <h2 class="auth-screen-title">SET NEW PASSWORD</h2>
         <p class="auth-screen-subtitle">Choose a new password for your account</p>
@@ -434,26 +309,11 @@
         <div class="auth-error" id="reset-error"></div>
         <button class="auth-submit-btn" id="reset-submit-btn" onclick="handleResetPassword()">Set Password</button>
       </div>
-
     </div>
     <button class="pin-cancel" onclick="closeAuthOverlay()">Cancel</button>
   </div>
 </div>
 
-<!-- CONFIG JSON MODAL -->
-<div class="modal-bg" id="config-modal-bg">
-  <div class="modal">
-    <h2>UPDATE CONFIG FILE</h2>
-    <div class="modal-sub">Copy this into <code>lib/config/notifications.json</code> and reload the page.</div>
-    <textarea id="config-json-output" class="config-json-textarea" readonly spellcheck="false"></textarea>
-    <div class="modal-actions">
-      <button class="btn-cancel" onclick="closeConfigModal()">Done</button>
-      <button class="btn-confirm" onclick="copyConfigJson()">COPY JSON</button>
-    </div>
-  </div>
-</div>
-
-<!-- PREVIEW MODAL -->
 <div class="modal-bg" id="modal-bg">
   <div class="modal">
     <h2>PATCH NOTES PREVIEW</h2>
@@ -466,20 +326,6 @@
   </div>
 </div>
 
-<!-- INVITE MODAL -->
-<div class="modal-bg" id="invite-modal-bg">
-  <div class="modal">
-    <h2>INVITE STAFF</h2>
-    <div class="modal-sub">Copy this message and send it to new staff members.</div>
-    <textarea id="invite-text-output" class="config-json-textarea" readonly spellcheck="false"></textarea>
-    <div class="modal-actions">
-      <button class="btn-cancel" onclick="closeInviteModal()">Done</button>
-      <button class="btn-confirm" onclick="copyInviteText()">COPY MESSAGE</button>
-    </div>
-  </div>
-</div>
-
-<!-- MENU PICKER OVERLAY -->
 <div id="menu-picker-overlay">
   <div class="picker-box" role="dialog" aria-modal="true" aria-label="Select a Menu">
     <h2 class="picker-title" id="picker-title">SELECT A MENU</h2>

--- a/manager/index.html
+++ b/manager/index.html
@@ -6,9 +6,12 @@
 <title>Manager | Current Menu</title>
 <link rel="icon" type="image/png" href="/HFLOGO.png">
 <link rel="stylesheet" href="/lib/fonts/fonts.css">
+<link rel="preconnect" href="https://fonts.googleapis.com">
+<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+<link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=Noto+Serif:ital,wght@0,400;0,600;0,700;1,600&display=swap" rel="stylesheet">
 <link rel="stylesheet" href="/style.css">
 </head>
-<body class="settings-shell-pending">
+<body class="settings-shell-pending manager-stitch-shell">
 <main id="site-picker-view" class="site-picker-view" hidden>
   <div class="site-picker-card">
     <p class="site-picker-kicker">Current Menu</p>
@@ -20,32 +23,59 @@
   </div>
 </main>
 
-<div class="wrapper" id="app-shell">
-  <header>
-    <img class="hf-logo" src="" alt="Logo" style="display:none"/>
-    <span class="logo-mark" style="display:none"></span>
-    <h1>MANAGER WORKSPACE</h1>
-    <div class="header-sub" id="last-updated-label">Last Updated: —</div>
-    <div class="header-action-group">
-      <button class="manager-btn" id="action-btn" onclick="onActionBtnClick()" style="display:none">⚙ Manager</button>
-      <button class="manager-btn admin-btn" id="admin-btn" onclick="onAdminBtnClick()" style="display:none">⚙ Admin</button>
-    </div>
-    <button class="header-signin-btn" id="signin-btn" onclick="openAuthOverlay()">Sign In</button>
-    <div class="user-chip" id="user-chip" style="display:none"
-         onclick="toggleUserDropdown()"
-         onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleUserDropdown()}"
-         tabindex="0"
-         role="button"
-         aria-haspopup="true"
-         aria-expanded="false"
-         aria-label="User menu">
-      <span id="user-initials">?</span>
-      <span>▾</span>
-      <div class="user-dropdown" id="user-dropdown">
-        <div class="user-dropdown-name" id="user-dropdown-name"></div>
-        <div class="user-dropdown-role" id="user-dropdown-role"></div>
-        <div class="user-dropdown-divider"></div>
-        <button class="user-dropdown-signout" onclick="signOut()">Sign Out</button>
+<div class="wrapper manager-shell-wrapper" id="app-shell">
+  <header class="manager-shell-topbar">
+    <div class="manager-shell-topbar-inner">
+      <div class="manager-shell-brand-wrap">
+        <button
+          class="manager-shell-menu-toggle"
+          id="settings-drawer-toggle"
+          type="button"
+          aria-label="Open section navigation"
+          aria-controls="manager-settings-rail"
+          aria-expanded="false"
+          onclick="toggleSettingsDrawer()"
+        >☰</button>
+
+        <div class="manager-shell-brand-copy">
+          <p class="manager-shell-brand-mark">The Ledger</p>
+          <div class="manager-shell-title-row">
+            <h1>Manager Workspace</h1>
+            <div class="header-action-group">
+              <button class="manager-btn" id="action-btn" onclick="onActionBtnClick()" style="display:none">⚙ Manager</button>
+              <button class="manager-btn admin-btn" id="admin-btn" onclick="onAdminBtnClick()" style="display:none">⚙ Admin</button>
+            </div>
+          </div>
+          <div class="manager-shell-header-meta">
+            <div class="header-sub" id="last-updated-label">Last Updated: —</div>
+            <div id="active-menu-bar" class="manager-shell-menu-bar" style="display:none;" aria-live="polite">
+              <span class="active-menu-label">Menu</span>
+              <span id="active-menu-name" class="active-menu-name-text"></span>
+              <button class="btn-small manager-shell-switch-btn" id="switch-menu-btn" onclick="onSwitchMenuClick()" style="display:none" aria-label="Switch to a different menu">Switch Menu</button>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="manager-shell-user-tools">
+        <button class="header-signin-btn" id="signin-btn" onclick="openAuthOverlay()">Sign In</button>
+        <div class="user-chip" id="user-chip" style="display:none"
+             onclick="toggleUserDropdown()"
+             onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleUserDropdown()}"
+             tabindex="0"
+             role="button"
+             aria-haspopup="true"
+             aria-expanded="false"
+             aria-label="User menu">
+          <span id="user-initials">?</span>
+          <span>▾</span>
+          <div class="user-dropdown" id="user-dropdown">
+            <div class="user-dropdown-name" id="user-dropdown-name"></div>
+            <div class="user-dropdown-role" id="user-dropdown-role"></div>
+            <div class="user-dropdown-divider"></div>
+            <button class="user-dropdown-signout" onclick="signOut()">Sign Out</button>
+          </div>
+        </div>
       </div>
     </div>
   </header>
@@ -73,94 +103,103 @@
   </div>
 
   <div id="manager-view">
-    <div class="settings-workspace settings-workspace--manager">
-      <aside class="settings-rail" aria-label="Manager workspace sections">
-        <p class="settings-rail-kicker">Manager</p>
+    <div class="manager-shell-backdrop" id="settings-drawer-backdrop" hidden onclick="closeSettingsDrawer()"></div>
+
+    <div class="settings-workspace manager-shell-layout">
+      <aside class="settings-rail manager-shell-rail" id="manager-settings-rail" aria-label="Manager workspace sections">
+        <div class="manager-shell-rail-head">
+          <p class="settings-rail-kicker">Manager</p>
+          <p class="manager-shell-rail-note">One continuous service board with anchored sections.</p>
+        </div>
         <button class="settings-rail-btn active" type="button" data-target="manager-overview-section" onclick="focusSettingsSection('manager-overview-section', this)">Overview</button>
-        <button class="settings-rail-btn" type="button" data-target="manager-edit-section" onclick="focusSettingsSection('manager-edit-section', this)">Edit Menu</button>
-        <button class="settings-rail-btn" type="button" data-target="manager-recent-section" onclick="focusSettingsSection('manager-recent-section', this)">Recent Changes</button>
         <button class="settings-rail-btn" type="button" data-target="manager-categories-section" onclick="focusSettingsSection('manager-categories-section', this)">Categories</button>
+        <button class="settings-rail-btn" type="button" data-target="manager-edit-section" onclick="focusSettingsSection('manager-edit-section', this)">Edit Menu</button>
         <button class="settings-rail-btn" type="button" data-target="manager-database-section" onclick="focusSettingsSection('manager-database-section', this)">Database</button>
       </aside>
 
-      <div class="settings-stage">
-        <section class="settings-hero settings-hero--manager" id="manager-overview-section">
-          <div class="settings-hero-copy">
-            <p class="settings-kicker">Live Service</p>
-            <h2>Run tonight's menu with confidence.</h2>
-            <p>Save quietly while you work, then use Send Update only when you are ready to notify staff and refresh the public timestamp.</p>
-          </div>
-
-          <div id="setup-banner">
-            <h3>⚙ One-Time Setup</h3>
-            <p>Click <strong style="color:var(--ember)">⚙ Admin</strong> in the header to configure notification channels. Everything syncs to the cloud from this point on.</p>
-          </div>
-
-          <div id="active-menu-bar" style="display:none;" aria-live="polite">
-            <span class="active-menu-label">MENU</span>
-            <span id="active-menu-name" class="active-menu-name-text"></span>
-            <button class="btn-small" id="switch-menu-btn" onclick="onSwitchMenuClick()" style="display:none" aria-label="Switch to a different menu">⇄ Switch</button>
-          </div>
-
-          <div id="featured-confirm-banner" class="featured-confirm-banner" style="display:none;">
-            <span>Today's featured items haven't been confirmed yet.</span>
-            <button class="btn-small" onclick="confirmFeaturedToday()">Keep Today's Featured</button>
-            <button class="btn-small" onclick="editFeaturedFromBanner()">Update Featured</button>
-          </div>
-        </section>
-
-        <div id="manager-panel" class="settings-panel" style="display:none">
-          <section class="settings-section settings-section--primary" id="manager-edit-section">
-            <div class="settings-section-head">
+      <div class="settings-stage manager-shell-stage">
+        <div id="manager-panel" class="settings-panel manager-shell-panel" style="display:none">
+          <section class="settings-section manager-shell-overview" id="manager-overview-section">
+            <div class="manager-shell-section-header">
               <div>
-                <p class="settings-section-kicker">Shift Control</p>
-                <h3>Edit Menu</h3>
+                <p class="settings-section-kicker">Service Overview</p>
+                <h2>Current kitchen state and recent modifications.</h2>
               </div>
-              <p class="settings-section-copy">Featured slots and live menu edits stay together here so the change you send matches the board your staff is staring at.</p>
+              <p class="manager-shell-section-copy">Save quietly while you work. Use Send Update only when you are ready to notify staff and refresh the public timestamp.</p>
             </div>
 
-            <div class="workspace-actions workspace-actions--sticky">
-              <div class="workspace-actions-copy">
-                <p class="workspace-actions-title">Publishing</p>
-                <p class="workspace-actions-sub">Save is silent. Send Update previews unsent changes before anything goes out.</p>
-              </div>
-              <div class="btn-row workspace-btn-row">
-                <button class="save-btn" id="save-btn" onclick="saveMenu()">💾 SAVE</button>
-                <button class="send-btn" id="send-btn" onclick="openPreview()">🔥 SEND UPDATE</button>
-              </div>
-              <div id="sync-status"></div>
+            <div id="setup-banner">
+              <h3>One-Time Setup</h3>
+              <p>Click <strong>Admin</strong> in the header to configure notification channels. Everything syncs to the cloud from this point on.</p>
             </div>
 
-            <div id="featured-mgr-wrap"></div>
+            <div id="featured-confirm-banner" class="featured-confirm-banner" style="display:none;">
+              <span>Today's featured items haven't been confirmed yet.</span>
+              <button class="btn-small" onclick="confirmFeaturedToday()">Keep Today's Featured</button>
+              <button class="btn-small" onclick="editFeaturedFromBanner()">Update Featured</button>
+            </div>
+
+            <div class="manager-shell-stats-grid">
+              <article class="manager-shell-stat-card">
+                <p class="manager-shell-stat-label">Menu Status</p>
+                <strong class="manager-shell-stat-value" id="manager-overview-status-value">Live</strong>
+                <span class="manager-shell-stat-meta" id="manager-overview-status-meta">No unsent changes</span>
+              </article>
+              <article class="manager-shell-stat-card">
+                <p class="manager-shell-stat-label">Active Items</p>
+                <strong class="manager-shell-stat-value" id="manager-overview-active-value">0</strong>
+                <span class="manager-shell-stat-meta" id="manager-overview-active-meta">active items</span>
+              </article>
+              <article class="manager-shell-stat-card manager-shell-stat-card--warn">
+                <p class="manager-shell-stat-label">86 Watch</p>
+                <strong class="manager-shell-stat-value" id="manager-overview-86-value">0</strong>
+                <span class="manager-shell-stat-meta" id="manager-overview-86-meta">items 86'd</span>
+              </article>
+            </div>
+
+            <div class="manager-shell-overview-grid">
+              <section class="manager-shell-overview-card">
+                <div class="manager-shell-card-head">
+                  <div>
+                    <p class="settings-section-kicker">Featured</p>
+                    <h3>Tonight's callouts</h3>
+                  </div>
+                  <p class="manager-shell-card-copy">Featured controls live here, and the confirmation prompt follows you into the floating action bar when it needs attention.</p>
+                </div>
+                <div id="featured-mgr-wrap"></div>
+              </section>
+
+              <section class="manager-shell-overview-card" id="manager-recent-section">
+                <div class="manager-shell-card-head">
+                  <div>
+                    <p class="settings-section-kicker">Recent Changes</p>
+                    <h3>Last 7 days</h3>
+                  </div>
+                  <p class="manager-shell-card-copy">This feed shows sent updates for the active menu only. Draft edits still live in the Send Update preview.</p>
+                </div>
+                <div id="recent-changes-wrap"></div>
+              </section>
+            </div>
+          </section>
+
+          <section class="settings-section manager-shell-edit" id="manager-edit-section">
+            <div class="manager-shell-section-header">
+              <div>
+                <p class="settings-section-kicker">Edit Menu</p>
+                <h2>Refine descriptions, prices, availability, and category order.</h2>
+              </div>
+              <p class="manager-shell-section-copy">Drag items within a category to reorder them. Expand item details only when you need to tune the sell copy or recipe notes.</p>
+            </div>
             <div id="manager-categories"></div>
-
-            <div id="off-menu-section" class="prune-section" style="display:none;">
-              <div class="prune-section-header">
-                <div class="section-label prune-section-label">Off Menu Items</div>
-              </div>
-              <p class="hint">Staff-only items hidden from the public menu. Visible to managers and admins.</p>
-              <div id="off-menu-items-wrap"></div>
-            </div>
           </section>
 
-          <section class="settings-section" id="manager-recent-section">
-            <div class="settings-section-head">
+          <section class="settings-section manager-shell-categories" id="manager-categories-section">
+            <div class="manager-shell-section-header">
               <div>
-                <p class="settings-section-kicker">Last 7 Days</p>
-                <h3>Recent Changes</h3>
+                <p class="settings-section-kicker">Category Management</p>
+                <h2>Organize your offerings into editorial sections.</h2>
               </div>
-              <p class="settings-section-copy">This feed shows sent updates for the active menu only. Draft edits still live in the Send Update preview.</p>
-            </div>
-            <div id="recent-changes-wrap"></div>
-          </section>
-
-          <section class="settings-section" id="manager-categories-section">
-            <div class="settings-section-head">
-              <div>
-                <p class="settings-section-kicker">Structure</p>
-                <h3>Category Tools</h3>
-              </div>
-              <p class="settings-section-copy">Reorder, rename, and add categories without leaving the manager workspace.</p>
+              <p class="manager-shell-section-copy">Reorder, rename, and add categories without leaving the manager workspace.</p>
             </div>
 
             <div class="active-menu-context" id="categories-menu-context"></div>
@@ -191,46 +230,91 @@
             <button class="btn-small" id="show-add-cat-btn" onclick="toggleAddCategoryForm()">+ Add Category</button>
           </section>
 
-          <section class="settings-section" id="manager-database-section">
-            <div class="settings-section-head">
+          <section class="settings-section manager-shell-database" id="manager-database-section">
+            <div class="manager-shell-section-header">
               <div>
-                <p class="settings-section-kicker">Maintenance</p>
-                <h3>Recipe Database</h3>
+                <p class="settings-section-kicker">Item Repository</p>
+                <h2>The master database for all culinary assets.</h2>
               </div>
-              <p class="settings-section-copy">Search active and off-menu items, then prune hidden inventory when you need to clean up autocomplete noise.</p>
+              <p class="manager-shell-section-copy">Search active and off-menu items, then open the maintenance drawers only when you need to clean up hidden inventory or prune stale entries.</p>
             </div>
 
-            <div class="db-search-row">
-              <input type="text" id="db-search" placeholder="Search drinks or ingredients…" oninput="filterDatabase()" />
-            </div>
-            <div class="db-filter-row">
-              <span class="db-filter-label">Recipe:</span>
-              <div class="db-filter-group" id="db-filter-recipe">
-                <button class="db-filter-btn active" data-value="all" onclick="setDbFilter('recipe','all')">All</button>
-                <button class="db-filter-btn" data-value="yes" onclick="setDbFilter('recipe','yes')">With Recipe</button>
-                <button class="db-filter-btn" data-value="no" onclick="setDbFilter('recipe','no')">No Recipe</button>
+            <div class="manager-shell-database-toolbar">
+              <div class="db-search-row manager-shell-db-search">
+                <label class="manager-shell-field-label" for="db-search">Search Database</label>
+                <input type="text" id="db-search" placeholder="Search drinks, dishes, or ingredients…" oninput="filterDatabase()" />
               </div>
-              <span class="db-filter-label">Status:</span>
-              <div class="db-filter-group" id="db-filter-status">
-                <button class="db-filter-btn active" data-value="all" onclick="setDbFilter('status','all')">All</button>
-                <button class="db-filter-btn" data-value="on" onclick="setDbFilter('status','on')">On Menu</button>
-                <button class="db-filter-btn" data-value="off" onclick="setDbFilter('status','off')">Off Menu</button>
+              <div class="manager-shell-db-filters">
+                <div class="manager-shell-filter-block">
+                  <span class="manager-shell-field-label">Recipe Status</span>
+                  <div class="db-filter-group" id="db-filter-recipe">
+                    <button class="db-filter-btn active" data-value="all" onclick="setDbFilter('recipe','all')">All</button>
+                    <button class="db-filter-btn" data-value="yes" onclick="setDbFilter('recipe','yes')">With Recipe</button>
+                    <button class="db-filter-btn" data-value="no" onclick="setDbFilter('recipe','no')">Missing</button>
+                  </div>
+                </div>
+                <div class="manager-shell-filter-block">
+                  <span class="manager-shell-field-label">Menu Status</span>
+                  <div class="db-filter-group" id="db-filter-status">
+                    <button class="db-filter-btn active" data-value="all" onclick="setDbFilter('status','all')">All</button>
+                    <button class="db-filter-btn" data-value="on" onclick="setDbFilter('status','on')">Live</button>
+                    <button class="db-filter-btn" data-value="off" onclick="setDbFilter('status','off')">Archive</button>
+                  </div>
+                </div>
               </div>
             </div>
+
             <div id="db-table-wrap"></div>
-            <div id="prune-section" class="prune-section" style="display:none;">
-              <div class="prune-section-header">
-                <div class="section-label prune-section-label">Prune Database</div>
-                <button id="prune-all-btn" class="btn-small btn-danger">Clear All</button>
+
+            <details class="manager-shell-disclosure" id="off-menu-section">
+              <summary>
+                <span>Off Menu Items</span>
+                <span class="manager-shell-disclosure-copy">Staff-only items hidden from the public menu.</span>
+              </summary>
+              <div class="manager-shell-disclosure-body">
+                <div id="off-menu-items-wrap"></div>
               </div>
-              <p class="hint">Permanently removes off-menu items from Supabase. Live menu items are unaffected.</p>
-              <div id="prune-items-wrap"></div>
-            </div>
+            </details>
+
+            <details class="manager-shell-disclosure manager-shell-disclosure--danger" id="prune-disclosure">
+              <summary>
+                <span>Prune Database</span>
+                <span class="manager-shell-disclosure-copy">Permanently remove archived items from Supabase.</span>
+              </summary>
+              <div class="manager-shell-disclosure-body">
+                <div id="prune-section" class="prune-section" style="display:none;">
+                  <div class="prune-section-header">
+                    <div class="section-label prune-section-label">Prune Database</div>
+                    <button id="prune-all-btn" class="btn-small btn-danger">Clear All</button>
+                  </div>
+                  <p class="hint">Permanently removes off-menu items from Supabase. Live menu items are unaffected.</p>
+                  <div id="prune-items-wrap"></div>
+                </div>
+              </div>
+            </details>
           </section>
         </div>
 
-        <button class="logout-link" onclick="exitView()">← Back to menu view</button>
+        <button class="logout-link manager-shell-exit" onclick="exitView()">← Back to menu view</button>
       </div>
+    </div>
+
+    <div class="manager-shell-actionbar" id="manager-action-bar" hidden>
+      <div class="manager-shell-actionbar-copy">
+        <p class="workspace-actions-title">Service Actions</p>
+        <p class="workspace-actions-sub" id="manager-action-bar-summary"></p>
+      </div>
+      <div class="manager-shell-actionbar-groups">
+        <div class="manager-shell-actionbar-featured" id="manager-featured-action-group" hidden>
+          <button class="btn-small" onclick="confirmFeaturedToday()">Keep Today's Featured</button>
+          <button class="btn-small" onclick="editFeaturedFromBanner()">Update Featured</button>
+        </div>
+        <div class="btn-row manager-shell-actionbar-primary" id="manager-primary-action-group" hidden>
+          <button class="save-btn" id="save-btn" onclick="saveMenu()">SAVE</button>
+          <button class="send-btn" id="send-btn" onclick="openPreview()">SEND UPDATE</button>
+        </div>
+      </div>
+      <div id="sync-status"></div>
     </div>
   </div>
 </div>

--- a/manager/index.html
+++ b/manager/index.html
@@ -12,6 +12,7 @@
 <link rel="stylesheet" href="/style.css">
 </head>
 <body class="settings-shell-pending manager-stitch-shell">
+<a class="manager-shell-skip-link" href="#manager-main-content">Skip to Content</a>
 <main id="site-picker-view" class="site-picker-view" hidden>
   <div class="site-picker-card">
     <p class="site-picker-kicker">Current Menu</p>
@@ -82,7 +83,7 @@
 
   <div id="loading-view">
     <div class="spinner"></div>
-    <p>Loading manager workspace...</p>
+    <p>Loading manager workspace…</p>
   </div>
 
   <div id="public-view" style="display:none;">
@@ -109,28 +110,23 @@
       <aside class="settings-rail manager-shell-rail" id="manager-settings-rail" aria-label="Manager workspace sections">
         <div class="manager-shell-rail-head">
           <p class="settings-rail-kicker">Manager</p>
-          <p class="manager-shell-rail-note">One continuous service board with anchored sections.</p>
+          <p class="manager-shell-rail-note">Sections</p>
         </div>
-        <button class="settings-rail-btn active" type="button" data-target="manager-overview-section" onclick="focusSettingsSection('manager-overview-section', this)">Overview</button>
-        <button class="settings-rail-btn" type="button" data-target="manager-categories-section" onclick="focusSettingsSection('manager-categories-section', this)">Categories</button>
-        <button class="settings-rail-btn" type="button" data-target="manager-edit-section" onclick="focusSettingsSection('manager-edit-section', this)">Edit Menu</button>
-        <button class="settings-rail-btn" type="button" data-target="manager-database-section" onclick="focusSettingsSection('manager-database-section', this)">Database</button>
+        <a class="settings-rail-btn active" href="#manager-overview-section" data-target="manager-overview-section" onclick="event.preventDefault();focusSettingsSection('manager-overview-section', this)">Overview</a>
+        <a class="settings-rail-btn" href="#manager-categories-section" data-target="manager-categories-section" onclick="event.preventDefault();focusSettingsSection('manager-categories-section', this)">Categories</a>
+        <a class="settings-rail-btn" href="#manager-edit-section" data-target="manager-edit-section" onclick="event.preventDefault();focusSettingsSection('manager-edit-section', this)">Edit Menu</a>
+        <a class="settings-rail-btn" href="#manager-database-section" data-target="manager-database-section" onclick="event.preventDefault();focusSettingsSection('manager-database-section', this)">Database</a>
       </aside>
 
-      <div class="settings-stage manager-shell-stage">
+      <main class="settings-stage manager-shell-stage" id="manager-main-content">
         <div id="manager-panel" class="settings-panel manager-shell-panel" style="display:none">
           <section class="settings-section manager-shell-overview" id="manager-overview-section">
             <div class="manager-shell-section-header">
               <div>
                 <p class="settings-section-kicker">Service Overview</p>
-                <h2>Current kitchen state and recent modifications.</h2>
+                <h2>Run service without losing the thread.</h2>
               </div>
-              <p class="manager-shell-section-copy">Save quietly while you work. Use Send Update only when you are ready to notify staff and refresh the public timestamp.</p>
-            </div>
-
-            <div id="setup-banner">
-              <h3>One-Time Setup</h3>
-              <p>Click <strong>Admin</strong> in the header to configure notification channels. Everything syncs to the cloud from this point on.</p>
+              <p class="manager-shell-section-copy">Save quietly while you work, then send one clean update when the board is ready.</p>
             </div>
 
             <div id="featured-confirm-banner" class="featured-confirm-banner" style="display:none;">
@@ -164,7 +160,7 @@
                     <p class="settings-section-kicker">Featured</p>
                     <h3>Tonight's callouts</h3>
                   </div>
-                  <p class="manager-shell-card-copy">Featured controls live here, and the confirmation prompt follows you into the floating action bar when it needs attention.</p>
+                  <p class="manager-shell-card-copy">Set the featured lineup here. If it still needs confirmation, the action bar will bring it back.</p>
                 </div>
                 <div id="featured-mgr-wrap"></div>
               </section>
@@ -175,7 +171,7 @@
                     <p class="settings-section-kicker">Recent Changes</p>
                     <h3>Last 7 days</h3>
                   </div>
-                  <p class="manager-shell-card-copy">This feed shows sent updates for the active menu only. Draft edits still live in the Send Update preview.</p>
+                  <p class="manager-shell-card-copy">Sent updates only. Draft work still stays in the Send Update preview.</p>
                 </div>
                 <div id="recent-changes-wrap"></div>
               </section>
@@ -188,7 +184,7 @@
                 <p class="settings-section-kicker">Edit Menu</p>
                 <h2>Refine descriptions, prices, availability, and category order.</h2>
               </div>
-              <p class="manager-shell-section-copy">Drag items within a category to reorder them. Expand item details only when you need to tune the sell copy or recipe notes.</p>
+              <p class="manager-shell-section-copy">Drag within a category to reorder. Expand details only when you need them.</p>
             </div>
             <div id="manager-categories"></div>
           </section>
@@ -199,7 +195,7 @@
                 <p class="settings-section-kicker">Category Management</p>
                 <h2>Organize your offerings into editorial sections.</h2>
               </div>
-              <p class="manager-shell-section-copy">Reorder, rename, and add categories without leaving the manager workspace.</p>
+              <p class="manager-shell-section-copy">Reorder, rename, and add categories without leaving the page.</p>
             </div>
 
             <div class="active-menu-context" id="categories-menu-context"></div>
@@ -207,20 +203,20 @@
             <div class="catmgr-add-form" id="catmgr-add-form" style="display:none">
               <h3>New Category</h3>
               <div class="catmgr-field-row">
-                <label>Icon</label>
-                <input type="text" id="new-cat-icon" class="catmgr-input catmgr-icon-input" value="🍸" maxlength="4" placeholder="Emoji"/>
+                <label for="new-cat-icon">Icon</label>
+                <input type="text" id="new-cat-icon" name="new-category-icon" class="catmgr-input catmgr-icon-input" value="🍸" maxlength="4" placeholder="Emoji…" autocomplete="off" spellcheck="false"/>
               </div>
               <div class="catmgr-field-row">
-                <label>Title</label>
-                <input type="text" id="new-cat-title" class="catmgr-input" placeholder="Category name (required)"/>
+                <label for="new-cat-title">Title</label>
+                <input type="text" id="new-cat-title" name="new-category-title" class="catmgr-input" placeholder="Category name (required)…" autocomplete="off"/>
               </div>
               <div class="catmgr-field-row">
-                <label>Subtitle</label>
-                <input type="text" id="new-cat-sub" class="catmgr-input" placeholder="Short description (optional)"/>
+                <label for="new-cat-sub">Subtitle</label>
+                <input type="text" id="new-cat-sub" name="new-category-subtitle" class="catmgr-input" placeholder="Short description (optional)…" autocomplete="off"/>
               </div>
               <div class="catmgr-field-row">
-                <label>Hint text</label>
-                <input type="text" id="new-cat-placeholder" class="catmgr-input" placeholder="Add item input hint (optional)"/>
+                <label for="new-cat-placeholder">Hint text</label>
+                <input type="text" id="new-cat-placeholder" name="new-category-hint" class="catmgr-input" placeholder="Add item input hint (optional)…" autocomplete="off"/>
               </div>
               <div class="catmgr-add-btn-row">
                 <button class="btn-small" onclick="confirmAddCategory()">Add Category</button>
@@ -236,13 +232,13 @@
                 <p class="settings-section-kicker">Item Repository</p>
                 <h2>The master database for all culinary assets.</h2>
               </div>
-              <p class="manager-shell-section-copy">Search active and off-menu items, then open the maintenance drawers only when you need to clean up hidden inventory or prune stale entries.</p>
+              <p class="manager-shell-section-copy">Search the full menu inventory, then open maintenance tools only when you need them.</p>
             </div>
 
             <div class="manager-shell-database-toolbar">
               <div class="db-search-row manager-shell-db-search">
                 <label class="manager-shell-field-label" for="db-search">Search Database</label>
-                <input type="text" id="db-search" placeholder="Search drinks, dishes, or ingredients…" oninput="filterDatabase()" />
+                <input type="search" id="db-search" name="database-search" placeholder="Search drinks, dishes, or ingredients…" autocomplete="off" spellcheck="false" oninput="filterDatabase()" />
               </div>
               <div class="manager-shell-db-filters">
                 <div class="manager-shell-filter-block">
@@ -296,7 +292,7 @@
         </div>
 
         <button class="logout-link manager-shell-exit" onclick="exitView()">← Back to menu view</button>
-      </div>
+      </main>
     </div>
 
     <div class="manager-shell-actionbar" id="manager-action-bar" hidden>
@@ -310,8 +306,8 @@
           <button class="btn-small" onclick="editFeaturedFromBanner()">Update Featured</button>
         </div>
         <div class="btn-row manager-shell-actionbar-primary" id="manager-primary-action-group" hidden>
-          <button class="save-btn" id="save-btn" onclick="saveMenu()">SAVE</button>
-          <button class="send-btn" id="send-btn" onclick="openPreview()">SEND UPDATE</button>
+          <button class="save-btn" id="save-btn" onclick="saveMenu()">Save</button>
+          <button class="send-btn" id="send-btn" onclick="openPreview()">Send Update</button>
         </div>
       </div>
       <div id="sync-status"></div>
@@ -324,13 +320,13 @@
     <div id="auth-no-config" style="display:none" class="auth-hint-msg">Supabase is not configured. Check server environment variables.</div>
     <div id="auth-form-wrap">
       <div id="auth-screen-signin" class="auth-screen">
-        <h2 class="auth-screen-title">SIGN IN</h2>
+        <h2 class="auth-screen-title">Sign In</h2>
         <p class="auth-screen-subtitle">Sign in to your account</p>
         <div class="auth-field">
-          <input type="email" id="signin-email" placeholder="Email address" autocomplete="email" aria-describedby="signin-error"/>
+          <input type="email" id="signin-email" name="signin-email" placeholder="Email address" autocomplete="email" aria-label="Email address" aria-describedby="signin-error"/>
         </div>
         <div class="auth-field">
-          <input type="password" id="signin-password" placeholder="Password" autocomplete="current-password" aria-describedby="signin-error"/>
+          <input type="password" id="signin-password" name="signin-password" placeholder="Password" autocomplete="current-password" aria-label="Password" aria-describedby="signin-error"/>
         </div>
         <div class="auth-error" id="signin-error"></div>
         <button class="auth-submit-btn" id="signin-submit-btn" onclick="handleSignIn()">Sign In</button>
@@ -342,25 +338,25 @@
       </div>
 
       <div id="auth-screen-signup" class="auth-screen" style="display:none">
-        <h2 class="auth-screen-title">CREATE ACCOUNT</h2>
+        <h2 class="auth-screen-title">Create Account</h2>
         <p class="auth-screen-subtitle">Sign up with your work email</p>
         <div class="auth-field">
-          <input type="text" id="signup-firstname" placeholder="First name" autocomplete="given-name"
+          <input type="text" id="signup-firstname" name="signup-firstname" placeholder="First name" autocomplete="given-name" aria-label="First name"
                  aria-describedby="signup-error"
                  onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-lastname').focus();}"/>
         </div>
         <div class="auth-field">
-          <input type="text" id="signup-lastname" placeholder="Last name" autocomplete="family-name"
+          <input type="text" id="signup-lastname" name="signup-lastname" placeholder="Last name" autocomplete="family-name" aria-label="Last name"
                  aria-describedby="signup-error"
                  onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-email').focus();}"/>
         </div>
         <div class="auth-field">
-          <input type="email" id="signup-email" placeholder="Email address" autocomplete="email"
+          <input type="email" id="signup-email" name="signup-email" placeholder="Email address" autocomplete="email" aria-label="Email address"
                  aria-describedby="signup-error"
                  onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-password').focus();}"/>
         </div>
         <div class="auth-field">
-          <input type="password" id="signup-password" placeholder="Password" autocomplete="new-password"
+          <input type="password" id="signup-password" name="signup-password" placeholder="Password" autocomplete="new-password" aria-label="Password"
                  aria-describedby="signup-error"
                  onkeydown="if(event.key==='Enter'){event.preventDefault();handleSignUp();}"/>
         </div>
@@ -371,10 +367,10 @@
       </div>
 
       <div id="auth-screen-forgot" class="auth-screen" style="display:none">
-        <h2 class="auth-screen-title">RESET PASSWORD</h2>
+        <h2 class="auth-screen-title">Reset Password</h2>
         <p class="auth-screen-subtitle">Enter your email and we'll send a reset link</p>
         <div class="auth-field">
-          <input type="email" id="forgot-email" placeholder="Email address" autocomplete="email" aria-describedby="forgot-error"/>
+          <input type="email" id="forgot-email" name="forgot-email" placeholder="Email address" autocomplete="email" aria-label="Email address" aria-describedby="forgot-error"/>
         </div>
         <div class="auth-error" id="forgot-error"></div>
         <button class="auth-submit-btn" id="forgot-submit-btn" onclick="handleForgotPassword()">Send Reset Link</button>
@@ -382,13 +378,13 @@
       </div>
 
       <div id="auth-screen-reset" class="auth-screen" style="display:none">
-        <h2 class="auth-screen-title">SET NEW PASSWORD</h2>
+        <h2 class="auth-screen-title">Set New Password</h2>
         <p class="auth-screen-subtitle">Choose a new password for your account</p>
         <div class="auth-field">
-          <input type="password" id="reset-password" placeholder="New password" autocomplete="new-password" aria-describedby="reset-error"/>
+          <input type="password" id="reset-password" name="reset-password" placeholder="New password" autocomplete="new-password" aria-label="New password" aria-describedby="reset-error"/>
         </div>
         <div class="auth-field">
-          <input type="password" id="reset-confirm" placeholder="Confirm new password" autocomplete="new-password" aria-describedby="reset-error"/>
+          <input type="password" id="reset-confirm" name="reset-confirm" placeholder="Confirm new password" autocomplete="new-password" aria-label="Confirm new password" aria-describedby="reset-error"/>
         </div>
         <div class="auth-error" id="reset-error"></div>
         <button class="auth-submit-btn" id="reset-submit-btn" onclick="handleResetPassword()">Set Password</button>
@@ -400,7 +396,7 @@
 
 <div class="modal-bg" id="modal-bg">
   <div class="modal">
-    <h2>PATCH NOTES PREVIEW</h2>
+    <h2>Patch Notes Preview</h2>
     <div class="modal-sub">Only changes since the last update will be sent.</div>
     <div id="preview-content"></div>
     <div class="modal-actions">
@@ -412,7 +408,7 @@
 
 <div id="menu-picker-overlay">
   <div class="picker-box" role="dialog" aria-modal="true" aria-label="Select a Menu">
-    <h2 class="picker-title" id="picker-title">SELECT A MENU</h2>
+    <h2 class="picker-title" id="picker-title">Select a Menu</h2>
     <p class="picker-subtitle" id="picker-subtitle">Choose which menu to view</p>
     <div id="picker-menu-list" class="picker-menu-list"></div>
     <div class="picker-actions">

--- a/style.css
+++ b/style.css
@@ -1287,8 +1287,8 @@ body.admin-console-page .wrapper {
 
 .admin-console-shell {
   display: grid;
-  grid-template-columns: 248px minmax(0, 1fr);
-  gap: 24px;
+  grid-template-columns: 220px minmax(0, 1fr);
+  gap: 20px;
   align-items: start;
 }
 
@@ -1301,11 +1301,11 @@ body.admin-console-page .wrapper {
   overscroll-behavior: contain;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 18px;
   background: var(--admin-sidebar);
   color: var(--admin-sidebar-text);
   border-radius: 12px;
-  padding: 24px 18px;
+  padding: 18px 16px;
   box-shadow: 0 24px 40px var(--admin-shadow);
 }
 
@@ -1326,9 +1326,9 @@ body.admin-console-page .wrapper {
 
 .admin-console-rail-title {
   font-family: "Public Sans", var(--font-heading);
-  font-size: 28px;
-  line-height: 0.95;
-  letter-spacing: -0.04em;
+  font-size: 20px;
+  line-height: 1;
+  letter-spacing: -0.03em;
   color: var(--admin-panel);
 }
 
@@ -1342,9 +1342,9 @@ body.admin-console-page .wrapper {
   background: transparent;
   border: 1px solid transparent;
   border-radius: 4px;
-  padding: 12px 14px;
+  padding: 10px 12px;
   font-family: "Public Sans", var(--font-heading);
-  font-size: 14px;
+  font-size: 13px;
   font-weight: 700;
   letter-spacing: -0.01em;
   color: var(--admin-sidebar-dim);
@@ -1389,7 +1389,7 @@ body.admin-console-page .wrapper {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 18px;
 }
 
 .admin-console-topbar {
@@ -1399,8 +1399,8 @@ body.admin-console-page .wrapper {
   display: flex;
   align-items: flex-start;
   justify-content: space-between;
-  gap: 20px;
-  padding: 22px 24px;
+  gap: 16px;
+  padding: 16px 18px;
   background: var(--admin-canvas-glass);
   backdrop-filter: blur(18px);
   border: 1px solid var(--admin-outline);
@@ -1412,7 +1412,7 @@ body.admin-console-page .wrapper {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 4px;
 }
 
 .admin-console-kicker,
@@ -1434,59 +1434,19 @@ body.admin-console-page .wrapper {
   color: var(--admin-muted);
 }
 
-.admin-console-title-row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-}
-
-.admin-console-title-row h2 {
+.admin-console-topbar-copy h2 {
   font-family: "Public Sans", var(--font-heading);
-  font-size: clamp(30px, 4vw, 42px);
-  line-height: 0.94;
-  letter-spacing: -0.05em;
+  font-size: clamp(18px, 2.2vw, 24px);
+  line-height: 1.05;
+  letter-spacing: -0.03em;
   color: var(--admin-ink);
-  max-width: 12ch;
-}
-
-.admin-console-status-pill {
-  flex-shrink: 0;
-  display: inline-flex;
-  align-items: center;
-  gap: 10px;
-  padding: 8px 12px;
-  background: var(--admin-panel);
-  border: 1px solid var(--admin-outline);
-  border-radius: 999px;
-}
-
-.admin-console-status-dot {
-  width: 9px;
-  height: 9px;
-  border-radius: 999px;
-  background: var(--admin-accent);
-  box-shadow: 0 0 0 6px var(--admin-status-glow);
-}
-
-.admin-console-topbar-sub,
-.admin-console-card-caption,
-.restaurant-copy,
-.admin-user-access-note {
-  font-size: 13px;
-  line-height: 1.6;
-  color: var(--admin-muted);
-}
-
-.admin-console-last-updated {
-  color: var(--admin-muted);
-  font-size: 12px;
+  text-wrap: balance;
 }
 
 .admin-console-topbar-actions {
   display: flex;
-  align-items: flex-start;
-  gap: 12px;
+  align-items: center;
+  gap: 10px;
 }
 
 .admin-console-topbar .header-action-group,
@@ -1504,7 +1464,7 @@ body.admin-console-page .wrapper {
 .admin-console-topbar .manager-btn,
 .admin-console-topbar .header-signin-btn,
 .admin-console-topbar .user-chip {
-  min-height: 42px;
+  min-height: 38px;
   border-radius: 4px;
   background: var(--admin-panel);
   border: 1px solid var(--admin-outline);
@@ -1530,7 +1490,7 @@ body.admin-console-page .wrapper {
 .admin-console-topbar .user-chip {
   gap: 8px;
   border-radius: 999px;
-  padding-inline: 14px;
+  padding-inline: 12px;
 }
 
 .admin-console-topbar .user-dropdown {
@@ -1539,90 +1499,13 @@ body.admin-console-page .wrapper {
   color: var(--admin-ink);
 }
 
-.admin-console-overview,
 .admin-console-section {
   display: flex;
   flex-direction: column;
-  gap: 20px;
+  gap: 16px;
   scroll-margin-top: 110px;
 }
 
-.admin-console-overview-grid {
-  display: grid;
-  grid-template-columns: minmax(0, 1.55fr) minmax(250px, 0.95fr);
-  gap: 18px;
-  align-items: start;
-}
-
-.admin-console-summary-card,
-.admin-console-metric-card,
-.admin-console-activity-card {
-  background: var(--admin-panel-soft);
-  border: 1px solid var(--admin-outline);
-  border-radius: 12px;
-  box-shadow: 0 18px 36px var(--admin-shadow);
-}
-
-.admin-console-summary-card {
-  min-height: 0;
-  padding: 22px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  gap: 18px;
-}
-
-.admin-console-card-head {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-.admin-console-summary-metrics {
-  display: flex;
-  gap: 24px;
-  flex-wrap: wrap;
-}
-
-.admin-console-summary-value,
-.admin-console-metric-value {
-  display: block;
-  font-family: "Public Sans", var(--font-heading);
-  font-weight: 900;
-  letter-spacing: -0.06em;
-  color: var(--admin-ink);
-}
-
-.admin-console-summary-value {
-  font-size: clamp(40px, 5vw, 64px);
-  line-height: 0.9;
-}
-
-.admin-console-metric-stack {
-  display: grid;
-  grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 12px;
-}
-
-.admin-console-metric-card {
-  min-height: 104px;
-  padding: 18px;
-  display: flex;
-  flex-direction: column;
-  justify-content: space-between;
-  background: var(--admin-panel);
-}
-
-.admin-console-metric-value {
-  font-size: 32px;
-  line-height: 0.95;
-}
-
-.admin-console-metric-card--alert .admin-console-metric-value {
-  color: var(--admin-alert);
-}
-
-.admin-console-summary-pill,
 .restaurant-summary-pill,
 .admin-user-status-pill {
   display: inline-flex;
@@ -1636,7 +1519,6 @@ body.admin-console-page .wrapper {
   text-transform: uppercase;
 }
 
-.admin-console-summary-pill,
 .restaurant-summary-pill,
 .admin-user-status-pill--active,
 .admin-user-status-pill--current {
@@ -1649,7 +1531,6 @@ body.admin-console-page .wrapper {
   color: var(--admin-alert);
 }
 
-.admin-console-activity-card,
 .admin-console-section,
 .admin-console-page .config-card {
   padding: 20px;
@@ -1657,54 +1538,6 @@ body.admin-console-page .wrapper {
   border: 1px solid var(--admin-outline);
   border-radius: 12px;
   box-shadow: 0 18px 36px var(--admin-shadow);
-}
-
-.admin-console-activity-feed {
-  display: flex;
-  flex-direction: column;
-  max-height: 232px;
-  overflow-y: auto;
-}
-
-.admin-activity-row {
-  display: flex;
-  align-items: flex-start;
-  justify-content: space-between;
-  gap: 16px;
-  padding: 14px 0;
-  border-top: 1px solid var(--admin-outline);
-}
-
-.admin-activity-row:first-child {
-  border-top: none;
-  padding-top: 6px;
-}
-
-.admin-activity-row-main {
-  min-width: 0;
-}
-
-.admin-activity-title {
-  font-family: "Public Sans", var(--font-heading);
-  font-size: 15px;
-  font-weight: 700;
-  color: var(--admin-ink);
-}
-
-.admin-activity-copy {
-  margin-top: 4px;
-  font-size: 13px;
-  line-height: 1.55;
-  color: var(--admin-muted);
-}
-
-.admin-activity-time {
-  flex-shrink: 0;
-  font-size: 11px;
-  font-weight: 700;
-  letter-spacing: 0.12em;
-  text-transform: uppercase;
-  color: var(--admin-muted);
 }
 
 .admin-console-split {
@@ -1958,25 +1791,20 @@ body.admin-console-page .wrapper {
 }
 
 @media (max-width: 1180px) {
-  .admin-console-topbar,
-  .admin-console-title-row {
+  .admin-console-topbar {
     flex-direction: column;
+    align-items: stretch;
   }
 
   .admin-console-topbar-actions {
     width: 100%;
-    justify-content: space-between;
+    justify-content: flex-start;
     flex-wrap: wrap;
   }
 
-  .admin-console-overview-grid,
   #menus-mgmt-list,
   .admin-console-split {
     grid-template-columns: 1fr;
-  }
-
-  .admin-console-activity-feed {
-    max-height: none;
   }
 
   .admin-users-head,
@@ -2025,8 +1853,6 @@ body.admin-console-page .wrapper {
 
 @media (max-width: 640px) {
   .admin-console-topbar,
-  .admin-console-summary-card,
-  .admin-console-activity-card,
   .admin-console-section,
   .admin-console-page .config-card,
   .restaurant-row {
@@ -2048,7 +1874,6 @@ body.admin-console-page .wrapper {
     width: 100%;
   }
 
-  .admin-console-metric-stack,
   .admin-users-head,
   .admin-user-row {
     grid-template-columns: 1fr;

--- a/style.css
+++ b/style.css
@@ -1255,6 +1255,26 @@ body.admin-console-page .wrapper {
   margin: 0 auto;
 }
 
+.admin-skip-link {
+  position: absolute;
+  left: 16px;
+  top: -48px;
+  z-index: 20;
+  padding: 10px 14px;
+  border-radius: 999px;
+  background: var(--admin-sidebar);
+  color: var(--admin-panel);
+  font-family: "Public Sans", var(--font-heading);
+  font-size: 12px;
+  font-weight: 700;
+  text-decoration: none;
+  transition: top 0.18s ease;
+}
+
+.admin-skip-link:focus-visible {
+  top: 16px;
+}
+
 .admin-console-loading {
   min-height: 56vh;
   display: flex;
@@ -1275,7 +1295,10 @@ body.admin-console-page .wrapper {
 .admin-console-rail {
   position: sticky;
   top: 16px;
-  min-height: calc(100vh - 32px);
+  align-self: start;
+  max-height: calc(100vh - 32px);
+  overflow-y: auto;
+  overscroll-behavior: contain;
   display: flex;
   flex-direction: column;
   gap: 24px;
@@ -1520,13 +1543,15 @@ body.admin-console-page .wrapper {
 .admin-console-section {
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: 20px;
+  scroll-margin-top: 110px;
 }
 
 .admin-console-overview-grid {
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
-  gap: 24px;
+  grid-template-columns: minmax(0, 1.55fr) minmax(250px, 0.95fr);
+  gap: 18px;
+  align-items: start;
 }
 
 .admin-console-summary-card,
@@ -1539,12 +1564,12 @@ body.admin-console-page .wrapper {
 }
 
 .admin-console-summary-card {
-  min-height: 300px;
-  padding: 28px;
+  min-height: 0;
+  padding: 22px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
-  gap: 24px;
+  gap: 18px;
 }
 
 .admin-console-card-head {
@@ -1555,7 +1580,7 @@ body.admin-console-page .wrapper {
 
 .admin-console-summary-metrics {
   display: flex;
-  gap: 40px;
+  gap: 24px;
   flex-wrap: wrap;
 }
 
@@ -1569,19 +1594,19 @@ body.admin-console-page .wrapper {
 }
 
 .admin-console-summary-value {
-  font-size: clamp(58px, 7vw, 92px);
+  font-size: clamp(40px, 5vw, 64px);
   line-height: 0.9;
 }
 
 .admin-console-metric-stack {
   display: grid;
   grid-template-columns: repeat(2, minmax(0, 1fr));
-  gap: 16px;
+  gap: 12px;
 }
 
 .admin-console-metric-card {
-  min-height: 142px;
-  padding: 22px;
+  min-height: 104px;
+  padding: 18px;
   display: flex;
   flex-direction: column;
   justify-content: space-between;
@@ -1589,7 +1614,7 @@ body.admin-console-page .wrapper {
 }
 
 .admin-console-metric-value {
-  font-size: 42px;
+  font-size: 32px;
   line-height: 0.95;
 }
 
@@ -1627,7 +1652,7 @@ body.admin-console-page .wrapper {
 .admin-console-activity-card,
 .admin-console-section,
 .admin-console-page .config-card {
-  padding: 24px;
+  padding: 20px;
   background: var(--admin-panel);
   border: 1px solid var(--admin-outline);
   border-radius: 12px;
@@ -1637,6 +1662,8 @@ body.admin-console-page .wrapper {
 .admin-console-activity-feed {
   display: flex;
   flex-direction: column;
+  max-height: 232px;
+  overflow-y: auto;
 }
 
 .admin-activity-row {
@@ -1644,7 +1671,7 @@ body.admin-console-page .wrapper {
   align-items: flex-start;
   justify-content: space-between;
   gap: 16px;
-  padding: 18px 0;
+  padding: 14px 0;
   border-top: 1px solid var(--admin-outline);
 }
 
@@ -1946,6 +1973,10 @@ body.admin-console-page .wrapper {
   #menus-mgmt-list,
   .admin-console-split {
     grid-template-columns: 1fr;
+  }
+
+  .admin-console-activity-feed {
+    max-height: none;
   }
 
   .admin-users-head,

--- a/style.css
+++ b/style.css
@@ -1347,3 +1347,1090 @@
     gap: 8px;
   }
 }
+
+/* ─── MANAGER STITCH SHELL ───────────────────────────────────────────────── */
+body.manager-stitch-shell,
+body.manager-mode.manager-stitch-shell {
+  --manager-shell-bg: #faf9f6;
+  --manager-shell-surface: #ffffff;
+  --manager-shell-surface-muted: #f4f3f0;
+  --manager-shell-surface-strong: #e9e8e5;
+  --manager-shell-border: rgba(25, 37, 25, 0.12);
+  --manager-shell-border-strong: rgba(25, 37, 25, 0.2);
+  --manager-shell-text: #1a1c1a;
+  --manager-shell-muted: #5f5e5e;
+  --manager-shell-primary: #192519;
+  --manager-shell-primary-soft: #2e3b2e;
+  --manager-shell-primary-faint: rgba(46, 59, 46, 0.12);
+  --manager-shell-accent: #301f08;
+  --manager-shell-accent-soft: #fdddb9;
+  --manager-shell-error: #ba1a1a;
+  --manager-shell-success: #315f31;
+  --manager-shell-overlay: rgba(26, 28, 26, 0.28);
+  --manager-shell-shadow: rgba(25, 37, 25, 0.08);
+  --manager-shell-shadow-strong: rgba(25, 37, 25, 0.16);
+  --manager-shell-glass-bg: rgba(250, 249, 246, 0.82);
+  --manager-shell-actionbar-bg: rgba(255, 255, 255, 0.88);
+  --bg: var(--manager-shell-bg);
+  --surface: var(--manager-shell-surface);
+  --card: var(--manager-shell-surface-muted);
+  --border: var(--manager-shell-border);
+  --text: var(--manager-shell-text);
+  --muted: var(--manager-shell-muted);
+  --fire: var(--manager-shell-primary);
+  --ember: var(--manager-shell-primary-soft);
+  --gold: var(--manager-shell-accent);
+  --green: var(--manager-shell-success);
+  --red: var(--manager-shell-error);
+  --danger-bg: var(--manager-shell-primary-faint);
+  --danger-border: var(--manager-shell-border-strong);
+  --prune-divider: var(--manager-shell-border);
+  background: var(--manager-shell-bg);
+  color: var(--manager-shell-text);
+  font-family: 'Inter', sans-serif;
+  align-items: stretch;
+  padding: 0 0 164px;
+}
+
+@media (prefers-color-scheme: dark) {
+  body.manager-stitch-shell,
+  body.manager-mode.manager-stitch-shell {
+    --manager-shell-bg: #171a17;
+    --manager-shell-surface: #202420;
+    --manager-shell-surface-muted: #262b26;
+    --manager-shell-surface-strong: #303630;
+    --manager-shell-border: rgba(242, 241, 238, 0.12);
+    --manager-shell-border-strong: rgba(242, 241, 238, 0.2);
+    --manager-shell-text: #f2f1ee;
+    --manager-shell-muted: #bcc1b8;
+    --manager-shell-primary: #d8e7d4;
+    --manager-shell-primary-soft: #bccbb9;
+    --manager-shell-primary-faint: rgba(216, 231, 212, 0.1);
+    --manager-shell-accent: #fdddb9;
+    --manager-shell-accent-soft: rgba(253, 221, 185, 0.16);
+    --manager-shell-error: #ffb4ab;
+    --manager-shell-success: #a9d6a7;
+    --manager-shell-overlay: rgba(0, 0, 0, 0.46);
+    --manager-shell-shadow: rgba(0, 0, 0, 0.26);
+    --manager-shell-shadow-strong: rgba(0, 0, 0, 0.38);
+    --manager-shell-glass-bg: rgba(23, 26, 23, 0.82);
+    --manager-shell-actionbar-bg: rgba(32, 36, 32, 0.9);
+  }
+}
+
+body.manager-stitch-shell .wrapper {
+  width: 100%;
+  max-width: none;
+}
+
+body.manager-stitch-shell #app-shell {
+  width: 100%;
+  max-width: none;
+}
+
+body.manager-stitch-shell #app-shell > header.manager-shell-topbar {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  z-index: 55;
+  margin: 0;
+  padding: 0;
+  border-radius: 0;
+  background: var(--manager-shell-glass-bg);
+  border-bottom: 1px solid var(--manager-shell-border);
+  box-shadow: none;
+  backdrop-filter: blur(18px);
+}
+
+body.manager-stitch-shell .manager-shell-topbar-inner {
+  width: min(1320px, calc(100% - 48px));
+  margin: 0 auto;
+  min-height: 88px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+body.manager-stitch-shell .manager-shell-brand-wrap {
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  gap: 16px;
+}
+
+body.manager-stitch-shell .manager-shell-menu-toggle {
+  display: none;
+  align-items: center;
+  justify-content: center;
+  width: 44px;
+  height: 44px;
+  border: 1px solid var(--manager-shell-border);
+  border-radius: 2px;
+  background: var(--manager-shell-surface-muted);
+  color: var(--manager-shell-primary);
+  font: inherit;
+  font-size: 18px;
+  cursor: pointer;
+}
+
+body.manager-stitch-shell .manager-shell-brand-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+body.manager-stitch-shell .manager-shell-brand-mark,
+body.manager-stitch-shell .manager-shell-stat-label,
+body.manager-stitch-shell .manager-shell-field-label,
+body.manager-stitch-shell .manager-shell-disclosure summary span:first-child,
+body.manager-stitch-shell .db-filter-btn,
+body.manager-stitch-shell .btn-small,
+body.manager-stitch-shell .save-btn,
+body.manager-stitch-shell .send-btn {
+  font-family: 'Inter', sans-serif;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+body.manager-stitch-shell .manager-shell-brand-mark {
+  margin: 0;
+  color: var(--manager-shell-muted);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+body.manager-stitch-shell .manager-shell-title-row {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+body.manager-stitch-shell #app-shell > header h1 {
+  margin: 0;
+  color: var(--manager-shell-primary);
+  font-family: 'Noto Serif', serif;
+  font-size: 34px;
+  line-height: 1;
+  letter-spacing: -0.03em;
+  text-shadow: none;
+}
+
+body.manager-stitch-shell .header-action-group {
+  position: static;
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+body.manager-stitch-shell .manager-btn,
+body.manager-stitch-shell .header-signin-btn {
+  position: static;
+  border: 1px solid var(--manager-shell-border);
+  border-radius: 2px;
+  background: var(--manager-shell-surface-muted);
+  color: var(--manager-shell-primary);
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 10px 14px;
+  backdrop-filter: none;
+}
+
+body.manager-stitch-shell .manager-btn:hover,
+body.manager-stitch-shell .header-signin-btn:hover,
+body.manager-stitch-shell .manager-btn.active {
+  background: var(--manager-shell-primary);
+  border-color: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
+}
+
+body.manager-stitch-shell .admin-btn {
+  border-color: var(--manager-shell-border-strong);
+}
+
+body.manager-stitch-shell .manager-shell-header-meta {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+body.manager-stitch-shell .header-sub {
+  margin: 0;
+  color: var(--manager-shell-muted);
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+body.manager-stitch-shell .manager-shell-menu-bar {
+  display: inline-flex;
+  align-items: center;
+  gap: 12px;
+  min-height: 38px;
+  padding: 0 14px;
+  background: var(--manager-shell-surface-muted);
+  border: 1px solid var(--manager-shell-border);
+  border-radius: 2px;
+}
+
+body.manager-stitch-shell .active-menu-label {
+  color: var(--manager-shell-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+body.manager-stitch-shell .active-menu-name-text {
+  color: var(--manager-shell-primary);
+  font-size: 13px;
+  font-weight: 700;
+}
+
+body.manager-stitch-shell .manager-shell-switch-btn,
+body.manager-stitch-shell .btn-small {
+  border-radius: 2px;
+  background: var(--manager-shell-surface);
+  border: 1px solid var(--manager-shell-border);
+  color: var(--manager-shell-primary);
+  font-size: 11px;
+  font-weight: 700;
+  padding: 10px 14px;
+}
+
+body.manager-stitch-shell .manager-shell-switch-btn:hover,
+body.manager-stitch-shell .btn-small:hover {
+  background: var(--manager-shell-primary);
+  border-color: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
+}
+
+body.manager-stitch-shell .manager-shell-user-tools {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+body.manager-stitch-shell .user-chip {
+  position: static;
+  border-radius: 2px;
+  background: var(--manager-shell-surface-muted);
+  border: 1px solid var(--manager-shell-border);
+  color: var(--manager-shell-primary);
+  padding: 10px 12px;
+}
+
+body.manager-stitch-shell .user-chip:hover {
+  background: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
+}
+
+body.manager-stitch-shell .user-dropdown {
+  background: var(--manager-shell-surface);
+  border-color: var(--manager-shell-border);
+  border-radius: 2px;
+  box-shadow: 0 20px 36px var(--manager-shell-shadow-strong);
+}
+
+body.manager-stitch-shell .user-dropdown-name,
+body.manager-stitch-shell .user-dropdown-signout {
+  color: var(--manager-shell-primary);
+}
+
+body.manager-stitch-shell .user-dropdown-role {
+  color: var(--manager-shell-muted);
+}
+
+body.manager-stitch-shell #loading-view {
+  min-height: 52vh;
+  padding-top: 164px;
+}
+
+body.manager-stitch-shell .spinner {
+  box-shadow: 0 0 0 8px var(--manager-shell-surface);
+}
+
+body.manager-stitch-shell #manager-view {
+  width: 100%;
+}
+
+body.manager-stitch-shell .manager-shell-layout {
+  width: min(1320px, calc(100% - 48px));
+  margin: 0 auto;
+  grid-template-columns: 224px minmax(0, 1fr);
+  gap: 40px;
+  align-items: start;
+  padding-top: 120px;
+}
+
+body.manager-stitch-shell .manager-shell-stage {
+  gap: 32px;
+}
+
+body.manager-stitch-shell .manager-shell-panel {
+  gap: 32px;
+}
+
+body.manager-stitch-shell .manager-shell-rail {
+  position: sticky;
+  top: 112px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  padding: 24px 18px;
+  border: none;
+  border-radius: 0;
+  background: var(--manager-shell-surface-muted);
+  box-shadow: none;
+}
+
+body.manager-stitch-shell .manager-shell-rail-head {
+  margin-bottom: 16px;
+}
+
+body.manager-stitch-shell .manager-shell-rail-note {
+  color: var(--manager-shell-muted);
+  font-size: 12px;
+  line-height: 1.6;
+}
+
+body.manager-stitch-shell .settings-rail-btn {
+  border: none;
+  border-left: 4px solid transparent;
+  border-radius: 0;
+  background: transparent;
+  color: var(--manager-shell-muted);
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  padding: 14px 14px 14px 18px;
+}
+
+body.manager-stitch-shell .settings-rail-btn:hover,
+body.manager-stitch-shell .settings-rail-btn.active {
+  transform: none;
+  background: transparent;
+  border-color: var(--manager-shell-primary);
+  color: var(--manager-shell-primary);
+}
+
+body.manager-stitch-shell .settings-section,
+body.manager-stitch-shell .manager-shell-overview-card,
+body.manager-stitch-shell .cat-card,
+body.manager-stitch-shell .catmgr-card,
+body.manager-stitch-shell .featured-mgr-group,
+body.manager-stitch-shell .history-entry,
+body.manager-stitch-shell .manager-shell-disclosure,
+body.manager-stitch-shell .workspace-actions,
+body.manager-stitch-shell .modal,
+body.manager-stitch-shell .picker-box,
+body.manager-stitch-shell .auth-box {
+  border-radius: 2px;
+}
+
+body.manager-stitch-shell .settings-section,
+body.manager-stitch-shell .manager-shell-overview-card {
+  padding: 32px;
+  border: 1px solid var(--manager-shell-border);
+  background: var(--manager-shell-surface-muted);
+  box-shadow: none;
+}
+
+body.manager-stitch-shell .manager-shell-section-header,
+body.manager-stitch-shell .manager-shell-card-head {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 24px;
+  margin-bottom: 24px;
+}
+
+body.manager-stitch-shell .manager-shell-section-header h2,
+body.manager-stitch-shell .manager-shell-card-head h3 {
+  margin: 6px 0 0;
+  color: var(--manager-shell-primary);
+  font-family: 'Noto Serif', serif;
+  font-size: 36px;
+  line-height: 1.08;
+  letter-spacing: -0.03em;
+}
+
+body.manager-stitch-shell .manager-shell-card-head h3 {
+  font-size: 26px;
+}
+
+body.manager-stitch-shell .manager-shell-section-copy,
+body.manager-stitch-shell .manager-shell-card-copy,
+body.manager-stitch-shell .settings-section-copy,
+body.manager-stitch-shell .workspace-actions-sub,
+body.manager-stitch-shell .hint {
+  max-width: 34rem;
+  color: var(--manager-shell-muted);
+  font-size: 14px;
+  line-height: 1.7;
+}
+
+body.manager-stitch-shell #setup-banner {
+  display: block;
+  margin-bottom: 24px;
+  border: 1px solid var(--manager-shell-border);
+  border-radius: 2px;
+  background: var(--manager-shell-surface);
+}
+
+body.manager-stitch-shell #setup-banner h3 {
+  color: var(--manager-shell-primary);
+}
+
+body.manager-stitch-shell #setup-banner p,
+body.manager-stitch-shell #setup-banner strong {
+  color: var(--manager-shell-muted);
+}
+
+body.manager-stitch-shell .featured-confirm-banner {
+  margin: 0 0 24px;
+  border-radius: 2px;
+  background: linear-gradient(135deg, var(--manager-shell-primary-soft), var(--manager-shell-primary));
+  border: none;
+  color: var(--manager-shell-bg);
+  padding: 22px 24px;
+}
+
+body.manager-stitch-shell .featured-confirm-banner .btn-small {
+  background: var(--manager-shell-surface);
+  border-color: var(--manager-shell-surface);
+  color: var(--manager-shell-primary);
+}
+
+body.manager-stitch-shell .featured-confirm-banner .btn-small:hover {
+  background: var(--manager-shell-accent-soft);
+  border-color: var(--manager-shell-accent-soft);
+  color: var(--manager-shell-accent);
+}
+
+body.manager-stitch-shell .manager-shell-stats-grid,
+body.manager-stitch-shell .manager-shell-overview-grid {
+  display: grid;
+  gap: 20px;
+}
+
+body.manager-stitch-shell .manager-shell-stats-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-bottom: 24px;
+}
+
+body.manager-stitch-shell .manager-shell-overview-grid {
+  grid-template-columns: minmax(0, 1.05fr) minmax(0, 0.95fr);
+}
+
+body.manager-stitch-shell .manager-shell-stat-card {
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  min-height: 164px;
+  padding: 24px;
+  background: var(--manager-shell-surface);
+  border: 1px solid var(--manager-shell-border);
+}
+
+body.manager-stitch-shell .manager-shell-stat-card--warn .manager-shell-stat-value {
+  color: var(--manager-shell-error);
+}
+
+body.manager-stitch-shell .manager-shell-stat-value {
+  color: var(--manager-shell-primary);
+  font-family: 'Noto Serif', serif;
+  font-size: 40px;
+  line-height: 1;
+}
+
+body.manager-stitch-shell .manager-shell-stat-meta {
+  color: var(--manager-shell-muted);
+  font-size: 12px;
+  text-transform: uppercase;
+  letter-spacing: 0.1em;
+}
+
+body.manager-stitch-shell .featured-mgr-group,
+body.manager-stitch-shell .history-entry,
+body.manager-stitch-shell .cat-card,
+body.manager-stitch-shell .catmgr-card,
+body.manager-stitch-shell .manager-shell-disclosure {
+  background: var(--manager-shell-surface);
+  border: 1px solid var(--manager-shell-border);
+  box-shadow: none;
+}
+
+body.manager-stitch-shell .featured-mgr-group {
+  padding: 18px;
+  margin-bottom: 14px;
+}
+
+body.manager-stitch-shell .featured-mgr-group-header {
+  margin-bottom: 14px;
+}
+
+body.manager-stitch-shell .featured-mgr-group-name,
+body.manager-stitch-shell .cat-title,
+body.manager-stitch-shell .catmgr-title,
+body.manager-stitch-shell .history-user {
+  color: var(--manager-shell-primary);
+  font-family: 'Noto Serif', serif;
+}
+
+body.manager-stitch-shell .featured-mgr-slot,
+body.manager-stitch-shell .prune-item {
+  border-bottom-color: var(--manager-shell-border);
+}
+
+body.manager-stitch-shell .featured-sell-note-input,
+body.manager-stitch-shell .featured-add-input,
+body.manager-stitch-shell .config-card input,
+body.manager-stitch-shell .catmgr-input,
+body.manager-stitch-shell .add-item-input,
+body.manager-stitch-shell .add-ingredient-input,
+body.manager-stitch-shell .desc-input,
+body.manager-stitch-shell .price-input,
+body.manager-stitch-shell .db-search-row input {
+  background: var(--manager-shell-surface);
+  border-color: var(--manager-shell-border);
+  color: var(--manager-shell-text);
+  border-radius: 0;
+}
+
+body.manager-stitch-shell .featured-add-input,
+body.manager-stitch-shell .db-search-row input {
+  min-height: 48px;
+}
+
+body.manager-stitch-shell .cat-card {
+  margin-bottom: 18px;
+  overflow: hidden;
+}
+
+body.manager-stitch-shell .cat-header {
+  padding: 22px 24px 18px;
+  gap: 14px;
+}
+
+body.manager-stitch-shell .cat-icon,
+body.manager-stitch-shell .catmgr-icon {
+  border-radius: 2px;
+}
+
+body.manager-stitch-shell .cat-title,
+body.manager-stitch-shell .catmgr-title {
+  font-size: 26px;
+  letter-spacing: -0.02em;
+}
+
+body.manager-stitch-shell .cat-sub,
+body.manager-stitch-shell .catmgr-sub,
+body.manager-stitch-shell .current-label,
+body.manager-stitch-shell .history-date,
+body.manager-stitch-shell .history-summary,
+body.manager-stitch-shell .featured-count,
+body.manager-stitch-shell .prune-item-cat,
+body.manager-stitch-shell .prune-empty,
+body.manager-stitch-shell .db-empty,
+body.manager-stitch-shell .db-no-recipe {
+  color: var(--manager-shell-muted);
+}
+
+body.manager-stitch-shell .current-section {
+  padding: 0 24px 24px;
+}
+
+body.manager-stitch-shell .current-items {
+  gap: 12px;
+}
+
+body.manager-stitch-shell .item-wrapper {
+  position: relative;
+}
+
+body.manager-stitch-shell .item-wrapper.is-dragging {
+  opacity: 0.5;
+}
+
+body.manager-stitch-shell .item-wrapper.is-drop-target .current-item {
+  border-color: var(--manager-shell-primary);
+  background: var(--manager-shell-surface-muted);
+}
+
+body.manager-stitch-shell .current-item {
+  gap: 12px;
+  padding: 14px 16px;
+  background: var(--manager-shell-surface);
+  border: 1px solid transparent;
+  border-radius: 0;
+}
+
+body.manager-stitch-shell .item-drag-handle {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  color: var(--manager-shell-muted);
+  cursor: grab;
+  user-select: none;
+}
+
+body.manager-stitch-shell .item-status-dot {
+  width: 8px;
+  height: 8px;
+}
+
+body.manager-stitch-shell .item-name input,
+body.manager-stitch-shell .item-name-static {
+  font-size: 15px;
+}
+
+body.manager-stitch-shell .item-name input {
+  font-weight: 600;
+}
+
+body.manager-stitch-shell .price-input {
+  width: 88px;
+  min-height: 38px;
+  padding: 0 10px;
+}
+
+body.manager-stitch-shell .desc-row,
+body.manager-stitch-shell .recipe-row {
+  margin-top: 0;
+  padding: 14px 16px 16px;
+  border-top: 1px solid var(--manager-shell-border);
+  border-right: 1px solid var(--manager-shell-border);
+  border-bottom: 1px solid var(--manager-shell-border);
+  border-left: 1px solid var(--manager-shell-border);
+  border-radius: 0;
+  background: var(--manager-shell-surface-muted);
+}
+
+body.manager-stitch-shell .ingredient-row {
+  background: var(--manager-shell-surface);
+  border-color: var(--manager-shell-border);
+  border-radius: 0;
+}
+
+body.manager-stitch-shell .catmgr-card {
+  margin-bottom: 14px;
+}
+
+body.manager-stitch-shell .catmgr-row,
+body.manager-stitch-shell .history-header {
+  padding: 18px 20px;
+}
+
+body.manager-stitch-shell .catmgr-edit {
+  border-top-color: var(--manager-shell-border);
+}
+
+body.manager-stitch-shell .catmgr-add-form {
+  margin-bottom: 16px;
+  border-radius: 2px;
+  background: var(--manager-shell-surface);
+  border-color: var(--manager-shell-border);
+}
+
+body.manager-stitch-shell .manager-shell-database-toolbar {
+  display: grid;
+  grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
+  gap: 18px;
+  margin-bottom: 20px;
+  padding: 24px;
+  background: var(--manager-shell-surface);
+  border: 1px solid var(--manager-shell-border);
+}
+
+body.manager-stitch-shell .manager-shell-db-search {
+  padding: 0;
+}
+
+body.manager-stitch-shell .manager-shell-db-filters {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+body.manager-stitch-shell .manager-shell-filter-block {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+body.manager-stitch-shell .db-filter-group {
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+body.manager-stitch-shell .db-filter-btn {
+  min-height: 40px;
+  padding: 0 16px;
+  border-radius: 2px;
+  border-color: var(--manager-shell-border);
+  background: var(--manager-shell-surface-muted);
+  color: var(--manager-shell-muted);
+  font-size: 10px;
+  font-weight: 700;
+}
+
+body.manager-stitch-shell .db-filter-btn.active,
+body.manager-stitch-shell .db-filter-btn:hover {
+  background: var(--manager-shell-primary);
+  border-color: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
+}
+
+body.manager-stitch-shell .db-table {
+  margin-top: 0;
+  background: var(--manager-shell-surface);
+}
+
+body.manager-stitch-shell .db-table th {
+  background: var(--manager-shell-surface-muted);
+  border-bottom-color: var(--manager-shell-border);
+  color: var(--manager-shell-muted);
+  font-size: 10px;
+}
+
+body.manager-stitch-shell .db-table td {
+  border-bottom-color: var(--manager-shell-border);
+}
+
+body.manager-stitch-shell .db-name {
+  color: var(--manager-shell-primary);
+}
+
+body.manager-stitch-shell .db-ing {
+  background: var(--manager-shell-surface-muted);
+  border-color: var(--manager-shell-border);
+  border-radius: 0;
+}
+
+body.manager-stitch-shell .db-badge {
+  border-radius: 2px;
+}
+
+body.manager-stitch-shell .manager-shell-disclosure {
+  margin-top: 16px;
+  overflow: hidden;
+}
+
+body.manager-stitch-shell .manager-shell-disclosure summary {
+  list-style: none;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 20px 22px;
+  cursor: pointer;
+}
+
+body.manager-stitch-shell .manager-shell-disclosure summary::-webkit-details-marker {
+  display: none;
+}
+
+body.manager-stitch-shell .manager-shell-disclosure-copy {
+  color: var(--manager-shell-muted);
+  font-size: 13px;
+  text-transform: none;
+  letter-spacing: normal;
+}
+
+body.manager-stitch-shell .manager-shell-disclosure-body {
+  padding: 0 22px 22px;
+}
+
+body.manager-stitch-shell .manager-shell-disclosure--danger summary {
+  background: var(--manager-shell-primary-faint);
+}
+
+body.manager-stitch-shell .prune-section {
+  margin-top: 0;
+  padding: 0;
+  border: none;
+  background: transparent;
+}
+
+body.manager-stitch-shell .section-label {
+  color: var(--manager-shell-error);
+}
+
+body.manager-stitch-shell .section-label::after {
+  background: var(--manager-shell-border);
+}
+
+body.manager-stitch-shell .btn-danger {
+  background: var(--manager-shell-surface) !important;
+  color: var(--manager-shell-error) !important;
+  border-color: var(--manager-shell-border) !important;
+}
+
+body.manager-stitch-shell .btn-danger:hover {
+  background: var(--manager-shell-error) !important;
+  border-color: var(--manager-shell-error) !important;
+  color: var(--manager-shell-bg) !important;
+}
+
+body.manager-stitch-shell .manager-shell-exit {
+  margin-top: 0;
+  padding: 0 0 12px;
+  color: var(--manager-shell-muted);
+  text-align: left;
+}
+
+body.manager-stitch-shell .manager-shell-exit:hover {
+  color: var(--manager-shell-primary);
+}
+
+body.manager-stitch-shell #manager-action-bar[hidden] {
+  display: none;
+}
+
+body.manager-stitch-shell .manager-shell-actionbar {
+  position: fixed;
+  left: 288px;
+  right: 24px;
+  bottom: 20px;
+  z-index: 56;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  padding: 18px 22px;
+  background: var(--manager-shell-actionbar-bg);
+  border: 1px solid var(--manager-shell-border);
+  box-shadow: 0 -12px 40px var(--manager-shell-shadow);
+  backdrop-filter: blur(18px);
+}
+
+body.manager-stitch-shell .manager-shell-actionbar-copy {
+  min-width: 0;
+  max-width: 32rem;
+}
+
+body.manager-stitch-shell .manager-shell-actionbar-groups {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+
+body.manager-stitch-shell .manager-shell-actionbar-featured,
+body.manager-stitch-shell .manager-shell-actionbar-primary {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+body.manager-stitch-shell .manager-shell-actionbar-primary {
+  margin-top: 0;
+}
+
+body.manager-stitch-shell .save-btn,
+body.manager-stitch-shell .send-btn {
+  min-height: 50px;
+  padding: 0 22px;
+  border-radius: 2px;
+  font-size: 12px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+body.manager-stitch-shell .save-btn {
+  background: var(--manager-shell-surface-muted);
+  color: var(--manager-shell-primary);
+  border: 1px solid var(--manager-shell-border);
+  box-shadow: none;
+}
+
+body.manager-stitch-shell .save-btn:hover {
+  background: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
+  opacity: 1;
+}
+
+body.manager-stitch-shell .send-btn {
+  min-width: 220px;
+  background: linear-gradient(135deg, var(--manager-shell-primary), var(--manager-shell-primary-soft));
+  box-shadow: 0 18px 30px var(--manager-shell-shadow);
+}
+
+body.manager-stitch-shell .send-btn:hover {
+  transform: translateY(-1px);
+}
+
+body.manager-stitch-shell #sync-status {
+  min-width: max-content;
+}
+
+body.manager-stitch-shell .toast {
+  bottom: 108px;
+}
+
+body.manager-stitch-shell .manager-shell-backdrop {
+  display: none;
+}
+
+body.manager-stitch-shell.settings-drawer-open {
+  overflow: hidden;
+}
+
+@media (max-width: 1100px) {
+  body.manager-stitch-shell .manager-shell-topbar-inner,
+  body.manager-stitch-shell .manager-shell-layout {
+    width: calc(100% - 32px);
+  }
+
+  body.manager-stitch-shell .manager-shell-overview-grid,
+  body.manager-stitch-shell .manager-shell-database-toolbar {
+    grid-template-columns: 1fr;
+  }
+
+  body.manager-stitch-shell .manager-shell-db-filters {
+    grid-template-columns: 1fr 1fr;
+  }
+}
+
+@media (max-width: 920px) {
+  body.manager-stitch-shell {
+    padding-bottom: 192px;
+  }
+
+  body.manager-stitch-shell .manager-shell-menu-toggle {
+    display: inline-flex;
+  }
+
+  body.manager-stitch-shell .manager-shell-topbar-inner {
+    width: calc(100% - 24px);
+    min-height: 82px;
+  }
+
+  body.manager-stitch-shell .manager-shell-layout {
+    width: calc(100% - 24px);
+    grid-template-columns: 1fr;
+    gap: 0;
+    padding-top: 108px;
+  }
+
+  body.manager-stitch-shell .manager-shell-rail {
+    position: fixed;
+    top: 0;
+    left: 0;
+    bottom: 0;
+    width: min(80vw, 320px);
+    padding: 104px 18px 24px;
+    transform: translateX(-100%);
+    transition: transform 0.22s ease;
+    z-index: 70;
+  }
+
+  body.manager-stitch-shell .manager-shell-rail.is-open {
+    transform: translateX(0);
+  }
+
+  body.manager-stitch-shell .manager-shell-backdrop:not([hidden]) {
+    display: block;
+    position: fixed;
+    inset: 0;
+    z-index: 60;
+    background: var(--manager-shell-overlay);
+  }
+
+  body.manager-stitch-shell .manager-shell-actionbar {
+    left: 12px;
+    right: 12px;
+    bottom: 12px;
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  body.manager-stitch-shell .manager-shell-actionbar-copy,
+  body.manager-stitch-shell .manager-shell-actionbar-groups,
+  body.manager-stitch-shell .manager-shell-actionbar-featured,
+  body.manager-stitch-shell .manager-shell-actionbar-primary {
+    width: 100%;
+  }
+
+  body.manager-stitch-shell .manager-shell-actionbar-featured,
+  body.manager-stitch-shell .manager-shell-actionbar-primary {
+    flex-direction: column;
+  }
+
+  body.manager-stitch-shell .manager-shell-actionbar-featured .btn-small,
+  body.manager-stitch-shell .manager-shell-actionbar-primary .save-btn,
+  body.manager-stitch-shell .manager-shell-actionbar-primary .send-btn {
+    width: 100%;
+  }
+}
+
+@media (max-width: 720px) {
+  body.manager-stitch-shell .manager-shell-topbar-inner {
+    align-items: flex-start;
+    padding: 14px 0;
+  }
+
+  body.manager-stitch-shell .manager-shell-title-row,
+  body.manager-stitch-shell .manager-shell-header-meta,
+  body.manager-stitch-shell .manager-shell-user-tools,
+  body.manager-stitch-shell .manager-shell-db-filters {
+    width: 100%;
+  }
+
+  body.manager-stitch-shell .manager-shell-topbar-inner,
+  body.manager-stitch-shell .manager-shell-brand-wrap,
+  body.manager-stitch-shell .manager-shell-user-tools {
+    flex-direction: column;
+    align-items: stretch;
+  }
+
+  body.manager-stitch-shell #app-shell > header h1 {
+    font-size: 28px;
+  }
+
+  body.manager-stitch-shell .manager-shell-stats-grid,
+  body.manager-stitch-shell .manager-shell-overview-grid {
+    grid-template-columns: 1fr;
+  }
+
+  body.manager-stitch-shell .settings-section,
+  body.manager-stitch-shell .manager-shell-overview-card {
+    padding: 24px 18px;
+  }
+
+  body.manager-stitch-shell .manager-shell-section-header h2,
+  body.manager-stitch-shell .manager-shell-card-head h3,
+  body.manager-stitch-shell .cat-title,
+  body.manager-stitch-shell .catmgr-title {
+    font-size: 24px;
+  }
+
+  body.manager-stitch-shell .cat-header,
+  body.manager-stitch-shell .current-section,
+  body.manager-stitch-shell .catmgr-row,
+  body.manager-stitch-shell .history-header {
+    padding-left: 18px;
+    padding-right: 18px;
+  }
+
+  body.manager-stitch-shell .current-item {
+    flex-wrap: wrap;
+  }
+
+  body.manager-stitch-shell .price-input {
+    width: 100%;
+  }
+}

--- a/style.css
+++ b/style.css
@@ -703,7 +703,42 @@
   .pin-cancel { background: none; border: none; color: var(--muted); font-size: 12px; cursor: pointer; margin-top: 14px; display: block; width: 100%; padding: 6px; transition: color 0.15s; }
   .pin-cancel:hover { color: var(--charcoal); }
   /* ── MANAGER VIEW (dark) ── */
-  #manager-view { display: none; }
+  #manager-view { display: none; width: 100%; }
+  .settings-workspace { display: grid; grid-template-columns: 190px minmax(0, 1fr); gap: 18px; align-items: start; }
+  .settings-rail { position: sticky; top: 16px; display: flex; flex-direction: column; gap: 8px; background: var(--card); border: 1px solid var(--border); border-radius: 16px; padding: 14px; box-shadow: 0 10px 28px rgba(0,0,0,0.14); }
+  .settings-rail-kicker { font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--muted); margin-bottom: 4px; }
+  .settings-rail-btn { background: var(--surface); border: 1px solid transparent; border-radius: 10px; color: var(--text); font-family: var(--font-body); font-size: 13px; font-weight: 600; padding: 10px 12px; text-align: left; cursor: pointer; transition: border-color 0.15s, background 0.15s, color 0.15s, transform 0.15s; }
+  .settings-rail-btn:hover { border-color: var(--border); transform: translateX(1px); }
+  .settings-rail-btn.active { background: var(--ember); border-color: var(--ember); color: var(--cream); }
+  .settings-stage { min-width: 0; display: flex; flex-direction: column; gap: 16px; }
+  .settings-panel { display: flex; flex-direction: column; gap: 16px; }
+  .settings-hero,
+  .settings-section,
+  .workspace-status-card { background: var(--card); border: 1px solid var(--border); border-radius: 18px; box-shadow: 0 12px 32px rgba(0,0,0,0.16); }
+  .settings-hero { padding: 22px; display: flex; flex-direction: column; gap: 16px; background: linear-gradient(135deg, var(--card), var(--surface)); }
+  .settings-hero--manager { border-top: 3px solid var(--ember); }
+  .settings-hero--admin { border-top: 3px solid var(--fire); }
+  .settings-hero-copy h2,
+  .settings-section-head h3 { font-family: var(--font-heading); color: var(--text); }
+  .settings-hero-copy h2 { font-size: 28px; line-height: 1; margin-bottom: 8px; }
+  .settings-hero-copy p:last-child { color: var(--muted); font-size: 14px; line-height: 1.6; }
+  .settings-kicker,
+  .settings-section-kicker,
+  .workspace-actions-title { font-size: 11px; letter-spacing: 0.14em; text-transform: uppercase; color: var(--ember); font-weight: 700; }
+  .settings-section { padding: 20px; }
+  .settings-section--primary { padding-top: 22px; }
+  .settings-section-head { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+  .settings-section-head h3 { font-size: 24px; line-height: 1; margin-top: 6px; }
+  .settings-section-copy { max-width: 30rem; color: var(--muted); font-size: 13px; line-height: 1.6; }
+  .workspace-status-card { padding: 16px 18px; }
+  .workspace-actions { background: var(--surface); border: 1px solid var(--border); border-radius: 16px; padding: 16px; margin-bottom: 18px; }
+  .workspace-actions--sticky { position: sticky; top: 12px; z-index: 5; }
+  .workspace-actions-copy { margin-bottom: 12px; }
+  .workspace-actions-sub { font-size: 13px; color: var(--muted); line-height: 1.5; margin-top: 6px; }
+  .workspace-btn-row { margin-top: 0; }
+  #recent-changes-wrap:empty::before { content: 'No sent updates yet.'; color: var(--muted); font-size: 13px; }
+  .settings-hero #active-menu-bar { border: 1px solid var(--border); border-radius: 12px; background: var(--surface); padding: 10px 14px; }
+  .settings-hero #active-menu-bar .btn-small { margin-left: auto; }
   .section-label { font-family: var(--font-heading); font-size: 11px; letter-spacing: 4px; color: var(--fire); margin-bottom: 14px; display: flex; align-items: center; gap: 10px; }
   .section-label::after { content: ''; flex: 1; height: 1px; background: var(--border); }
   .config-card { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 18px 20px; margin-bottom: 12px; }
@@ -1186,6 +1221,14 @@
 .featured-admin-group-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
 .featured-admin-menu-label { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: var(--text); margin-right: 10px; }
 
+@media (max-width: 900px) {
+  .settings-workspace { grid-template-columns: 1fr; }
+  .settings-rail { position: static; flex-direction: row; flex-wrap: nowrap; overflow-x: auto; }
+  .settings-rail-btn { flex: 0 0 auto; white-space: nowrap; }
+  .settings-section-head { flex-direction: column; }
+  .workspace-actions--sticky { position: static; }
+}
+
 @media (max-width: 640px) {
   body { padding: 0 12px 64px; }
   #app-shell > header {
@@ -1228,7 +1271,10 @@
   }
   .menu-section,
   .config-card,
-  .cat-card {
+  .cat-card,
+  .settings-section,
+  .settings-hero,
+  .workspace-status-card {
     padding-left: 16px;
     padding-right: 16px;
   }
@@ -1260,6 +1306,19 @@
   .send-btn,
   .btn-small {
     width: 100%;
+  }
+  .settings-rail {
+    padding: 10px;
+  }
+  .settings-rail-kicker {
+    display: none;
+  }
+  .settings-hero-copy h2,
+  .settings-section-head h3 {
+    font-size: 22px;
+  }
+  .workspace-actions {
+    padding: 14px;
   }
   #active-menu-bar,
   .featured-mgr-group-header,

--- a/style.css
+++ b/style.css
@@ -1243,16 +1243,26 @@
 
 /* ─── ADMIN STITCH SHELL ─────────────────────────────────────────────────── */
 body.admin-console-page {
+  --bg: var(--admin-canvas);
+  --surface: var(--admin-panel-soft);
+  --card: var(--admin-panel);
+  --border: var(--admin-outline);
+  --text: var(--admin-ink);
+  --muted: var(--admin-muted);
+  --font-heading: "Public Sans", sans-serif;
+  --font-body: "Inter", sans-serif;
+  --font-accent: "Inter", sans-serif;
   background: var(--admin-canvas);
   color: var(--admin-ink);
   align-items: stretch;
   padding: 16px;
+  color-scheme: light;
 }
 
 body.admin-console-page .wrapper {
   width: 100%;
-  max-width: min(1540px, calc(100vw - 32px));
-  margin: 0 auto;
+  max-width: none;
+  margin: 0;
 }
 
 .admin-skip-link {
@@ -1286,17 +1296,17 @@ body.admin-console-page .wrapper {
 }
 
 .admin-console-shell {
-  display: grid;
-  grid-template-columns: 220px minmax(0, 1fr);
-  gap: 20px;
-  align-items: start;
+  display: block;
+  min-height: calc(100vh - 32px);
 }
 
 .admin-console-rail {
-  position: sticky;
+  position: fixed;
+  left: 16px;
   top: 16px;
-  align-self: start;
-  max-height: calc(100vh - 32px);
+  bottom: 16px;
+  width: 236px;
+  max-height: none;
   overflow-y: auto;
   overscroll-behavior: contain;
   display: flex;
@@ -1304,8 +1314,8 @@ body.admin-console-page .wrapper {
   gap: 18px;
   background: var(--admin-sidebar);
   color: var(--admin-sidebar-text);
-  border-radius: 12px;
-  padding: 18px 16px;
+  border-radius: 16px;
+  padding: 22px 16px 18px;
   box-shadow: 0 24px 40px var(--admin-shadow);
 }
 
@@ -1390,6 +1400,8 @@ body.admin-console-page .wrapper {
   display: flex;
   flex-direction: column;
   gap: 18px;
+  margin-left: calc(236px + 36px);
+  width: min(1280px, calc(100vw - 236px - 68px));
 }
 
 .admin-console-topbar {
@@ -1397,22 +1409,22 @@ body.admin-console-page .wrapper {
   top: 16px;
   z-index: 5;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   justify-content: space-between;
   gap: 16px;
-  padding: 16px 18px;
+  padding: 12px 16px;
   background: var(--admin-canvas-glass);
-  backdrop-filter: blur(18px);
+  backdrop-filter: blur(12px);
   border: 1px solid var(--admin-outline);
   border-radius: 12px;
-  box-shadow: 0 18px 36px var(--admin-shadow);
+  box-shadow: 0 10px 22px var(--admin-shadow);
 }
 
 .admin-console-topbar-copy {
   min-width: 0;
   display: flex;
   flex-direction: column;
-  gap: 4px;
+  gap: 2px;
 }
 
 .admin-console-kicker,
@@ -1436,8 +1448,8 @@ body.admin-console-page .wrapper {
 
 .admin-console-topbar-copy h2 {
   font-family: "Public Sans", var(--font-heading);
-  font-size: clamp(18px, 2.2vw, 24px);
-  line-height: 1.05;
+  font-size: clamp(16px, 1.8vw, 21px);
+  line-height: 1.08;
   letter-spacing: -0.03em;
   color: var(--admin-ink);
   text-wrap: balance;
@@ -1828,16 +1840,23 @@ body.admin-console-page .wrapper {
   }
 
   body.admin-console-page .wrapper {
-    max-width: calc(100vw - 24px);
+    max-width: none;
   }
 
   .admin-console-shell {
-    grid-template-columns: 1fr;
+    min-height: 0;
   }
 
   .admin-console-rail {
     position: static;
+    left: auto;
+    top: auto;
+    bottom: auto;
+    width: auto;
+    margin-bottom: 12px;
     min-height: 0;
+    border-radius: 12px;
+    padding: 16px;
   }
 
   .admin-console-rail-nav {
@@ -1848,6 +1867,11 @@ body.admin-console-page .wrapper {
 
   .admin-console-rail .settings-rail-btn {
     flex: 0 0 auto;
+  }
+
+  .admin-console-stage {
+    margin-left: 0;
+    width: 100%;
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1351,6 +1351,9 @@
 /* ─── MANAGER STITCH SHELL ───────────────────────────────────────────────── */
 body.manager-stitch-shell,
 body.manager-mode.manager-stitch-shell {
+  --font-heading: 'Noto Serif', serif;
+  --font-body: 'Inter', sans-serif;
+  --font-accent: 'Inter', sans-serif;
   --manager-shell-bg: #faf9f6;
   --manager-shell-surface: #ffffff;
   --manager-shell-surface-muted: #f4f3f0;
@@ -1388,8 +1391,11 @@ body.manager-mode.manager-stitch-shell {
   background: var(--manager-shell-bg);
   color: var(--manager-shell-text);
   font-family: 'Inter', sans-serif;
+  color-scheme: light;
   align-items: stretch;
-  padding: 0 0 164px;
+  overflow-x: hidden;
+  padding: 0 0 calc(164px + env(safe-area-inset-bottom));
+  -webkit-tap-highlight-color: transparent;
 }
 
 @media (prefers-color-scheme: dark) {
@@ -1415,7 +1421,44 @@ body.manager-mode.manager-stitch-shell {
     --manager-shell-shadow-strong: rgba(0, 0, 0, 0.38);
     --manager-shell-glass-bg: rgba(23, 26, 23, 0.82);
     --manager-shell-actionbar-bg: rgba(32, 36, 32, 0.9);
+    color-scheme: dark;
   }
+}
+
+body.manager-stitch-shell a,
+body.manager-stitch-shell button,
+body.manager-stitch-shell input,
+body.manager-stitch-shell textarea,
+body.manager-stitch-shell summary {
+  touch-action: manipulation;
+}
+
+body.manager-stitch-shell a:focus-visible,
+body.manager-stitch-shell button:focus-visible,
+body.manager-stitch-shell input:focus-visible,
+body.manager-stitch-shell textarea:focus-visible,
+body.manager-stitch-shell summary:focus-visible,
+body.manager-stitch-shell .user-chip:focus-visible,
+body.manager-stitch-shell .settings-rail-btn:focus-visible {
+  outline: 2px solid var(--manager-shell-primary);
+  outline-offset: 2px;
+}
+
+body.manager-stitch-shell .manager-shell-skip-link {
+  position: fixed;
+  top: 12px;
+  left: 12px;
+  z-index: 90;
+  padding: 10px 14px;
+  background: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
+  text-decoration: none;
+  transform: translateY(-140%);
+  transition: transform 0.18s ease;
+}
+
+body.manager-stitch-shell .manager-shell-skip-link:focus {
+  transform: translateY(0);
 }
 
 body.manager-stitch-shell .wrapper {
@@ -1446,11 +1489,12 @@ body.manager-stitch-shell #app-shell > header.manager-shell-topbar {
 body.manager-stitch-shell .manager-shell-topbar-inner {
   width: min(1320px, calc(100% - 48px));
   margin: 0 auto;
-  min-height: 88px;
+  min-height: calc(88px + env(safe-area-inset-top));
   display: flex;
   align-items: center;
   justify-content: space-between;
   gap: 24px;
+  padding-top: env(safe-area-inset-top);
 }
 
 body.manager-stitch-shell .manager-shell-brand-wrap {
@@ -1540,6 +1584,10 @@ body.manager-stitch-shell .header-signin-btn {
   text-transform: uppercase;
   padding: 10px 14px;
   backdrop-filter: none;
+}
+
+body.manager-stitch-shell #action-btn {
+  display: none !important;
 }
 
 body.manager-stitch-shell .manager-btn:hover,
@@ -1651,7 +1699,7 @@ body.manager-stitch-shell .user-dropdown-role {
 
 body.manager-stitch-shell #loading-view {
   min-height: 52vh;
-  padding-top: 164px;
+  padding-top: calc(164px + env(safe-area-inset-top));
 }
 
 body.manager-stitch-shell .spinner {
@@ -1668,7 +1716,14 @@ body.manager-stitch-shell .manager-shell-layout {
   grid-template-columns: 224px minmax(0, 1fr);
   gap: 40px;
   align-items: start;
-  padding-top: 120px;
+  padding-top: calc(120px + env(safe-area-inset-top));
+}
+
+body.manager-stitch-shell #manager-overview-section,
+body.manager-stitch-shell #manager-categories-section,
+body.manager-stitch-shell #manager-edit-section,
+body.manager-stitch-shell #manager-database-section {
+  scroll-margin-top: calc(108px + env(safe-area-inset-top));
 }
 
 body.manager-stitch-shell .manager-shell-stage {
@@ -1703,6 +1758,7 @@ body.manager-stitch-shell .manager-shell-rail-note {
 }
 
 body.manager-stitch-shell .settings-rail-btn {
+  display: block;
   border: none;
   border-left: 4px solid transparent;
   border-radius: 0;
@@ -1713,6 +1769,7 @@ body.manager-stitch-shell .settings-rail-btn {
   letter-spacing: 0.12em;
   text-transform: uppercase;
   padding: 14px 14px 14px 18px;
+  text-decoration: none;
 }
 
 body.manager-stitch-shell .settings-rail-btn:hover,
@@ -1780,7 +1837,7 @@ body.manager-stitch-shell .hint {
 }
 
 body.manager-stitch-shell #setup-banner {
-  display: block;
+  display: none;
   margin-bottom: 24px;
   border: 1px solid var(--manager-shell-border);
   border-radius: 2px;
@@ -1851,6 +1908,7 @@ body.manager-stitch-shell .manager-shell-stat-value {
   font-family: 'Noto Serif', serif;
   font-size: 40px;
   line-height: 1;
+  font-variant-numeric: tabular-nums;
 }
 
 body.manager-stitch-shell .manager-shell-stat-meta {
@@ -1905,6 +1963,25 @@ body.manager-stitch-shell .db-search-row input {
   border-color: var(--manager-shell-border);
   color: var(--manager-shell-text);
   border-radius: 0;
+}
+
+body.manager-stitch-shell .manager-btn,
+body.manager-stitch-shell .header-signin-btn,
+body.manager-stitch-shell .user-chip,
+body.manager-stitch-shell .settings-rail-btn,
+body.manager-stitch-shell .btn-small,
+body.manager-stitch-shell .save-btn,
+body.manager-stitch-shell .send-btn,
+body.manager-stitch-shell .current-item,
+body.manager-stitch-shell .manager-shell-actionbar,
+body.manager-stitch-shell .manager-shell-skip-link {
+  transition:
+    background-color 0.18s ease,
+    border-color 0.18s ease,
+    color 0.18s ease,
+    box-shadow 0.18s ease,
+    transform 0.18s ease,
+    opacity 0.18s ease;
 }
 
 body.manager-stitch-shell .featured-add-input,
@@ -1980,6 +2057,10 @@ body.manager-stitch-shell .item-drag-handle {
   align-items: center;
   justify-content: center;
   width: 22px;
+  min-height: 36px;
+  padding: 0;
+  background: transparent;
+  border: none;
   color: var(--manager-shell-muted);
   cursor: grab;
   user-select: none;
@@ -1995,8 +2076,25 @@ body.manager-stitch-shell .item-name-static {
   font-size: 15px;
 }
 
+body.manager-stitch-shell .item-name {
+  min-width: 0;
+  flex: 1 1 12rem;
+}
+
 body.manager-stitch-shell .item-name input {
   font-weight: 600;
+}
+
+body.manager-stitch-shell .desc-btn,
+body.manager-stitch-shell .recipe-btn,
+body.manager-stitch-shell .eighty-six-btn,
+body.manager-stitch-shell .visibility-btn,
+body.manager-stitch-shell .del-item {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 36px;
+  min-height: 36px;
 }
 
 body.manager-stitch-shell .price-input {
@@ -2030,6 +2128,13 @@ body.manager-stitch-shell .catmgr-card {
 body.manager-stitch-shell .catmgr-row,
 body.manager-stitch-shell .history-header {
   padding: 18px 20px;
+}
+
+body.manager-stitch-shell .history-header {
+  width: 100%;
+  background: transparent;
+  border: none;
+  text-align: left;
 }
 
 body.manager-stitch-shell .catmgr-edit {
@@ -2125,6 +2230,7 @@ body.manager-stitch-shell .db-badge {
 body.manager-stitch-shell .manager-shell-disclosure {
   margin-top: 16px;
   overflow: hidden;
+  overscroll-behavior: contain;
 }
 
 body.manager-stitch-shell .manager-shell-disclosure summary {
@@ -2202,7 +2308,7 @@ body.manager-stitch-shell .manager-shell-actionbar {
   position: fixed;
   left: 288px;
   right: 24px;
-  bottom: 20px;
+  bottom: calc(20px + env(safe-area-inset-bottom));
   z-index: 56;
   display: flex;
   align-items: center;
@@ -2213,6 +2319,7 @@ body.manager-stitch-shell .manager-shell-actionbar {
   border: 1px solid var(--manager-shell-border);
   box-shadow: 0 -12px 40px var(--manager-shell-shadow);
   backdrop-filter: blur(18px);
+  overscroll-behavior: contain;
 }
 
 body.manager-stitch-shell .manager-shell-actionbar-copy {
@@ -2285,6 +2392,12 @@ body.manager-stitch-shell .manager-shell-backdrop {
   display: none;
 }
 
+body.manager-stitch-shell #auth-overlay,
+body.manager-stitch-shell .modal-bg,
+body.manager-stitch-shell #menu-picker-overlay {
+  overscroll-behavior: contain;
+}
+
 body.manager-stitch-shell.settings-drawer-open {
   overflow: hidden;
 }
@@ -2307,7 +2420,7 @@ body.manager-stitch-shell.settings-drawer-open {
 
 @media (max-width: 920px) {
   body.manager-stitch-shell {
-    padding-bottom: 192px;
+    padding-bottom: calc(192px + env(safe-area-inset-bottom));
   }
 
   body.manager-stitch-shell .manager-shell-menu-toggle {
@@ -2336,6 +2449,7 @@ body.manager-stitch-shell.settings-drawer-open {
     transform: translateX(-100%);
     transition: transform 0.22s ease;
     z-index: 70;
+    overscroll-behavior: contain;
   }
 
   body.manager-stitch-shell .manager-shell-rail.is-open {
@@ -2353,7 +2467,7 @@ body.manager-stitch-shell.settings-drawer-open {
   body.manager-stitch-shell .manager-shell-actionbar {
     left: 12px;
     right: 12px;
-    bottom: 12px;
+    bottom: calc(12px + env(safe-area-inset-bottom));
     flex-direction: column;
     align-items: stretch;
   }
@@ -2411,6 +2525,12 @@ body.manager-stitch-shell.settings-drawer-open {
     padding: 24px 18px;
   }
 
+  body.manager-stitch-shell .manager-shell-section-copy,
+  body.manager-stitch-shell .manager-shell-card-copy,
+  body.manager-stitch-shell .manager-shell-rail-note {
+    display: none;
+  }
+
   body.manager-stitch-shell .manager-shell-section-header h2,
   body.manager-stitch-shell .manager-shell-card-head h3,
   body.manager-stitch-shell .cat-title,
@@ -2428,9 +2548,49 @@ body.manager-stitch-shell.settings-drawer-open {
 
   body.manager-stitch-shell .current-item {
     flex-wrap: wrap;
+    gap: 10px;
   }
 
   body.manager-stitch-shell .price-input {
+    order: 8;
     width: 100%;
+  }
+
+  body.manager-stitch-shell .item-name {
+    flex-basis: calc(100% - 44px);
+  }
+
+  body.manager-stitch-shell .db-table,
+  body.manager-stitch-shell .db-table thead,
+  body.manager-stitch-shell .db-table tbody,
+  body.manager-stitch-shell .db-table tr,
+  body.manager-stitch-shell .db-table td {
+    display: block;
+    width: 100%;
+  }
+
+  body.manager-stitch-shell .db-table thead {
+    display: none;
+  }
+
+  body.manager-stitch-shell .db-table tr {
+    padding: 14px 16px;
+    border-bottom: 1px solid var(--manager-shell-border);
+  }
+
+  body.manager-stitch-shell .db-table td {
+    padding: 6px 0;
+    border-bottom: none;
+  }
+
+  body.manager-stitch-shell .db-table td::before {
+    content: attr(data-label);
+    display: block;
+    margin-bottom: 4px;
+    color: var(--manager-shell-muted);
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.12em;
+    text-transform: uppercase;
   }
 }

--- a/style.css
+++ b/style.css
@@ -20,6 +20,26 @@
     --gold: #f6ad55;
     --green: #2ecc71;
     --red: #e74c3c;
+    --admin-canvas: #f7f9fb;
+    --admin-canvas-glass: rgba(247,249,251,0.94);
+    --admin-panel: #ffffff;
+    --admin-panel-soft: #f2f4f6;
+    --admin-panel-strong: #eceef0;
+    --admin-ink: #191c1e;
+    --admin-muted: #76777d;
+    --admin-sidebar: #002116;
+    --admin-sidebar-text: #8bd6b6;
+    --admin-sidebar-dim: rgba(139,214,182,0.68);
+    --admin-sidebar-active: rgba(166,242,209,0.12);
+    --admin-sidebar-hover: rgba(255,255,255,0.04);
+    --admin-outline: rgba(198,198,205,0.52);
+    --admin-outline-strong: rgba(69,70,77,0.12);
+    --admin-accent: #1b6b51;
+    --admin-pill: #a6f2d1;
+    --admin-alert: #ba1a1a;
+    --admin-alert-bg: #ffdad6;
+    --admin-status-glow: rgba(166,242,209,0.18);
+    --admin-shadow: rgba(25,28,30,0.08);
     /* Badge and danger semantic vars */
     --badge-on-bg: #e6f4ea;
     --badge-on-text: #1a7f37;
@@ -1220,6 +1240,805 @@
 .featured-admin-group { border: 1px solid var(--border); border-radius: 8px; padding: 10px; margin-bottom: 8px; }
 .featured-admin-group-header { display: flex; align-items: center; justify-content: space-between; margin-bottom: 6px; }
 .featured-admin-menu-label { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: var(--text); margin-right: 10px; }
+
+/* ─── ADMIN STITCH SHELL ─────────────────────────────────────────────────── */
+body.admin-console-page {
+  background: var(--admin-canvas);
+  color: var(--admin-ink);
+  align-items: stretch;
+  padding: 16px;
+}
+
+body.admin-console-page .wrapper {
+  width: 100%;
+  max-width: min(1540px, calc(100vw - 32px));
+  margin: 0 auto;
+}
+
+.admin-console-loading {
+  min-height: 56vh;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+  color: var(--admin-muted);
+}
+
+.admin-console-shell {
+  display: grid;
+  grid-template-columns: 248px minmax(0, 1fr);
+  gap: 24px;
+  align-items: start;
+}
+
+.admin-console-rail {
+  position: sticky;
+  top: 16px;
+  min-height: calc(100vh - 32px);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  background: var(--admin-sidebar);
+  color: var(--admin-sidebar-text);
+  border-radius: 12px;
+  padding: 24px 18px;
+  box-shadow: 0 24px 40px var(--admin-shadow);
+}
+
+.admin-console-rail-brand {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.admin-console-rail-kicker {
+  font-size: 11px;
+  font-family: "Public Sans", var(--font-heading);
+  font-weight: 800;
+  letter-spacing: 0.2em;
+  text-transform: uppercase;
+  color: var(--admin-sidebar-text);
+}
+
+.admin-console-rail-title {
+  font-family: "Public Sans", var(--font-heading);
+  font-size: 28px;
+  line-height: 0.95;
+  letter-spacing: -0.04em;
+  color: var(--admin-panel);
+}
+
+.admin-console-rail-nav {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.admin-console-rail .settings-rail-btn {
+  background: transparent;
+  border: 1px solid transparent;
+  border-radius: 4px;
+  padding: 12px 14px;
+  font-family: "Public Sans", var(--font-heading);
+  font-size: 14px;
+  font-weight: 700;
+  letter-spacing: -0.01em;
+  color: var(--admin-sidebar-dim);
+}
+
+.admin-console-rail .settings-rail-btn:hover,
+.admin-console-rail .settings-rail-btn:focus-visible {
+  border-color: transparent;
+  background: var(--admin-sidebar-hover);
+  color: var(--admin-sidebar-text);
+  transform: none;
+  outline: none;
+}
+
+.admin-console-rail .settings-rail-btn.active {
+  background: var(--admin-sidebar-active);
+  color: var(--admin-panel);
+  border-color: transparent;
+}
+
+.admin-console-rail-footer {
+  margin-top: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.admin-console-rail-note {
+  font-size: 12px;
+  line-height: 1.55;
+  color: var(--admin-sidebar-dim);
+}
+
+.admin-console-back-link {
+  justify-content: flex-start;
+  padding: 0;
+  border: none;
+  color: var(--admin-sidebar-text);
+}
+
+.admin-console-stage {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.admin-console-topbar {
+  position: sticky;
+  top: 16px;
+  z-index: 5;
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 20px;
+  padding: 22px 24px;
+  background: var(--admin-canvas-glass);
+  backdrop-filter: blur(18px);
+  border: 1px solid var(--admin-outline);
+  border-radius: 12px;
+  box-shadow: 0 18px 36px var(--admin-shadow);
+}
+
+.admin-console-topbar-copy {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.admin-console-kicker,
+.admin-console-card-kicker,
+.restaurant-kicker,
+.admin-users-head,
+.admin-console-summary-label,
+.admin-console-metric-label {
+  font-size: 11px;
+  font-family: "Inter", var(--font-body);
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+.admin-console-kicker,
+.admin-console-card-kicker,
+.restaurant-kicker {
+  color: var(--admin-muted);
+}
+
+.admin-console-title-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+}
+
+.admin-console-title-row h2 {
+  font-family: "Public Sans", var(--font-heading);
+  font-size: clamp(30px, 4vw, 42px);
+  line-height: 0.94;
+  letter-spacing: -0.05em;
+  color: var(--admin-ink);
+  max-width: 12ch;
+}
+
+.admin-console-status-pill {
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: var(--admin-panel);
+  border: 1px solid var(--admin-outline);
+  border-radius: 999px;
+}
+
+.admin-console-status-dot {
+  width: 9px;
+  height: 9px;
+  border-radius: 999px;
+  background: var(--admin-accent);
+  box-shadow: 0 0 0 6px var(--admin-status-glow);
+}
+
+.admin-console-topbar-sub,
+.admin-console-card-caption,
+.restaurant-copy,
+.admin-user-access-note {
+  font-size: 13px;
+  line-height: 1.6;
+  color: var(--admin-muted);
+}
+
+.admin-console-last-updated {
+  color: var(--admin-muted);
+  font-size: 12px;
+}
+
+.admin-console-topbar-actions {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.admin-console-topbar .header-action-group,
+.admin-console-topbar .header-signin-btn,
+.admin-console-topbar .user-chip {
+  position: static;
+}
+
+.admin-console-topbar .header-action-group {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+}
+
+.admin-console-topbar .manager-btn,
+.admin-console-topbar .header-signin-btn,
+.admin-console-topbar .user-chip {
+  min-height: 42px;
+  border-radius: 4px;
+  background: var(--admin-panel);
+  border: 1px solid var(--admin-outline);
+  color: var(--admin-ink);
+  font-family: "Public Sans", var(--font-heading);
+  letter-spacing: 0;
+  text-transform: none;
+  box-shadow: none;
+}
+
+.admin-console-topbar .manager-btn.active {
+  background: var(--admin-pill);
+  border-color: transparent;
+  color: var(--admin-sidebar);
+}
+
+.admin-console-topbar .manager-btn:hover,
+.admin-console-topbar .header-signin-btn:hover,
+.admin-console-topbar .user-chip:hover {
+  background: var(--admin-panel-soft);
+}
+
+.admin-console-topbar .user-chip {
+  gap: 8px;
+  border-radius: 999px;
+  padding-inline: 14px;
+}
+
+.admin-console-topbar .user-dropdown {
+  background: var(--admin-panel);
+  border-color: var(--admin-outline);
+  color: var(--admin-ink);
+}
+
+.admin-console-overview,
+.admin-console-section {
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.admin-console-overview-grid {
+  display: grid;
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  gap: 24px;
+}
+
+.admin-console-summary-card,
+.admin-console-metric-card,
+.admin-console-activity-card {
+  background: var(--admin-panel-soft);
+  border: 1px solid var(--admin-outline);
+  border-radius: 12px;
+  box-shadow: 0 18px 36px var(--admin-shadow);
+}
+
+.admin-console-summary-card {
+  min-height: 300px;
+  padding: 28px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  gap: 24px;
+}
+
+.admin-console-card-head {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.admin-console-summary-metrics {
+  display: flex;
+  gap: 40px;
+  flex-wrap: wrap;
+}
+
+.admin-console-summary-value,
+.admin-console-metric-value {
+  display: block;
+  font-family: "Public Sans", var(--font-heading);
+  font-weight: 900;
+  letter-spacing: -0.06em;
+  color: var(--admin-ink);
+}
+
+.admin-console-summary-value {
+  font-size: clamp(58px, 7vw, 92px);
+  line-height: 0.9;
+}
+
+.admin-console-metric-stack {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.admin-console-metric-card {
+  min-height: 142px;
+  padding: 22px;
+  display: flex;
+  flex-direction: column;
+  justify-content: space-between;
+  background: var(--admin-panel);
+}
+
+.admin-console-metric-value {
+  font-size: 42px;
+  line-height: 0.95;
+}
+
+.admin-console-metric-card--alert .admin-console-metric-value {
+  color: var(--admin-alert);
+}
+
+.admin-console-summary-pill,
+.restaurant-summary-pill,
+.admin-user-status-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 999px;
+  padding: 6px 12px;
+  font-size: 11px;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+.admin-console-summary-pill,
+.restaurant-summary-pill,
+.admin-user-status-pill--active,
+.admin-user-status-pill--current {
+  background: var(--admin-pill);
+  color: var(--admin-sidebar);
+}
+
+.admin-user-status-pill--pending {
+  background: var(--admin-alert-bg);
+  color: var(--admin-alert);
+}
+
+.admin-console-activity-card,
+.admin-console-section,
+.admin-console-page .config-card {
+  padding: 24px;
+  background: var(--admin-panel);
+  border: 1px solid var(--admin-outline);
+  border-radius: 12px;
+  box-shadow: 0 18px 36px var(--admin-shadow);
+}
+
+.admin-console-activity-feed {
+  display: flex;
+  flex-direction: column;
+}
+
+.admin-activity-row {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 18px 0;
+  border-top: 1px solid var(--admin-outline);
+}
+
+.admin-activity-row:first-child {
+  border-top: none;
+  padding-top: 6px;
+}
+
+.admin-activity-row-main {
+  min-width: 0;
+}
+
+.admin-activity-title {
+  font-family: "Public Sans", var(--font-heading);
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--admin-ink);
+}
+
+.admin-activity-copy {
+  margin-top: 4px;
+  font-size: 13px;
+  line-height: 1.55;
+  color: var(--admin-muted);
+}
+
+.admin-activity-time {
+  flex-shrink: 0;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--admin-muted);
+}
+
+.admin-console-split {
+  display: grid;
+  grid-template-columns: minmax(0, 1.1fr) minmax(320px, 0.9fr);
+  gap: 24px;
+}
+
+.admin-console-side-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.admin-console-fold {
+  padding: 0;
+  overflow: hidden;
+}
+
+.admin-console-fold summary {
+  list-style: none;
+}
+
+.admin-console-fold summary::-webkit-details-marker {
+  display: none;
+}
+
+.admin-console-fold-summary {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  padding: 18px 20px;
+  cursor: pointer;
+  font-family: "Public Sans", var(--font-heading);
+  font-size: 14px;
+  font-weight: 700;
+  color: var(--admin-ink);
+}
+
+.admin-console-fold-note {
+  font-family: "Inter", var(--font-body);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--admin-muted);
+}
+
+.admin-console-fold[open] .admin-console-fold-summary {
+  border-bottom: 1px solid var(--admin-outline);
+}
+
+.admin-console-fold .config-hint,
+.admin-console-fold .notif-cred-row,
+.admin-console-fold .admin-console-url-row,
+.admin-console-fold .admin-console-button-row {
+  margin-inline: 20px;
+}
+
+.admin-console-fold .config-hint {
+  margin-top: 18px;
+}
+
+.admin-console-button-row {
+  margin-top: 16px;
+}
+
+.admin-console-primary-btn {
+  background: var(--admin-ink);
+  border-color: var(--admin-ink);
+  color: var(--admin-panel);
+}
+
+.admin-console-primary-btn:hover {
+  background: var(--admin-accent);
+  border-color: var(--admin-accent);
+  color: var(--admin-panel);
+}
+
+.admin-context-switcher--admin {
+  margin-bottom: 18px;
+  padding-bottom: 18px;
+  border-bottom-color: var(--admin-outline);
+}
+
+#menus-mgmt-list {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 24px;
+}
+
+.restaurant-row {
+  margin: 0;
+  padding: 24px;
+  border: 1px solid var(--admin-outline);
+  border-radius: 12px;
+  background: var(--admin-panel);
+  box-shadow: 0 18px 36px var(--admin-shadow);
+}
+
+.restaurant-header {
+  align-items: flex-start;
+  justify-content: space-between;
+  padding: 0;
+  background: transparent;
+}
+
+.restaurant-name {
+  display: block;
+  margin-top: 6px;
+  font-family: "Public Sans", var(--font-heading);
+  font-size: 26px;
+  font-weight: 800;
+  line-height: 0.98;
+  letter-spacing: -0.05em;
+}
+
+.restaurant-copy {
+  margin-top: 16px;
+}
+
+.restaurant-menus {
+  padding: 20px 0 0;
+  gap: 10px;
+}
+
+.menu-chip {
+  background: var(--admin-panel-soft);
+  border-color: var(--admin-outline);
+  border-radius: 999px;
+  padding: 7px 12px;
+  color: var(--admin-ink);
+}
+
+.menu-type-badge {
+  background: var(--admin-panel);
+  border-color: var(--admin-outline-strong);
+  color: var(--admin-muted);
+}
+
+.admin-users-toolbar {
+  margin-bottom: 0;
+}
+
+.admin-users-table {
+  display: flex;
+  flex-direction: column;
+  border: 1px solid var(--admin-outline);
+  border-radius: 12px;
+  overflow: hidden;
+  background: var(--admin-panel);
+}
+
+.admin-users-head,
+.admin-user-row {
+  display: grid;
+  grid-template-columns: minmax(220px, 1.35fr) minmax(180px, 0.8fr) minmax(240px, 1.15fr) 132px;
+  gap: 16px;
+}
+
+.admin-users-head {
+  padding: 16px 20px;
+  background: var(--admin-panel-soft);
+  color: var(--admin-muted);
+}
+
+.admin-user-row {
+  align-items: start;
+  padding: 20px;
+  border-top: 1px solid var(--admin-outline);
+}
+
+.admin-user-row:first-of-type {
+  border-top: none;
+}
+
+.admin-user-cell {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.admin-user-cell--identity {
+  flex-direction: row;
+  align-items: center;
+}
+
+.admin-user-avatar {
+  width: 42px;
+  height: 42px;
+  flex-shrink: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 4px;
+  background: var(--admin-panel-strong);
+  color: var(--admin-ink);
+  font-family: "Public Sans", var(--font-heading);
+  font-size: 14px;
+  font-weight: 800;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.admin-user-name-row,
+.admin-user-role-editor {
+  align-items: stretch;
+}
+
+.admin-user-name-row .btn-small,
+.admin-user-role-editor .btn-small,
+.user-menu-access-row .btn-small {
+  align-self: stretch;
+}
+
+.admin-user-cell--role {
+  align-items: flex-start;
+}
+
+.admin-user-cell--status {
+  align-items: flex-end;
+}
+
+.user-menu-access {
+  margin-top: 0;
+  padding-top: 0;
+  border-top: none;
+}
+
+.user-menu-access-row {
+  gap: 10px;
+}
+
+.user-menu-access-grid {
+  display: grid;
+  gap: 8px;
+}
+
+.user-menu-access-label {
+  padding: 9px 10px;
+  border: 1px solid var(--admin-outline);
+  border-radius: 10px;
+  background: var(--admin-panel-soft);
+  font-size: 12px;
+}
+
+.admin-user-status-pill {
+  width: 100%;
+}
+
+@media (max-width: 1180px) {
+  .admin-console-topbar,
+  .admin-console-title-row {
+    flex-direction: column;
+  }
+
+  .admin-console-topbar-actions {
+    width: 100%;
+    justify-content: space-between;
+    flex-wrap: wrap;
+  }
+
+  .admin-console-overview-grid,
+  #menus-mgmt-list,
+  .admin-console-split {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-users-head,
+  .admin-user-row {
+    grid-template-columns: minmax(220px, 1.3fr) minmax(180px, 0.8fr);
+  }
+
+  .admin-user-cell--access,
+  .admin-user-cell--status {
+    grid-column: 1 / -1;
+  }
+
+  .admin-user-cell--status {
+    align-items: flex-start;
+  }
+}
+
+@media (max-width: 900px) {
+  body.admin-console-page {
+    padding: 12px;
+  }
+
+  body.admin-console-page .wrapper {
+    max-width: calc(100vw - 24px);
+  }
+
+  .admin-console-shell {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-console-rail {
+    position: static;
+    min-height: 0;
+  }
+
+  .admin-console-rail-nav {
+    flex-direction: row;
+    overflow-x: auto;
+    padding-bottom: 4px;
+  }
+
+  .admin-console-rail .settings-rail-btn {
+    flex: 0 0 auto;
+  }
+}
+
+@media (max-width: 640px) {
+  .admin-console-topbar,
+  .admin-console-summary-card,
+  .admin-console-activity-card,
+  .admin-console-section,
+  .admin-console-page .config-card,
+  .restaurant-row {
+    padding: 18px;
+  }
+
+  .admin-console-topbar-actions,
+  .admin-console-topbar .header-action-group {
+    width: 100%;
+  }
+
+  .admin-console-topbar .manager-btn,
+  .admin-console-topbar .header-signin-btn,
+  .admin-console-topbar .user-chip,
+  .admin-console-primary-btn,
+  .admin-user-name-row .btn-small,
+  .admin-user-role-editor .btn-small,
+  .user-menu-access-row .btn-small {
+    width: 100%;
+  }
+
+  .admin-console-metric-stack,
+  .admin-users-head,
+  .admin-user-row {
+    grid-template-columns: 1fr;
+  }
+
+  .admin-user-cell--identity {
+    align-items: flex-start;
+  }
+
+  .admin-user-name-row,
+  .admin-user-role-editor,
+  .admin-console-url-row,
+  .notif-cred-row {
+    flex-direction: column;
+  }
+
+  .notif-cred-label {
+    min-width: 0;
+    width: 100%;
+  }
+}
 
 @media (max-width: 900px) {
   .settings-workspace { grid-template-columns: 1fr; }

--- a/supabase/migrations/20260404091500_v0.8.5_last_sent_featured.sql
+++ b/supabase/migrations/20260404091500_v0.8.5_last_sent_featured.sql
@@ -1,0 +1,4 @@
+-- v0.8.5 — track featured lineup at last send so featured diffs stay accurate
+
+ALTER TABLE public.menu_meta
+  ADD COLUMN IF NOT EXISTS last_sent_featured jsonb NOT NULL DEFAULT '[]';


### PR DESCRIPTION
## Summary
- **Separate manager and admin workspaces** into dedicated route pages (`/manager/` and `/admin/`)
- **Rebuild manager settings** with Stitch-inspired workspace, drag-to-reorder items, improved mobile navigation and accessibility
- **Redesign admin console** with fixed drawer navigation, isolated theme, Stitch-inspired live operations shell, and streamlined section layout
- **Fix send update sync** and featured history fallback
- **Add Stitch4Settings skill** for generating manager and admin route designs from Stitch

## Changed files
- `app.js` — settings drawer, hash-based section navigation, admin user list reset, merged manager + admin helpers
- `manager/index.html` — rebuilt Stitch workspace layout
- `admin/index.html` — new fixed-drawer admin console shell
- `style.css` — ~2k lines of new manager and admin workspace styles
- `.agents/skills/stitch4settings/SKILL.md` — new skill definition
- `supabase/migrations/20260404091500_v0.8.5_last_sent_featured.sql` — migration for featured history

## Test plan
- [ ] Verify manager workspace loads at `/manager/` with correct menu items
- [ ] Confirm drag-to-reorder works on manager items
- [ ] Verify admin console loads at `/admin/` with drawer navigation
- [ ] Test section deep-linking via URL hash (e.g. `/admin/#users-section`)
- [ ] Confirm Send Update flow completes and updates public timestamp
- [ ] Check mobile responsiveness on both manager and admin screens
- [ ] Verify public menu pages are unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)