### PR TITLE
Release v0.8.6

### DIFF
--- a/.agents/skills/improve-codebase-architecture/REFERENCE.md
+++ b/.agents/skills/improve-codebase-architecture/REFERENCE.md
@@ -1,0 +1,78 @@
+# Reference
+
+## Dependency Categories
+
+When assessing a candidate for deepening, classify its dependencies:
+
+### 1. In-process
+
+Pure computation, in-memory state, no I/O. Always deepenable — just merge the modules and test directly.
+
+### 2. Local-substitutable
+
+Dependencies that have local test stand-ins (e.g., PGLite for Postgres, in-memory filesystem). Deepenable if the test substitute exists. The deepened module is tested with the local stand-in running in the test suite.
+
+### 3. Remote but owned (Ports & Adapters)
+
+Your own services across a network boundary (microservices, internal APIs). Define a port (interface) at the module boundary. The deep module owns the logic; the transport is injected. Tests use an in-memory adapter. Production uses the real HTTP/gRPC/queue adapter.
+
+Recommendation shape: "Define a shared interface (port), implement an HTTP adapter for production and an in-memory adapter for testing, so the logic can be tested as one deep module even though it's deployed across a network boundary."
+
+### 4. True external (Mock)
+
+Third-party services (Stripe, Twilio, etc.) you don't control. Mock at the boundary. The deepened module takes the external dependency as an injected port, and tests provide a mock implementation.
+
+## Testing Strategy
+
+The core principle: **replace, don't layer.**
+
+- Old unit tests on shallow modules are waste once boundary tests exist — delete them
+- Write new tests at the deepened module's interface boundary
+- Tests assert on observable outcomes through the public interface, not internal state
+- Tests should survive internal refactors — they describe behavior, not implementation
+
+## Issue Template
+
+<issue-template>
+
+## Problem
+
+Describe the architectural friction:
+
+- Which modules are shallow and tightly coupled
+- What integration risk exists in the seams between them
+- Why this makes the codebase harder to navigate and maintain
+
+## Proposed Interface
+
+The chosen interface design:
+
+- Interface signature (types, methods, params)
+- Usage example showing how callers use it
+- What complexity it hides internally
+
+## Dependency Strategy
+
+Which category applies and how dependencies are handled:
+
+- **In-process**: merged directly
+- **Local-substitutable**: tested with [specific stand-in]
+- **Ports & adapters**: port definition, production adapter, test adapter
+- **Mock**: mock boundary for external services
+
+## Testing Strategy
+
+- **New boundary tests to write**: describe the behaviors to verify at the interface
+- **Old tests to delete**: list the shallow module tests that become redundant
+- **Test environment needs**: any local stand-ins or adapters required
+
+## Implementation Recommendations
+
+Durable architectural guidance that is NOT coupled to current file paths:
+
+- What the module should own (responsibilities)
+- What it should hide (implementation details)
+- What it should expose (the interface contract)
+- How callers should migrate to the new interface
+
+</issue-template>

--- a/.agents/skills/improve-codebase-architecture/SKILL.md
+++ b/.agents/skills/improve-codebase-architecture/SKILL.md
@@ -1,0 +1,76 @@
+---
+name: improve-codebase-architecture
+description: Explore a codebase to find opportunities for architectural improvement, focusing on making the codebase more testable by deepening shallow modules. Use when user wants to improve architecture, find refactoring opportunities, consolidate tightly-coupled modules, or make a codebase more AI-navigable.
+---
+
+# Improve Codebase Architecture
+
+Explore a codebase like an AI would, surface architectural friction, discover opportunities for improving testability, and propose module-deepening refactors as GitHub issue RFCs.
+
+A **deep module** (John Ousterhout, "A Philosophy of Software Design") has a small interface hiding a large implementation. Deep modules are more testable, more AI-navigable, and let you test at the boundary instead of inside.
+
+## Process
+
+### 1. Explore the codebase
+
+Use the Agent tool with subagent_type=Explore to navigate the codebase naturally. Do NOT follow rigid heuristics — explore organically and note where you experience friction:
+
+- Where does understanding one concept require bouncing between many small files?
+- Where are modules so shallow that the interface is nearly as complex as the implementation?
+- Where have pure functions been extracted just for testability, but the real bugs hide in how they're called?
+- Where do tightly-coupled modules create integration risk in the seams between them?
+- Which parts of the codebase are untested, or hard to test?
+
+The friction you encounter IS the signal.
+
+### 2. Present candidates
+
+Present a numbered list of deepening opportunities. For each candidate, show:
+
+- **Cluster**: Which modules/concepts are involved
+- **Why they're coupled**: Shared types, call patterns, co-ownership of a concept
+- **Dependency category**: See [REFERENCE.md](REFERENCE.md) for the four categories
+- **Test impact**: What existing tests would be replaced by boundary tests
+
+Do NOT propose interfaces yet. Ask the user: "Which of these would you like to explore?"
+
+### 3. User picks a candidate
+
+### 4. Frame the problem space
+
+Before spawning sub-agents, write a user-facing explanation of the problem space for the chosen candidate:
+
+- The constraints any new interface would need to satisfy
+- The dependencies it would need to rely on
+- A rough illustrative code sketch to make the constraints concrete — this is not a proposal, just a way to ground the constraints
+
+Show this to the user, then immediately proceed to Step 5. The user reads and thinks about the problem while the sub-agents work in parallel.
+
+### 5. Design multiple interfaces
+
+Spawn 3+ sub-agents in parallel using the Agent tool. Each must produce a **radically different** interface for the deepened module.
+
+Prompt each sub-agent with a separate technical brief (file paths, coupling details, dependency category, what's being hidden). This brief is independent of the user-facing explanation in Step 4. Give each agent a different design constraint:
+
+- Agent 1: "Minimize the interface — aim for 1-3 entry points max"
+- Agent 2: "Maximize flexibility — support many use cases and extension"
+- Agent 3: "Optimize for the most common caller — make the default case trivial"
+- Agent 4 (if applicable): "Design around the ports & adapters pattern for cross-boundary dependencies"
+
+Each sub-agent outputs:
+
+1. Interface signature (types, methods, params)
+2. Usage example showing how callers use it
+3. What complexity it hides internally
+4. Dependency strategy (how deps are handled — see [REFERENCE.md](REFERENCE.md))
+5. Trade-offs
+
+Present designs sequentially, then compare them in prose.
+
+After comparing, give your own recommendation: which design you think is strongest and why. If elements from different designs would combine well, propose a hybrid. Be opinionated — the user wants a strong read, not just a menu.
+
+### 6. User picks an interface (or accepts recommendation)
+
+### 7. Create GitHub issue
+
+Create a refactor RFC as a GitHub issue using `gh issue create`. Use the template in [REFERENCE.md](REFERENCE.md). Do NOT ask the user to review before creating — just create it and share the URL.

--- a/.agents/skills/recursive-design-loop/SKILL.md
+++ b/.agents/skills/recursive-design-loop/SKILL.md
@@ -124,10 +124,13 @@ detail is off, zoom in on that detail.
    - what you are changing
    - why it matters — not just "improves spacing" but why the current state
      falls short and what the change does for the experience
-2. If the pass adds a feature or creates a major design shift, stop and ask the
-   user first.
-3. Implement the smallest cohesive set of changes with the strongest
-   user-visible ROI.
+2. If the pass adds a new feature, ask the user first.
+3. Match the scale of changes to what the screen actually needs. If a large
+   redesign is the right move, propose it and get user approval before
+   proceeding — do not artificially shrink the scope just to avoid a big diff.
+   If polish is what's needed, polish. If a structural overhaul is what's
+   needed, say so clearly and ask. The goal is the strongest user-visible ROI,
+   not the smallest change.
 4. Run targeted validation for the changed files and flows.
 5. Commit with a clear message and push the current branch.
 6. Wait for the Vercel preview deployment to finish updating.

--- a/.claude/skills/recursive-design-loop/SKILL.md
+++ b/.claude/skills/recursive-design-loop/SKILL.md
@@ -124,10 +124,13 @@ detail is off, zoom in on that detail.
    - what you are changing
    - why it matters — not just "improves spacing" but why the current state
      falls short and what the change does for the experience
-2. If the pass adds a feature or creates a major design shift, stop and ask the
-   user first.
-3. Implement the smallest cohesive set of changes with the strongest
-   user-visible ROI.
+2. If the pass adds a new feature, ask the user first.
+3. Match the scale of changes to what the screen actually needs. If a large
+   redesign is the right move, propose it and get user approval before
+   proceeding — do not artificially shrink the scope just to avoid a big diff.
+   If polish is what's needed, polish. If a structural overhaul is what's
+   needed, say so clearly and ask. The goal is the strongest user-visible ROI,
+   not the smallest change.
 4. Run targeted validation for the changed files and flows.
 5. Commit with a clear message and push the current branch.
 6. Wait for the Vercel preview deployment to finish updating.

--- a/api/specials.js
+++ b/api/specials.js
@@ -270,6 +270,138 @@ async function fetchSlot(sbUrl, slotId) {
   return slots?.[0] || null;
 }
 
+function createRestaurantSpecialsMutationService({ sbUrl, caller, config }) {
+  return {
+    async ensureForRestaurant(restaurantId) {
+      const group = await fetchRestaurantSpecialGroup(sbUrl, restaurantId);
+      return { status: group ? 204 : 404 };
+    },
+
+    async migrate(restaurantId) {
+      await migrateRestaurantSpecialGroup(sbUrl, restaurantId);
+      return { status: 204 };
+    },
+
+    async add({ restaurantId, itemId }) {
+      if (!itemId) return { status: 400, body: { error: 'Missing itemId' } };
+      if (!(await itemBelongsToRestaurantMenus(sbUrl, config.menuIds, itemId))) {
+        return { status: 403, body: { error: 'Item is not part of this restaurant.' } };
+      }
+      const group = await fetchRestaurantSpecialGroup(sbUrl, restaurantId, { createIfMissing: true });
+      if (!group?.id) throw new Error('Missing specials group');
+      const slots = await fetchGroupSlots(sbUrl, group.id);
+      if (slots.length >= 5) return { status: 400, body: { error: 'Max 5 specials per restaurant.' } };
+      if (slots.some(slot => slot.item_id === itemId)) {
+        return { status: 409, body: { error: 'That item is already in specials.' } };
+      }
+      const insertRes = await fetch(`${sbUrl}/rest/v1/featured_slots`, {
+        method: 'POST',
+        headers: serviceHeaders({
+          'Content-Type': 'application/json',
+          Prefer: 'return=minimal',
+        }),
+        body: JSON.stringify({
+          featured_group_id: group.id,
+          item_id: itemId,
+          display_order: slots.length,
+        }),
+      });
+      if (!insertRes.ok) throw new Error('Failed to add special');
+      return { status: 204 };
+    },
+
+    async remove({ groupId, slotId }) {
+      if (!slotId) return { status: 400, body: { error: 'Missing slotId' } };
+      const slot = await fetchSlot(sbUrl, slotId);
+      if (!slot || slot.featured_group_id !== groupId) return { status: 404, body: { error: 'Special not found' } };
+      const deleteRes = await fetch(`${sbUrl}/rest/v1/featured_slots?id=eq.${slotId}`, {
+        method: 'DELETE',
+        headers: serviceHeaders(),
+      });
+      if (!deleteRes.ok) throw new Error('Failed to remove special');
+      return { status: 204 };
+    },
+
+    async move({ groupId, slotId, direction }) {
+      if (!slotId || ![-1, 1].includes(Number(direction))) {
+        return { status: 400, body: { error: 'Invalid move request' } };
+      }
+      const slots = await fetchGroupSlots(sbUrl, groupId);
+      const idx = slots.findIndex(slot => slot.id === slotId);
+      if (idx < 0) return { status: 404, body: { error: 'Special not found' } };
+      const newIdx = idx + Number(direction);
+      if (newIdx < 0 || newIdx >= slots.length) return { status: 204 };
+      const current = slots[idx];
+      const target = slots[newIdx];
+      const [patchA, patchB] = await Promise.all([
+        fetch(`${sbUrl}/rest/v1/featured_slots?id=eq.${current.id}`, {
+          method: 'PATCH',
+          headers: serviceHeaders({
+            'Content-Type': 'application/json',
+            Prefer: 'return=minimal',
+          }),
+          body: JSON.stringify({ display_order: target.display_order }),
+        }),
+        fetch(`${sbUrl}/rest/v1/featured_slots?id=eq.${target.id}`, {
+          method: 'PATCH',
+          headers: serviceHeaders({
+            'Content-Type': 'application/json',
+            Prefer: 'return=minimal',
+          }),
+          body: JSON.stringify({ display_order: current.display_order }),
+        }),
+      ]);
+      if (!patchA.ok || !patchB.ok) throw new Error('Failed to reorder specials');
+      return { status: 204 };
+    },
+
+    async note({ groupId, slotId, note }) {
+      if (!slotId) return { status: 400, body: { error: 'Missing slotId' } };
+      const slot = await fetchSlot(sbUrl, slotId);
+      if (!slot || slot.featured_group_id !== groupId) return { status: 404, body: { error: 'Special not found' } };
+      const patchRes = await fetch(`${sbUrl}/rest/v1/featured_slots?id=eq.${slotId}`, {
+        method: 'PATCH',
+        headers: serviceHeaders({
+          'Content-Type': 'application/json',
+          Prefer: 'return=minimal',
+        }),
+        body: JSON.stringify({ sell_note: String(note || '') }),
+      });
+      if (!patchRes.ok) throw new Error('Failed to save note');
+      return { status: 204 };
+    },
+
+    async confirm({ groupId }) {
+      const slots = await fetchGroupSlots(sbUrl, groupId);
+      if (!slots.length) return { status: 204 };
+      const confirmedAt = new Date().toISOString();
+      const results = await Promise.all(
+        slots.map(slot =>
+          fetch(`${sbUrl}/rest/v1/featured_slots?id=eq.${slot.id}`, {
+            method: 'PATCH',
+            headers: serviceHeaders({
+              'Content-Type': 'application/json',
+              Prefer: 'return=minimal',
+            }),
+            body: JSON.stringify({
+              confirmed_at: confirmedAt,
+              confirmed_by: caller.uid,
+            }),
+          })
+        )
+      );
+      if (results.some(result => !result.ok)) throw new Error('Failed to confirm specials');
+      return { status: 204 };
+    },
+  };
+}
+
+function respondWithServiceResult(res, result = {}) {
+  const status = Number(result.status) || 204;
+  if (result.body) return res.status(status).json(result.body);
+  return res.status(status).end();
+}
+
 export default async function handler(req, res) {
   if (req.method !== 'POST') return res.status(405).end();
 
@@ -297,132 +429,38 @@ export default async function handler(req, res) {
     return res.status(e.status).json({ error: e.message });
   }
 
+  const service = createRestaurantSpecialsMutationService({ sbUrl, caller, config });
+
   try {
     if (action === 'ensure') {
-      // Read-only check: returns 204 if group exists, 404 if not. Does NOT create.
-      const group = await fetchRestaurantSpecialGroup(sbUrl, restaurantId);
-      return res.status(group ? 204 : 404).end();
+      return respondWithServiceResult(res, await service.ensureForRestaurant(restaurantId));
     }
 
     if (action === 'migrate') {
-      // Idempotent create-if-missing + seed from legacy data. Safe to call repeatedly.
-      await migrateRestaurantSpecialGroup(sbUrl, restaurantId);
-      return res.status(204).end();
+      return respondWithServiceResult(res, await service.migrate(restaurantId));
     }
 
     if (action === 'add') {
-      if (!itemId) return res.status(400).json({ error: 'Missing itemId' });
-      if (!(await itemBelongsToRestaurantMenus(sbUrl, config.menuIds, itemId))) {
-        return res.status(403).json({ error: 'Item is not part of this restaurant.' });
-      }
-      const group = await fetchRestaurantSpecialGroup(sbUrl, restaurantId, { createIfMissing: true });
-      if (!group?.id) throw new Error('Missing specials group');
-      const slots = await fetchGroupSlots(sbUrl, group.id);
-      if (slots.length >= 5) return res.status(400).json({ error: 'Max 5 specials per restaurant.' });
-      if (slots.some(slot => slot.item_id === itemId)) {
-        return res.status(409).json({ error: 'That item is already in specials.' });
-      }
-      const insertRes = await fetch(`${sbUrl}/rest/v1/featured_slots`, {
-        method: 'POST',
-        headers: serviceHeaders({
-          'Content-Type': 'application/json',
-          Prefer: 'return=minimal',
-        }),
-        body: JSON.stringify({
-          featured_group_id: group.id,
-          item_id: itemId,
-          display_order: slots.length,
-        }),
-      });
-      if (!insertRes.ok) throw new Error('Failed to add special');
-      return res.status(204).end();
+      return respondWithServiceResult(res, await service.add({ restaurantId, itemId }));
     }
 
     const group = await fetchRestaurantSpecialGroup(sbUrl, restaurantId, { createIfMissing: true });
     if (!group?.id) return res.status(404).json({ error: `${config.name} does not exist yet.` });
 
     if (action === 'remove') {
-      if (!slotId) return res.status(400).json({ error: 'Missing slotId' });
-      const slot = await fetchSlot(sbUrl, slotId);
-      if (!slot || slot.featured_group_id !== group.id) return res.status(404).json({ error: 'Special not found' });
-      const deleteRes = await fetch(`${sbUrl}/rest/v1/featured_slots?id=eq.${slotId}`, {
-        method: 'DELETE',
-        headers: serviceHeaders(),
-      });
-      if (!deleteRes.ok) throw new Error('Failed to remove special');
-      return res.status(204).end();
+      return respondWithServiceResult(res, await service.remove({ groupId: group.id, slotId }));
     }
 
     if (action === 'move') {
-      if (!slotId || ![-1, 1].includes(Number(direction))) {
-        return res.status(400).json({ error: 'Invalid move request' });
-      }
-      const slots = await fetchGroupSlots(sbUrl, group.id);
-      const idx = slots.findIndex(slot => slot.id === slotId);
-      if (idx < 0) return res.status(404).json({ error: 'Special not found' });
-      const newIdx = idx + Number(direction);
-      if (newIdx < 0 || newIdx >= slots.length) return res.status(204).end();
-      const current = slots[idx];
-      const target = slots[newIdx];
-      const [patchA, patchB] = await Promise.all([
-        fetch(`${sbUrl}/rest/v1/featured_slots?id=eq.${current.id}`, {
-          method: 'PATCH',
-          headers: serviceHeaders({
-            'Content-Type': 'application/json',
-            Prefer: 'return=minimal',
-          }),
-          body: JSON.stringify({ display_order: target.display_order }),
-        }),
-        fetch(`${sbUrl}/rest/v1/featured_slots?id=eq.${target.id}`, {
-          method: 'PATCH',
-          headers: serviceHeaders({
-            'Content-Type': 'application/json',
-            Prefer: 'return=minimal',
-          }),
-          body: JSON.stringify({ display_order: current.display_order }),
-        }),
-      ]);
-      if (!patchA.ok || !patchB.ok) throw new Error('Failed to reorder specials');
-      return res.status(204).end();
+      return respondWithServiceResult(res, await service.move({ groupId: group.id, slotId, direction }));
     }
 
     if (action === 'note') {
-      if (!slotId) return res.status(400).json({ error: 'Missing slotId' });
-      const slot = await fetchSlot(sbUrl, slotId);
-      if (!slot || slot.featured_group_id !== group.id) return res.status(404).json({ error: 'Special not found' });
-      const patchRes = await fetch(`${sbUrl}/rest/v1/featured_slots?id=eq.${slotId}`, {
-        method: 'PATCH',
-        headers: serviceHeaders({
-          'Content-Type': 'application/json',
-          Prefer: 'return=minimal',
-        }),
-        body: JSON.stringify({ sell_note: String(note || '') }),
-      });
-      if (!patchRes.ok) throw new Error('Failed to save note');
-      return res.status(204).end();
+      return respondWithServiceResult(res, await service.note({ groupId: group.id, slotId, note }));
     }
 
     if (action === 'confirm') {
-      const slots = await fetchGroupSlots(sbUrl, group.id);
-      if (!slots.length) return res.status(204).end();
-      const confirmedAt = new Date().toISOString();
-      const results = await Promise.all(
-        slots.map(slot =>
-          fetch(`${sbUrl}/rest/v1/featured_slots?id=eq.${slot.id}`, {
-            method: 'PATCH',
-            headers: serviceHeaders({
-              'Content-Type': 'application/json',
-              Prefer: 'return=minimal',
-            }),
-            body: JSON.stringify({
-              confirmed_at: confirmedAt,
-              confirmed_by: caller.uid,
-            }),
-          })
-        )
-      );
-      if (results.some(result => !result.ok)) throw new Error('Failed to confirm specials');
-      return res.status(204).end();
+      return respondWithServiceResult(res, await service.confirm({ groupId: group.id }));
     }
 
     return res.status(400).json({ error: 'Unsupported action' });

--- a/api/specials.js
+++ b/api/specials.js
@@ -13,6 +13,30 @@ function serviceHeaders(extra = {}) {
   };
 }
 
+async function readJsonSafe(response) {
+  try {
+    return await response.json();
+  } catch (_) {
+    return null;
+  }
+}
+
+function getApiErrorMessage(payload, fallback) {
+  return payload?.error || payload?.message || payload?.hint || payload?.details || fallback;
+}
+
+function isMissingColumnIssue(payload, columnName) {
+  const message = `${payload?.error || payload?.message || payload?.hint || payload?.details || ''}`.toLowerCase();
+  return message.includes(columnName.toLowerCase()) &&
+    (message.includes('column') || message.includes('schema cache'));
+}
+
+function isOnConflictConstraintIssue(payload) {
+  const message = `${payload?.error || payload?.message || payload?.hint || payload?.details || ''}`.toLowerCase();
+  return message.includes('on conflict') ||
+    message.includes('unique or exclusion constraint');
+}
+
 async function itemBelongsToRestaurantMenus(sbUrl, menuIds, itemId) {
   const categoriesRes = await fetch(
     `${sbUrl}/rest/v1/categories?menu_id=in.(${menuIds.join(',')})&select=items(id)`,
@@ -116,33 +140,55 @@ async function fetchRestaurantSpecialGroup(sbUrl, restaurantId, options = {}) {
   const { createIfMissing = false } = options;
   const config = getRestaurantSpecialConfig(restaurantId);
   if (!config?.canonicalId) return null;
+  let supportsCanonicalId = true;
 
   const selectGroup = async () => {
-    // Primary lookup by canonical_id
-    let groupRes = await fetch(
-      `${sbUrl}/rest/v1/featured_groups?canonical_id=eq.${encodeURIComponent(config.canonicalId)}&select=id,name,canonical_id&limit=1`,
-      { headers: serviceHeaders() }
-    );
-    if (!groupRes.ok) throw new Error('Failed to load specials group');
-    let groups = await groupRes.json();
-    if (groups?.[0]) return groups[0];
+    if (supportsCanonicalId && config.canonicalId) {
+      const groupRes = await fetch(
+        `${sbUrl}/rest/v1/featured_groups?canonical_id=eq.${encodeURIComponent(config.canonicalId)}&select=id,name,canonical_id&limit=1`,
+        { headers: serviceHeaders() }
+      );
+      if (groupRes.ok) {
+        const groups = await groupRes.json();
+        if (groups?.[0]) return groups[0];
+      } else {
+        const payload = await readJsonSafe(groupRes);
+        if (isMissingColumnIssue(payload, 'canonical_id')) {
+          supportsCanonicalId = false;
+        } else {
+          throw new Error(getApiErrorMessage(payload, 'Failed to load specials group'));
+        }
+      }
+    }
 
     // Fallback to name for pre-migration data
     if (config.name) {
-      groupRes = await fetch(
-        `${sbUrl}/rest/v1/featured_groups?name=eq.${encodeURIComponent(config.name)}&select=id,name,canonical_id&limit=1`,
+      const selectFields = supportsCanonicalId ? 'id,name,canonical_id' : 'id,name';
+      const groupRes = await fetch(
+        `${sbUrl}/rest/v1/featured_groups?name=eq.${encodeURIComponent(config.name)}&select=${selectFields}&limit=1`,
         { headers: serviceHeaders() }
       );
-      if (!groupRes.ok) throw new Error('Failed to load specials group');
-      groups = await groupRes.json();
+      if (!groupRes.ok) {
+        const payload = await readJsonSafe(groupRes);
+        throw new Error(getApiErrorMessage(payload, 'Failed to load specials group'));
+      }
+      const groups = await groupRes.json();
       if (groups?.[0]) {
         // Stamp canonical_id on legacy row
-        if (!groups[0].canonical_id) {
-          await fetch(`${sbUrl}/rest/v1/featured_groups?id=eq.${groups[0].id}`, {
+        if (supportsCanonicalId && config.canonicalId && !groups[0].canonical_id) {
+          const patchRes = await fetch(`${sbUrl}/rest/v1/featured_groups?id=eq.${groups[0].id}`, {
             method: 'PATCH',
             headers: serviceHeaders({ 'Content-Type': 'application/json', Prefer: 'return=minimal' }),
             body: JSON.stringify({ canonical_id: config.canonicalId }),
           });
+          if (!patchRes.ok) {
+            const payload = await readJsonSafe(patchRes);
+            if (isMissingColumnIssue(payload, 'canonical_id')) {
+              supportsCanonicalId = false;
+            } else {
+              throw new Error(getApiErrorMessage(payload, 'Failed to update specials group'));
+            }
+          }
         }
         return groups[0];
       }
@@ -152,21 +198,56 @@ async function fetchRestaurantSpecialGroup(sbUrl, restaurantId, options = {}) {
 
   if (!createIfMissing) return selectGroup();
 
-  const createRes = await fetch(`${sbUrl}/rest/v1/featured_groups?on_conflict=name&select=id,name,canonical_id`, {
-    method: 'POST',
-    headers: serviceHeaders({
-      'Content-Type': 'application/json',
-      Prefer: 'resolution=ignore-duplicates,return=representation',
-    }),
-    body: JSON.stringify({ name: config.name, canonical_id: config.canonicalId }),
-  });
-  if (!createRes.ok) throw new Error('Failed to upsert specials group');
-  const created = await createRes.json();
-  let group = created?.[0] || null;
+  let group = await selectGroup();
   if (group?.id) return group;
 
+  let useCanonicalId = supportsCanonicalId && !!config.canonicalId;
+  let useOnConflict = true;
+  let lastCreateError = 'Failed to upsert specials group';
+
+  for (let attempt = 0; attempt < 4; attempt += 1) {
+    const selectFields = useCanonicalId ? 'id,name,canonical_id' : 'id,name';
+    const createUrl = `${sbUrl}/rest/v1/featured_groups${useOnConflict ? '?on_conflict=name&' : '?'}select=${selectFields}`;
+    const createRes = await fetch(createUrl, {
+      method: 'POST',
+      headers: serviceHeaders({
+        'Content-Type': 'application/json',
+        Prefer: 'resolution=ignore-duplicates,return=representation',
+      }),
+      body: JSON.stringify(useCanonicalId
+        ? { name: config.name, canonical_id: config.canonicalId }
+        : { name: config.name }),
+    });
+    if (createRes.ok) {
+      const created = await createRes.json();
+      group = created?.[0] || null;
+      if (group?.id) return group;
+      group = await selectGroup();
+      if (group?.id) return group;
+      lastCreateError = 'Failed to resolve specials group';
+      break;
+    }
+
+    const payload = await readJsonSafe(createRes);
+    lastCreateError = getApiErrorMessage(payload, lastCreateError);
+
+    group = await selectGroup();
+    if (group?.id) return group;
+
+    if (useCanonicalId && isMissingColumnIssue(payload, 'canonical_id')) {
+      useCanonicalId = false;
+      supportsCanonicalId = false;
+      continue;
+    }
+    if (useOnConflict && isOnConflictConstraintIssue(payload)) {
+      useOnConflict = false;
+      continue;
+    }
+    break;
+  }
+
   group = await selectGroup();
-  if (!group?.id) throw new Error('Failed to resolve specials group');
+  if (!group?.id) throw new Error(lastCreateError || 'Failed to resolve specials group');
   return group;
 }
 

--- a/app.js
+++ b/app.js
@@ -803,6 +803,8 @@ function createAccessSessionService() {
       };
 
       if (!currentUser) return requireAuth();
+      const authOverlay = document.getElementById('auth-overlay');
+      if (authOverlay?.classList.contains('open')) closeAuthOverlay();
 
       if (_appPageMode === 'manager') {
         _setLoadingMessage('Checking manager access…');
@@ -1555,26 +1557,6 @@ function getRestaurantSpecialsService() {
   if (_restaurantSpecialsService) return _restaurantSpecialsService;
   _restaurantSpecialsService = createRestaurantSpecialsService();
   return _restaurantSpecialsService;
-}
-
-function resetRestaurantSpecialsCatalog() {
-  return getRestaurantSpecialsService().resetCatalog();
-}
-
-function buildCurrentMenuSpecialsCatalog() {
-  return getRestaurantSpecialsService().buildCurrentMenuCatalog();
-}
-
-function getRestaurantSpecialsCatalog() {
-  return getRestaurantSpecialsService().getCatalog();
-}
-
-async function ensureRestaurantSpecialsGroup(restaurantId = RESTAURANT_ID) {
-  return getRestaurantSpecialsService().ensureGroup(restaurantId);
-}
-
-async function refreshRestaurantSpecialsCatalog(restaurantId = RESTAURANT_ID) {
-  return getRestaurantSpecialsService().refreshCatalog(restaurantId);
 }
 
 async function refreshFeaturedForActiveMenu() {
@@ -6609,10 +6591,6 @@ document.getElementById('invite-modal-bg')?.addEventListener('click', e => {
 
 function getActiveRestaurantSpecialGroup() {
   return getRestaurantSpecialsService().getActiveGroup();
-}
-
-async function callRestaurantSpecialsApi(action, payload = {}) {
-  return getRestaurantSpecialsService().request(action, payload);
 }
 
 function renderFeaturedTab() {

--- a/app.js
+++ b/app.js
@@ -6160,9 +6160,6 @@ setInterval(() => {
   });
 })();
 
-// ─── PREVIEW ROLE-SWITCHER TOOLBAR ───────────────────────────────────────────
-let _previewRole = null; // tracks active mock role; null = using real session
-
 // ─── RESTAURANT & MENU MANAGEMENT ─────────────────────────────────────────────
 
 async function fetchRestaurantMenuIndex() {
@@ -6236,51 +6233,4 @@ async function renderMenusPanel() {
   }
 }
 
-function _initPreviewToolbar() {
-  if (!IS_PREVIEW) return;
-  const toolbar = document.createElement('div');
-  toolbar.id = 'preview-toolbar';
-  toolbar.setAttribute('aria-label', 'Preview role switcher');
-  toolbar.innerHTML = `
-    <div class="preview-toolbar-label">PREVIEW</div>
-    <button class="preview-toolbar-btn" data-role="public"  onclick="_setPreviewRole('public')">Public</button>
-    <button class="preview-toolbar-btn" data-role="manager" onclick="_setPreviewRole('manager')">Manager</button>
-    <button class="preview-toolbar-btn" data-role="admin"   onclick="_setPreviewRole('admin')">Admin</button>
-    <div class="preview-toolbar-divider"></div>
-    <button class="preview-toolbar-btn preview-toolbar-login" onclick="openAuthOverlay()">Login</button>
-  `;
-  document.body.appendChild(toolbar);
-  _updatePreviewToolbar();
-}
-
-function _setPreviewRole(role) {
-  _previewRole = role;
-  if (role === 'public') {
-    if (isManagerMode || isAdminMode) exitView();
-    currentUser = null;
-    applyRole('none');
-    renderUserHeader();
-  } else {
-    // Mock session — no real tokens; writes will fail gracefully
-    currentUser = {
-      uid: 'preview-user', email: 'preview@preview.test',
-      name: 'Preview User', role, accessibleMenuIds: MENU_ID ? [MENU_ID] : [],
-      accessToken: null, refreshToken: null, expiresAt: 0,
-    };
-    applyRole(role);
-    renderUserHeader();
-    if (role === 'admin') { if (!isAdminMode) enterAdmin(); }
-    else { if (!isManagerMode) enterManager(); }
-  }
-  _updatePreviewToolbar();
-}
-
-function _updatePreviewToolbar() {
-  const active = _previewRole ?? (currentUser?.role || 'public');
-  document.querySelectorAll('#preview-toolbar .preview-toolbar-btn[data-role]').forEach(btn => {
-    btn.classList.toggle('active', btn.dataset.role === active);
-  });
-}
-
 init();
-if (IS_PREVIEW) _initPreviewToolbar();

--- a/app.js
+++ b/app.js
@@ -450,6 +450,22 @@ function navigateToPage(path) {
   window.location.assign(path);
 }
 
+function restoreMenuStateFromFallback(expectedRestaurantId = '') {
+  const cached = readCachedMenuState(expectedRestaurantId);
+  if (cached) {
+    try {
+      hydrateState(cached);
+      return { source: 'cache', usedFallback: true };
+    } catch (_) {
+      /* fall through to defaults */
+    }
+  }
+  menuState = defaultState();
+  currentDesign = { ...DESIGN_DEFAULTS };
+  _restaurantCustomDesignEnabled = true;
+  return { source: 'default', usedFallback: true };
+}
+
 function buildCurrentMenuPageRequest(overrides = {}) {
   const pathname = overrides.pathname ?? window.location.pathname;
   const search = overrides.search ?? window.location.search;
@@ -487,9 +503,15 @@ function buildMenuSessionSnapshot(source = 'live') {
 
 function createMenuLifecycleService(ports) {
   return {
+    async openPageState(options = {}) {
+      return ports.openPageState(options);
+    },
     async refreshPageState(options = {}) {
       if (options.reason === 'poll') return ports.pollPageState(options);
-      return ports.loadPageState(options);
+      return {
+        ok: true,
+        snapshot: await ports.loadPageState(options),
+      };
     },
     async savePageDraft(options = {}) {
       return ports.savePageDraft(options);
@@ -508,6 +530,10 @@ function createMenuRuntime({ lifecycle }) {
         _syncRequest(nextRequest = {}) {
           this._request = { ...this._request, ...nextRequest };
           return this._request;
+        },
+        async open(options = {}) {
+          this._syncRequest(buildCurrentMenuPageRequest(options));
+          return lifecycle.openPageState({ request: this._request, ...options });
         },
         getSnapshot(source = 'live') {
           this._syncRequest(buildCurrentMenuPageRequest());
@@ -562,6 +588,7 @@ function createMenuRuntime({ lifecycle }) {
 function getMenuLifecycleService() {
   if (_menuLifecycleService) return _menuLifecycleService;
   _menuLifecycleService = createMenuLifecycleService({
+    openPageState: options => _openCurrentMenuPageInternal(options),
     loadPageState: options => _loadActiveMenuStateInternal(options),
     pollPageState: options => _pollActiveMenuStateInternal(options),
     savePageDraft: options => _saveActiveMenuDraftInternal(options),
@@ -1105,6 +1132,56 @@ async function refreshFeaturedForActiveMenu() {
   return _featuredGroups;
 }
 
+async function _openCurrentMenuPageInternal(options = {}) {
+  const {
+    request = buildCurrentMenuPageRequest(),
+    resolveMenu = true,
+    fallbackToDefault = true,
+    includeFeatured = true,
+    persistCache = true,
+    expectedRestaurantId = request.siteRestaurantId || '',
+  } = options;
+
+  if (resolveMenu && SUPABASE_URL) await sbResolveMenu();
+
+  if (!SUPABASE_URL || !MENU_ID) {
+    const fallback = restoreMenuStateFromFallback(expectedRestaurantId);
+    return {
+      ok: true,
+      source: fallback.source,
+      usedFallback: fallback.usedFallback,
+      showLoadError: false,
+      snapshot: buildMenuSessionSnapshot(fallback.source),
+    };
+  }
+
+  try {
+    const snapshot = await _loadActiveMenuStateInternal({
+      fallbackToDefault,
+      includeFeatured,
+      persistCache,
+      source: 'network',
+    });
+    return {
+      ok: true,
+      source: snapshot.source || 'network',
+      usedFallback: false,
+      showLoadError: false,
+      snapshot,
+    };
+  } catch (error) {
+    const fallback = restoreMenuStateFromFallback(expectedRestaurantId);
+    return {
+      ok: false,
+      error,
+      source: fallback.source,
+      usedFallback: fallback.usedFallback,
+      showLoadError: true,
+      snapshot: buildMenuSessionSnapshot(fallback.source),
+    };
+  }
+}
+
 async function _loadActiveMenuStateInternal(options = {}) {
   const {
     fallbackToDefault = true,
@@ -1164,7 +1241,8 @@ async function _pollActiveMenuStateInternal() {
 }
 
 async function loadActiveMenuState(options = {}) {
-  return ensureCurrentMenuSession().refresh(options);
+  const result = await ensureCurrentMenuSession().refresh(options);
+  return result?.snapshot || result;
 }
 
 async function sbPatchMenuMeta(update) {
@@ -2152,34 +2230,16 @@ async function init() {
     return;
   }
 
-  if (SUPABASE_URL) await sbResolveMenu();
-
-  if (!SUPABASE_URL || !MENU_ID) {
-    // Offline or unconfigured — serve from localStorage cache if available
-    const cached = readCachedMenuState(_siteRestaurant?.id || RESTAURANT_ID || '');
-    if (cached) {
-      try { hydrateState(cached); } catch(e) { menuState = defaultState(); }
-    } else {
-      menuState = defaultState();
-    }
-    applyDesign(currentDesign);
-    await showPublicView();
+  const pageSession = ensureCurrentMenuSession();
+  const openResult = await pageSession.open({
+    resolveMenu: true,
+    expectedRestaurantId: _siteRestaurant?.id || RESTAURANT_ID || '',
+  });
+  applyDesign(currentDesign);
+  if (openResult?.showLoadError) {
+    await showPublicViewWithError('⚠️ Could not load menu data. Check your connection.');
   } else {
-    try {
-      await loadActiveMenuState();
-      applyDesign(currentDesign);
-      await showPublicView();
-    } catch(e) {
-      // Fallback to localStorage cache
-      const cached = readCachedMenuState(_siteRestaurant?.id || RESTAURANT_ID || '');
-      if (cached) {
-        try { hydrateState(cached); } catch(e2) { menuState = defaultState(); }
-      } else {
-        menuState = defaultState();
-      }
-      applyDesign(currentDesign);
-      await showPublicViewWithError('⚠️ Could not load menu data. Check your connection.');
-    }
+    await showPublicView();
   }
 
   // Restore Supabase session — recovery callback takes priority over stored tokens
@@ -2352,9 +2412,19 @@ async function _loadSettingsPageMenuContext(menuId) {
     url.searchParams.set('menu', fallbackMenu.slug);
     history.replaceState({}, '', url.toString());
   }
-  await sbResolveMenu();
-  if (!MENU_ID) return false;
-  await loadActiveMenuState();
+  const session = ensureCurrentMenuSession({
+    requestedMenuId: menuId,
+    requestedMenuSlug: fallbackMenu?.slug || '',
+    siteRestaurantId: fallbackMenu?.restaurantId || '',
+  });
+  const openResult = await session.open({
+    resolveMenu: true,
+    expectedRestaurantId: fallbackMenu?.restaurantId || '',
+    requestedMenuId: menuId,
+    requestedMenuSlug: fallbackMenu?.slug || '',
+    siteRestaurantId: fallbackMenu?.restaurantId || '',
+  });
+  if (!MENU_ID || !openResult?.snapshot?.menuId) return false;
   applyDesign(currentDesign);
   return true;
 }
@@ -3462,6 +3532,11 @@ function selectMenu(menuId, slug, menuName, menuType, restaurantId) {
   const url = new URL(location.href);
   url.searchParams.set('menu', slug);
   history.replaceState({}, '', url.toString());
+  ensureCurrentMenuSession({
+    requestedMenuId: menuId,
+    requestedMenuSlug: slug,
+    siteRestaurantId: restaurantId || '',
+  });
   closeMenuPicker({ skipOnClose: true });
   updateActiveMenuBar();
   renderUserHeader();

--- a/app.js
+++ b/app.js
@@ -186,6 +186,8 @@ let _managerDraggedCatId = '';
 let _menuLifecycleService = null;
 let _menuRuntime = null;
 let _currentMenuSession = null;
+let _updatePublisher = null;
+let _menuMetaSupportsLastSentFeatured = true;
 function invalidateDiff() { _diffDirty = true; _dirty = true; updateSaveBtn(); }
 function updateSaveBtn() {
   const btn = document.getElementById('save-btn');
@@ -1355,13 +1357,13 @@ function isMissingColumnError(error, columnName) {
     (message.includes('column') || message.includes('schema cache'));
 }
 
-async function patchMenuMetaWithCompatibility(update) {
+async function patchMenuMetaForMenuWithCompatibility(menuId, update) {
   const payload = { ...update };
   if (_menuMetaSupportsLastSentFeatured === false) {
     delete payload.last_sent_featured;
   }
   try {
-    await sbPatchMenuMeta(payload);
+    await sbPatchMenuMetaForMenu(menuId, payload);
     if (Object.prototype.hasOwnProperty.call(payload, 'last_sent_featured')) {
       _menuMetaSupportsLastSentFeatured = true;
     }
@@ -1369,12 +1371,16 @@ async function patchMenuMetaWithCompatibility(update) {
   } catch (error) {
     if (Object.prototype.hasOwnProperty.call(payload, 'last_sent_featured') && isMissingColumnError(error, 'last_sent_featured')) {
       const { last_sent_featured, ...fallbackPayload } = payload;
-      await sbPatchMenuMeta(fallbackPayload);
+      await sbPatchMenuMetaForMenu(menuId, fallbackPayload);
       _menuMetaSupportsLastSentFeatured = false;
       return { downgradedFields: ['last_sent_featured'] };
     }
     throw error;
   }
+}
+
+async function patchMenuMetaWithCompatibility(update) {
+  return patchMenuMetaForMenuWithCompatibility(MENU_ID, update);
 }
 
 async function sbPatchRestaurantDesign(design) {
@@ -4651,7 +4657,8 @@ function finalizePersistStatus(ok) {
   syncManagerActionBarStatus(syncEl);
 }
 
-async function persistState() {
+async function persistState(options = {}) {
+  const { silentFailure = false } = options;
   if (!SUPABASE_URL || !MENU_ID || !currentUser?.accessToken) return;
   try {
     const catRows = buildCategoryUpsertRows();
@@ -4687,7 +4694,7 @@ async function persistState() {
     return true;
   } catch(e) {
     finalizePersistStatus(false);
-    showToast('⚠️ Cloud save failed.', 'error');
+    if (!silentFailure) showToast('⚠️ Cloud save failed.', 'error');
     return false;
   }
 }
@@ -5459,18 +5466,18 @@ function buildPreviewBlockHtml(section) {
 }
 
 function openPreview() {
-  const diff = getCachedDiff();
+  const preview = getUpdatePublisher().preview();
   const content = document.getElementById('preview-content');
   const confirmBtn = document.getElementById('confirm-btn');
   const modal = document.getElementById('modal-bg');
   if (!content || !confirmBtn || !modal) return;
   content.innerHTML = '';
-  if (!diff.length) {
+  if (!preview.hasChanges) {
     content.innerHTML = `<div class="no-changes">🎉 No changes since the last update.<br><span style="font-size:11px;color:#444;">Add, remove, or 86 items to generate an update.</span></div>`;
     confirmBtn.disabled = true;
   } else {
     confirmBtn.disabled = false;
-    diff.forEach(s => {
+    preview.sections.forEach(s => {
       const block = document.createElement('div');
       block.className = 'preview-block';
       block.innerHTML = buildPreviewBlockHtml(s);
@@ -5499,6 +5506,265 @@ function buildPatchMessage(diff) {
   });
   if (MENU_URL) lines.push(`📋 Full menu: ${MENU_URL}`);
   return lines.join('\n').trim();
+}
+
+function getUpdatePublisher() {
+  if (_updatePublisher) return _updatePublisher;
+  _updatePublisher = createUpdatePublisher();
+  return _updatePublisher;
+}
+
+function createUpdatePublisher() {
+  return {
+    preview() {
+      const diff = getCachedDiff();
+      const patchMessage = diff.length ? buildPatchMessage(diff) : '';
+      return {
+        hasChanges: diff.length > 0,
+        diff,
+        sections: diff,
+        patchMessage,
+        truncated: patchMessage.length > 1000,
+        snapshot: buildMenuSessionSnapshot('preview'),
+      };
+    },
+
+    async publish(options = {}) {
+      const preview = options.preview?.diff ? options.preview : this.preview();
+      if (!preview.hasChanges) {
+        return {
+          ok: false,
+          noop: true,
+          preview,
+          snapshot: buildMenuSessionSnapshot('send-noop'),
+        };
+      }
+
+      const delivery = await dispatchMenuUpdateNotification({
+        menuId: MENU_ID,
+        patchMessage: preview.patchMessage,
+      });
+      if (!delivery.ok) {
+        return {
+          ok: false,
+          preview,
+          notificationStatus: delivery,
+          userMessage: delivery.userMessage,
+          snapshot: buildMenuSessionSnapshot('send-failed'),
+        };
+      }
+
+      const warnings = collectNotificationWarnings(delivery.summary);
+      try {
+        const persisted = await persistState({ silentFailure: true });
+        if (!persisted) throw new Error('persist failed');
+
+        const ts = Date.now();
+        const lastSentState = snapshotCurrentItemsAsLastSent();
+        const currentFeaturedIds = getCurrentFeaturedIds();
+        const restaurantMenuIds = currentUserCanEditRestaurantSpecials(RESTAURANT_ID)
+          ? (getRestaurantSpecialConfig(RESTAURANT_ID)?.menuIds || [])
+          : [];
+        const patchResults = await Promise.all([
+          patchMenuMetaWithCompatibility({
+            last_updated_ts: ts,
+            last_sent_ts: ts,
+            last_sent_state: lastSentState,
+            last_sent_categories: preview.diff.map(section => section.id),
+            last_sent_featured: currentFeaturedIds,
+          }),
+          ...restaurantMenuIds
+            .filter(menuId => menuId && menuId !== MENU_ID)
+            .map(menuId => patchMenuMetaForMenuWithCompatibility(menuId, {
+              last_sent_featured: currentFeaturedIds,
+            })),
+        ]);
+        if (patchResults.some(result => (result?.downgradedFields || []).includes('last_sent_featured'))) {
+          warnings.push('Featured sync used legacy metadata compatibility on this deployment.');
+        }
+
+        _lastSentFeaturedIds = new Set(currentFeaturedIds);
+        applySentState(preview.diff, ts);
+        _dirty = false;
+        updateSaveBtn();
+        updateLastUpdatedLabel();
+
+        const cacheSynced = syncLocalMenuCache({ silent: true });
+        if (!cacheSynced) {
+          warnings.push('This device could not refresh its local cache after the send.');
+        }
+
+        const logged = await logUpdate(preview.diff, preview.patchMessage);
+        if (!logged) {
+          warnings.push('The recent-changes audit log could not be written for this send.');
+        }
+
+        const finalWarnings = dedupePublisherWarnings(warnings);
+        return {
+          ok: true,
+          preview,
+          ts,
+          truncated: preview.truncated,
+          notificationStatus: delivery,
+          warnings: finalWarnings,
+          warningMessage: finalWarnings[0] || '',
+          successMessage: `✅ ${_activeMenuName || 'Menu'} update sent!`,
+          snapshot: buildMenuSessionSnapshot(finalWarnings.length ? 'sent-warning' : 'sent'),
+        };
+      } catch (syncError) {
+        console.warn('sendUpdate post-send sync failed:', syncError);
+        warnings.push('Update sent, but database sync needs attention. Refresh before sending again.');
+        const finalWarnings = dedupePublisherWarnings(warnings);
+        return {
+          ok: true,
+          preview,
+          truncated: preview.truncated,
+          notificationStatus: delivery,
+          warnings: finalWarnings,
+          warningMessage: finalWarnings[0] || '',
+          successMessage: `✅ ${_activeMenuName || 'Menu'} update sent!`,
+          snapshot: buildMenuSessionSnapshot('sent-warning'),
+        };
+      }
+    },
+  };
+}
+
+function dedupePublisherWarnings(warnings = []) {
+  return Array.from(new Set((warnings || []).filter(Boolean)));
+}
+
+function formatNotificationChannelName(channel) {
+  switch (channel) {
+    case 'groupme': return 'GroupMe';
+    case 'sms': return 'SMS';
+    case 'discord': return 'Discord';
+    case 'webhook': return 'Webhook';
+    default: return channel || 'Unknown channel';
+  }
+}
+
+function summarizeNotificationResults(results = {}) {
+  const entries = Object.entries(results || {}).filter(([channel]) => !!channel);
+  const okChannels = [];
+  const skippedChannels = [];
+  const failedChannels = [];
+  const failedDetails = [];
+
+  entries.forEach(([channel, status]) => {
+    if (status === 'ok') {
+      okChannels.push(channel);
+      return;
+    }
+    if (status === 'skipped') {
+      skippedChannels.push(channel);
+      return;
+    }
+    failedChannels.push(channel);
+    failedDetails.push({
+      channel,
+      status: typeof status === 'string' ? status : 'error:unknown',
+    });
+  });
+
+  return {
+    results,
+    okChannels,
+    skippedChannels,
+    failedChannels,
+    failedDetails,
+    anyOk: okChannels.length > 0,
+    anyError: failedChannels.length > 0,
+    allSkipped: entries.length > 0 && skippedChannels.length === entries.length,
+  };
+}
+
+function collectNotificationWarnings(summary) {
+  if (!summary) return [];
+  const warnings = [];
+  if (summary.allSkipped) {
+    warnings.push('No notification channels were enabled for this menu.');
+  } else if (summary.anyOk && summary.anyError) {
+    warnings.push(`Some notification channels failed: ${summary.failedChannels.map(formatNotificationChannelName).join(', ')}.`);
+  }
+  return warnings;
+}
+
+async function dispatchMenuUpdateNotification({ menuId, patchMessage }) {
+  const authHeaders = currentUser?.accessToken
+    ? { 'Authorization': `Bearer ${currentUser.accessToken}` }
+    : {};
+
+  let response;
+  try {
+    response = await fetch('/api/send-notification', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json', ...authHeaders },
+      body: JSON.stringify({ menu_id: menuId, text: patchMessage }),
+    });
+  } catch (_) {
+    return {
+      ok: false,
+      statusCode: 0,
+      summary: summarizeNotificationResults({}),
+      userMessage: '❌ Network error. Check connection.',
+    };
+  }
+
+  let body = {};
+  try {
+    body = await response.json();
+  } catch (_) {
+    body = {};
+  }
+
+  const summary = summarizeNotificationResults(body?.results || {});
+  if (response.status >= 200 && response.status < 300) {
+    return {
+      ok: true,
+      statusCode: response.status,
+      partial: response.status === 207,
+      results: body?.results || {},
+      summary,
+    };
+  }
+
+  if (response.status === 401) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      summary,
+      userMessage: '❌ Not authorized. Please sign in.',
+    };
+  }
+
+  if (response.status === 403) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      summary,
+      userMessage: '❌ Access denied. Your account role does not allow sending updates.',
+    };
+  }
+
+  if (response.status === 400 && typeof body?.error === 'string' && body.error.trim()) {
+    return {
+      ok: false,
+      statusCode: response.status,
+      summary,
+      userMessage: `❌ ${body.error.trim()}`,
+    };
+  }
+
+  const failedSummary = summary.failedChannels.length
+    ? ` Failed: ${summary.failedChannels.map(formatNotificationChannelName).join(', ')}.`
+    : '';
+  return {
+    ok: false,
+    statusCode: response.status,
+    summary,
+    userMessage: `❌ Notification error. Check channel config in Admin settings.${failedSummary}`,
+  };
 }
 
 function snapshotLastSentState() {
@@ -5547,89 +5813,15 @@ async function logUpdate(diff, patchMessage) {
   }
 }
 
-async function _publishActiveMenuUpdateInternal() {
-  const diff = getCachedDiff();
-  if (!diff.length) {
-    return { ok: false, noop: true, snapshot: buildMenuSessionSnapshot('send-noop') };
-  }
-  const patchMessage = buildPatchMessage(diff);
-  try {
-    const authHeaders = currentUser?.accessToken
-      ? { 'Authorization': `Bearer ${currentUser.accessToken}` }
-      : {};
-    const r1 = await fetch('/api/send-notification', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...authHeaders },
-      body: JSON.stringify({ menu_id: MENU_ID, text: patchMessage })
-    });
-
-    if (r1.status >= 200 && r1.status < 300) {
-      const ts = Date.now();
-      try {
-        const persisted = await persistState();
-        if (!persisted) throw new Error('persist failed');
-        const lastSentState = snapshotCurrentItemsAsLastSent();
-        const currentFeaturedIds = getCurrentFeaturedIds();
-        const restaurantMenuIds = currentUserCanEditRestaurantSpecials(RESTAURANT_ID)
-          ? (getRestaurantSpecialConfig(RESTAURANT_ID)?.menuIds || [])
-          : [];
-        _lastSentFeaturedIds = new Set(currentFeaturedIds);
-        await Promise.all([
-          sbPatchMenuMeta({
-            last_updated_ts:      ts,
-            last_sent_ts:         ts,
-            last_sent_state:      lastSentState,
-            last_sent_categories: diff.map(d => d.id),
-            last_sent_featured:   currentFeaturedIds,
-          }),
-          ...restaurantMenuIds
-            .filter(menuId => menuId && menuId !== MENU_ID)
-            .map(menuId => sbPatchMenuMetaForMenu(menuId, { last_sent_featured: currentFeaturedIds })),
-        ]);
-        applySentState(diff, ts);
-        _dirty = false;
-        updateSaveBtn();
-        updateLastUpdatedLabel();
-        const cacheSynced = syncLocalMenuCache({ silent: true });
-        const logged = await logUpdate(diff, patchMessage);
-        if (!logged) console.warn('sendUpdate audit log insert failed');
-        return {
-          ok: true,
-          truncated: patchMessage.length > 1000,
-          warningMessage: !cacheSynced
-            ? '⚠️ Update sent, but this device could not refresh its local cache.'
-            : '',
-          successMessage: `✅ ${_activeMenuName || 'Menu'} update sent!`,
-          snapshot: buildMenuSessionSnapshot('sent'),
-        };
-      } catch (syncError) {
-        console.warn('sendUpdate post-send sync failed:', syncError);
-        return {
-          ok: true,
-          truncated: patchMessage.length > 1000,
-          warningMessage: '⚠️ Update sent, but database sync needs attention. Refresh before sending again.',
-          successMessage: `✅ ${_activeMenuName || 'Menu'} update sent!`,
-          snapshot: buildMenuSessionSnapshot('sent-warning'),
-        };
-      }
-    } else if (r1.status === 401) {
-      return { ok: false, userMessage: '❌ Not authorized. Please sign in.' };
-    } else if (r1.status === 403) {
-      return { ok: false, userMessage: '❌ Access denied. Your account role does not allow sending updates.' };
-    } else {
-      return { ok: false, userMessage: '❌ Notification error. Check channel config in Admin settings.' };
-    }
-  } catch(e) {
-    return { ok: false, userMessage: '❌ Network error. Check connection.' };
-  }
+async function _publishActiveMenuUpdateInternal(options = {}) {
+  return getUpdatePublisher().publish(options);
 }
 
 async function sendUpdate() {
-  const diff = getCachedDiff();
-  if (!diff.length) { closeModal(); return; }
+  const preview = getUpdatePublisher().preview();
+  if (!preview.hasChanges) { closeModal(); return; }
 
-  const patchMessage = buildPatchMessage(diff);
-  if (patchMessage.length > 1000) {
+  if (preview.truncated) {
     showToast('Update is long and will be truncated.', 'info');
   }
 
@@ -5638,7 +5830,7 @@ async function sendUpdate() {
   confirmBtn.textContent = 'SENDING…';
 
   try {
-    const result = await ensureCurrentMenuSession().sendUpdate();
+    const result = await ensureCurrentMenuSession().sendUpdate({ preview });
     if (result?.noop) {
       closeModal();
       return;
@@ -5649,7 +5841,8 @@ async function sendUpdate() {
       renderManagerWorkspace({ includeRecentChanges: false });
       updateDraftIndicator();
       renderRecentChanges();
-      if (result.warningMessage) showToast(result.warningMessage, 'warning');
+      const warnings = Array.isArray(result.warnings) ? result.warnings : (result.warningMessage ? [result.warningMessage] : []);
+      warnings.forEach(message => showToast(`⚠️ ${message}`, 'warning'));
       return;
     }
     if (result?.userMessage) showToast(result.userMessage, 'error');

--- a/app.js
+++ b/app.js
@@ -61,6 +61,8 @@ let _pickerOnSelect    = null;     // callback invoked after selectMenu()
 let _pickerOnClose     = null;
 let _settingsRedirectTimer = null;
 let _settingsRedirectCleanup = null;
+let _accessSessionService = null;
+let _restaurantSpecialsService = null;
 
 let _featuredGroups = []; // [{id, name, displayOrder, slots: [{id, itemId, sellNote, displayOrder, confirmedAt, confirmedBy, item: {…}}]}]
 let _lastSentFeaturedIds = new Set(); // item IDs that were featured at last Send Update
@@ -614,6 +616,299 @@ function ensureCurrentMenuSession(overrides = {}) {
   return _currentMenuSession;
 }
 
+function resolveRequestedSettingsRoute(user = currentUser) {
+  if (!user) {
+    return {
+      kind: 'auth-required',
+      pageMode: _appPageMode,
+    };
+  }
+
+  if (_appPageMode === 'admin') {
+    if (user.role !== 'admin') {
+      return {
+        kind: 'admin-denied',
+        pageMode: 'admin',
+        message: 'Admin access required for this page.',
+      };
+    }
+
+    return {
+      kind: 'admin',
+      pageMode: 'admin',
+      targetMenuId: KNOWN_MENU_ORDER.includes(MENU_ID) ? MENU_ID : (KNOWN_MENU_ORDER[0] || ''),
+    };
+  }
+
+  const requestedMenu = getRequestedMenuForSettingsPage();
+  if (!requestedMenu) {
+    return {
+      kind: 'manager-denied',
+      pageMode: 'manager',
+      message: 'No menu context available for this page.',
+    };
+  }
+
+  if (!currentUserCanManageMenu(requestedMenu.id, user)) {
+    const fallbackMenuId = getFirstAccessibleManagerMenuId(user);
+    if (fallbackMenuId) {
+      const targetPath = getManagerHrefForMenuId(fallbackMenuId);
+      if (targetPath) {
+        return {
+          kind: 'manager-redirect',
+          pageMode: 'manager',
+          targetPath,
+          menuId: fallbackMenuId,
+        };
+      }
+    }
+
+    return {
+      kind: 'manager-denied',
+      pageMode: 'manager',
+      message: 'You don\'t have manager access to this menu.',
+      targetPath: getPublicHrefForMenuId(requestedMenu.id),
+      redirectLabel: 'the public menu',
+      actionLabel: 'Return to the public menu',
+    };
+  }
+
+  return {
+    kind: 'manager',
+    pageMode: 'manager',
+    targetMenuId: requestedMenu.id,
+    requestedMenu,
+  };
+}
+
+function createAccessSessionService() {
+  return {
+    async applyAuthenticatedSession(data, options = {}) {
+      const { closeOverlay = false } = options;
+      let role = 'none';
+      let name = '';
+      let accessibleMenuIds = [];
+      if (data?.access_token) {
+        const profile = await sbGetProfile(data.access_token);
+        role = profile.role;
+        name = profile.name;
+        accessibleMenuIds = profile.accessibleMenuIds;
+      }
+      _applySession(data, role, name, accessibleMenuIds);
+      applyRole(role);
+      if (closeOverlay) closeAuthOverlay();
+      return { role, name, accessibleMenuIds };
+    },
+
+    async handleRecoveryCallback() {
+      const hash = window.location.hash.slice(1);
+      if (!hash) return { handled: false };
+      const params = new URLSearchParams(hash);
+      if (params.get('type') !== 'recovery') return { handled: false };
+      const accessToken = params.get('access_token');
+      if (!accessToken) return { handled: false };
+      history.replaceState({}, '', window.location.pathname);
+      _recoverySessionData = {
+        access_token: accessToken,
+        refresh_token: params.get('refresh_token') || '',
+        expires_in: Number(params.get('expires_in') || 3600),
+      };
+      return {
+        handled: true,
+        screen: 'reset',
+      };
+    },
+
+    async restoreStoredSession() {
+      if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return { restored: false, reason: 'not-configured' };
+      const storedAccess = localStorage.getItem(LS_KEYS.accessToken);
+      const storedRefresh = localStorage.getItem(LS_KEYS.refreshToken);
+      const storedExpiresAt = Number(localStorage.getItem(LS_KEYS.expiresAt) || 0);
+      const storedUid = localStorage.getItem(LS_KEYS.uid) || '';
+      const storedEmail = localStorage.getItem(LS_KEYS.email) || '';
+      if (!storedRefresh) return { restored: false, reason: 'no-refresh-token' };
+
+      if (storedAccess && storedExpiresAt > Date.now() + 120_000) {
+        try {
+          const profile = await sbGetProfile(storedAccess);
+          currentUser = {
+            uid: storedUid,
+            email: storedEmail,
+            name: profile.name,
+            role: profile.role,
+            accessibleMenuIds: profile.accessibleMenuIds,
+            accessToken: storedAccess,
+            refreshToken: storedRefresh,
+            expiresAt: storedExpiresAt,
+          };
+          _scheduleTokenRefresh(storedExpiresAt);
+          applyRole(profile.role);
+          return { restored: true, source: 'stored-access', profile };
+        } catch (_) {
+          // fall through to refresh flow
+        }
+      }
+
+      const refreshStoredSession = async () => {
+        const refresh = localStorage.getItem(LS_KEYS.refreshToken);
+        if (!refresh) throw new Error('no refresh token');
+        const data = await sbRefreshToken(refresh);
+        const session = await this.applyAuthenticatedSession(data);
+        return { data, session };
+      };
+
+      try {
+        const refreshed = await refreshStoredSession();
+        return { restored: true, source: 'refresh-token', ...refreshed };
+      } catch (_) {
+        setTimeout(async () => {
+          try {
+            await refreshStoredSession();
+            await this.syncRequestedPageMode();
+          } catch (_) {
+            localStorage.removeItem(LS_KEYS.accessToken);
+            localStorage.removeItem(LS_KEYS.refreshToken);
+            localStorage.removeItem(LS_KEYS.expiresAt);
+            localStorage.removeItem(LS_KEYS.uid);
+            localStorage.removeItem(LS_KEYS.email);
+          }
+        }, 2000);
+        return { restored: false, reason: 'retry-scheduled' };
+      }
+    },
+
+    async syncRequestedPageMode() {
+      if (!isSettingsPage()) return { handled: false };
+
+      const publicView = document.getElementById('public-view');
+      const managerView = document.getElementById('manager-view');
+      if (!publicView || !managerView) return { handled: false };
+
+      _clearSettingsRedirectPrompt();
+      renderUserHeader();
+
+      const requireAuth = () => {
+        isManagerMode = false;
+        isAdminMode = false;
+        document.body.classList.remove('manager-mode');
+        publicView.style.display = 'none';
+        managerView.style.display = 'none';
+        _setLoadingMessage('Sign in to access settings.', { hideSpinner: true });
+        openAuthOverlay('signin');
+        return {
+          handled: true,
+          status: 'auth-required',
+          pageMode: _appPageMode,
+        };
+      };
+
+      if (!currentUser) return requireAuth();
+
+      if (_appPageMode === 'manager') {
+        _setLoadingMessage('Checking manager access…');
+        await refreshCurrentUserProfile();
+      }
+
+      const routeDecision = resolveRequestedSettingsRoute();
+
+      if (routeDecision.kind === 'auth-required') {
+        return requireAuth();
+      }
+
+      if (routeDecision.kind === 'admin-denied') {
+        showAdminAccessDenied(routeDecision.message);
+        return {
+          handled: true,
+          status: 'access-denied',
+          pageMode: 'admin',
+        };
+      }
+
+      if (routeDecision.kind === 'admin') {
+        _setLoadingMessage('Loading settings…');
+        if (!routeDecision.targetMenuId) {
+          showAdminAccessDenied('No menu context available for this page.');
+          return {
+            handled: true,
+            status: 'context-missing',
+            pageMode: 'admin',
+          };
+        }
+        const hasMenuContext = await _loadSettingsPageMenuContext(routeDecision.targetMenuId);
+        if (!hasMenuContext) {
+          showAdminAccessDenied('No menu context available for this page.');
+          return {
+            handled: true,
+            status: 'context-missing',
+            pageMode: 'admin',
+          };
+        }
+        enterAdmin();
+        return {
+          handled: true,
+          status: 'entered',
+          pageMode: 'admin',
+          menuId: routeDecision.targetMenuId,
+        };
+      }
+
+      if (routeDecision.kind === 'manager-redirect') {
+        navigateToPage(routeDecision.targetPath);
+        return {
+          handled: true,
+          status: 'redirected',
+          pageMode: 'manager',
+          menuId: routeDecision.menuId,
+          targetPath: routeDecision.targetPath,
+        };
+      }
+
+      if (routeDecision.kind === 'manager-denied') {
+        showManagerAccessDenied(routeDecision.message, {
+          targetPath: routeDecision.targetPath,
+          redirectLabel: routeDecision.redirectLabel,
+          actionLabel: routeDecision.actionLabel,
+        });
+        return {
+          handled: true,
+          status: 'access-denied',
+          pageMode: 'manager',
+        };
+      }
+
+      _managerMenuPicked = true;
+      _setLoadingMessage('Loading settings…');
+      const hasMenuContext = await _loadSettingsPageMenuContext(routeDecision.targetMenuId);
+      if (!hasMenuContext) {
+        showManagerAccessDenied('Selected menu is no longer available for this account.', {
+          targetPath: getPublicHrefForMenuId(routeDecision.targetMenuId),
+          redirectLabel: 'the public menu',
+          actionLabel: 'Return to the public menu',
+        });
+        return {
+          handled: true,
+          status: 'context-missing',
+          pageMode: 'manager',
+          menuId: routeDecision.targetMenuId,
+        };
+      }
+      enterManager();
+      return {
+        handled: true,
+        status: 'entered',
+        pageMode: 'manager',
+        menuId: routeDecision.targetMenuId,
+      };
+    },
+  };
+}
+
+function getAccessSessionService() {
+  if (_accessSessionService) return _accessSessionService;
+  _accessSessionService = createAccessSessionService();
+  return _accessSessionService;
+}
+
 function readCachedMenuState(expectedRestaurantId = '') {
   const cached = localStorage.getItem(LS_KEYS.menuCache);
   if (!cached) return null;
@@ -1010,128 +1305,280 @@ function getFeaturedSnapshot() {
   })));
 }
 
+function createRestaurantSpecialsService() {
+  return {
+    resetCatalog() {
+      _restaurantSpecialsSiblingCatalog = [];
+      _restaurantSpecialsCatalogKey = '';
+      _restaurantSpecialsCatalogPromise = null;
+      return [];
+    },
+
+    buildCurrentMenuCatalog() {
+      const currentMenu = getMenuById(MENU_ID);
+      const fromCategories = getManagedCategoryDefs().flatMap(cat =>
+        (menuState[cat.id]?.items || []).map(item => ({
+          id: item.id,
+          name: item.name,
+          cat: cat.title,
+          menuId: MENU_ID,
+          menuLabel: currentMenu ? getMenuTypeLabel(currentMenu.type) : 'Current Menu',
+          onMenu: item.onMenu,
+          visibility: item.visibility || 'public',
+        }))
+      );
+      const uncatItems = (menuState[UNCATEGORIZED_ID]?.items || []).map(item => ({
+        id: item.id,
+        name: item.name,
+        cat: 'Uncategorized',
+        menuId: MENU_ID,
+        menuLabel: currentMenu ? getMenuTypeLabel(currentMenu.type) : 'Current Menu',
+        onMenu: true,
+        visibility: item.visibility || 'off_menu',
+      }));
+      return [...fromCategories, ...uncatItems];
+    },
+
+    getCatalog() {
+      return [...this.buildCurrentMenuCatalog(), ..._restaurantSpecialsSiblingCatalog];
+    },
+
+    async ensureGroup(restaurantId = RESTAURANT_ID) {
+      if (!restaurantId || !currentUser?.accessToken) return false;
+      try {
+        await fetch('/api/specials', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'Authorization': `Bearer ${currentUser.accessToken}`,
+          },
+          body: JSON.stringify({ action: 'ensure', restaurantId }),
+        });
+        return true;
+      } catch (_) {
+        return false;
+      }
+    },
+
+    async refreshCatalog(restaurantId = RESTAURANT_ID) {
+      const cacheKey = `${restaurantId || ''}:${MENU_ID || ''}`;
+      if (!restaurantId || !currentUserCanEditRestaurantSpecials(restaurantId)) {
+        return this.resetCatalog();
+      }
+      if (_restaurantSpecialsCatalogKey === cacheKey && _restaurantSpecialsCatalogPromise) {
+        return _restaurantSpecialsCatalogPromise;
+      }
+
+      const siblingMenuIds = (getRestaurantSpecialConfig(restaurantId)?.menuIds || getRestaurantMenuIds(restaurantId))
+        .filter(menuId => menuId && menuId !== MENU_ID);
+      if (!siblingMenuIds.length) {
+        _restaurantSpecialsSiblingCatalog = [];
+        _restaurantSpecialsCatalogKey = cacheKey;
+        _restaurantSpecialsCatalogPromise = Promise.resolve([]);
+        return _restaurantSpecialsCatalogPromise;
+      }
+
+      _restaurantSpecialsCatalogKey = cacheKey;
+      _restaurantSpecialsCatalogPromise = (async () => {
+        const requestKey = cacheKey;
+        try {
+          const categories = await sbReadJsonOrThrow(
+            `${SUPABASE_URL}/rest/v1/categories?menu_id=in.(${siblingMenuIds.join(',')})&select=menu_id,key,label,items(id,name,visibility,on_menu)&order=display_order.asc`,
+            { headers: sbHeaders() }
+          );
+          const menusById = knownMenuList().reduce((acc, menu) => {
+            acc[menu.id] = menu;
+            return acc;
+          }, {});
+          const catalog = categories
+            .filter(category => !isLegacySpecialCategory(category.key))
+            .flatMap(category =>
+              (category.items || []).map(item => ({
+                id: item.id,
+                name: item.name,
+                cat: category.label || '',
+                menuId: category.menu_id,
+                menuLabel: getMenuTypeLabel(menusById[category.menu_id]?.type || ''),
+                onMenu: category.key === UNCATEGORIZED_ID ? true : item.on_menu,
+                visibility: category.key === UNCATEGORIZED_ID ? (item.visibility || 'off_menu') : (item.visibility || 'public'),
+              }))
+            );
+          if (_restaurantSpecialsCatalogKey === requestKey) {
+            _restaurantSpecialsSiblingCatalog = catalog;
+          }
+        } catch (_) {
+          if (_restaurantSpecialsCatalogKey === requestKey) {
+            _restaurantSpecialsSiblingCatalog = [];
+          }
+        }
+        return _restaurantSpecialsSiblingCatalog;
+      })();
+      return _restaurantSpecialsCatalogPromise;
+    },
+
+    async refreshForActiveMenu(restaurantId = RESTAURANT_ID) {
+      if (!restaurantId) {
+        _featuredGroups = [];
+        this.resetCatalog();
+        return _featuredGroups;
+      }
+      if (currentUserCanEditRestaurantSpecials(restaurantId) && currentUser?.accessToken) {
+        await this.ensureGroup(restaurantId);
+        await this.refreshCatalog(restaurantId);
+      } else {
+        this.resetCatalog();
+      }
+      _featuredGroups = await sbReadRestaurantSpecials(restaurantId);
+      return _featuredGroups;
+    },
+
+    getActiveGroup(groupId = '') {
+      if (groupId) return _featuredGroups.find(group => group.id === groupId) || null;
+      return _featuredGroups[0] || null;
+    },
+
+    getMatches(groupId, query) {
+      const q = query.trim().toLowerCase();
+      if (!q) return [];
+      const group = this.getActiveGroup(groupId) || this.getActiveGroup();
+      const existingItemIds = new Set((group?.slots || []).map(slot => slot.itemId));
+      return this.getCatalog()
+        .filter(item =>
+          item.onMenu !== false &&
+          !existingItemIds.has(item.id) &&
+          String(item.name || '').toLowerCase().includes(q)
+        )
+        .slice(0, 8);
+    },
+
+    async request(action, payload = {}) {
+      const response = await fetch('/api/specials', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': `Bearer ${currentUser?.accessToken || ''}`,
+        },
+        body: JSON.stringify({
+          action,
+          restaurantId: RESTAURANT_ID,
+          ...payload,
+        }),
+      });
+      let data = {};
+      try {
+        data = await response.json();
+      } catch (_) {
+        data = {};
+      }
+      if (!response.ok) throw new Error(data.error || `Request failed (${response.status})`);
+      return data;
+    },
+
+    async addSlot({ groupId = '', itemId }) {
+      if (!currentUserCanEditRestaurantSpecials()) {
+        return { ok: false, userMessage: 'Specials require access to both menus for this restaurant.' };
+      }
+      const group = this.getActiveGroup(groupId) || this.getActiveGroup();
+      const slotCount = group?.slots?.length || 0;
+      if (slotCount >= 5) return { ok: false, userMessage: 'Max 5 specials per restaurant.', userHandled: true };
+      if ((group?.slots || []).some(slot => slot.itemId === itemId)) {
+        return { ok: false, userMessage: 'That item is already in specials.', userHandled: true };
+      }
+      if (_dirty || _deletedItemIds.size) {
+        const persisted = await persistState();
+        if (persisted === false) return { ok: false, userHandled: true };
+      }
+      await this.request('add', { itemId });
+      await this.refreshForActiveMenu();
+      invalidateDiff();
+      updateDraftIndicator();
+      return { ok: true, successMessage: 'Special added!' };
+    },
+
+    async removeSlot({ slotId }) {
+      if (!currentUserCanEditRestaurantSpecials()) {
+        return { ok: false, userMessage: 'Specials require access to both menus for this restaurant.' };
+      }
+      await this.request('remove', { slotId });
+      await this.refreshForActiveMenu();
+      invalidateDiff();
+      updateDraftIndicator();
+      return { ok: true, successMessage: 'Special removed.' };
+    },
+
+    async saveNote({ slotId, note }) {
+      if (!currentUserCanEditRestaurantSpecials()) return { ok: false, userHandled: true };
+      await this.request('note', { slotId, note });
+      return { ok: true };
+    },
+
+    async moveSlot({ groupId = '', slotId, direction }) {
+      if (!currentUserCanEditRestaurantSpecials()) {
+        return { ok: false, userMessage: 'Specials require access to both menus for this restaurant.' };
+      }
+      const group = this.getActiveGroup(groupId) || this.getActiveGroup();
+      if (!group) return { ok: false, userHandled: true };
+      const idx = group.slots.findIndex(slot => slot.id === slotId);
+      if (idx < 0) return { ok: false, userHandled: true };
+      const newIdx = idx + direction;
+      if (newIdx < 0 || newIdx >= group.slots.length) return { ok: false, userHandled: true };
+      await this.request('move', { slotId, direction });
+      await this.refreshForActiveMenu();
+      return { ok: true };
+    },
+
+    needsConfirmation(restaurantId = RESTAURANT_ID) {
+      if (!currentUserCanEditRestaurantSpecials(restaurantId)) return false;
+      if (sessionStorage.getItem(getFeaturedConfirmationKey(restaurantId))) return false;
+      if (!_featuredGroups.some(group => group.slots.length)) return false;
+      return _featuredGroups.some(group => group.slots.some(slot => {
+        if (!slot.confirmedAt) return true;
+        const confirmed = new Date(slot.confirmedAt);
+        const today = new Date();
+        today.setHours(0, 0, 0, 0);
+        return confirmed < today;
+      }));
+    },
+
+    async confirmToday() {
+      if (!currentUserCanEditRestaurantSpecials()) {
+        return { ok: false, userMessage: 'Specials require access to both menus for this restaurant.' };
+      }
+      await this.request('confirm');
+      sessionStorage.setItem(getFeaturedConfirmationKey(), '1');
+      return { ok: true, successMessage: 'Specials confirmed for today!' };
+    },
+  };
+}
+
+function getRestaurantSpecialsService() {
+  if (_restaurantSpecialsService) return _restaurantSpecialsService;
+  _restaurantSpecialsService = createRestaurantSpecialsService();
+  return _restaurantSpecialsService;
+}
+
 function resetRestaurantSpecialsCatalog() {
-  _restaurantSpecialsSiblingCatalog = [];
-  _restaurantSpecialsCatalogKey = '';
-  _restaurantSpecialsCatalogPromise = null;
+  return getRestaurantSpecialsService().resetCatalog();
 }
 
 function buildCurrentMenuSpecialsCatalog() {
-  const currentMenu = getMenuById(MENU_ID);
-  const fromCategories = getManagedCategoryDefs().flatMap(cat =>
-    (menuState[cat.id]?.items || []).map(item => ({
-      id: item.id,
-      name: item.name,
-      cat: cat.title,
-      menuId: MENU_ID,
-      menuLabel: currentMenu ? getMenuTypeLabel(currentMenu.type) : 'Current Menu',
-      onMenu: item.onMenu,
-      visibility: item.visibility || 'public',
-    }))
-  );
-  const uncatItems = (menuState[UNCATEGORIZED_ID]?.items || []).map(item => ({
-    id: item.id,
-    name: item.name,
-    cat: 'Uncategorized',
-    menuId: MENU_ID,
-    menuLabel: currentMenu ? getMenuTypeLabel(currentMenu.type) : 'Current Menu',
-    onMenu: true,
-    visibility: item.visibility || 'off_menu',
-  }));
-  return [...fromCategories, ...uncatItems];
+  return getRestaurantSpecialsService().buildCurrentMenuCatalog();
 }
 
 function getRestaurantSpecialsCatalog() {
-  return [...buildCurrentMenuSpecialsCatalog(), ..._restaurantSpecialsSiblingCatalog];
+  return getRestaurantSpecialsService().getCatalog();
 }
 
 async function ensureRestaurantSpecialsGroup(restaurantId = RESTAURANT_ID) {
-  if (!restaurantId || !currentUser?.accessToken) return;
-  try {
-    await fetch('/api/specials', {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        'Authorization': `Bearer ${currentUser.accessToken}`,
-      },
-      body: JSON.stringify({ action: 'ensure', restaurantId }),
-    });
-  } catch (_) {
-    /* allow reads to continue with legacy fallback */
-  }
+  return getRestaurantSpecialsService().ensureGroup(restaurantId);
 }
 
 async function refreshRestaurantSpecialsCatalog(restaurantId = RESTAURANT_ID) {
-  const cacheKey = `${restaurantId || ''}:${MENU_ID || ''}`;
-  if (!restaurantId || !currentUserCanEditRestaurantSpecials(restaurantId)) {
-    resetRestaurantSpecialsCatalog();
-    return [];
-  }
-  if (_restaurantSpecialsCatalogKey === cacheKey && _restaurantSpecialsCatalogPromise) {
-    return _restaurantSpecialsCatalogPromise;
-  }
-
-  const siblingMenuIds = (getRestaurantSpecialConfig(restaurantId)?.menuIds || getRestaurantMenuIds(restaurantId))
-    .filter(menuId => menuId && menuId !== MENU_ID);
-  if (!siblingMenuIds.length) {
-    _restaurantSpecialsSiblingCatalog = [];
-    _restaurantSpecialsCatalogKey = cacheKey;
-    _restaurantSpecialsCatalogPromise = Promise.resolve([]);
-    return _restaurantSpecialsCatalogPromise;
-  }
-
-  _restaurantSpecialsCatalogKey = cacheKey;
-  _restaurantSpecialsCatalogPromise = (async () => {
-    const requestKey = cacheKey;
-    try {
-      const categories = await sbReadJsonOrThrow(
-        `${SUPABASE_URL}/rest/v1/categories?menu_id=in.(${siblingMenuIds.join(',')})&select=menu_id,key,label,items(id,name,visibility,on_menu)&order=display_order.asc`,
-        { headers: sbHeaders() }
-      );
-      const menusById = knownMenuList().reduce((acc, menu) => {
-        acc[menu.id] = menu;
-        return acc;
-      }, {});
-      const catalog = categories
-        .filter(category => !isLegacySpecialCategory(category.key))
-        .flatMap(category =>
-        (category.items || []).map(item => ({
-          id: item.id,
-          name: item.name,
-          cat: category.label || '',
-          menuId: category.menu_id,
-          menuLabel: getMenuTypeLabel(menusById[category.menu_id]?.type || ''),
-          onMenu: category.key === UNCATEGORIZED_ID ? true : item.on_menu,
-          visibility: category.key === UNCATEGORIZED_ID ? (item.visibility || 'off_menu') : (item.visibility || 'public'),
-        }))
-      );
-      if (_restaurantSpecialsCatalogKey === requestKey) {
-        _restaurantSpecialsSiblingCatalog = catalog;
-      }
-    } catch (_) {
-      if (_restaurantSpecialsCatalogKey === requestKey) {
-        _restaurantSpecialsSiblingCatalog = [];
-      }
-    }
-    return _restaurantSpecialsSiblingCatalog;
-  })();
-  return _restaurantSpecialsCatalogPromise;
+  return getRestaurantSpecialsService().refreshCatalog(restaurantId);
 }
 
 async function refreshFeaturedForActiveMenu() {
-  if (!RESTAURANT_ID) {
-    _featuredGroups = [];
-    resetRestaurantSpecialsCatalog();
-    return _featuredGroups;
-  }
-  if (currentUserCanEditRestaurantSpecials(RESTAURANT_ID) && currentUser?.accessToken) {
-    await ensureRestaurantSpecialsGroup(RESTAURANT_ID);
-    await refreshRestaurantSpecialsCatalog(RESTAURANT_ID);
-  } else {
-    resetRestaurantSpecialsCatalog();
-  }
-  _featuredGroups = await sbReadRestaurantSpecials(RESTAURANT_ID);
-  return _featuredGroups;
+  return getRestaurantSpecialsService().refreshForActiveMenu(RESTAURANT_ID);
 }
 
 async function _openCurrentMenuPageInternal(options = {}) {
@@ -2257,81 +2704,13 @@ async function init() {
 }
 
 async function _tryHandleRecoveryCallback() {
-  const hash = window.location.hash.slice(1);
-  if (!hash) return false;
-  const params = new URLSearchParams(hash);
-  if (params.get('type') !== 'recovery') return false;
-  const accessToken = params.get('access_token');
-  if (!accessToken) return false;
-  history.replaceState({}, '', window.location.pathname);
-  _recoverySessionData = {
-    access_token:  accessToken,
-    refresh_token: params.get('refresh_token') || '',
-    expires_in:    Number(params.get('expires_in') || 3600),
-  };
-  openAuthOverlay('reset');
-  return true;
+  const result = await getAccessSessionService().handleRecoveryCallback();
+  if (result?.handled) openAuthOverlay(result.screen || 'reset');
+  return !!result?.handled;
 }
 
 async function _tryRestoreSession() {
-  if (!SUPABASE_URL || !SUPABASE_ANON_KEY) return;
-  const storedAccess    = localStorage.getItem(LS_KEYS.accessToken);
-  const storedRefresh   = localStorage.getItem(LS_KEYS.refreshToken);
-  const storedExpiresAt = Number(localStorage.getItem(LS_KEYS.expiresAt) || 0);
-  const storedUid       = localStorage.getItem(LS_KEYS.uid)   || '';
-  const storedEmail     = localStorage.getItem(LS_KEYS.email) || '';
-  if (!storedRefresh) return;
-
-  // If access token is still valid (2-min buffer), use it directly — skip refresh call.
-  // This avoids unnecessary network round-trips and is resilient to Supabase cold starts.
-  if (storedAccess && storedExpiresAt > Date.now() + 120_000) {
-    try {
-      const profile = await sbGetProfile(storedAccess);
-      currentUser = {
-        uid: storedUid, email: storedEmail,
-        name: profile.name, role: profile.role,
-        accessibleMenuIds: profile.accessibleMenuIds,
-        accessToken: storedAccess, refreshToken: storedRefresh,
-        expiresAt: storedExpiresAt,
-      };
-      _scheduleTokenRefresh(storedExpiresAt);
-      applyRole(profile.role);
-      return;
-    } catch(e) { /* fall through to refresh */ }
-  }
-
-  // Access token expired or unusable — exchange refresh token for a new one.
-  const _doRefresh = async () => {
-    const refresh = localStorage.getItem(LS_KEYS.refreshToken);
-    if (!refresh) throw new Error('no refresh token');
-    const data = await sbRefreshToken(refresh);
-    let role = 'none', name = '', accessibleMenuIds = [];
-    if (data.access_token) {
-      const profile = await sbGetProfile(data.access_token);
-      role = profile.role; name = profile.name; accessibleMenuIds = profile.accessibleMenuIds;
-    }
-    _applySession(data, role, name, accessibleMenuIds);
-    applyRole(role);
-    await _syncRequestedPageMode();
-  };
-
-  try {
-    await _doRefresh();
-  } catch(e) {
-    // First attempt failed — Supabase may be cold-starting. Retry once after 2s
-    // before giving up and clearing tokens.
-    setTimeout(async () => {
-      try {
-        await _doRefresh();
-      } catch(e2) {
-        localStorage.removeItem(LS_KEYS.accessToken);
-        localStorage.removeItem(LS_KEYS.refreshToken);
-        localStorage.removeItem(LS_KEYS.expiresAt);
-        localStorage.removeItem(LS_KEYS.uid);
-        localStorage.removeItem(LS_KEYS.email);
-      }
-    }, 2000);
-  }
+  return getAccessSessionService().restoreStoredSession();
 }
 
 async function showPublicView() {
@@ -2505,82 +2884,7 @@ function showManagerAccessDenied(message = 'Manager access required for this pag
 }
 
 async function _syncRequestedPageMode() {
-  if (!isSettingsPage()) return;
-
-  const publicView = document.getElementById('public-view');
-  const managerView = document.getElementById('manager-view');
-  if (!publicView || !managerView) return;
-
-  _clearSettingsRedirectPrompt();
-  renderUserHeader();
-
-  if (!currentUser) {
-    isManagerMode = false;
-    isAdminMode = false;
-    document.body.classList.remove('manager-mode');
-    publicView.style.display = 'none';
-    managerView.style.display = 'none';
-    _setLoadingMessage('Sign in to access settings.', { hideSpinner: true });
-    openAuthOverlay('signin');
-    return;
-  }
-
-  const isAdmin = currentUser.role === 'admin';
-  if (_appPageMode === 'admin') {
-    if (!isAdmin) {
-      showAdminAccessDenied();
-      return;
-    }
-
-    _setLoadingMessage('Loading settings…');
-    const targetMenuId = KNOWN_MENU_ORDER.includes(MENU_ID) ? MENU_ID : (KNOWN_MENU_ORDER[0] || '');
-    const hasMenuContext = await _loadSettingsPageMenuContext(targetMenuId);
-    if (!hasMenuContext) {
-      showAdminAccessDenied('No menu context available for this page.');
-      return;
-    }
-    enterAdmin();
-    return;
-  }
-
-  _setLoadingMessage('Checking manager access…');
-  await refreshCurrentUserProfile();
-
-  const requestedMenu = getRequestedMenuForSettingsPage();
-  if (!requestedMenu) {
-    showManagerAccessDenied('No menu context available for this page.');
-    return;
-  }
-
-  if (!currentUserCanManageMenu(requestedMenu.id)) {
-    const fallbackMenuId = getFirstAccessibleManagerMenuId();
-    if (fallbackMenuId) {
-      const targetPath = getManagerHrefForMenuId(fallbackMenuId);
-      if (targetPath) {
-        navigateToPage(targetPath);
-        return;
-      }
-    }
-    showManagerAccessDenied('You don\'t have manager access to this menu.', {
-      targetPath: getPublicHrefForMenuId(requestedMenu.id),
-      redirectLabel: 'the public menu',
-      actionLabel: 'Return to the public menu',
-    });
-    return;
-  }
-
-  _managerMenuPicked = true;
-  _setLoadingMessage('Loading settings…');
-  const hasMenuContext = await _loadSettingsPageMenuContext(requestedMenu.id);
-  if (!hasMenuContext) {
-    showManagerAccessDenied('Selected menu is no longer available for this account.', {
-      targetPath: getPublicHrefForMenuId(requestedMenu.id),
-      redirectLabel: 'the public menu',
-      actionLabel: 'Return to the public menu',
-    });
-    return;
-  }
-  enterManager();
+  return getAccessSessionService().syncRequestedPageMode();
 }
 
 // ─── AUTO-REFRESH POLLING ────────────────────────────────────────────────────
@@ -3747,10 +4051,7 @@ async function handleSignIn() {
   errEl.textContent = '';
   try {
     const data = await sbSignIn(email, password);
-    const { role, name, accessibleMenuIds } = await sbGetProfile(data.access_token);
-    _applySession(data, role, name, accessibleMenuIds);
-    closeAuthOverlay();
-    applyRole(role);
+    const { role } = await getAccessSessionService().applyAuthenticatedSession(data, { closeOverlay: true });
     await _syncRequestedPageMode();
     if (role === 'none') showToast('Signed in. Contact admin to get manager access.', 'info');
   } catch(err) {
@@ -3821,12 +4122,9 @@ async function handleResetPassword() {
   btn.textContent = 'Saving\u2026';
   errEl.textContent = '';
   try {
-    await sbUpdatePassword(password, _recoverySessionData.access_token);
-    const { role, name, accessibleMenuIds } = await sbGetProfile(_recoverySessionData.access_token);
-    _applySession(_recoverySessionData, role, name, accessibleMenuIds);
-    _recoverySessionData = null;
-    closeAuthOverlay();
-    applyRole(role);
+    const recoveryData = _recoverySessionData;
+    await sbUpdatePassword(password, recoveryData.access_token);
+    await getAccessSessionService().applyAuthenticatedSession(recoveryData, { closeOverlay: true });
     await _syncRequestedPageMode();
     showToast('Password updated. You are now signed in.', 'info');
   } catch(err) {
@@ -6228,30 +6526,11 @@ document.getElementById('invite-modal-bg')?.addEventListener('click', e => {
 // ─── FEATURED ITEMS ──────────────────────────────────────────────────────────
 
 function getActiveRestaurantSpecialGroup() {
-  return _featuredGroups[0] || null;
+  return getRestaurantSpecialsService().getActiveGroup();
 }
 
 async function callRestaurantSpecialsApi(action, payload = {}) {
-  const response = await fetch('/api/specials', {
-    method: 'POST',
-    headers: {
-      'Content-Type': 'application/json',
-      'Authorization': `Bearer ${currentUser?.accessToken || ''}`,
-    },
-    body: JSON.stringify({
-      action,
-      restaurantId: RESTAURANT_ID,
-      ...payload,
-    }),
-  });
-  let data = {};
-  try {
-    data = await response.json();
-  } catch (_) {
-    data = {};
-  }
-  if (!response.ok) throw new Error(data.error || `Request failed (${response.status})`);
-  return data;
+  return getRestaurantSpecialsService().request(action, payload);
 }
 
 function renderFeaturedTab() {
@@ -6338,17 +6617,7 @@ function renderFeaturedTab() {
 }
 
 function getFeatureableMatches(groupId, query) {
-  const q = query.trim().toLowerCase();
-  if (!q) return [];
-  const group = _featuredGroups.find(g => g.id === groupId) || getActiveRestaurantSpecialGroup();
-  const existingItemIds = new Set((group?.slots || []).map(s => s.itemId));
-  return getRestaurantSpecialsCatalog()
-    .filter(item =>
-      item.onMenu !== false &&
-      !existingItemIds.has(item.id) &&
-      String(item.name || '').toLowerCase().includes(q)
-    )
-    .slice(0, 8);
+  return getRestaurantSpecialsService().getMatches(groupId, query);
 }
 
 function filterFeaturedPicker(groupId, query) {
@@ -6394,72 +6663,47 @@ async function addFeaturedSlotFromInput(groupId) {
 }
 
 async function addFeaturedSlot(groupId, itemId) {
-  if (!currentUserCanEditRestaurantSpecials()) {
-    showToast('Specials require access to both menus for this restaurant.', 'error');
-    return;
-  }
   try {
-    const existingGroup = _featuredGroups.find(g => g.id === groupId) || getActiveRestaurantSpecialGroup();
-    const slotCount = existingGroup?.slots?.length || 0;
-    if (slotCount >= 5) { showToast('Max 5 specials per restaurant.', 'info'); return; }
-    if ((existingGroup?.slots || []).some(slot => slot.itemId === itemId)) {
-      showToast('That item is already in specials.', 'info');
+    const result = await getRestaurantSpecialsService().addSlot({ groupId, itemId });
+    if (!result?.ok) {
+      if (result?.userMessage) showToast(result.userMessage, result.userHandled ? 'info' : 'error');
       return;
     }
-    if (_dirty || _deletedItemIds.size) {
-      const persisted = await persistState();
-      if (persisted === false) return;
-    }
-    await callRestaurantSpecialsApi('add', { itemId });
-    await refreshFeaturedForActiveMenu();
     renderFeaturedTab();
     renderPublicView();
-    invalidateDiff();
-    updateDraftIndicator();
     const input = document.getElementById('featured-add-' + (groupId || 'pending'));
     if (input) input.value = '';
     filterFeaturedPicker(groupId, '');
-    showToast('Special added!', 'success');
+    showToast(result.successMessage || 'Special added!', 'success');
   } catch(e) { showToast(e?.message || 'Failed to add special.', 'error'); }
 }
 
 async function removeFeaturedSlot(slotId, groupId) {
-  if (!currentUserCanEditRestaurantSpecials()) {
-    showToast('Specials require access to both menus for this restaurant.', 'error');
-    return;
-  }
   try {
-    await callRestaurantSpecialsApi('remove', { slotId });
-    await refreshFeaturedForActiveMenu();
+    const result = await getRestaurantSpecialsService().removeSlot({ slotId, groupId });
+    if (!result?.ok) {
+      if (result?.userMessage) showToast(result.userMessage, result.userHandled ? 'info' : 'error');
+      return;
+    }
     renderFeaturedTab();
     renderPublicView();
-    invalidateDiff();
-    updateDraftIndicator();
-    showToast('Special removed.', 'success');
+    showToast(result.successMessage || 'Special removed.', 'success');
   } catch(e) { showToast(e?.message || 'Failed to remove.', 'error'); }
 }
 
 async function saveFeaturedSellNote(slotId, note) {
-  if (!currentUserCanEditRestaurantSpecials()) return;
   try {
-    await callRestaurantSpecialsApi('note', { slotId, note });
+    await getRestaurantSpecialsService().saveNote({ slotId, note });
   } catch(e) {}
 }
 
 async function moveFeaturedSlot(groupId, slotId, direction) {
-  if (!currentUserCanEditRestaurantSpecials()) {
-    showToast('Specials require access to both menus for this restaurant.', 'error');
-    return;
-  }
-  const group = _featuredGroups.find(g => g.id === groupId) || getActiveRestaurantSpecialGroup();
-  if (!group) return;
-  const idx = group.slots.findIndex(s => s.id === slotId);
-  if (idx < 0) return;
-  const newIdx = idx + direction;
-  if (newIdx < 0 || newIdx >= group.slots.length) return;
   try {
-    await callRestaurantSpecialsApi('move', { slotId, direction });
-    await refreshFeaturedForActiveMenu();
+    const result = await getRestaurantSpecialsService().moveSlot({ groupId, slotId, direction });
+    if (!result?.ok) {
+      if (result?.userMessage) showToast(result.userMessage, result.userHandled ? 'info' : 'error');
+      return;
+    }
     renderFeaturedTab();
     renderPublicView();
   } catch(e) { showToast(e?.message || 'Failed to reorder.', 'error'); }
@@ -6468,16 +6712,7 @@ async function moveFeaturedSlot(groupId, slotId, direction) {
 // ─── FEATURED DAILY CONFIRMATION ─────────────────────────────────────────────
 
 function _needsFeaturedConfirmation() {
-  if (!currentUserCanEditRestaurantSpecials()) return false;
-  if (sessionStorage.getItem(getFeaturedConfirmationKey())) return false;
-  if (!_featuredGroups.some(g => g.slots.length)) return false;
-  return _featuredGroups.some(g => g.slots.some(s => {
-    if (!s.confirmedAt) return true;
-    const confirmed = new Date(s.confirmedAt);
-    const today = new Date();
-    today.setHours(0, 0, 0, 0);
-    return confirmed < today;
-  }));
+  return getRestaurantSpecialsService().needsConfirmation();
 }
 
 function checkFeaturedConfirmation() {
@@ -6485,15 +6720,14 @@ function checkFeaturedConfirmation() {
 }
 
 async function confirmFeaturedToday() {
-  if (!currentUserCanEditRestaurantSpecials()) {
-    showToast('Specials require access to both menus for this restaurant.', 'error');
-    return;
-  }
   try {
-    await callRestaurantSpecialsApi('confirm');
-    sessionStorage.setItem(getFeaturedConfirmationKey(), '1');
+    const result = await getRestaurantSpecialsService().confirmToday();
+    if (!result?.ok) {
+      if (result?.userMessage) showToast(result.userMessage, result.userHandled ? 'info' : 'error');
+      return;
+    }
     updateManagerActionBar();
-    showToast('Specials confirmed for today!', 'success');
+    showToast(result.successMessage || 'Specials confirmed for today!', 'success');
   } catch(e) { showToast(e?.message || 'Failed to confirm.', 'error'); }
 }
 

--- a/app.js
+++ b/app.js
@@ -261,6 +261,23 @@ function getManagedCategoryDefs() {
   ));
 }
 
+function getUncategorizedCategoryDef() {
+  return {
+    id: UNCATEGORIZED_ID,
+    label: 'Uncategorized',
+    title: 'Uncategorized',
+    icon: '📦',
+    color: 'rgba(120,120,120,0.12)',
+    sub: 'Items for specials & autocomplete — not shown on public menu',
+    placeholder: 'Add to pool…',
+  };
+}
+
+function getRenderableCategoryItems(catId) {
+  const items = menuState[catId]?.items || [];
+  return catId === UNCATEGORIZED_ID ? items : items.filter(item => item.onMenu !== false);
+}
+
 function getMenuBySlug(slug) {
   const normalizedSlug = normalizeKnownMenuSlug(slug || '');
   return knownMenuList().find(menu => menu.slug === normalizedSlug) || null;
@@ -834,7 +851,7 @@ function resetRestaurantSpecialsCatalog() {
 
 function buildCurrentMenuSpecialsCatalog() {
   const currentMenu = getMenuById(MENU_ID);
-  return getManagedCategoryDefs().flatMap(cat =>
+  const fromCategories = getManagedCategoryDefs().flatMap(cat =>
     (menuState[cat.id]?.items || []).map(item => ({
       id: item.id,
       name: item.name,
@@ -845,6 +862,16 @@ function buildCurrentMenuSpecialsCatalog() {
       visibility: item.visibility || 'public',
     }))
   );
+  const uncatItems = (menuState[UNCATEGORIZED_ID]?.items || []).map(item => ({
+    id: item.id,
+    name: item.name,
+    cat: 'Uncategorized',
+    menuId: MENU_ID,
+    menuLabel: currentMenu ? getMenuTypeLabel(currentMenu.type) : 'Current Menu',
+    onMenu: true,
+    visibility: item.visibility || 'off_menu',
+  }));
+  return [...fromCategories, ...uncatItems];
 }
 
 function getRestaurantSpecialsCatalog() {
@@ -899,7 +926,7 @@ async function refreshRestaurantSpecialsCatalog(restaurantId = RESTAURANT_ID) {
         return acc;
       }, {});
       const catalog = categories
-        .filter(category => category.key !== UNCATEGORIZED_ID && !isLegacySpecialCategory(category.key))
+        .filter(category => !isLegacySpecialCategory(category.key))
         .flatMap(category =>
         (category.items || []).map(item => ({
           id: item.id,
@@ -907,8 +934,8 @@ async function refreshRestaurantSpecialsCatalog(restaurantId = RESTAURANT_ID) {
           cat: category.label || '',
           menuId: category.menu_id,
           menuLabel: getMenuTypeLabel(menusById[category.menu_id]?.type || ''),
-          onMenu: item.on_menu,
-          visibility: item.visibility || 'public',
+          onMenu: category.key === UNCATEGORIZED_ID ? true : item.on_menu,
+          visibility: category.key === UNCATEGORIZED_ID ? (item.visibility || 'off_menu') : (item.visibility || 'public'),
         }))
       );
       if (_restaurantSpecialsCatalogKey === requestKey) {
@@ -1804,8 +1831,13 @@ async function deleteCategory(catId) {
         name:            item.name,
         desc:            item.desc            || '',
         recipe:          item.recipe          || [],
-        is_eighty_sixed: false,
+        price:           item.price           || null,
+        is_eighty_sixed: item.eightySixed     || false,
         on_menu:         false,
+        visibility:      item.visibility      || 'public',
+        upcharges:       item.upcharges       || [],
+        show_description:isItemDescriptionPublic(item),
+        show_recipe:     isItemRecipePublic(item),
         display_order:   idx,
       }));
       await fetch(`${SUPABASE_URL}/rest/v1/items`, {
@@ -3892,6 +3924,7 @@ function renderManagerCategories() {
   container.innerHTML = '';
   // Preserve uncategorized expansion state across re-renders
   const _uncatWasExpanded = !document.getElementById('mgr-card-' + UNCATEGORIZED_ID)?.classList.contains('collapsed');
+  const uncategorized = getUncategorizedCategoryDef();
 
   getManagedCategoryDefs().forEach(cat => {
     const isReadOnlyCategory = cat.readOnly || cat.deprecated;
@@ -3934,8 +3967,8 @@ function renderManagerCategories() {
          aria-expanded="${_uncatWasExpanded ? 'true' : 'false'}"
          onclick="toggleManagerCategory('${UNCATEGORIZED_ID}')"
          onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleManagerCategory('${UNCATEGORIZED_ID}')}">
-      <div class="cat-icon" style="background:rgba(120,120,120,0.12)">📦</div>
-      <div><div class="cat-title">Uncategorized</div><div class="cat-sub">Autocomplete pool — not shown on public menu</div></div>
+      <div class="cat-icon" style="background:${escHtml(uncategorized.color)}">${escHtml(uncategorized.icon)}</div>
+      <div><div class="cat-title">${escHtml(uncategorized.title)}</div><div class="cat-sub">${escHtml(uncategorized.sub)}</div></div>
       <span class="category-chevron">›</span>
     </div>
     <div class="current-section">
@@ -3943,59 +3976,17 @@ function renderManagerCategories() {
       <div class="current-items" id="mgr-items-${UNCATEGORIZED_ID}"></div>
       <div class="add-item-wrap">
         <div class="add-item-area">
-          <input class="add-item-input" id="new-input-${UNCATEGORIZED_ID}" type="text" placeholder="Add to pool…" aria-label="Add item to uncategorized pool" autocomplete="off"
-            onkeydown="if(event.key==='Enter'){event.preventDefault();addUncategorizedItem()}"/>
-          <button class="add-item-btn" onclick="addUncategorizedItem()" aria-label="Add item to uncategorized pool">+</button>
+          <input class="add-item-input" id="new-input-${UNCATEGORIZED_ID}" type="text" placeholder="${escHtml(uncategorized.placeholder)}" aria-label="Add item to uncategorized pool" autocomplete="off"
+            oninput="showAutocomplete('${UNCATEGORIZED_ID}')"
+            onblur="setTimeout(()=>hideAutocomplete('${UNCATEGORIZED_ID}'),150)"
+            onkeydown="handleAddItemKeydown(event,'${UNCATEGORIZED_ID}')"/>
+          <button class="add-item-btn" onclick="addItem('${UNCATEGORIZED_ID}')" aria-label="Add item to uncategorized pool">+</button>
         </div>
+        <div class="autocomplete-list" id="ac-${UNCATEGORIZED_ID}"></div>
       </div>
     </div>`;
   container.appendChild(uncatCard);
-  renderUncategorizedItems();
-}
-
-function renderUncategorizedItems() {
-  const listEl = document.getElementById('mgr-items-' + UNCATEGORIZED_ID);
-  if (!listEl) return;
-  const items = menuState[UNCATEGORIZED_ID]?.items || [];
-  listEl.innerHTML = '';
-  if (!items.length) {
-    listEl.innerHTML = `<div class="empty-state"><span class="empty-state-icon">+</span><span>Pool is empty — add items or delete a category to populate it.</span></div>`;
-    return;
-  }
-  items.forEach(item => {
-    const wrapper = document.createElement('div');
-    wrapper.className = 'item-wrapper';
-    wrapper.id = 'wrapper-' + item.id;
-    wrapper.innerHTML = buildUncategorizedItemHtml(item);
-    listEl.appendChild(wrapper);
-  });
-}
-
-async function addUncategorizedItem() {
-  const input = document.getElementById('new-input-' + UNCATEGORIZED_ID);
-  if (!input) return;
-  const name = input.value.trim();
-  if (!name) return;
-  if (!menuState[UNCATEGORIZED_ID]) menuState[UNCATEGORIZED_ID] = { items: [], lastSent: [] };
-  const pool = menuState[UNCATEGORIZED_ID].items;
-  if (pool.some(i => i.name.trim().toLowerCase() === name.toLowerCase())) {
-    showToast('Already in pool.', 'info'); return;
-  }
-  pool.push({
-    id: uid(),
-    name,
-    desc: '',
-    recipe: [],
-    price: '',
-    eightySixed: false,
-    onMenu: false,
-    upcharges: [],
-    showDescription: true,
-    showRecipe: false,
-  });
-  input.value = '';
-  renderUncategorizedItems();
-  await persistState();
+  renderManagerItems(UNCATEGORIZED_ID);
 }
 
 function toggleManagerCategory(catId) {
@@ -4014,34 +4005,6 @@ function buildRecipeListHtml(catId, itemId, ingredients) {
       <button class="del-ingredient" onclick="removeIngredient('${catId}','${itemId}',${idx})" aria-label="Remove ingredient">×</button>
     </div>`
   ).join('');
-}
-
-function buildManagerItemEditorHtml(item, catId, itemId, ingredients) {
-  return `<div class="desc-row" id="desc-row-${itemId}">
-      <textarea class="desc-input" aria-label="Item description" placeholder="Ingredients, description, how to sell it…"
-        onblur="saveDesc('${catId}','${itemId}',this.value)">${escHtml(item.desc || '')}</textarea>
-    </div>
-    <div class="recipe-row" id="recipe-row-${itemId}">
-      <div class="recipe-ingredient-list" id="recipe-list-${itemId}">${buildRecipeListHtml(catId, itemId, ingredients)}</div>
-      <div class="add-ingredient-area">
-        <input class="add-ingredient-input" id="ingredient-input-${itemId}" type="text"
-          placeholder="Add ingredient…"
-          onkeydown="handleIngredientKeydown(event,'${catId}','${itemId}')"/>
-        <button class="add-ingredient-btn" onclick="addIngredient('${catId}','${itemId}')">+</button>
-      </div>
-    </div>`;
-}
-
-function buildUncategorizedItemHtml(item) {
-  const ingredients = recipeArray(item.recipe);
-  const hasDesc = !!(item.desc && item.desc.trim());
-  const hasRecipe = ingredients.length > 0;
-  return `<div class="current-item">
-      <div class="item-name"><span class="item-name-static">${escHtml(item.name)}</span></div>
-      <button class="desc-btn${hasDesc ? ' has-desc' : ''}" title="Edit description" aria-label="Edit description for ${escHtml(item.name)}" onclick="toggleItemDesc('${item.id}')">📝</button>
-      <button class="recipe-btn${hasRecipe ? ' has-recipe' : ''}" title="Add recipe" aria-label="Edit recipe for ${escHtml(item.name)}" onclick="toggleItemRecipe('${item.id}')">🧪</button>
-    </div>
-    ${buildManagerItemEditorHtml(item, UNCATEGORIZED_ID, item.id, ingredients)}`;
 }
 
 function buildItemsRowHtml(item, catId, lastSentNames) {
@@ -4174,14 +4137,17 @@ function buildDescriptionRowHtml(item, catId) {
 function renderManagerItems(catId) {
   const state = menuState[catId] || { items: [], lastSent: [] };
   const lastSentNames = new Set(state.lastSent.filter(i => i.onMenu !== false).map(i => i.name.trim().toLowerCase()));
-  const visibleItems = state.items.filter(i => i.onMenu !== false);
+  const visibleItems = getRenderableCategoryItems(catId);
   const listEl = document.getElementById('mgr-items-' + catId);
   if (!listEl) return;
   listEl.innerHTML = '';
   if (!visibleItems.length) {
-    const cat = CATEGORY_DEFS.find(c => c.id === catId);
+    const cat = catId === UNCATEGORIZED_ID ? getUncategorizedCategoryDef() : CATEGORY_DEFS.find(c => c.id === catId);
     const ph = cat?.placeholder ? ` Try: "${escHtml(cat.placeholder)}"` : '';
-    listEl.innerHTML = `<div class="empty-state"><span class="empty-state-icon">+</span><span>Nothing here yet.${ph}</span></div>`;
+    const emptyCopy = catId === UNCATEGORIZED_ID
+      ? 'Pool is empty — add items or delete a category to populate it.'
+      : `Nothing here yet.${ph}`;
+    listEl.innerHTML = `<div class="empty-state"><span class="empty-state-icon">+</span><span>${emptyCopy}</span></div>`;
     return;
   }
   visibleItems.forEach(item => {
@@ -4210,9 +4176,8 @@ function renderPricingSection() {
   const container = document.getElementById('manager-pricing-categories');
   if (!container) return;
   container.innerHTML = '';
-  getManagedCategoryDefs().forEach(cat => {
-    const state = menuState[cat.id] || { items: [] };
-    const visibleItems = state.items.filter(i => i.onMenu !== false);
+  const renderCategoryPricing = cat => {
+    const visibleItems = getRenderableCategoryItems(cat.id);
     if (!visibleItems.length) return;
     const card = document.createElement('div');
     card.className = 'cat-card';
@@ -4238,7 +4203,9 @@ function renderPricingSection() {
       wrapper.innerHTML = buildPricingRowHtml(item, cat.id);
       listEl.appendChild(wrapper);
     });
-  });
+  };
+  getManagedCategoryDefs().forEach(renderCategoryPricing);
+  renderCategoryPricing(getUncategorizedCategoryDef());
 }
 
 // ─── DESCRIPTION SECTION RENDERER ────────────────────────────────────────────
@@ -4246,9 +4213,8 @@ function renderDescriptionSection() {
   const container = document.getElementById('manager-description-categories');
   if (!container) return;
   container.innerHTML = '';
-  getManagedCategoryDefs().forEach(cat => {
-    const state = menuState[cat.id] || { items: [] };
-    const visibleItems = state.items.filter(i => i.onMenu !== false);
+  const renderCategoryDescriptions = cat => {
+    const visibleItems = getRenderableCategoryItems(cat.id);
     if (!visibleItems.length) return;
     const card = document.createElement('div');
     card.className = 'cat-card';
@@ -4274,7 +4240,9 @@ function renderDescriptionSection() {
       wrapper.innerHTML = buildDescriptionRowHtml(item, cat.id);
       listEl.appendChild(wrapper);
     });
-  });
+  };
+  getManagedCategoryDefs().forEach(renderCategoryDescriptions);
+  renderCategoryDescriptions(getUncategorizedCategoryDef());
 }
 
 function startManagerItemDrag(event, catId, itemId) {
@@ -4309,7 +4277,7 @@ function handleManagerItemDrop(event, catId, targetItemId) {
   if (!_managerDraggedItemId || _managerDraggedCatId !== catId || _managerDraggedItemId === targetItemId) return;
   event.preventDefault();
   const items = menuState[catId]?.items || [];
-  const visibleItems = items.filter(item => item.onMenu !== false);
+  const visibleItems = getRenderableCategoryItems(catId);
   const fromIndex = visibleItems.findIndex(item => item.id === _managerDraggedItemId);
   const toIndex = visibleItems.findIndex(item => item.id === targetItemId);
   if (fromIndex < 0 || toIndex < 0) return;
@@ -4317,10 +4285,12 @@ function handleManagerItemDrop(event, catId, targetItemId) {
   const reorderedVisible = [...visibleItems];
   const [movedItem] = reorderedVisible.splice(fromIndex, 1);
   reorderedVisible.splice(toIndex, 0, movedItem);
-  menuState[catId].items = [
-    ...reorderedVisible,
-    ...items.filter(item => item.onMenu === false),
-  ];
+  menuState[catId].items = catId === UNCATEGORIZED_ID
+    ? reorderedVisible
+    : [
+      ...reorderedVisible,
+      ...items.filter(item => item.onMenu === false),
+    ];
 
   invalidateDiff();
   renderManagerItems(catId);
@@ -4399,7 +4369,7 @@ function buildItemUpsertRows() {
         desc:            item.desc   || '',
         recipe:          item.recipe || [],
         price:           item.price  || null,
-        is_eighty_sixed: false,
+        is_eighty_sixed: item.eightySixed || false,
         on_menu:         false,
         visibility:      item.visibility || 'public',
         upcharges:       item.upcharges || [],
@@ -4496,11 +4466,39 @@ async function saveMenu() {
 
 function addItem(catId) {
   const input = document.getElementById('new-input-' + catId);
+  if (!input) return;
   const name = input.value.trim();
   if (!name) return;
   const nameLower = name.toLowerCase();
   let movedFromUncategorized = false;
   if (!menuState[catId]) menuState[catId] = { items: [], lastSent: [] };
+  if (catId === UNCATEGORIZED_ID) {
+    const pool = menuState[catId].items;
+    if (pool.some(item => item.name.trim().toLowerCase() === nameLower)) {
+      showToast('Already in pool.', 'info');
+      return;
+    }
+    pool.push({
+      id: uid(),
+      name,
+      desc: '',
+      recipe: [],
+      price: '',
+      eightySixed: false,
+      onMenu: false,
+      upcharges: [],
+      showDescription: true,
+      showRecipe: false,
+    });
+    input.value = '';
+    hideAutocomplete(catId);
+    invalidateDiff();
+    renderManagerItems(catId);
+    markSectionsStale(_activeManagerSection);
+    input.focus();
+    updateDraftIndicator();
+    return;
+  }
   const alreadyOnMenu = menuState[catId].items.find(
     i => i.onMenu !== false && i.name.toLowerCase() === nameLower
   );
@@ -4539,7 +4537,7 @@ function addItem(catId) {
   invalidateDiff();
   renderManagerItems(catId);
   markSectionsStale(_activeManagerSection);
-  if (movedFromUncategorized) renderUncategorizedItems();
+  if (movedFromUncategorized) renderManagerItems(UNCATEGORIZED_ID);
   input.focus();
   updateDraftIndicator();
 }
@@ -4558,6 +4556,7 @@ function getAutocompleteIndex(catId) {
 }
 
 function showAutocomplete(catId) {
+  if (catId === UNCATEGORIZED_ID) { hideAutocomplete(catId); return; }
   const val = document.getElementById('new-input-' + catId).value.trim();
   const list = document.getElementById('ac-' + catId);
   _acIdx = -1;
@@ -4816,14 +4815,6 @@ function initDrawerSwipe() {
 }
 
 // ─── DESCRIPTION ──────────────────────────────────────────────────────────────
-function toggleItemDesc(itemId) {
-  const row = document.getElementById('desc-row-' + itemId);
-  if (!row) return;
-  const opening = !row.classList.contains('open');
-  row.classList.toggle('open', opening);
-  if (opening) row.querySelector('textarea').focus();
-}
-
 function toggleDescriptionEditor(itemId) {
   const card = document.getElementById('description-editor-' + itemId);
   const body = document.getElementById('desc-edit-body-' + itemId);
@@ -4871,14 +4862,6 @@ function recipeArray(recipe) {
   if (Array.isArray(recipe)) return recipe.filter(Boolean);
   if (typeof recipe === 'string' && recipe.trim()) return [recipe.trim()];
   return [];
-}
-
-function toggleItemRecipe(itemId) {
-  const row = document.getElementById('recipe-row-' + itemId);
-  if (!row) return;
-  const opening = !row.classList.contains('open');
-  row.classList.toggle('open', opening);
-  if (opening) document.getElementById('ingredient-input-' + itemId)?.focus();
 }
 
 function renderRecipeIngredients(catId, itemId) {
@@ -4961,8 +4944,29 @@ async function savePrice(catId, itemId, val) {
 }
 
 function removeItem(catId, itemId) {
-  const item = findItem(catId, itemId);
+  const state = menuState[catId];
+  const itemIndex = state?.items.findIndex(i => i.id === itemId) ?? -1;
+  const item = itemIndex === -1 ? null : state.items[itemIndex];
   if (!item) return false;
+  if (catId === UNCATEGORIZED_ID) {
+    const [removedItem] = state.items.splice(itemIndex, 1);
+    _deletedItemIds.add(removedItem.id);
+    invalidateDiff();
+    renderManagerItems(catId);
+    markSectionsStale(_activeManagerSection);
+    updateDraftIndicator();
+    const removedName = removedItem.name;
+    showToast(`"${removedName}" removed`, 'info', () => {
+      state.items.splice(Math.min(itemIndex, state.items.length), 0, removedItem);
+      _deletedItemIds.delete(removedItem.id);
+      invalidateDiff();
+      renderManagerItems(catId);
+      markSectionsStale(_activeManagerSection);
+      updateDraftIndicator();
+      showToast(`"${removedName}" restored`, 'success');
+    });
+    return true;
+  }
   item.onMenu = false;
   invalidateDiff();
   renderManagerItems(catId);
@@ -6059,7 +6063,7 @@ function buildDatabaseRows() {
       category: 'Uncategorized',
       recipe: recipeArray(item.recipe),
       onMenu: false,
-      eightySixed: false,
+      eightySixed: !!item.eightySixed,
     });
     totalItems++;
   });

--- a/app.js
+++ b/app.js
@@ -183,6 +183,9 @@ let _deletedItemIds    = new Set();  // item UUIDs to DELETE on next persistStat
 let _uncatCategoryUuid = '';         // DB UUID of the __uncategorized__ category row
 let _managerDraggedItemId = '';
 let _managerDraggedCatId = '';
+let _menuLifecycleService = null;
+let _menuRuntime = null;
+let _currentMenuSession = null;
 function invalidateDiff() { _diffDirty = true; _dirty = true; updateSaveBtn(); }
 function updateSaveBtn() {
   const btn = document.getElementById('save-btn');
@@ -445,6 +448,141 @@ function getManagerHrefForMenuId(menuId) {
 
 function navigateToPage(path) {
   window.location.assign(path);
+}
+
+function buildCurrentMenuPageRequest(overrides = {}) {
+  const pathname = overrides.pathname ?? window.location.pathname;
+  const search = overrides.search ?? window.location.search;
+  const derivedSiteRestaurant = getSiteRestaurantFromPath(pathname);
+  const siteRestaurantId = overrides.siteRestaurantId ??
+    (_siteRestaurant?.id || (isValidRestaurant(derivedSiteRestaurant?.id) ? derivedSiteRestaurant.id : ''));
+  return {
+    pathname,
+    search,
+    pageMode: overrides.pageMode ?? _appPageMode,
+    actor: overrides.actor ?? currentUser,
+    siteRestaurantId: isValidRestaurant(siteRestaurantId) ? siteRestaurantId : '',
+    requestedMenuId: overrides.requestedMenuId ?? MENU_ID,
+    requestedMenuSlug: overrides.requestedMenuSlug ??
+      normalizeKnownMenuSlug(new URLSearchParams(search).get('menu') || ''),
+  };
+}
+
+function buildMenuSessionSnapshot(source = 'live') {
+  return {
+    request: buildCurrentMenuPageRequest(),
+    source,
+    menuId: MENU_ID,
+    menuType: MENU_TYPE,
+    menuName: _activeMenuName,
+    restaurantId: RESTAURANT_ID,
+    restaurantName: _activeRestaurantName,
+    menuState,
+    currentDesign,
+    featuredGroups: _featuredGroups,
+    dirty: _dirty,
+    hasMultipleMenus: _hasMultipleMenus,
+  };
+}
+
+function createMenuLifecycleService(ports) {
+  return {
+    async refreshPageState(options = {}) {
+      if (options.reason === 'poll') return ports.pollPageState(options);
+      return ports.loadPageState(options);
+    },
+    async savePageDraft(options = {}) {
+      return ports.savePageDraft(options);
+    },
+    async publishPageUpdate(options = {}) {
+      return ports.publishPageUpdate(options);
+    },
+  };
+}
+
+function createMenuRuntime({ lifecycle }) {
+  return {
+    openPage(pageRequest = {}) {
+      const session = {
+        _request: { ...pageRequest },
+        _syncRequest(nextRequest = {}) {
+          this._request = { ...this._request, ...nextRequest };
+          return this._request;
+        },
+        getSnapshot(source = 'live') {
+          this._syncRequest(buildCurrentMenuPageRequest());
+          return buildMenuSessionSnapshot(source);
+        },
+        update(mutator) {
+          if (typeof mutator === 'function') {
+            mutator({
+              menuState,
+              currentDesign,
+              featuredGroups: _featuredGroups,
+              menuId: MENU_ID,
+              restaurantId: RESTAURANT_ID,
+            });
+            invalidateDiff();
+          }
+          return this.getSnapshot();
+        },
+        async refresh(options = {}) {
+          this._syncRequest(buildCurrentMenuPageRequest(options));
+          return lifecycle.refreshPageState({ request: this._request, ...options });
+        },
+        async save(options = {}) {
+          this._syncRequest(buildCurrentMenuPageRequest(options));
+          return lifecycle.savePageDraft({ request: this._request, ...options });
+        },
+        async sendUpdate(options = {}) {
+          this._syncRequest(buildCurrentMenuPageRequest(options));
+          return lifecycle.publishPageUpdate({ request: this._request, ...options });
+        },
+        async switchMenu(menuRef) {
+          const requested = typeof menuRef === 'string'
+            ? (getMenuById(menuRef) || getMenuBySlug(menuRef))
+            : (menuRef?.id ? getMenuById(menuRef.id) : getMenuBySlug(menuRef?.slug || ''));
+          if (!requested) return this.getSnapshot();
+          selectMenu(
+            requested.id,
+            requested.slug,
+            requested.name,
+            requested.type,
+            requested.restaurantId
+          );
+          return this.refresh();
+        },
+      };
+      session._syncRequest(buildCurrentMenuPageRequest(pageRequest));
+      return session;
+    },
+  };
+}
+
+function getMenuLifecycleService() {
+  if (_menuLifecycleService) return _menuLifecycleService;
+  _menuLifecycleService = createMenuLifecycleService({
+    loadPageState: options => _loadActiveMenuStateInternal(options),
+    pollPageState: options => _pollActiveMenuStateInternal(options),
+    savePageDraft: options => _saveActiveMenuDraftInternal(options),
+    publishPageUpdate: options => _publishActiveMenuUpdateInternal(options),
+  });
+  return _menuLifecycleService;
+}
+
+function getMenuRuntime() {
+  if (_menuRuntime) return _menuRuntime;
+  _menuRuntime = createMenuRuntime({ lifecycle: getMenuLifecycleService() });
+  return _menuRuntime;
+}
+
+function ensureCurrentMenuSession(overrides = {}) {
+  if (!_currentMenuSession) {
+    _currentMenuSession = getMenuRuntime().openPage(buildCurrentMenuPageRequest(overrides));
+  } else {
+    _currentMenuSession._syncRequest(buildCurrentMenuPageRequest(overrides));
+  }
+  return _currentMenuSession;
 }
 
 function readCachedMenuState(expectedRestaurantId = '') {
@@ -967,7 +1105,7 @@ async function refreshFeaturedForActiveMenu() {
   return _featuredGroups;
 }
 
-async function loadActiveMenuState(options = {}) {
+async function _loadActiveMenuStateInternal(options = {}) {
   const {
     fallbackToDefault = true,
     includeFeatured = true,
@@ -993,6 +1131,40 @@ async function loadActiveMenuState(options = {}) {
     }
   }
   if (includeFeatured) await refreshFeaturedForActiveMenu();
+  return buildMenuSessionSnapshot(options.source || 'network');
+}
+
+async function _pollActiveMenuStateInternal() {
+  const oldTs = menuState._meta?.lastUpdatedTs;
+  const oldCats = getCategoryStateSnapshot();
+  const oldDesign = getDesignSnapshot();
+  const oldFeatured = getFeaturedSnapshot();
+  const data = await sbRead();
+  if (!data) {
+    return {
+      changed: false,
+      designChanged: false,
+      snapshot: buildMenuSessionSnapshot('poll'),
+    };
+  }
+
+  hydrateState(data);
+  lsSet(LS_KEYS.menuCache, JSON.stringify(data));
+  const newTs = menuState._meta?.lastUpdatedTs;
+  if (newTs !== oldTs) await refreshFeaturedForActiveMenu();
+
+  const afterCats = getCategoryStateSnapshot();
+  const newDesign = getDesignSnapshot();
+  const newFeatured = getFeaturedSnapshot();
+  return {
+    changed: afterCats !== oldCats || newTs !== oldTs || newFeatured !== oldFeatured,
+    designChanged: newDesign !== oldDesign,
+    snapshot: buildMenuSessionSnapshot('poll'),
+  };
+}
+
+async function loadActiveMenuState(options = {}) {
+  return ensureCurrentMenuSession().refresh(options);
 }
 
 async function sbPatchMenuMeta(update) {
@@ -2343,25 +2515,11 @@ function startPolling() {
   const pollCycle = async () => {
     if (isManagerMode) return;
     try {
-      const oldTs = menuState._meta?.lastUpdatedTs;
-      const oldCats = getCategoryStateSnapshot();
-      const oldDesign = getDesignSnapshot();
-      const oldFeatured = getFeaturedSnapshot();
-      const data = await sbRead();
-      if (!data) return;
-      hydrateState(data);
-      lsSet(LS_KEYS.menuCache, JSON.stringify(data));
-      const newTs = menuState._meta?.lastUpdatedTs;
-      if (newTs !== oldTs) await refreshFeaturedForActiveMenu();
-
-      const afterCats = getCategoryStateSnapshot();
-      const newDesign = getDesignSnapshot();
-      const newFeatured = getFeaturedSnapshot();
-
-      if (afterCats !== oldCats || newTs !== oldTs || newFeatured !== oldFeatured) {
+      const result = await ensureCurrentMenuSession().refresh({ reason: 'poll' });
+      if (result?.changed) {
         await renderPublicViews();
       }
-      if (newDesign !== oldDesign) applyDesign(currentDesign);
+      if (result?.designChanged) applyDesign(currentDesign);
 
       _pollFailCount = 0;
       const syncEl = document.getElementById('sync-status');
@@ -3337,7 +3495,7 @@ async function onSwitchMenuClick() {
   showMenuPicker(async () => {
     // Reload menu data into the manager view for the newly selected menu
     _uncatCategoryUuid = null;
-    await loadActiveMenuState();
+    await ensureCurrentMenuSession().refresh();
     applyDesign(currentDesign);
     await sbEnsureUncategorized();
     renderManagerWorkspace();
@@ -3359,7 +3517,7 @@ async function onPublicSwitchMenuClick() {
     }
 
     // Reload public view in place when the selection stays on the same route.
-    await loadActiveMenuState();
+    await ensureCurrentMenuSession().refresh();
     applyDesign(currentDesign);
     renderPublicViews();
   });
@@ -4459,11 +4617,17 @@ async function persistState() {
   }
 }
 
-async function saveMenu() {
+async function _saveActiveMenuDraftInternal() {
   const ts = Date.now();
   try {
     const persisted = await persistState();
-    if (!persisted) return;
+    if (!persisted) {
+      return {
+        ok: false,
+        userHandled: true,
+        snapshot: buildMenuSessionSnapshot('save-failed'),
+      };
+    }
     await patchMenuMetaWithCompatibility({ last_updated_ts: ts });
     menuState._meta = { ...(menuState._meta || {}), lastUpdatedTs: ts.toString() };
     lsSet(LS_KEYS.lastUpdated, ts.toString());
@@ -4471,11 +4635,33 @@ async function saveMenu() {
     updateSaveBtn();
     updateLastUpdatedLabel();
     syncLocalMenuCache({ silent: true });
-    showToast('✅ Menu saved!', 'success');
+    return {
+      ok: true,
+      ts,
+      snapshot: buildMenuSessionSnapshot('saved'),
+    };
   } catch(e) {
     finalizePersistStatus(false);
-    showToast('⚠️ Cloud save failed.', 'error');
+    return {
+      ok: false,
+      userHandled: false,
+      snapshot: buildMenuSessionSnapshot('save-failed'),
+    };
   }
+}
+
+async function saveMenu() {
+  try {
+    const result = await ensureCurrentMenuSession().save();
+    if (result?.ok) {
+      showToast('✅ Menu saved!', 'success');
+      return;
+    }
+    if (result?.userHandled) return;
+  } catch (_) {
+    finalizePersistStatus(false);
+  }
+  showToast('⚠️ Cloud save failed.', 'error');
 }
 
 function addItem(catId) {
@@ -5286,19 +5472,12 @@ async function logUpdate(diff, patchMessage) {
   }
 }
 
-async function sendUpdate() {
+async function _publishActiveMenuUpdateInternal() {
   const diff = getCachedDiff();
-  if (!diff.length) { closeModal(); return; }
-  const patchMessage = buildPatchMessage(diff);
-
-  if (patchMessage.length > 1000) {
-    showToast('Update is long and will be truncated.', 'info');
+  if (!diff.length) {
+    return { ok: false, noop: true, snapshot: buildMenuSessionSnapshot('send-noop') };
   }
-
-  const confirmBtn = document.getElementById('confirm-btn');
-  confirmBtn.disabled = true;
-  confirmBtn.textContent = 'SENDING…';
-
+  const patchMessage = buildPatchMessage(diff);
   try {
     const authHeaders = currentUser?.accessToken
       ? { 'Authorization': `Bearer ${currentUser.accessToken}` }
@@ -5310,9 +5489,7 @@ async function sendUpdate() {
     });
 
     if (r1.status >= 200 && r1.status < 300) {
-      showToast(`✅ ${_activeMenuName || 'Menu'} update sent!`, 'success');
       const ts = Date.now();
-      closeModal();
       try {
         const persisted = await persistState();
         if (!persisted) throw new Error('persist failed');
@@ -5338,32 +5515,73 @@ async function sendUpdate() {
         _dirty = false;
         updateSaveBtn();
         updateLastUpdatedLabel();
-        renderManagerWorkspace({ includeRecentChanges: false });
-        updateDraftIndicator();
         const cacheSynced = syncLocalMenuCache({ silent: true });
-        if (!cacheSynced) {
-          showToast('⚠️ Update sent, but this device could not refresh its local cache.', 'warning');
-        }
         const logged = await logUpdate(diff, patchMessage);
         if (!logged) console.warn('sendUpdate audit log insert failed');
-        renderRecentChanges();
+        return {
+          ok: true,
+          truncated: patchMessage.length > 1000,
+          warningMessage: !cacheSynced
+            ? '⚠️ Update sent, but this device could not refresh its local cache.'
+            : '',
+          successMessage: `✅ ${_activeMenuName || 'Menu'} update sent!`,
+          snapshot: buildMenuSessionSnapshot('sent'),
+        };
       } catch (syncError) {
         console.warn('sendUpdate post-send sync failed:', syncError);
-        showToast('⚠️ Update sent, but database sync needs attention. Refresh before sending again.', 'warning');
+        return {
+          ok: true,
+          truncated: patchMessage.length > 1000,
+          warningMessage: '⚠️ Update sent, but database sync needs attention. Refresh before sending again.',
+          successMessage: `✅ ${_activeMenuName || 'Menu'} update sent!`,
+          snapshot: buildMenuSessionSnapshot('sent-warning'),
+        };
       }
     } else if (r1.status === 401) {
-      showToast('❌ Not authorized. Please sign in.', 'error');
+      return { ok: false, userMessage: '❌ Not authorized. Please sign in.' };
     } else if (r1.status === 403) {
-      showToast('❌ Access denied. Your account role does not allow sending updates.', 'error');
+      return { ok: false, userMessage: '❌ Access denied. Your account role does not allow sending updates.' };
     } else {
-      showToast('❌ Notification error. Check channel config in Admin settings.', 'error');
+      return { ok: false, userMessage: '❌ Notification error. Check channel config in Admin settings.' };
     }
   } catch(e) {
-    showToast('❌ Network error. Check connection.', 'error');
+    return { ok: false, userMessage: '❌ Network error. Check connection.' };
+  }
+}
+
+async function sendUpdate() {
+  const diff = getCachedDiff();
+  if (!diff.length) { closeModal(); return; }
+
+  const patchMessage = buildPatchMessage(diff);
+  if (patchMessage.length > 1000) {
+    showToast('Update is long and will be truncated.', 'info');
   }
 
-  confirmBtn.disabled = false;
-  confirmBtn.textContent = 'SEND UPDATE';
+  const confirmBtn = document.getElementById('confirm-btn');
+  confirmBtn.disabled = true;
+  confirmBtn.textContent = 'SENDING…';
+
+  try {
+    const result = await ensureCurrentMenuSession().sendUpdate();
+    if (result?.noop) {
+      closeModal();
+      return;
+    }
+    if (result?.ok) {
+      closeModal();
+      showToast(result.successMessage || `✅ ${_activeMenuName || 'Menu'} update sent!`, 'success');
+      renderManagerWorkspace({ includeRecentChanges: false });
+      updateDraftIndicator();
+      renderRecentChanges();
+      if (result.warningMessage) showToast(result.warningMessage, 'warning');
+      return;
+    }
+    if (result?.userMessage) showToast(result.userMessage, 'error');
+  } finally {
+    confirmBtn.disabled = false;
+    confirmBtn.textContent = 'SEND UPDATE';
+  }
 }
 
 // ─── TOAST ───────────────────────────────────────────────────────────────────

--- a/app.js
+++ b/app.js
@@ -2735,13 +2735,109 @@ async function showPublicViewWithError(msg) {
   await renderPublicView();
 }
 
+function buildPublicRouteRenderSnapshot() {
+  const restaurantSpecials = _featuredGroups.length > 1
+    ? {
+        id: '__restaurant_specials__',
+        name: getRestaurantSpecialLabel(RESTAURANT_ID),
+        slots: _featuredGroups.flatMap(group => group.slots || []),
+      }
+    : (_featuredGroups[0] || null);
+  return {
+    activeMenuName: _activeMenuName,
+    appVersion: APP_VERSION,
+    canEditRestaurantSpecials: currentUserCanEditRestaurantSpecials(RESTAURANT_ID, currentUser),
+    categoryDefs: getManagedCategoryDefs(),
+    currentUser,
+    featuredGroups: _featuredGroups,
+    isPreview: IS_PREVIEW,
+    knownMenus: knownMenuList(),
+    lastUpdatedTs: getLastUpdatedTs(),
+    menuId: MENU_ID,
+    menuState,
+    menuType: MENU_TYPE,
+    restaurantId: RESTAURANT_ID,
+    restaurantSpecials,
+    siteRestaurant: _siteRestaurant,
+  };
+}
+
+async function switchPublicRouteMenu(menuRef) {
+  const menu = typeof menuRef === 'string'
+    ? (getMenuById(menuRef) || getMenuBySlug(menuRef))
+    : menuRef;
+  if (!menu?.id) return { ok: false, userHandled: true };
+
+  selectMenu(menu.id, menu.slug, menu.name, menu.type, menu.restaurantId);
+  const targetHref = getPublicHrefForCurrentMenu();
+  const currentHref = `${window.location.pathname}${window.location.search}`;
+  if (targetHref && targetHref !== currentHref) {
+    navigateToPage(targetHref);
+    return { ok: true, navigated: true, targetHref };
+  }
+
+  await loadActiveMenuState();
+  applyDesign(currentDesign);
+  await renderPublicViews();
+  return {
+    ok: true,
+    navigated: false,
+    snapshot: buildPublicRouteRenderSnapshot(),
+  };
+}
+
+function createPublicRouteContract() {
+  return {
+    version: 1,
+    snapshot: buildPublicRouteRenderSnapshot(),
+    helpers: {
+      escHtml,
+      formatUpdatedAt,
+      getMenuTypeLabel,
+    },
+    actions: {
+      closeDropdowns: () => closeRouteDropdowns(),
+      openManager: () => onActionBtnClick(),
+      openAdmin: () => onAdminBtnClick(),
+      canManageMenu: (menuId, user = currentUser) => currentUserCanManageMenu(menuId, user),
+      switchMenu: menu => switchPublicRouteMenu(menu),
+    },
+  };
+}
+
+function getRegisteredPublicRouteRenderer() {
+  const renderer = window.__publicRouteRenderer || window.__pendingPublicRouteRenderer || null;
+  if (!renderer || typeof renderer.render !== 'function') return null;
+  if (window.__pendingPublicRouteRenderer && !window.__publicRouteRenderer) {
+    window.__publicRouteRenderer = window.__pendingPublicRouteRenderer;
+    delete window.__pendingPublicRouteRenderer;
+  }
+  if (renderer.restaurantId && _siteRestaurant?.id && renderer.restaurantId !== _siteRestaurant.id) {
+    return null;
+  }
+  return renderer;
+}
+
+window.registerPublicRouteRenderer = function registerPublicRouteRenderer(renderer) {
+  window.__publicRouteRenderer = renderer || null;
+  if (window.__pendingPublicRouteRenderer) delete window.__pendingPublicRouteRenderer;
+  return window.__publicRouteRenderer;
+};
+
 function showRouteBootView() {
   if (!isDedicatedRestaurantPage()) return;
   const publicView = document.getElementById('public-view');
   const loadingView = document.getElementById('loading-view');
   if (loadingView) loadingView.style.display = 'none';
   if (publicView) publicView.style.display = 'block';
-  if (typeof window.renderRouteBootShell === 'function') {
+  const renderer = getRegisteredPublicRouteRenderer();
+  if (renderer?.boot) {
+    const didRender = renderer.boot(createPublicRouteContract());
+    if (didRender !== false) {
+      _togglePublicShellMode('site');
+      return;
+    }
+  } else if (typeof window.renderRouteBootShell === 'function') {
     const didRender = window.renderRouteBootShell();
     if (didRender !== false) {
       _togglePublicShellMode('site');
@@ -3153,13 +3249,6 @@ async function _renderCustomDesignView() {
   const siteWrapper = document.getElementById('restaurant-site-wrapper');
   const renderIntoSiteWrapper = isDedicatedRestaurantPage() && !!siteWrapper;
   const container = renderIntoSiteWrapper ? siteWrapper : fallbackContainer;
-  const restaurantSpecials = _featuredGroups.length > 1
-    ? {
-        id: '__restaurant_specials__',
-        name: getRestaurantSpecialLabel(RESTAURANT_ID),
-        slots: _featuredGroups.flatMap(group => group.slots || []),
-      }
-    : (_featuredGroups[0] || null);
   if (!_restaurantCustomDesignEnabled || !container) {
     _togglePublicShellMode('default');
     _renderDefaultPublicView();
@@ -3168,23 +3257,16 @@ async function _renderCustomDesignView() {
 
   document.getElementById('custom-design-style')?.remove();
 
-  if (renderIntoSiteWrapper && typeof window.initializeRoute === 'function') {
-    const didRender = window.initializeRoute(menuState, {
-      activeMenuName: _activeMenuName,
-      appVersion: APP_VERSION,
-      canEditRestaurantSpecials: currentUserCanEditRestaurantSpecials(RESTAURANT_ID, currentUser),
-      categoryDefs: getManagedCategoryDefs(),
-      currentUser,
-      featuredGroups: _featuredGroups,
-      isPreview: IS_PREVIEW,
-      knownMenus: knownMenuList(),
-      lastUpdatedTs: getLastUpdatedTs(),
-      menuId: MENU_ID,
-      menuType: MENU_TYPE,
-      restaurantSpecials,
-      restaurantId: RESTAURANT_ID,
-      siteRestaurant: _siteRestaurant,
-    });
+  const routeContract = createPublicRouteContract();
+  const renderer = renderIntoSiteWrapper ? getRegisteredPublicRouteRenderer() : null;
+  if (renderer?.render) {
+    const didRender = renderer.render(routeContract);
+    if (didRender !== false) {
+      _togglePublicShellMode('site');
+      return;
+    }
+  } else if (renderIntoSiteWrapper && typeof window.initializeRoute === 'function') {
+    const didRender = window.initializeRoute(routeContract.snapshot.menuState, routeContract.snapshot);
     if (didRender !== false) {
       _togglePublicShellMode('site');
       return;

--- a/app.js
+++ b/app.js
@@ -4015,16 +4015,18 @@ function buildItemsRowHtml(item, catId, lastSentNames) {
   const badgeText = is86 ? '86' : isNew ? 'NEW' : '';
   const stateLabel = is86 ? "86'd" : isNew ? 'New' : 'Active';
   return `<div class="current-item items-row ${stateClass}">
-      <button class="item-drag-handle" type="button" draggable="true"
-        ondragstart="startManagerItemDrag(event,'${catId}','${item.id}')"
-        ondragend="endManagerItemDrag(event)"
-        title="Drag to reorder"
-        aria-label="Drag to reorder ${escHtml(item.name)}">⋮⋮</button>
-      ${badgeText ? `<div class="item-state-badge ${badgeClass}" role="img" aria-label="${stateLabel}" title="${stateLabel}">${badgeText}</div>` : ''}
-      <div class="item-name"><input type="text" value="${escHtml(item.name)}"
-        aria-label="Item name for ${escHtml(item.name)}"
-        onblur="renameItem('${catId}','${item.id}',this.value)"
-        onkeydown="if(event.key==='Enter')this.blur()"/></div>
+      <div class="item-row-main">
+        <button class="item-drag-handle" type="button" draggable="true"
+          ondragstart="startManagerItemDrag(event,'${catId}','${item.id}')"
+          ondragend="endManagerItemDrag(event)"
+          title="Drag to reorder"
+          aria-label="Drag to reorder ${escHtml(item.name)}">⋮⋮</button>
+        ${badgeText ? `<div class="item-state-badge ${badgeClass}" role="img" aria-label="${stateLabel}" title="${stateLabel}">${badgeText}</div>` : ''}
+        <div class="item-name"><input type="text" value="${escHtml(item.name)}"
+          aria-label="Item name for ${escHtml(item.name)}"
+          onblur="renameItem('${catId}','${item.id}',this.value)"
+          onkeydown="if(event.key==='Enter')this.blur()"/></div>
+      </div>
       <span class="item-actions-compact">
         <button class="eighty-six-btn${is86 ? ' restore' : ''}" title="${is86 ? 'Restore' : '86'}" aria-label="${is86 ? `Restore ${escHtml(item.name)}` : `Mark ${escHtml(item.name)} 86'd`}" onclick="toggle86('${catId}','${item.id}')">${is86 ? '↩' : '86'}</button>
         <button class="del-item" onclick="removeItem('${catId}','${item.id}')" aria-label="Remove ${escHtml(item.name)}">×</button>
@@ -4039,6 +4041,9 @@ function buildPricingRowHtml(item, catId) {
   const badgeText = is86 ? '86' : '';
   const upcharges = item.upcharges || [];
   const upchargeCount = upcharges.length;
+  const upchargeMeta = upchargeCount
+    ? `${upchargeCount} upcharge${upchargeCount === 1 ? '' : 's'} ready`
+    : 'Base price only';
   let summaryHtml = '';
   if (upchargeCount > 0) {
     summaryHtml = `<div class="upcharges-summary" id="upcharges-summary-${item.id}">${upcharges.map(u => `<span class="upcharge-chip">${escHtml(u.label)} <strong>${escHtml(u.price)}</strong></span>`).join('')}</div>`;
@@ -4056,18 +4061,27 @@ function buildPricingRowHtml(item, catId) {
     </div>
   </div>`;
   return `<div class="current-item pricing-row ${stateClass}">
-      <div class="item-name">
-        <span class="item-name-static">${escHtml(item.name)}</span>
-        ${badgeText ? `<span class="item-state-badge ${badgeClass}" style="margin-left:8px">${badgeText}</span>` : ''}
+      <div class="pricing-row-main">
+        <div class="pricing-row-title">
+          <span class="item-name-static">${escHtml(item.name)}</span>
+          ${badgeText ? `<span class="item-state-badge ${badgeClass}">${badgeText}</span>` : ''}
+        </div>
+        <p class="pricing-row-meta">${escHtml(upchargeMeta)}</p>
       </div>
-      <input class="price-input" type="text" placeholder="Price…" aria-label="Price for ${escHtml(item.name)}"
-        onblur="savePrice('${catId}','${item.id}',this.value)"
-        onkeydown="if(event.key==='Enter')this.blur()"
-        value="${escHtml(item.price||'')}"/>
-      <button class="upcharge-toggle-btn" title="Manage upcharges" aria-label="Manage upcharges for ${escHtml(item.name)}" aria-expanded="false" onclick="toggleUpcharges('${catId}','${item.id}')">
-        <span class="upcharge-toggle-icon">+$</span>
-        ${upchargeCount > 0 ? `<span class="upcharge-count">${upchargeCount}</span>` : ''}
-      </button>
+      <div class="pricing-row-controls">
+        <label class="pricing-inline-field">
+          <span class="pricing-inline-label">Base price</span>
+          <input class="price-input" type="text" placeholder="Price…" aria-label="Price for ${escHtml(item.name)}"
+            onblur="savePrice('${catId}','${item.id}',this.value)"
+            onkeydown="if(event.key==='Enter')this.blur()"
+            value="${escHtml(item.price||'')}"/>
+        </label>
+        <button class="upcharge-toggle-btn" title="Manage upcharges" aria-label="Manage upcharges for ${escHtml(item.name)}" aria-expanded="false" onclick="toggleUpcharges('${catId}','${item.id}')">
+          <span class="upcharge-toggle-icon">+$</span>
+          <span class="upcharge-toggle-label">Upcharges</span>
+          ${upchargeCount > 0 ? `<span class="upcharge-count">${upchargeCount}</span>` : ''}
+        </button>
+      </div>
     </div>
     ${summaryHtml}
     ${panelHtml}`;

--- a/app.js
+++ b/app.js
@@ -1,5 +1,5 @@
 // ─── CONFIG ───────────────────────────────────────────────────────────────────
-const APP_VERSION = 'v0.8.5';
+const APP_VERSION = 'v0.8.6';
 const RESTAURANTS = {
   LEROYS: { id: '00000000-0000-0000-0000-000000000010', name: "Leroy's Lounge", slug: 'leroys-lounge' },
   ELROYS: { id: '00000000-0000-0000-0000-000000000001', name: "El Roy's Cantina", slug: 'el-roys-cantina' },

--- a/app.js
+++ b/app.js
@@ -5883,6 +5883,10 @@ async function addFeaturedSlot(groupId, itemId) {
       showToast('That item is already in specials.', 'info');
       return;
     }
+    if (_dirty || _deletedItemIds.size) {
+      const persisted = await persistState();
+      if (persisted === false) return;
+    }
     await callRestaurantSpecialsApi('add', { itemId });
     await refreshFeaturedForActiveMenu();
     renderFeaturedTab();
@@ -5893,7 +5897,7 @@ async function addFeaturedSlot(groupId, itemId) {
     if (input) input.value = '';
     filterFeaturedPicker(groupId, '');
     showToast('Special added!', 'success');
-  } catch(e) { showToast('Failed to add special.', 'error'); }
+  } catch(e) { showToast(e?.message || 'Failed to add special.', 'error'); }
 }
 
 async function removeFeaturedSlot(slotId, groupId) {
@@ -5909,7 +5913,7 @@ async function removeFeaturedSlot(slotId, groupId) {
     invalidateDiff();
     updateDraftIndicator();
     showToast('Special removed.', 'success');
-  } catch(e) { showToast('Failed to remove.', 'error'); }
+  } catch(e) { showToast(e?.message || 'Failed to remove.', 'error'); }
 }
 
 async function saveFeaturedSellNote(slotId, note) {
@@ -5935,7 +5939,7 @@ async function moveFeaturedSlot(groupId, slotId, direction) {
     await refreshFeaturedForActiveMenu();
     renderFeaturedTab();
     renderPublicView();
-  } catch(e) { showToast('Failed to reorder.', 'error'); }
+  } catch(e) { showToast(e?.message || 'Failed to reorder.', 'error'); }
 }
 
 // ─── FEATURED DAILY CONFIRMATION ─────────────────────────────────────────────
@@ -5967,7 +5971,7 @@ async function confirmFeaturedToday() {
     sessionStorage.setItem(getFeaturedConfirmationKey(), '1');
     updateManagerActionBar();
     showToast('Specials confirmed for today!', 'success');
-  } catch(e) { showToast('Failed to confirm.', 'error'); }
+  } catch(e) { showToast(e?.message || 'Failed to confirm.', 'error'); }
 }
 
 function editFeaturedFromBanner() {

--- a/app.js
+++ b/app.js
@@ -5354,24 +5354,48 @@ async function sendUpdate() {
 
 // ─── TOAST ───────────────────────────────────────────────────────────────────
 let _toastUndoTimer = null;
+let _toastResetTimer = null;
 function _flashSaved(el) {
   if (!el) return;
   el.classList.add('field-saved');
   setTimeout(() => el.classList.remove('field-saved'), 1200);
 }
 
+function hideToast() {
+  const t = document.getElementById('toast');
+  if (!t) return;
+  t.classList.remove('show');
+  if (_toastResetTimer) clearTimeout(_toastResetTimer);
+  _toastResetTimer = setTimeout(() => {
+    if (t.classList.contains('show')) return;
+    t.className = 'toast';
+    t.textContent = '';
+  }, 280);
+}
+
 function showToast(msg, type='info', undoCallback=null) {
   if (_toastUndoTimer) { clearTimeout(_toastUndoTimer); _toastUndoTimer = null; }
+  if (_toastResetTimer) { clearTimeout(_toastResetTimer); _toastResetTimer = null; }
   const t = document.getElementById('toast');
+  if (!t) return;
+  const message = String(msg ?? '').trim();
+  if (!message) {
+    window._toastUndoCallback = null;
+    hideToast();
+    return;
+  }
   t.className = `toast ${type} show`;
   if (undoCallback) {
-    t.innerHTML = `<span>${escHtml(msg)}</span><button class="toast-undo-btn" onclick="_toastUndo()">Undo</button>`;
+    t.innerHTML = `<span>${escHtml(message)}</span><button class="toast-undo-btn" onclick="_toastUndo()">Undo</button>`;
     window._toastUndoCallback = undoCallback;
-    _toastUndoTimer = setTimeout(() => { t.classList.remove('show'); window._toastUndoCallback = null; }, 5000);
+    _toastUndoTimer = setTimeout(() => {
+      window._toastUndoCallback = null;
+      hideToast();
+    }, 5000);
   } else {
-    t.textContent = msg;
+    t.textContent = message;
     window._toastUndoCallback = null;
-    _toastUndoTimer = setTimeout(() => t.classList.remove('show'), 3200);
+    _toastUndoTimer = setTimeout(() => hideToast(), 3200);
   }
 }
 function _toastUndo() {
@@ -5379,9 +5403,8 @@ function _toastUndo() {
     window._toastUndoCallback();
     window._toastUndoCallback = null;
   }
-  const t = document.getElementById('toast');
-  t.classList.remove('show');
   if (_toastUndoTimer) { clearTimeout(_toastUndoTimer); _toastUndoTimer = null; }
+  hideToast();
 }
 
 document.getElementById('modal-bg')?.addEventListener('click', e => {

--- a/elroyscantina/app.js
+++ b/elroyscantina/app.js
@@ -44,7 +44,7 @@
       : (is86 ? `<span class="erc-badge erc-badge--86d">86'D</span>` : '');
     const recipeHtml = recipe.length ? `<p class="erc-item-desc erc-item-desc--recipe">Recipe: ${esc(recipe.join(', '))}</p>` : '';
     const upchargesHtml = upcharges.length
-      ? `<div class="erc-item-upcharges">${upcharges.map(upcharge => `<span class="erc-upcharge-chip">${esc(upcharge.label || 'Upcharge')}${upcharge.price ? ` <strong>${esc(upcharge.price)}</strong>` : ''}</span>`).join('')}</div>`
+      ? `<div class="erc-item-upcharges">${upcharges.map(upcharge => `<span class="erc-upcharge-chip">${esc(upcharge.label || 'Upcharge')}${upcharge.price ? ` <strong>+${esc(upcharge.price)}</strong>` : ''}</span>`).join('')}</div>`
       : '';
 
     return `<article class="erc-item${is86 ? ' is-86d' : ''}">

--- a/elroyscantina/app.js
+++ b/elroyscantina/app.js
@@ -93,6 +93,53 @@
       });
   }
 
+  function createLegacyRouteActions(sharedState) {
+    return {
+      closeDropdowns: () => window.closeRouteDropdowns?.(),
+      openManager: () => window.onActionBtnClick?.(),
+      openAdmin: () => window.onAdminBtnClick?.(),
+      canManageMenu: (menuId, user = sharedState.currentUser) => (
+        typeof window.currentUserCanManageMenu === 'function'
+          ? window.currentUserCanManageMenu(menuId, user)
+          : ((user?.role || 'none') === 'admin')
+      ),
+      switchMenu: async menu => {
+        if (!menu?.id) return { ok: false, userHandled: true };
+        window.selectMenu?.(menu.id, menu.slug, menu.name, menu.type, menu.restaurantId);
+        const targetHref = window.getPublicHrefForCurrentMenu?.();
+        const currentHref = `${window.location.pathname}${window.location.search}`;
+        if (targetHref && targetHref !== currentHref) {
+          window.navigateToPage?.(targetHref);
+          return { ok: true, navigated: true, targetHref };
+        }
+        await window.loadActiveMenuState?.();
+        if (typeof window.applyDesign === 'function' && typeof currentDesign !== 'undefined') {
+          window.applyDesign(currentDesign);
+        }
+        await window.renderPublicViews?.();
+        return { ok: true, navigated: false };
+      },
+    };
+  }
+
+  function resolveRouteContract(contractOrMenuState, legacyState) {
+    if (contractOrMenuState?.snapshot && contractOrMenuState?.actions) return contractOrMenuState;
+    const snapshot = {
+      menuState: contractOrMenuState,
+      ...(legacyState || {}),
+    };
+    return {
+      version: 0,
+      snapshot,
+      helpers: {
+        escHtml: typeof window.escHtml === 'function' ? window.escHtml : esc,
+        formatUpdatedAt: typeof window.formatUpdatedAt === 'function' ? window.formatUpdatedAt : (() => ''),
+        getMenuTypeLabel: typeof window.getMenuTypeLabel === 'function' ? window.getMenuTypeLabel : (value => value || ''),
+      },
+      actions: createLegacyRouteActions(snapshot),
+    };
+  }
+
   function updateToggleState(sharedState) {
     document.querySelectorAll('[data-route-menu-toggle]').forEach(button => {
       const isActive = button.getAttribute('data-route-menu-toggle') === sharedState.menuType;
@@ -101,22 +148,21 @@
     });
   }
 
-  function renderSettingsDropdown(sharedState) {
+  function renderSettingsDropdown(contract) {
+    const sharedState = contract.snapshot;
     const wrapper = document.querySelector('[data-route-settings]');
     const dropdown = document.getElementById('erc-settings-dropdown');
     if (!wrapper || !dropdown) return;
 
     const role = sharedState.currentUser?.role || 'none';
-    const canManageCurrentMenu = typeof window.currentUserCanManageMenu === 'function'
-      ? window.currentUserCanManageMenu(sharedState.menuId, sharedState.currentUser)
-      : (role === 'admin');
+    const canManageCurrentMenu = contract.actions.canManageMenu(sharedState.menuId, sharedState.currentUser);
     const options = [];
 
     if (canManageCurrentMenu) {
-      options.push({ label: 'Manager', icon: 'tune', onClick: () => window.onActionBtnClick?.() });
+      options.push({ label: 'Manager', icon: 'tune', onClick: () => contract.actions.openManager?.() });
     }
     if (role === 'admin') {
-      options.push({ label: 'Admin', icon: 'shield_person', onClick: () => window.onAdminBtnClick?.() });
+      options.push({ label: 'Admin', icon: 'shield_person', onClick: () => contract.actions.openAdmin?.() });
     }
 
     wrapper.style.display = options.length ? '' : 'none';
@@ -129,31 +175,21 @@
 
     dropdown.querySelectorAll('[data-route-settings-option]').forEach((button, index) => {
       button.onclick = () => {
-        window.closeRouteDropdowns?.();
+        contract.actions.closeDropdowns?.();
         options[index]?.onClick?.();
       };
     });
   }
 
-  function bindMenuToggles(sharedState) {
+  function bindMenuToggles(contract) {
+    const sharedState = contract.snapshot;
     const menus = getMenusForRoute(sharedState);
     document.querySelectorAll('[data-route-menu-toggle]').forEach(button => {
       button.onclick = async () => {
         const targetType = button.getAttribute('data-route-menu-toggle');
         const menu = menus.find(entry => entry.type === targetType);
         if (!menu || menu.id === sharedState.menuId) return;
-
-        window.selectMenu?.(menu.id, menu.slug, menu.name, menu.type, menu.restaurantId);
-        const targetHref = window.getPublicHrefForCurrentMenu?.();
-        const currentHref = `${window.location.pathname}${window.location.search}`;
-        if (targetHref && targetHref !== currentHref) {
-          window.navigateToPage?.(targetHref);
-          return;
-        }
-
-        await window.loadActiveMenuState?.();
-        window.applyDesign?.(typeof currentDesign !== 'undefined' ? currentDesign : null);
-        window.renderPublicViews?.();
+        await contract.actions.switchMenu(menu);
       };
     });
 
@@ -286,17 +322,12 @@
     return true;
   }
 
-  window.renderRouteBootShell = renderBootShell;
-
-  window.initializeRoute = function initializeRoute(menuState, authState) {
+  function renderRoute(contractOrMenuState, legacyState) {
+    const contract = resolveRouteContract(contractOrMenuState, legacyState);
+    const sharedState = contract.snapshot;
     const template = document.getElementById('elroy-route-template');
     const container = document.getElementById('restaurant-site-wrapper');
     if (!template || !container) return false;
-
-    const sharedState = {
-      menuState,
-      ...authState,
-    };
 
     if (sharedState.siteRestaurant?.id !== '00000000-0000-0000-0000-000000000001') return false;
 
@@ -304,7 +335,7 @@
     container.appendChild(template.content.cloneNode(true));
 
     const timestamp = sharedState.lastUpdatedTs
-      ? (window.formatUpdatedAt?.(sharedState.lastUpdatedTs, '') || '')
+      ? (contract.helpers.formatUpdatedAt?.(sharedState.lastUpdatedTs, '') || '')
       : 'Awaiting first update';
 
     const statusTsEl = document.getElementById('erc-route-status-timestamp');
@@ -332,9 +363,24 @@
     }
 
     renderHeaderState(sharedState);
-    renderSettingsDropdown(sharedState);
-    bindMenuToggles(sharedState);
+    renderSettingsDropdown(contract);
+    bindMenuToggles(contract);
     bindMobileHeader(container.querySelector('.erc-page'));
     return true;
+  }
+
+  const renderer = {
+    restaurantId: '00000000-0000-0000-0000-000000000001',
+    boot: renderBootShell,
+    render: renderRoute,
   };
+
+  if (typeof window.registerPublicRouteRenderer === 'function') {
+    window.registerPublicRouteRenderer(renderer);
+  } else {
+    window.__pendingPublicRouteRenderer = renderer;
+  }
+
+  window.renderRouteBootShell = renderBootShell;
+  window.initializeRoute = renderRoute;
 })();

--- a/elroyscantina/index.html
+++ b/elroyscantina/index.html
@@ -1,345 +1,632 @@
-<!DOCTYPE html>
+<!doctype html>
 <html lang="en">
-<head>
-<meta charset="UTF-8">
-<meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
-<meta name="theme-color" content="#fcf6e8">
-<title>El Roy's Cantina | Current Menu</title>
-<link rel="icon" type="image/png" href="/HFLOGO.png">
-<link rel="preconnect" href="https://fonts.googleapis.com">
-<link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-<link href="https://fonts.googleapis.com/css2?family=Newsreader:ital,wght@0,400..800;1,400..800&family=Plus+Jakarta+Sans:wght@200..800&display=swap" rel="stylesheet">
-<link href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap" rel="stylesheet">
-<link rel="stylesheet" href="/style.css">
-<link rel="stylesheet" href="/elroyscantina/style.css">
-</head>
-<body class="route-restaurant route-restaurant--elroy route-shell-pending">
-<main id="site-picker-view" class="site-picker-view" hidden>
-  <div class="site-picker-card">
-    <p class="site-picker-kicker">Current Menu</p>
-    <h1 class="site-picker-title">Choose a restaurant</h1>
-    <div class="site-picker-actions">
-      <a class="site-picker-link" href="/leroyslounge">Leroy's Lounge</a>
-      <a class="site-picker-link" href="/elroyscantina">El Roy's Cantina</a>
-    </div>
-  </div>
-</main>
-
-<template id="elroy-route-template">
-  <div class="erc-page">
-    <a class="erc-skip-link" href="#erc-route-main">Skip to menu content</a>
-    <header class="erc-topbar">
-      <div class="erc-topbar-inner">
-        <div class="erc-brand-group">
-          <h1 class="erc-brand">El Roy's Cantina</h1>
-          <a class="erc-sister-link" href="/leroyslounge" aria-label="Open Leroy's Lounge menu">
-            <img class="erc-sister-badge" src="/assets/el-roys-cantina/cantina-badge.png" alt="Leroy's Lounge" width="495" height="335">
-          </a>
+  <head>
+    <meta charset="UTF-8" />
+    <meta
+      name="viewport"
+      content="width=device-width, initial-scale=1.0, viewport-fit=cover"
+    />
+    <meta name="theme-color" content="#fcf6e8" />
+    <title>El Roy's Cantina | Current Menu</title>
+    <link rel="icon" type="image/png" href="/HFLOGO.png" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Newsreader:ital,wght@0,400..800;1,400..800&family=Plus+Jakarta+Sans:wght@200..800&display=swap"
+      rel="stylesheet"
+    />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap"
+      rel="stylesheet"
+    />
+    <link rel="stylesheet" href="/style.css" />
+    <link rel="stylesheet" href="/elroyscantina/style.css" />
+  </head>
+  <body class="route-restaurant route-restaurant--elroy route-shell-pending">
+    <main id="site-picker-view" class="site-picker-view" hidden>
+      <div class="site-picker-card">
+        <p class="site-picker-kicker">Current Menu</p>
+        <h1 class="site-picker-title">Choose a restaurant</h1>
+        <div class="site-picker-actions">
+          <a class="site-picker-link" href="/leroyslounge">Leroy's Lounge</a>
+          <a class="site-picker-link" href="/elroyscantina">El Roy's Cantina</a>
         </div>
+      </div>
+    </main>
 
-        <nav class="erc-menu-toggle" aria-label="Swap menu">
-          <button id="erc-nav-food"
-                  class="erc-menu-toggle-btn"
-                  type="button"
-                  data-route-menu-toggle="food">
-            Food
-          </button>
-          <button id="erc-nav-drinks"
-                  class="erc-menu-toggle-btn"
-                  type="button"
-                  data-route-menu-toggle="drinks">
-            Drinks
-          </button>
-        </nav>
+    <template id="elroy-route-template">
+      <div class="erc-page">
+        <a class="erc-skip-link" href="#erc-route-main">Skip to menu content</a>
+        <header class="erc-topbar">
+          <div class="erc-topbar-inner">
+            <div class="erc-brand-group">
+              <h1 class="erc-brand">El Roy's Cantina</h1>
+              <a
+                class="erc-sister-link"
+                href="/leroyslounge"
+                aria-label="Open Leroy's Lounge menu"
+              >
+                <img
+                  class="erc-sister-badge"
+                  src="/assets/el-roys-cantina/cantina-badge.png"
+                  alt="Leroy's Lounge"
+                  width="495"
+                  height="335"
+                />
+              </a>
+            </div>
 
-        <div class="erc-actions">
-          <button class="erc-login-btn" data-route-signin type="button" onclick="openAuthOverlay()">Login</button>
-          <button class="erc-login-btn erc-route-exit-btn"
-                  type="button"
-                  data-route-manager
-                  onclick="exitView()"
-                  aria-label="Exit manager view">
-            Exit
-          </button>
-          <button class="erc-login-btn erc-route-exit-btn"
-                  type="button"
-                  data-route-admin
-                  onclick="exitView()"
-                  aria-label="Exit admin view">
-            Exit
-          </button>
+            <nav class="erc-menu-toggle" aria-label="Swap menu">
+              <button
+                id="erc-nav-food"
+                class="erc-menu-toggle-btn"
+                type="button"
+                data-route-menu-toggle="food"
+              >
+                Food
+              </button>
+              <button
+                id="erc-nav-drinks"
+                class="erc-menu-toggle-btn"
+                type="button"
+                data-route-menu-toggle="drinks"
+              >
+                Drinks
+              </button>
+            </nav>
 
-          <div class="erc-userchip" data-route-user-chip style="display:none"
-               onclick="toggleUserDropdown('erc-user-chip')"
-               onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleUserDropdown('erc-user-chip')}"
-               tabindex="0"
-               role="button"
-               aria-haspopup="true"
-               aria-expanded="false"
-               id="erc-user-chip"
-               aria-label="User menu">
-            <span class="material-symbols-outlined erc-icon" aria-hidden="true">account_circle</span>
-            <div class="erc-userdropdown" id="erc-user-dropdown">
-              <div class="user-dropdown-name" id="erc-user-dropdown-name"></div>
-              <div class="user-dropdown-role" id="erc-user-dropdown-role"></div>
-              <div class="user-dropdown-divider"></div>
-              <button class="user-dropdown-signout" onclick="signOut()">Sign Out</button>
+            <div class="erc-actions">
+              <button
+                class="erc-login-btn"
+                data-route-signin
+                type="button"
+                onclick="openAuthOverlay()"
+              >
+                Login
+              </button>
+              <button
+                class="erc-login-btn erc-route-exit-btn"
+                type="button"
+                data-route-manager
+                onclick="exitView()"
+                aria-label="Exit manager view"
+              >
+                Exit
+              </button>
+              <button
+                class="erc-login-btn erc-route-exit-btn"
+                type="button"
+                data-route-admin
+                onclick="exitView()"
+                aria-label="Exit admin view"
+              >
+                Exit
+              </button>
+
+              <div
+                class="erc-userchip"
+                data-route-user-chip
+                style="display: none"
+                onclick="toggleUserDropdown('erc-user-chip')"
+                onkeydown="
+                  if (event.key === 'Enter' || event.key === ' ') {
+                    event.preventDefault();
+                    toggleUserDropdown('erc-user-chip');
+                  }
+                "
+                tabindex="0"
+                role="button"
+                aria-haspopup="true"
+                aria-expanded="false"
+                id="erc-user-chip"
+                aria-label="User menu"
+              >
+                <span
+                  class="material-symbols-outlined erc-icon"
+                  aria-hidden="true"
+                  >account_circle</span
+                >
+                <div class="erc-userdropdown" id="erc-user-dropdown">
+                  <div
+                    class="user-dropdown-name"
+                    id="erc-user-dropdown-name"
+                  ></div>
+                  <div
+                    class="user-dropdown-role"
+                    id="erc-user-dropdown-role"
+                  ></div>
+                  <div class="user-dropdown-divider"></div>
+                  <button class="user-dropdown-signout" onclick="signOut()">
+                    Sign Out
+                  </button>
+                </div>
+              </div>
+
+              <div
+                class="erc-action-dropdown"
+                data-route-dropdown
+                data-route-settings
+                style="display: none"
+              >
+                <button
+                  id="erc-settings-trigger"
+                  class="erc-icon-btn"
+                  type="button"
+                  data-route-dropdown-trigger
+                  aria-label="Manager and admin actions"
+                  aria-haspopup="true"
+                  aria-expanded="false"
+                  aria-controls="erc-settings-dropdown"
+                  onclick="
+                    toggleRouteDropdown(
+                      'erc-settings-trigger',
+                      'erc-settings-dropdown',
+                    )
+                  "
+                >
+                  <span
+                    class="material-symbols-outlined erc-icon"
+                    aria-hidden="true"
+                    >settings</span
+                  >
+                </button>
+                <div
+                  id="erc-settings-dropdown"
+                  class="erc-dropdown"
+                  data-route-dropdown-panel
+                  hidden
+                ></div>
+              </div>
+            </div>
+          </div>
+          <div class="erc-topbar-divider"></div>
+        </header>
+
+        <main class="erc-main" id="erc-route-main" tabindex="-1">
+          <div class="erc-hero">
+            <div class="erc-hero-copy">
+              <span class="erc-kicker">Our Daily Offering</span>
+              <h2 class="erc-title">THE MENU</h2>
+            </div>
+            <div class="erc-timestamp">
+              <p class="erc-timestamp-label">Last Updated</p>
+              <p class="erc-timestamp-value" id="erc-route-status-timestamp">
+                Awaiting first update
+              </p>
             </div>
           </div>
 
-          <div class="erc-action-dropdown" data-route-dropdown data-route-settings style="display:none">
-            <button id="erc-settings-trigger"
-                    class="erc-icon-btn"
-                    type="button"
-                    data-route-dropdown-trigger
-                    aria-label="Manager and admin actions"
-                    aria-haspopup="true"
-                    aria-expanded="false"
-                    aria-controls="erc-settings-dropdown"
-                    onclick="toggleRouteDropdown('erc-settings-trigger', 'erc-settings-dropdown')">
-              <span class="material-symbols-outlined erc-icon" aria-hidden="true">settings</span>
+          <section class="erc-section menu-category" data-category="special">
+            <div class="erc-section-head">
+              <h3 class="erc-section-title">Specials</h3>
+              <div class="erc-section-line" aria-hidden="true"></div>
+            </div>
+            <div id="erc-route-specials" class="erc-items"></div>
+          </section>
+
+          <div id="erc-route-sections"></div>
+        </main>
+
+        <footer class="erc-footer">
+          <div class="erc-footer-main">
+            <div class="erc-footer-copy">
+              <h2 class="erc-footer-title">El Roy's Cantina</h2>
+              <p class="erc-footer-quote">
+                “The sun never sets on the perfect taco.”
+              </p>
+            </div>
+            <div class="erc-footer-meta">
+              <p class="erc-footer-updated">
+                Updated:
+                <span id="erc-route-footer-timestamp"
+                  >Awaiting first update</span
+                >
+              </p>
+              <p id="erc-route-footer-version" class="erc-footer-version"></p>
+            </div>
+          </div>
+        </footer>
+      </div>
+    </template>
+
+    <div class="wrapper" id="app-shell">
+      <header>
+        <img class="hf-logo" src="" alt="Logo" style="display: none" />
+        <span class="logo-mark" style="display: none"></span>
+        <h1>CURRENT MENU</h1>
+        <div class="header-sub" id="last-updated-label">Last Updated: —</div>
+        <div class="header-action-group">
+          <button
+            class="manager-btn"
+            id="action-btn"
+            onclick="onActionBtnClick()"
+            style="display: none"
+          >
+            ⚙ Manager
+          </button>
+          <button
+            class="manager-btn admin-btn"
+            id="admin-btn"
+            onclick="onAdminBtnClick()"
+            style="display: none"
+          >
+            ⚙ Admin
+          </button>
+        </div>
+        <button
+          class="header-signin-btn"
+          id="signin-btn"
+          onclick="openAuthOverlay()"
+        >
+          Sign In
+        </button>
+        <div
+          class="user-chip"
+          id="user-chip"
+          style="display: none"
+          onclick="toggleUserDropdown()"
+          onkeydown="
+            if (event.key === 'Enter' || event.key === ' ') {
+              event.preventDefault();
+              toggleUserDropdown();
+            }
+          "
+          tabindex="0"
+          role="button"
+          aria-haspopup="true"
+          aria-expanded="false"
+          aria-label="User menu"
+        >
+          <span id="user-initials">?</span>
+          <span>▾</span>
+          <div class="user-dropdown" id="user-dropdown">
+            <div class="user-dropdown-name" id="user-dropdown-name"></div>
+            <div class="user-dropdown-role" id="user-dropdown-role"></div>
+            <div class="user-dropdown-divider"></div>
+            <button class="user-dropdown-signout" onclick="signOut()">
+              Sign Out
             </button>
-            <div id="erc-settings-dropdown"
-                 class="erc-dropdown"
-                 data-route-dropdown-panel
-                 hidden></div>
           </div>
         </div>
-      </div>
-      <div class="erc-topbar-divider"></div>
-    </header>
+      </header>
 
-    <main class="erc-main" id="erc-route-main" tabindex="-1">
-      <div class="erc-hero">
-        <div class="erc-hero-copy">
-          <span class="erc-kicker">Our Daily Offering</span>
-          <h2 class="erc-title">THE MENU</h2>
-        </div>
-        <div class="erc-timestamp">
-          <p class="erc-timestamp-label">Last Updated</p>
-          <p class="erc-timestamp-value" id="erc-route-status-timestamp">Awaiting first update</p>
-        </div>
+      <!-- LOADING -->
+      <div id="loading-view">
+        <div class="spinner"></div>
+        <p>Loading menu...</p>
       </div>
 
-      <section class="erc-section menu-category" data-category="special">
-        <div class="erc-section-head">
-          <h3 class="erc-section-title">Daily Specials</h3>
-          <div class="erc-section-line" aria-hidden="true"></div>
+      <!-- PUBLIC VIEW -->
+      <div id="public-view" style="display: none">
+        <div id="restaurant-site-wrapper" hidden></div>
+        <div id="public-default-shell">
+          <div class="error-banner" id="public-error"></div>
+          <div class="collapse-all-row">
+            <button
+              id="collapse-all-btn"
+              class="collapse-all-btn"
+              onclick="toggleAllCategories()"
+            >
+              Collapse All
+            </button>
+            <button
+              id="public-switch-menu-btn"
+              class="public-switch-btn"
+              onclick="onPublicSwitchMenuClick()"
+              style="display: none"
+              aria-label="Switch to a different menu"
+            >
+              ⇄ Switch Menu
+            </button>
+          </div>
+          <div id="featured-public-section" style="display: none"></div>
+          <div id="public-categories"></div>
+          <footer id="menu-footer">
+            <span id="footer-version"></span>
+            <span id="footer-last-updated"></span>
+          </footer>
         </div>
-        <div id="erc-route-specials" class="erc-items"></div>
-      </section>
-
-      <div id="erc-route-sections"></div>
-    </main>
-
-    <footer class="erc-footer">
-      <div class="erc-footer-main">
-        <div class="erc-footer-copy">
-          <h2 class="erc-footer-title">El Roy's Cantina</h2>
-          <p class="erc-footer-quote">“The sun never sets on the perfect taco.”</p>
-        </div>
-        <div class="erc-footer-meta">
-          <p class="erc-footer-updated">Updated: <span id="erc-route-footer-timestamp">Awaiting first update</span></p>
-          <p id="erc-route-footer-version" class="erc-footer-version"></p>
-        </div>
-      </div>
-    </footer>
-  </div>
-</template>
-
-<div class="wrapper" id="app-shell">
-  <header>
-    <img class="hf-logo" src="" alt="Logo" style="display:none"/>
-    <span class="logo-mark" style="display:none"></span>
-    <h1>CURRENT MENU</h1>
-    <div class="header-sub" id="last-updated-label">Last Updated: —</div>
-    <div class="header-action-group">
-      <button class="manager-btn" id="action-btn" onclick="onActionBtnClick()" style="display:none">⚙ Manager</button>
-      <button class="manager-btn admin-btn" id="admin-btn" onclick="onAdminBtnClick()" style="display:none">⚙ Admin</button>
-    </div>
-    <button class="header-signin-btn" id="signin-btn" onclick="openAuthOverlay()">Sign In</button>
-    <div class="user-chip" id="user-chip" style="display:none"
-         onclick="toggleUserDropdown()"
-         onkeydown="if(event.key==='Enter'||event.key===' '){event.preventDefault();toggleUserDropdown()}"
-         tabindex="0"
-         role="button"
-         aria-haspopup="true"
-         aria-expanded="false"
-         aria-label="User menu">
-      <span id="user-initials">?</span>
-      <span>▾</span>
-      <div class="user-dropdown" id="user-dropdown">
-        <div class="user-dropdown-name" id="user-dropdown-name"></div>
-        <div class="user-dropdown-role" id="user-dropdown-role"></div>
-        <div class="user-dropdown-divider"></div>
-        <button class="user-dropdown-signout" onclick="signOut()">Sign Out</button>
       </div>
     </div>
-  </header>
 
-  <!-- LOADING -->
-  <div id="loading-view">
-    <div class="spinner"></div>
-    <p>Loading menu...</p>
-  </div>
+    <!-- AUTH OVERLAY -->
+    <div id="auth-overlay">
+      <div
+        class="auth-box"
+        id="auth-box"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Sign In"
+      >
+        <div id="auth-no-config" style="display: none" class="auth-hint-msg">
+          Supabase is not configured. Check server environment variables.
+        </div>
+        <div id="auth-form-wrap">
+          <!-- SIGN IN -->
+          <div id="auth-screen-signin" class="auth-screen">
+            <h2 class="auth-screen-title">SIGN IN</h2>
+            <p class="auth-screen-subtitle">Sign in to your account</p>
+            <div class="auth-field">
+              <input
+                type="email"
+                id="signin-email"
+                placeholder="Email address"
+                autocomplete="email"
+                aria-describedby="signin-error"
+              />
+            </div>
+            <div class="auth-field">
+              <input
+                type="password"
+                id="signin-password"
+                placeholder="Password"
+                autocomplete="current-password"
+                aria-describedby="signin-error"
+              />
+            </div>
+            <div class="auth-error" id="signin-error"></div>
+            <button
+              class="auth-submit-btn"
+              id="signin-submit-btn"
+              onclick="handleSignIn()"
+            >
+              Sign In
+            </button>
+            <button class="auth-link-btn" onclick="renderAuthScreen('forgot')">
+              Forgot password?
+            </button>
+            <div class="auth-toggle">
+              <span>Don't have an account?</span>
+              <button
+                class="auth-toggle-btn"
+                onclick="renderAuthScreen('signup')"
+              >
+                Sign Up
+              </button>
+            </div>
+          </div>
 
-  <!-- PUBLIC VIEW -->
-  <div id="public-view" style="display:none;">
-    <div id="restaurant-site-wrapper" hidden></div>
-    <div id="public-default-shell">
-      <div class="error-banner" id="public-error"></div>
-      <div class="collapse-all-row">
-        <button id="collapse-all-btn" class="collapse-all-btn" onclick="toggleAllCategories()">Collapse All</button>
-        <button id="public-switch-menu-btn" class="public-switch-btn" onclick="onPublicSwitchMenuClick()" style="display:none" aria-label="Switch to a different menu">⇄ Switch Menu</button>
+          <!-- SIGN UP -->
+          <div
+            id="auth-screen-signup"
+            class="auth-screen"
+            style="display: none"
+          >
+            <h2 class="auth-screen-title">CREATE ACCOUNT</h2>
+            <p class="auth-screen-subtitle">Sign up with your work email</p>
+            <div class="auth-field">
+              <input
+                type="text"
+                id="signup-firstname"
+                placeholder="First name"
+                autocomplete="given-name"
+                aria-describedby="signup-error"
+                onkeydown="
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    document.getElementById('signup-lastname').focus();
+                  }
+                "
+              />
+            </div>
+            <div class="auth-field">
+              <input
+                type="text"
+                id="signup-lastname"
+                placeholder="Last name"
+                autocomplete="family-name"
+                aria-describedby="signup-error"
+                onkeydown="
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    document.getElementById('signup-email').focus();
+                  }
+                "
+              />
+            </div>
+            <div class="auth-field">
+              <input
+                type="email"
+                id="signup-email"
+                placeholder="Email address"
+                autocomplete="email"
+                aria-describedby="signup-error"
+                onkeydown="
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    document.getElementById('signup-password').focus();
+                  }
+                "
+              />
+            </div>
+            <div class="auth-field">
+              <input
+                type="password"
+                id="signup-password"
+                placeholder="Password"
+                autocomplete="new-password"
+                aria-describedby="signup-error"
+                onkeydown="
+                  if (event.key === 'Enter') {
+                    event.preventDefault();
+                    handleSignUp();
+                  }
+                "
+              />
+            </div>
+            <div class="auth-error" id="signup-error"></div>
+            <button
+              class="auth-submit-btn"
+              id="signup-submit-btn"
+              onclick="handleSignUp()"
+            >
+              Create Account
+            </button>
+            <p class="auth-approval-notice">
+              New accounts require admin approval before menu access is granted.
+            </p>
+            <button class="auth-back-btn" onclick="renderAuthScreen('signin')">
+              ← Back to Sign In
+            </button>
+          </div>
+
+          <!-- FORGOT PASSWORD -->
+          <div
+            id="auth-screen-forgot"
+            class="auth-screen"
+            style="display: none"
+          >
+            <h2 class="auth-screen-title">RESET PASSWORD</h2>
+            <p class="auth-screen-subtitle">
+              Enter your email and we'll send a reset link
+            </p>
+            <div class="auth-field">
+              <input
+                type="email"
+                id="forgot-email"
+                placeholder="Email address"
+                autocomplete="email"
+                aria-describedby="forgot-error"
+              />
+            </div>
+            <div class="auth-error" id="forgot-error"></div>
+            <button
+              class="auth-submit-btn"
+              id="forgot-submit-btn"
+              onclick="handleForgotPassword()"
+            >
+              Send Reset Link
+            </button>
+            <button class="auth-back-btn" onclick="renderAuthScreen('signin')">
+              ← Back to Sign In
+            </button>
+          </div>
+
+          <!-- RESET PASSWORD -->
+          <div id="auth-screen-reset" class="auth-screen" style="display: none">
+            <h2 class="auth-screen-title">SET NEW PASSWORD</h2>
+            <p class="auth-screen-subtitle">
+              Choose a new password for your account
+            </p>
+            <div class="auth-field">
+              <input
+                type="password"
+                id="reset-password"
+                placeholder="New password"
+                autocomplete="new-password"
+                aria-describedby="reset-error"
+              />
+            </div>
+            <div class="auth-field">
+              <input
+                type="password"
+                id="reset-confirm"
+                placeholder="Confirm new password"
+                autocomplete="new-password"
+                aria-describedby="reset-error"
+              />
+            </div>
+            <div class="auth-error" id="reset-error"></div>
+            <button
+              class="auth-submit-btn"
+              id="reset-submit-btn"
+              onclick="handleResetPassword()"
+            >
+              Set Password
+            </button>
+          </div>
+        </div>
+        <button class="pin-cancel" onclick="closeAuthOverlay()">Cancel</button>
       </div>
-      <div id="featured-public-section" style="display:none;"></div>
-      <div id="public-categories"></div>
-      <footer id="menu-footer">
-        <span id="footer-version"></span>
-        <span id="footer-last-updated"></span>
-      </footer>
     </div>
-  </div>
 
-</div>
-
-<!-- AUTH OVERLAY -->
-<div id="auth-overlay">
-  <div class="auth-box" id="auth-box" role="dialog" aria-modal="true" aria-label="Sign In">
-    <div id="auth-no-config" style="display:none" class="auth-hint-msg">Supabase is not configured. Check server environment variables.</div>
-    <div id="auth-form-wrap">
-
-      <!-- SIGN IN -->
-      <div id="auth-screen-signin" class="auth-screen">
-        <h2 class="auth-screen-title">SIGN IN</h2>
-        <p class="auth-screen-subtitle">Sign in to your account</p>
-        <div class="auth-field">
-          <input type="email" id="signin-email" placeholder="Email address" autocomplete="email" aria-describedby="signin-error"/>
+    <!-- CONFIG JSON MODAL -->
+    <div class="modal-bg" id="config-modal-bg">
+      <div class="modal">
+        <h2>UPDATE CONFIG FILE</h2>
+        <div class="modal-sub">
+          Copy this into <code>lib/config/notifications.json</code> and reload
+          the page.
         </div>
-        <div class="auth-field">
-          <input type="password" id="signin-password" placeholder="Password" autocomplete="current-password" aria-describedby="signin-error"/>
-        </div>
-        <div class="auth-error" id="signin-error"></div>
-        <button class="auth-submit-btn" id="signin-submit-btn" onclick="handleSignIn()">Sign In</button>
-        <button class="auth-link-btn" onclick="renderAuthScreen('forgot')">Forgot password?</button>
-        <div class="auth-toggle">
-          <span>Don't have an account?</span>
-          <button class="auth-toggle-btn" onclick="renderAuthScreen('signup')">Sign Up</button>
+        <textarea
+          id="config-json-output"
+          class="config-json-textarea"
+          readonly
+          spellcheck="false"
+        ></textarea>
+        <div class="modal-actions">
+          <button class="btn-cancel" onclick="closeConfigModal()">Done</button>
+          <button class="btn-confirm" onclick="copyConfigJson()">
+            COPY JSON
+          </button>
         </div>
       </div>
+    </div>
 
-      <!-- SIGN UP -->
-      <div id="auth-screen-signup" class="auth-screen" style="display:none">
-        <h2 class="auth-screen-title">CREATE ACCOUNT</h2>
-        <p class="auth-screen-subtitle">Sign up with your work email</p>
-        <div class="auth-field">
-          <input type="text" id="signup-firstname" placeholder="First name" autocomplete="given-name"
-                 aria-describedby="signup-error"
-                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-lastname').focus();}"/>
+    <!-- PREVIEW MODAL -->
+    <div class="modal-bg" id="modal-bg">
+      <div class="modal">
+        <h2>PATCH NOTES PREVIEW</h2>
+        <div class="modal-sub">
+          Only changes since the last update will be sent.
         </div>
-        <div class="auth-field">
-          <input type="text" id="signup-lastname" placeholder="Last name" autocomplete="family-name"
-                 aria-describedby="signup-error"
-                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-email').focus();}"/>
+        <div id="preview-content"></div>
+        <div class="modal-actions">
+          <button class="btn-cancel" onclick="closeModal()">Cancel</button>
+          <button class="btn-confirm" id="confirm-btn" onclick="sendUpdate()">
+            SEND UPDATE
+          </button>
         </div>
-        <div class="auth-field">
-          <input type="email" id="signup-email" placeholder="Email address" autocomplete="email"
-                 aria-describedby="signup-error"
-                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-password').focus();}"/>
-        </div>
-        <div class="auth-field">
-          <input type="password" id="signup-password" placeholder="Password" autocomplete="new-password"
-                 aria-describedby="signup-error"
-                 onkeydown="if(event.key==='Enter'){event.preventDefault();handleSignUp();}"/>
-        </div>
-        <div class="auth-error" id="signup-error"></div>
-        <button class="auth-submit-btn" id="signup-submit-btn" onclick="handleSignUp()">Create Account</button>
-        <p class="auth-approval-notice">New accounts require admin approval before menu access is granted.</p>
-        <button class="auth-back-btn" onclick="renderAuthScreen('signin')">← Back to Sign In</button>
       </div>
+    </div>
 
-      <!-- FORGOT PASSWORD -->
-      <div id="auth-screen-forgot" class="auth-screen" style="display:none">
-        <h2 class="auth-screen-title">RESET PASSWORD</h2>
-        <p class="auth-screen-subtitle">Enter your email and we'll send a reset link</p>
-        <div class="auth-field">
-          <input type="email" id="forgot-email" placeholder="Email address" autocomplete="email" aria-describedby="forgot-error"/>
+    <!-- INVITE MODAL -->
+    <div class="modal-bg" id="invite-modal-bg">
+      <div class="modal">
+        <h2>INVITE STAFF</h2>
+        <div class="modal-sub">
+          Copy this message and send it to new staff members.
         </div>
-        <div class="auth-error" id="forgot-error"></div>
-        <button class="auth-submit-btn" id="forgot-submit-btn" onclick="handleForgotPassword()">Send Reset Link</button>
-        <button class="auth-back-btn" onclick="renderAuthScreen('signin')">← Back to Sign In</button>
+        <textarea
+          id="invite-text-output"
+          class="config-json-textarea"
+          readonly
+          spellcheck="false"
+        ></textarea>
+        <div class="modal-actions">
+          <button class="btn-cancel" onclick="closeInviteModal()">Done</button>
+          <button class="btn-confirm" onclick="copyInviteText()">
+            COPY MESSAGE
+          </button>
+        </div>
       </div>
+    </div>
 
-      <!-- RESET PASSWORD -->
-      <div id="auth-screen-reset" class="auth-screen" style="display:none">
-        <h2 class="auth-screen-title">SET NEW PASSWORD</h2>
-        <p class="auth-screen-subtitle">Choose a new password for your account</p>
-        <div class="auth-field">
-          <input type="password" id="reset-password" placeholder="New password" autocomplete="new-password" aria-describedby="reset-error"/>
-        </div>
-        <div class="auth-field">
-          <input type="password" id="reset-confirm" placeholder="Confirm new password" autocomplete="new-password" aria-describedby="reset-error"/>
-        </div>
-        <div class="auth-error" id="reset-error"></div>
-        <button class="auth-submit-btn" id="reset-submit-btn" onclick="handleResetPassword()">Set Password</button>
+    <!-- MENU PICKER OVERLAY -->
+    <div id="menu-picker-overlay">
+      <div
+        class="picker-box"
+        role="dialog"
+        aria-modal="true"
+        aria-label="Select a Menu"
+      >
+        <h2 class="picker-title" id="picker-title">SELECT A MENU</h2>
+        <p class="picker-subtitle" id="picker-subtitle">
+          Choose which menu to view
+        </p>
+        <div id="picker-menu-list" class="picker-menu-list"></div>
       </div>
-
     </div>
-    <button class="pin-cancel" onclick="closeAuthOverlay()">Cancel</button>
-  </div>
-</div>
 
-<!-- CONFIG JSON MODAL -->
-<div class="modal-bg" id="config-modal-bg">
-  <div class="modal">
-    <h2>UPDATE CONFIG FILE</h2>
-    <div class="modal-sub">Copy this into <code>lib/config/notifications.json</code> and reload the page.</div>
-    <textarea id="config-json-output" class="config-json-textarea" readonly spellcheck="false"></textarea>
-    <div class="modal-actions">
-      <button class="btn-cancel" onclick="closeConfigModal()">Done</button>
-      <button class="btn-confirm" onclick="copyConfigJson()">COPY JSON</button>
-    </div>
-  </div>
-</div>
+    <div
+      class="toast"
+      id="toast"
+      role="status"
+      aria-live="polite"
+      aria-atomic="true"
+    ></div>
 
-<!-- PREVIEW MODAL -->
-<div class="modal-bg" id="modal-bg">
-  <div class="modal">
-    <h2>PATCH NOTES PREVIEW</h2>
-    <div class="modal-sub">Only changes since the last update will be sent.</div>
-    <div id="preview-content"></div>
-    <div class="modal-actions">
-      <button class="btn-cancel" onclick="closeModal()">Cancel</button>
-      <button class="btn-confirm" id="confirm-btn" onclick="sendUpdate()">SEND UPDATE</button>
-    </div>
-  </div>
-</div>
-
-<!-- INVITE MODAL -->
-<div class="modal-bg" id="invite-modal-bg">
-  <div class="modal">
-    <h2>INVITE STAFF</h2>
-    <div class="modal-sub">Copy this message and send it to new staff members.</div>
-    <textarea id="invite-text-output" class="config-json-textarea" readonly spellcheck="false"></textarea>
-    <div class="modal-actions">
-      <button class="btn-cancel" onclick="closeInviteModal()">Done</button>
-      <button class="btn-confirm" onclick="copyInviteText()">COPY MESSAGE</button>
-    </div>
-  </div>
-</div>
-
-<!-- MENU PICKER OVERLAY -->
-<div id="menu-picker-overlay">
-  <div class="picker-box" role="dialog" aria-modal="true" aria-label="Select a Menu">
-    <h2 class="picker-title" id="picker-title">SELECT A MENU</h2>
-    <p class="picker-subtitle" id="picker-subtitle">Choose which menu to view</p>
-    <div id="picker-menu-list" class="picker-menu-list"></div>
-  </div>
-</div>
-
-<div class="toast" id="toast" role="status" aria-live="polite" aria-atomic="true"></div>
-
-<script src="/elroyscantina/app.js"></script>
-<script src="/app.js"></script>
-</body>
+    <script src="/elroyscantina/app.js"></script>
+    <script src="/app.js"></script>
+  </body>
 </html>

--- a/elroyscantina/style.css
+++ b/elroyscantina/style.css
@@ -685,7 +685,7 @@ body.route-restaurant.route-restaurant--elroy {
 
   #restaurant-site-wrapper .erc-brand-group {
     flex-wrap: wrap;
-    gap: 0.75rem;
+    gap: 0.4rem 0.75rem;
   }
 
   #restaurant-site-wrapper .erc-brand {
@@ -698,13 +698,12 @@ body.route-restaurant.route-restaurant--elroy {
   }
 
   #restaurant-site-wrapper .erc-item-row {
-    flex-direction: column;
-    align-items: flex-start;
-    gap: 0.25rem;
+    flex-wrap: wrap;
+    gap: 0.15rem 1rem;
   }
 
   #restaurant-site-wrapper .erc-topbar-inner {
-    gap: 0.75rem;
+    gap: 0.5rem;
   }
 
   #restaurant-site-wrapper .erc-menu-toggle,
@@ -723,12 +722,20 @@ body.route-restaurant.route-restaurant--elroy {
     padding: 0.55rem 0.85rem;
   }
 
+  #restaurant-site-wrapper .erc-main {
+    padding-top: 2rem;
+  }
+
   #restaurant-site-wrapper .erc-title {
-    font-size: clamp(3rem, 18vw, 4.75rem);
+    font-size: clamp(2.8rem, 15vw, 4.25rem);
+  }
+
+  #restaurant-site-wrapper .erc-hero {
+    margin-bottom: 2.5rem;
   }
 
   #restaurant-site-wrapper .erc-section {
-    margin-bottom: 3rem;
+    margin-bottom: 2.5rem;
   }
 
   #restaurant-site-wrapper .erc-footer-main {
@@ -778,7 +785,7 @@ body.route-restaurant.route-restaurant--elroy {
   }
 
   #restaurant-site-wrapper .erc-page.is-mobile-compact .erc-hero {
-    margin-bottom: 3rem;
+    margin-bottom: 2rem;
   }
 }
 

--- a/elroyscantina/style.css
+++ b/elroyscantina/style.css
@@ -697,6 +697,10 @@ body.route-restaurant.route-restaurant--elroy {
     padding-left: 0.75rem;
   }
 
+  #restaurant-site-wrapper .erc-sister-badge {
+    height: 2rem;
+  }
+
   #restaurant-site-wrapper .erc-item-row {
     flex-wrap: wrap;
     gap: 0.15rem 1rem;
@@ -720,6 +724,15 @@ body.route-restaurant.route-restaurant--elroy {
 
   #restaurant-site-wrapper .erc-login-btn {
     padding: 0.55rem 0.85rem;
+  }
+
+  #restaurant-site-wrapper .erc-section-title {
+    font-size: 1.3rem;
+    letter-spacing: 0.08em;
+  }
+
+  #restaurant-site-wrapper .erc-section-line {
+    min-width: 2rem;
   }
 
   #restaurant-site-wrapper .erc-main {

--- a/leroyslounge/app.js
+++ b/leroyslounge/app.js
@@ -106,6 +106,53 @@
       });
   }
 
+  function createLegacyRouteActions(sharedState) {
+    return {
+      closeDropdowns: () => window.closeRouteDropdowns?.(),
+      openManager: () => window.onActionBtnClick?.(),
+      openAdmin: () => window.onAdminBtnClick?.(),
+      canManageMenu: (menuId, user = sharedState.currentUser) => (
+        typeof window.currentUserCanManageMenu === 'function'
+          ? window.currentUserCanManageMenu(menuId, user)
+          : ((user?.role || 'none') === 'admin')
+      ),
+      switchMenu: async menu => {
+        if (!menu?.id) return { ok: false, userHandled: true };
+        window.selectMenu?.(menu.id, menu.slug, menu.name, menu.type, menu.restaurantId);
+        const targetHref = window.getPublicHrefForCurrentMenu?.();
+        const currentHref = `${window.location.pathname}${window.location.search}`;
+        if (targetHref && targetHref !== currentHref) {
+          window.navigateToPage?.(targetHref);
+          return { ok: true, navigated: true, targetHref };
+        }
+        await window.loadActiveMenuState?.();
+        if (typeof window.applyDesign === 'function' && typeof currentDesign !== 'undefined') {
+          window.applyDesign(currentDesign);
+        }
+        await window.renderPublicViews?.();
+        return { ok: true, navigated: false };
+      },
+    };
+  }
+
+  function resolveRouteContract(contractOrMenuState, legacyState) {
+    if (contractOrMenuState?.snapshot && contractOrMenuState?.actions) return contractOrMenuState;
+    const snapshot = {
+      menuState: contractOrMenuState,
+      ...(legacyState || {}),
+    };
+    return {
+      version: 0,
+      snapshot,
+      helpers: {
+        escHtml: typeof window.escHtml === 'function' ? window.escHtml : esc,
+        formatUpdatedAt: typeof window.formatUpdatedAt === 'function' ? window.formatUpdatedAt : (() => ''),
+        getMenuTypeLabel: typeof window.getMenuTypeLabel === 'function' ? window.getMenuTypeLabel : (value => value || ''),
+      },
+      actions: createLegacyRouteActions(snapshot),
+    };
+  }
+
   function updateToggleState(sharedState) {
     document.querySelectorAll('[data-route-menu-toggle]').forEach(button => {
       const isActive = button.getAttribute('data-route-menu-toggle') === sharedState.menuType;
@@ -114,22 +161,21 @@
     });
   }
 
-  function renderSettingsDropdown(sharedState) {
+  function renderSettingsDropdown(contract) {
+    const sharedState = contract.snapshot;
     const wrapper = document.querySelector('[data-route-settings]');
     const dropdown = document.getElementById('ll-route-settings-dropdown');
     if (!wrapper || !dropdown) return;
 
     const role = sharedState.currentUser?.role || 'none';
-    const canManageCurrentMenu = typeof window.currentUserCanManageMenu === 'function'
-      ? window.currentUserCanManageMenu(sharedState.menuId, sharedState.currentUser)
-      : (role === 'admin');
+    const canManageCurrentMenu = contract.actions.canManageMenu(sharedState.menuId, sharedState.currentUser);
     const options = [];
 
     if (canManageCurrentMenu) {
-      options.push({ label: 'Manager', icon: 'tune', onClick: () => window.onActionBtnClick?.() });
+      options.push({ label: 'Manager', icon: 'tune', onClick: () => contract.actions.openManager?.() });
     }
     if (role === 'admin') {
-      options.push({ label: 'Admin', icon: 'shield_person', onClick: () => window.onAdminBtnClick?.() });
+      options.push({ label: 'Admin', icon: 'shield_person', onClick: () => contract.actions.openAdmin?.() });
     }
 
     wrapper.style.display = options.length ? '' : 'none';
@@ -142,13 +188,14 @@
 
     dropdown.querySelectorAll('[data-route-settings-option]').forEach((button, index) => {
       button.onclick = () => {
-        window.closeRouteDropdowns?.();
+        contract.actions.closeDropdowns?.();
         options[index]?.onClick?.();
       };
     });
   }
 
-  function renderSwapDropdown(sharedState) {
+  function renderSwapDropdown(contract) {
+    const sharedState = contract.snapshot;
     const dropdown = document.getElementById('ll-route-swap-dropdown');
     const trigger = document.getElementById('ll-route-swap-trigger');
     if (!dropdown || !trigger) return;
@@ -159,7 +206,7 @@
       const isActive = menu.id === sharedState.menuId;
       return `
         <button class="ll-board-route-option${isActive ? ' is-active' : ''}" type="button" data-route-menu-option="${esc(menu.id)}">
-          <span class="ll-board-route-option-label">${esc((window.getMenuTypeLabel?.(menu.type) || menu.type || '').toUpperCase())}</span>
+          <span class="ll-board-route-option-label">${esc((contract.helpers.getMenuTypeLabel?.(menu.type) || menu.type || '').toUpperCase())}</span>
           <span class="material-symbols-outlined ll-board-route-option-icon" aria-hidden="true">${menu.type === 'food' ? 'restaurant_menu' : 'sports_bar'}</span>
         </button>
       `;
@@ -170,42 +217,21 @@
         const menuId = button.getAttribute('data-route-menu-option') || '';
         const menu = menus.find(entry => entry.id === menuId);
         if (!menu) return;
-        window.closeRouteDropdowns?.();
-        window.selectMenu?.(menu.id, menu.slug, menu.name, menu.type, menu.restaurantId);
-
-        const targetHref = window.getPublicHrefForCurrentMenu?.();
-        const currentHref = `${window.location.pathname}${window.location.search}`;
-        if (targetHref && targetHref !== currentHref) {
-          window.navigateToPage?.(targetHref);
-          return;
-        }
-
-        await window.loadActiveMenuState?.();
-        window.applyDesign?.(typeof currentDesign !== 'undefined' ? currentDesign : null);
-        window.renderPublicViews?.();
+        contract.actions.closeDropdowns?.();
+        await contract.actions.switchMenu(menu);
       };
     });
   }
 
-  function bindMenuToggles(sharedState) {
+  function bindMenuToggles(contract) {
+    const sharedState = contract.snapshot;
     const menus = getMenusForRoute(sharedState);
     document.querySelectorAll('[data-route-menu-toggle]').forEach(button => {
       button.onclick = async () => {
         const targetType = button.getAttribute('data-route-menu-toggle');
         const menu = menus.find(entry => entry.type === targetType);
         if (!menu || menu.id === sharedState.menuId) return;
-
-        window.selectMenu?.(menu.id, menu.slug, menu.name, menu.type, menu.restaurantId);
-        const targetHref = window.getPublicHrefForCurrentMenu?.();
-        const currentHref = `${window.location.pathname}${window.location.search}`;
-        if (targetHref && targetHref !== currentHref) {
-          window.navigateToPage?.(targetHref);
-          return;
-        }
-
-        await window.loadActiveMenuState?.();
-        window.applyDesign?.(typeof currentDesign !== 'undefined' ? currentDesign : null);
-        window.renderPublicViews?.();
+        await contract.actions.switchMenu(menu);
       };
     });
 
@@ -340,23 +366,18 @@
     return true;
   }
 
-  window.renderRouteBootShell = renderBootShell;
-
-  window.initializeRoute = function initializeRoute(menuState, authState) {
+  function renderRoute(contractOrMenuState, legacyState) {
+    const contract = resolveRouteContract(contractOrMenuState, legacyState);
+    const sharedState = contract.snapshot;
     const template = document.getElementById('leroy-route-template');
     const container = document.getElementById('restaurant-site-wrapper');
     if (!template || !container) return false;
-
-    const sharedState = {
-      menuState,
-      ...authState,
-    };
 
     container.innerHTML = '';
     container.appendChild(template.content.cloneNode(true));
 
     const timestamp = sharedState.lastUpdatedTs
-      ? (window.formatUpdatedAt?.(sharedState.lastUpdatedTs, '') || '')
+      ? (contract.helpers.formatUpdatedAt?.(sharedState.lastUpdatedTs, '') || '')
       : 'Awaiting first update';
 
     const menuNameEl = document.getElementById('ll-route-menu-name');
@@ -387,11 +408,26 @@
     }
 
     renderHeaderState(sharedState);
-    renderSwapDropdown(sharedState);
-    renderSettingsDropdown(sharedState);
-    bindMenuToggles(sharedState);
+    renderSwapDropdown(contract);
+    renderSettingsDropdown(contract);
+    bindMenuToggles(contract);
     bindMobileHeader(container.querySelector('.ll-board-page'));
 
     return true;
+  }
+
+  const renderer = {
+    restaurantId: '00000000-0000-0000-0000-000000000010',
+    boot: renderBootShell,
+    render: renderRoute,
   };
+
+  if (typeof window.registerPublicRouteRenderer === 'function') {
+    window.registerPublicRouteRenderer(renderer);
+  } else {
+    window.__pendingPublicRouteRenderer = renderer;
+  }
+
+  window.renderRouteBootShell = renderBootShell;
+  window.initializeRoute = renderRoute;
 })();

--- a/leroyslounge/style.css
+++ b/leroyslounge/style.css
@@ -42,10 +42,24 @@ body.route-restaurant.route-restaurant--leroy {
 }
 
 #restaurant-site-wrapper .ll-board-page {
+  /* Light-theme vars must live on .ll-board-page so they outweigh the
+     duplicate block in the shared style.css at the same specificity
+     (style.css ~L345). Dark-mode values are set at the bottom of this
+     file inside the prefers-color-scheme media query. */
+  --ll-board-bg: rgb(125 127 124 / 1);
+  --ll-board-frame: rgb(65 0 0 / 0.95);
+  --ll-board-line: rgb(17 24 39 / 0.28);
+  --ll-board-ink: rgb(17 24 39 / 1);
+  --ll-board-ink-muted: rgb(17 24 39 / 0.72);
+  --ll-board-red: rgb(211 11 11 / 1);
+  --ll-board-red-dark: rgb(125 6 6 / 1);
+  --ll-board-pill-bg: rgb(17 24 39 / 0.08);
+  --ll-board-pill-border: rgb(17 24 39 / 0.22);
+  color-scheme: light;
   min-height: 100vh;
   min-height: 100dvh;
   background: var(--ll-board-surface);
-  color: rgb(229 226 225 / 1);
+  color: var(--ll-board-ink);
   font-family: 'Work Sans', sans-serif;
   display: flex;
   flex-direction: column;

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,10 @@
+{
+  "version": 1,
+  "skills": {
+    "improve-codebase-architecture": {
+      "source": "mattpocock/skills",
+      "sourceType": "github",
+      "computedHash": "76d07c4c0bebc162cc76ca7494bfe7a90e279f35832f7ce6dfc4ce16518fd560"
+    }
+  }
+}

--- a/style.css
+++ b/style.css
@@ -3283,12 +3283,12 @@ body.manager-stitch-shell .manager-shell-actionbar {
     "copy groups"
     "status groups";
   align-items: center;
-  gap: 8px 18px;
-  padding: 12px 16px;
+  gap: 6px 14px;
+  padding: 10px 14px;
   background: var(--manager-shell-actionbar-bg);
   border: 1px solid var(--manager-shell-border);
-  border-radius: 24px;
-  box-shadow: 0 18px 38px var(--manager-shell-shadow-strong);
+  border-radius: 22px;
+  box-shadow: 0 16px 32px var(--manager-shell-shadow-strong);
   backdrop-filter: blur(18px);
   overscroll-behavior: contain;
 }
@@ -3296,10 +3296,10 @@ body.manager-stitch-shell .manager-shell-actionbar {
 body.manager-stitch-shell .manager-shell-actionbar-copy {
   grid-area: copy;
   min-width: 0;
-  max-width: 19rem;
+  max-width: 16.5rem;
   display: flex;
   flex-direction: column;
-  gap: 2px;
+  gap: 1px;
 }
 
 body.manager-stitch-shell .manager-shell-actionbar-groups {
@@ -3307,7 +3307,7 @@ body.manager-stitch-shell .manager-shell-actionbar-groups {
   display: flex;
   align-items: center;
   justify-content: flex-end;
-  gap: 12px;
+  gap: 10px;
   flex-wrap: nowrap;
   align-self: center;
 }
@@ -3325,12 +3325,12 @@ body.manager-stitch-shell .manager-shell-actionbar-primary {
 
 body.manager-stitch-shell .save-btn,
 body.manager-stitch-shell .send-btn {
-  min-height: 46px;
-  padding: 0 18px;
+  min-height: 44px;
+  padding: 0 16px;
   border-radius: 2px;
-  font-size: 12px;
+  font-size: 11px;
   font-weight: 800;
-  letter-spacing: 0.12em;
+  letter-spacing: 0.1em;
   text-transform: uppercase;
 }
 
@@ -3343,8 +3343,8 @@ body.manager-stitch-shell .manager-shell-actionbar .workspace-actions-title {
 
 body.manager-stitch-shell .manager-shell-actionbar .workspace-actions-sub {
   margin-top: 0;
-  font-size: 13px;
-  line-height: 1.35;
+  font-size: 12px;
+  line-height: 1.3;
 }
 
 body.manager-stitch-shell #sync-status {
@@ -5474,7 +5474,7 @@ body.manager-stitch-shell .del-item {
 
 @media (max-width: 920px) {
   body.manager-stitch-shell {
-    padding-bottom: calc(214px + env(safe-area-inset-bottom));
+    padding-bottom: calc(182px + env(safe-area-inset-bottom));
   }
 
   body.manager-stitch-shell .manager-shell-actionbar {
@@ -5484,15 +5484,19 @@ body.manager-stitch-shell .del-item {
     left: 10px;
     right: 10px;
     bottom: calc(10px + env(safe-area-inset-bottom));
-    gap: 10px;
-    padding: 9px 11px calc(9px + env(safe-area-inset-bottom));
-    border-radius: 22px;
+    gap: 8px;
+    padding: 8px 10px calc(8px + env(safe-area-inset-bottom));
+    border-radius: 20px;
     border: 1px solid var(--manager-shell-border);
   }
 
   body.manager-stitch-shell .manager-shell-actionbar-copy {
     max-width: none;
-    gap: 1px;
+    gap: 0;
+  }
+
+  body.manager-stitch-shell .manager-shell-actionbar-copy .workspace-actions-title {
+    display: none;
   }
 
   body.manager-stitch-shell .manager-shell-actionbar-copy .workspace-actions-title {
@@ -5504,8 +5508,8 @@ body.manager-stitch-shell .del-item {
     max-width: none;
     display: block;
     overflow: hidden;
-    font-size: 11px;
-    line-height: 1.35;
+    font-size: 10.5px;
+    line-height: 1.25;
     white-space: nowrap;
     text-overflow: ellipsis;
   }
@@ -5514,7 +5518,7 @@ body.manager-stitch-shell .del-item {
     width: 100%;
     flex-direction: column;
     align-items: stretch;
-    gap: 8px;
+    gap: 6px;
   }
 
   body.manager-stitch-shell .manager-shell-actionbar-featured,
@@ -5522,7 +5526,7 @@ body.manager-stitch-shell .del-item {
     width: 100%;
     display: grid;
     grid-template-columns: repeat(2, minmax(0, 1fr));
-    gap: 8px;
+    gap: 6px;
   }
 
   body.manager-stitch-shell .manager-shell-actionbar-featured .btn-small,
@@ -5530,10 +5534,10 @@ body.manager-stitch-shell .del-item {
   body.manager-stitch-shell .manager-shell-actionbar-primary .send-btn {
     width: 100%;
     min-width: 0;
-    min-height: 44px;
-    padding: 0 14px;
-    font-size: 10px;
-    letter-spacing: 0.08em;
+    min-height: 42px;
+    padding: 0 12px;
+    font-size: 9.5px;
+    letter-spacing: 0.06em;
     line-height: 1.25;
     white-space: normal;
     text-align: center;
@@ -5544,7 +5548,7 @@ body.manager-stitch-shell .del-item {
   }
 
   body.manager-stitch-shell .toast {
-    bottom: calc(196px + env(safe-area-inset-bottom));
+    bottom: calc(166px + env(safe-area-inset-bottom));
   }
 
   body.manager-stitch-shell .manager-shell-stats-grid {
@@ -5716,26 +5720,26 @@ body.manager-stitch-shell .del-item {
 
 @media (max-width: 520px) {
   body.manager-stitch-shell {
-    padding-bottom: calc(198px + env(safe-area-inset-bottom));
+    padding-bottom: calc(168px + env(safe-area-inset-bottom));
   }
 
   body.manager-stitch-shell .manager-shell-actionbar {
     left: 8px;
     right: 8px;
     bottom: calc(8px + env(safe-area-inset-bottom));
-    padding: 8px 9px calc(8px + env(safe-area-inset-bottom));
+    padding: 7px 8px calc(7px + env(safe-area-inset-bottom));
   }
 
   body.manager-stitch-shell .manager-shell-actionbar-featured,
   body.manager-stitch-shell .manager-shell-actionbar-primary {
-    gap: 6px;
+    gap: 5px;
   }
 
   body.manager-stitch-shell .manager-shell-actionbar-featured .btn-small,
   body.manager-stitch-shell .manager-shell-actionbar-primary .save-btn,
   body.manager-stitch-shell .manager-shell-actionbar-primary .send-btn {
-    min-height: 44px;
-    font-size: 10px;
+    min-height: 40px;
+    font-size: 9px;
   }
 
   body.manager-stitch-shell .item-name input,

--- a/style.css
+++ b/style.css
@@ -5769,6 +5769,311 @@ body.manager-stitch-shell .del-item {
   }
 }
 
+/* 10. Manager edit-section pass */
+body.manager-stitch-shell #manager-items-section .current-items,
+body.manager-stitch-shell #manager-pricing-section .current-items,
+body.manager-stitch-shell #manager-description-section .current-items {
+  gap: 10px;
+}
+
+body.manager-stitch-shell #manager-items-section .items-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px;
+  padding: 14px 16px;
+  border: 1px solid var(--manager-shell-border);
+  border-radius: 18px;
+  background: var(--manager-shell-surface);
+}
+
+body.manager-stitch-shell #manager-items-section .item-row-main {
+  min-width: 0;
+  display: grid;
+  grid-template-columns: auto auto minmax(0, 1fr);
+  align-items: center;
+  gap: 10px 12px;
+}
+
+body.manager-stitch-shell #manager-items-section .item-drag-handle {
+  width: 32px;
+  min-height: 44px;
+  border: 1px dashed var(--manager-shell-border);
+  border-radius: 12px;
+  background: var(--manager-shell-surface-muted);
+}
+
+body.manager-stitch-shell #manager-items-section .item-name {
+  flex: 0 1 auto;
+  min-width: 0;
+}
+
+body.manager-stitch-shell #manager-items-section .item-name input {
+  min-height: 44px;
+  padding: 0 14px;
+  border: 1px solid var(--manager-shell-border);
+  border-radius: 14px;
+  background: var(--manager-shell-surface-muted);
+}
+
+body.manager-stitch-shell #manager-items-section .item-actions-compact {
+  margin-left: 0;
+  gap: 8px;
+}
+
+body.manager-stitch-shell #manager-items-section .items-row.is-eighty-sixed,
+body.manager-stitch-shell #manager-pricing-section .pricing-row.is-eighty-sixed {
+  background: rgba(186, 26, 26, 0.04);
+  border-color: rgba(186, 26, 26, 0.16);
+}
+
+body.manager-stitch-shell #manager-items-section .items-row.is-off-menu {
+  background: var(--manager-shell-surface-muted);
+}
+
+body.manager-stitch-shell #manager-pricing-section .pricing-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  align-items: center;
+  gap: 14px 16px;
+  padding: 16px 18px;
+  border: 1px solid var(--manager-shell-border);
+  border-radius: 20px;
+  background: var(--manager-shell-surface);
+}
+
+body.manager-stitch-shell #manager-pricing-section .pricing-row-main {
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+body.manager-stitch-shell #manager-pricing-section .pricing-row-title {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+  min-width: 0;
+}
+
+body.manager-stitch-shell #manager-pricing-section .pricing-row-meta {
+  margin: 0;
+  color: var(--manager-shell-muted);
+  font-size: 12px;
+  line-height: 1.4;
+}
+
+body.manager-stitch-shell #manager-pricing-section .pricing-row-controls {
+  display: flex;
+  align-items: flex-end;
+  gap: 10px;
+  flex-shrink: 0;
+}
+
+body.manager-stitch-shell #manager-pricing-section .pricing-inline-field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  min-width: 96px;
+}
+
+body.manager-stitch-shell #manager-pricing-section .pricing-inline-label {
+  color: var(--manager-shell-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+body.manager-stitch-shell #manager-pricing-section .price-input {
+  width: 96px;
+  min-height: 44px;
+  padding: 0 12px;
+  border: 1px solid var(--manager-shell-border);
+  border-radius: 14px;
+  background: var(--manager-shell-surface-muted);
+}
+
+body.manager-stitch-shell #manager-pricing-section .upcharge-toggle-btn {
+  min-height: 44px;
+  padding: 0 14px;
+  border-radius: 14px;
+  gap: 8px;
+}
+
+body.manager-stitch-shell #manager-pricing-section .upcharge-toggle-label {
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+}
+
+body.manager-stitch-shell #manager-pricing-section .upcharges-summary,
+body.manager-stitch-shell #manager-pricing-section .upcharges-panel {
+  margin-top: -8px;
+  border-radius: 0 0 18px 18px;
+}
+
+body.manager-stitch-shell #manager-pricing-section .upcharges-summary {
+  padding: 0 18px 14px;
+  background: transparent;
+  border: 0;
+}
+
+body.manager-stitch-shell #manager-pricing-section .upcharges-panel {
+  padding: 12px 18px 16px;
+  background: var(--manager-shell-surface-muted);
+}
+
+body.manager-stitch-shell #manager-pricing-section .upcharge-row,
+body.manager-stitch-shell #manager-pricing-section .upcharge-add-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) 96px auto;
+  gap: 8px;
+  align-items: center;
+}
+
+body.manager-stitch-shell #manager-pricing-section .upcharge-add-row {
+  margin-top: 10px;
+  padding-top: 10px;
+}
+
+body.manager-stitch-shell #manager-description-section .description-editor-card {
+  border-radius: 20px;
+}
+
+body.manager-stitch-shell #manager-description-section .desc-row-header {
+  padding: 16px 18px;
+  gap: 12px;
+}
+
+body.manager-stitch-shell #manager-description-section .desc-row-title .item-name-static {
+  font-size: 18px;
+  line-height: 1.1;
+}
+
+body.manager-stitch-shell #manager-description-section .desc-row-meta {
+  max-width: 42ch;
+}
+
+body.manager-stitch-shell #manager-description-section .desc-edit-body {
+  padding: 16px;
+}
+
+body.manager-stitch-shell #manager-description-section .desc-field-block,
+body.manager-stitch-shell #manager-description-section .recipe-field-block {
+  padding: 14px;
+  border-radius: 16px;
+}
+
+body.manager-stitch-shell #manager-description-section .desc-field-heading {
+  align-items: flex-start;
+}
+
+body.manager-stitch-shell #manager-description-section .recipe-field-block .add-ingredient-area {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 10px;
+}
+
+@media (prefers-color-scheme: dark) {
+  body.manager-stitch-shell #manager-items-section .items-row.is-eighty-sixed,
+  body.manager-stitch-shell #manager-pricing-section .pricing-row.is-eighty-sixed {
+    background: rgba(255, 180, 171, 0.06);
+    border-color: rgba(255, 180, 171, 0.18);
+  }
+}
+
+@media (max-width: 720px) {
+  body.manager-stitch-shell #manager-items-section .items-row {
+    gap: 10px;
+    padding: 12px;
+  }
+
+  body.manager-stitch-shell #manager-items-section .item-row-main {
+    gap: 8px 10px;
+  }
+
+  body.manager-stitch-shell #manager-items-section .item-drag-handle {
+    width: 30px;
+  }
+
+  body.manager-stitch-shell #manager-items-section .item-actions-compact {
+    gap: 6px;
+  }
+
+  body.manager-stitch-shell #manager-pricing-section .pricing-row {
+    grid-template-columns: 1fr;
+    align-items: stretch;
+    gap: 12px;
+    padding: 14px;
+  }
+
+  body.manager-stitch-shell #manager-pricing-section .pricing-row-controls {
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    gap: 8px;
+    align-items: end;
+  }
+
+  body.manager-stitch-shell #manager-pricing-section .pricing-inline-field {
+    min-width: 0;
+  }
+
+  body.manager-stitch-shell #manager-pricing-section .price-input {
+    width: 100%;
+    text-align: left;
+    font-size: 16px;
+  }
+
+  body.manager-stitch-shell #manager-pricing-section .upcharge-row,
+  body.manager-stitch-shell #manager-pricing-section .upcharge-add-row {
+    grid-template-columns: minmax(0, 1fr) 84px auto;
+  }
+
+  body.manager-stitch-shell #manager-description-section .desc-row-header {
+    padding: 14px 16px;
+    gap: 8px;
+  }
+
+  body.manager-stitch-shell #manager-description-section .desc-row-title .item-name-static {
+    font-size: 17px;
+  }
+
+  body.manager-stitch-shell #manager-description-section .desc-indicator {
+    padding: 5px 8px;
+    font-size: 9px;
+  }
+
+  body.manager-stitch-shell #manager-description-section .desc-edit-body {
+    padding: 12px;
+  }
+
+  body.manager-stitch-shell #manager-description-section .desc-field-block,
+  body.manager-stitch-shell #manager-description-section .recipe-field-block {
+    padding: 12px;
+  }
+
+  body.manager-stitch-shell #manager-description-section .desc-field-heading {
+    gap: 8px;
+  }
+
+  body.manager-stitch-shell #manager-description-section .desc-visibility-toggle {
+    width: 100%;
+    justify-content: space-between;
+  }
+
+  body.manager-stitch-shell #manager-description-section .recipe-field-block .add-ingredient-area {
+    grid-template-columns: 1fr;
+  }
+
+  body.manager-stitch-shell #manager-description-section .recipe-field-block .add-ingredient-btn {
+    width: 100%;
+    justify-content: center;
+  }
+}
+
 /* ─── REDUCED MOTION ─────────────────────────────────────────────────────── */
 @media (prefers-reduced-motion: reduce) {
   *, *::before, *::after {

--- a/style.css
+++ b/style.css
@@ -882,8 +882,8 @@
   .config-json-textarea { width: 100%; min-height: 110px; background: var(--surface); border: 1px solid var(--border); border-radius: 9px; color: var(--text); font-family: monospace; font-size: 13px; padding: 12px; resize: none; box-sizing: border-box; margin-top: 4px; }
 
   /* ── TOAST ── */
-  .toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%) translateY(70px); background: var(--card); border: 1px solid var(--border); border-radius: 11px; padding: 12px 18px; font-size: 13px; z-index: 100; transition: transform 0.3s cubic-bezier(0.34,1.56,0.64,1); white-space: nowrap; box-shadow: 0 7px 24px rgba(0,0,0,0.18); color: var(--text); }
-  .toast.show { transform: translateX(-50%) translateY(0); }
+  .toast { position: fixed; bottom: 20px; left: 50%; transform: translateX(-50%) translateY(calc(100% + 16px)); opacity: 0; visibility: hidden; pointer-events: none; background: var(--card); border: 1px solid var(--border); border-radius: 11px; padding: 12px 18px; font-size: 13px; z-index: 100; transition: transform 0.28s cubic-bezier(0.34,1.56,0.64,1), opacity 0.22s ease, visibility 0s linear 0.28s; white-space: normal; line-height: 1.4; box-shadow: 0 7px 24px rgba(0,0,0,0.18); color: var(--text); max-width: min(calc(100vw - 24px), 34rem); text-align: left; }
+  .toast.show { transform: translateX(-50%) translateY(0); opacity: 1; visibility: visible; pointer-events: auto; transition: transform 0.28s cubic-bezier(0.34,1.56,0.64,1), opacity 0.22s ease; }
   .toast.success { border-color: var(--green); color: var(--green); }
   .toast.error { border-color: var(--red); color: var(--red); }
   .toast.warning { border-color: var(--gold); color: var(--gold); }
@@ -3380,6 +3380,7 @@ body.manager-stitch-shell .manager-shell-actionbar-featured .btn-small {
 
 body.manager-stitch-shell .toast {
   bottom: 108px;
+  max-width: min(calc(100vw - 32px), 28rem);
 }
 
 body.manager-stitch-shell .manager-shell-backdrop {
@@ -5083,19 +5084,36 @@ body.manager-stitch-shell .manager-shell-actionbar-status {
 }
 
 @media (max-width: 920px) {
+  body.manager-stitch-shell #app-shell > header.manager-shell-topbar {
+    margin-bottom: 8px;
+    background: transparent;
+    border-bottom: none;
+    box-shadow: none;
+    backdrop-filter: none;
+  }
+
   body.manager-stitch-shell .settings-section {
     scroll-margin-top: 68px;
   }
 
   body.manager-stitch-shell .manager-shell-topbar-inner {
-    width: calc(100% - 24px);
-    min-height: calc(58px + env(safe-area-inset-top));
-    padding: calc(7px + env(safe-area-inset-top)) 0 7px;
+    width: calc(100% - 20px);
+    min-height: 0;
+    margin: calc(8px + env(safe-area-inset-top)) auto 0;
+    padding: 10px 12px;
+    border: 1px solid var(--manager-shell-border);
+    border-radius: 22px;
+    background:
+      radial-gradient(circle at top right, var(--manager-shell-accent-soft), transparent 38%),
+      linear-gradient(135deg, var(--manager-shell-glass-bg), var(--manager-shell-surface-muted));
+    box-shadow: 0 16px 28px var(--manager-shell-shadow);
+    backdrop-filter: blur(18px);
   }
 
   body.manager-stitch-shell .manager-shell-topbar-primary {
     grid-template-columns: minmax(0, 1fr) auto;
-    gap: 8px;
+    gap: 10px;
+    align-items: start;
   }
 
   body.manager-stitch-shell .manager-shell-layout {
@@ -5224,8 +5242,10 @@ body.manager-stitch-shell .manager-shell-actionbar-status {
   }
 
   body.manager-stitch-shell .manager-shell-user-tools {
-    align-items: center;
-    gap: 6px;
+    align-items: flex-start;
+    justify-content: flex-start;
+    gap: 0;
+    flex-direction: row;
   }
 
   body.manager-stitch-shell .manager-shell-header-summary,
@@ -5240,12 +5260,23 @@ body.manager-stitch-shell .manager-shell-actionbar-status {
     border-radius: 12px;
   }
 
+  body.manager-stitch-shell .manager-shell-brand-wrap {
+    display: grid;
+    grid-template-columns: auto minmax(0, 1fr);
+    align-items: start;
+    gap: 10px;
+  }
+
   body.manager-stitch-shell .manager-shell-brand-copy {
-    gap: 2px;
+    gap: 5px;
+    min-width: 0;
   }
 
   body.manager-stitch-shell .manager-shell-brand-row {
     margin-bottom: 0;
+    flex-direction: column;
+    align-items: flex-start;
+    gap: 6px;
   }
 
   body.manager-stitch-shell .manager-shell-brand-mark {
@@ -5254,6 +5285,8 @@ body.manager-stitch-shell .manager-shell-actionbar-status {
 
   body.manager-stitch-shell .manager-shell-header-badges {
     gap: 6px;
+    min-width: 0;
+    max-width: 100%;
   }
 
   body.manager-stitch-shell .header-action-group {
@@ -5265,7 +5298,24 @@ body.manager-stitch-shell .manager-shell-actionbar-status {
   }
 
   body.manager-stitch-shell #app-shell > header h1 {
-    font-size: 1.08rem;
+    font-size: 1.16rem;
+    line-height: 1.02;
+  }
+
+  body.manager-stitch-shell .manager-shell-title-row {
+    align-items: flex-start;
+    gap: 0;
+  }
+
+  body.manager-stitch-shell .manager-shell-title-copy {
+    gap: 4px;
+  }
+
+  body.manager-stitch-shell .manager-shell-header-badge--muted {
+    max-width: min(58vw, 270px);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
   }
 
   body.manager-stitch-shell.settings-drawer-open #app-shell > header.manager-shell-topbar {
@@ -5525,42 +5575,48 @@ body.manager-stitch-shell .del-item {
   }
 
   body.manager-stitch-shell .manager-shell-topbar-inner {
-    width: calc(100% - 18px);
-    min-height: calc(48px + env(safe-area-inset-top));
-    padding: calc(5px + env(safe-area-inset-top)) 0 5px;
+    width: calc(100% - 16px);
+    min-height: 0;
+    margin-top: calc(6px + env(safe-area-inset-top));
+    padding: 8px 10px;
+    border-radius: 18px;
   }
 
   body.manager-stitch-shell .manager-shell-topbar-primary {
-    gap: 6px;
+    gap: 8px;
   }
 
   body.manager-stitch-shell .manager-shell-brand-wrap {
     gap: 8px;
-    align-items: center;
+    align-items: start;
   }
 
   body.manager-stitch-shell .manager-shell-menu-toggle {
-    width: 34px;
-    height: 34px;
-    border-radius: 10px;
+    width: 36px;
+    height: 36px;
+    border-radius: 12px;
   }
 
   body.manager-stitch-shell .manager-shell-brand-copy {
-    gap: 1px;
+    gap: 5px;
   }
 
   body.manager-stitch-shell .manager-shell-header-badges {
-    gap: 4px;
+    gap: 5px;
   }
 
   body.manager-stitch-shell .manager-shell-header-badge {
-    min-height: 18px;
-    padding: 0 6px;
+    min-height: 20px;
+    padding: 0 7px;
     font-size: 8px;
   }
 
+  body.manager-stitch-shell .manager-shell-header-badge--muted {
+    max-width: min(50vw, 190px);
+  }
+
   body.manager-stitch-shell #app-shell > header h1 {
-    font-size: 0.98rem;
+    font-size: 1.08rem;
   }
 
   body.manager-stitch-shell .manager-shell-layout {
@@ -5670,6 +5726,16 @@ body.manager-stitch-shell .del-item {
     grid-column: 2;
     grid-row: 1 / span 3;
     align-self: center;
+  }
+
+  body.manager-stitch-shell .toast {
+    top: calc(env(safe-area-inset-top) + 82px);
+    bottom: auto;
+    max-width: calc(100vw - 20px);
+    padding: 10px 14px;
+    font-size: 12px;
+    border-radius: 12px;
+    box-shadow: 0 12px 28px rgba(0,0,0,0.18);
   }
 }
 

--- a/style.css
+++ b/style.css
@@ -1000,15 +1000,6 @@
   .db-status--ok    { color:var(--green, #27ae60); }
   .db-status--error { color:var(--red); }
 
-  /* ── PREVIEW TOOLBAR ── */
-  #preview-toolbar { position:fixed; right:max(12px, calc(env(safe-area-inset-right) + 6px)); bottom:max(12px, calc(env(safe-area-inset-bottom) + 6px)); z-index:110; display:flex; flex-direction:column; align-items:stretch; background:var(--card); border:1px solid var(--border); border-radius:14px; padding:9px 8px; gap:5px; min-width:84px; box-shadow:0 14px 34px rgba(0,0,0,0.18); }
-  .preview-toolbar-label { font-size:9px; font-weight:700; letter-spacing:1.5px; text-align:center; color:var(--muted); text-transform:uppercase; padding:0 2px 4px; }
-  .preview-toolbar-btn { background:var(--surface); border:1px solid var(--border); border-radius:8px; color:var(--muted); font-size:11px; font-family:var(--font-body); padding:7px 10px; cursor:pointer; text-align:center; transition:all 0.14s; white-space:nowrap; }
-  .preview-toolbar-btn:hover { border-color:var(--ember); color:var(--ember); }
-  .preview-toolbar-btn.active { background:var(--ember); border-color:var(--ember); color:#fff; font-weight:600; box-shadow:0 6px 16px rgba(0,0,0,0.12); }
-  .preview-toolbar-login { color:var(--fire); border-color:var(--fire); }
-  .preview-toolbar-login:hover { background:var(--fire); color:#fff; border-color:var(--fire); }
-  .preview-toolbar-divider { height:1px; background:var(--border); margin:2px 0; }
   .auth-screen-form { display:block; margin:0; }
 
   /* ── DATABASE TAB ── */
@@ -5230,42 +5221,6 @@ body.manager-stitch-shell .manager-shell-actionbar-status {
 
   body.manager-stitch-shell .featured-specials-list {
     gap: 8px;
-  }
-
-  /* Preview toolbar: keep it off primary content on mobile */
-  #preview-toolbar {
-    right: max(8px, calc(env(safe-area-inset-right) + 4px));
-    bottom: max(8px, calc(env(safe-area-inset-bottom) + 4px));
-    left: auto;
-    top: auto;
-    flex-direction: row;
-    align-items: center;
-    justify-content: flex-end;
-    flex-wrap: wrap;
-    max-width: min(calc(100vw - 16px), 312px);
-    padding: 6px;
-    gap: 4px 6px;
-    min-width: 0;
-    border-radius: 12px;
-    border: 1px solid var(--border);
-    box-shadow: 0 12px 28px rgba(0,0,0,0.18);
-  }
-
-  #preview-toolbar .preview-toolbar-label {
-    flex: 1 0 100%;
-    font-size: 8px;
-    letter-spacing: 1.2px;
-    padding: 0 2px;
-    text-align: left;
-  }
-
-  #preview-toolbar .preview-toolbar-btn {
-    padding: 5px 9px;
-    font-size: 10px;
-  }
-
-  #preview-toolbar .preview-toolbar-divider {
-    display: none;
   }
 
   body.manager-stitch-shell .manager-shell-user-tools {

--- a/style.css
+++ b/style.css
@@ -5987,6 +5987,7 @@ body.manager-stitch-shell #manager-description-section .recipe-field-block .add-
 
 @media (max-width: 720px) {
   body.manager-stitch-shell #manager-items-section .items-row {
+    grid-template-columns: 1fr;
     gap: 10px;
     padding: 12px;
   }
@@ -6001,6 +6002,7 @@ body.manager-stitch-shell #manager-description-section .recipe-field-block .add-
 
   body.manager-stitch-shell #manager-items-section .item-actions-compact {
     gap: 6px;
+    justify-content: flex-end;
   }
 
   body.manager-stitch-shell #manager-pricing-section .pricing-row {

--- a/tests/architecture-boundaries.test.cjs
+++ b/tests/architecture-boundaries.test.cjs
@@ -1,0 +1,481 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+
+const {
+  createElement,
+  createFetchResponse,
+  getState,
+  loadAppSandbox,
+  loadScript,
+  setState,
+} = require('./helpers/runtime.cjs');
+
+function setupRouteDom(sandbox, prefix) {
+  const doc = sandbox.document;
+  const pageClass = prefix === 'll' ? '.ll-board-page' : '.erc-page';
+  const templateId = prefix === 'll' ? 'leroy-route-template' : 'elroy-route-template';
+  const menuNameId = prefix === 'll' ? 'll-route-menu-name' : null;
+  const statusTsId = prefix === 'll' ? 'll-route-status-timestamp' : 'erc-route-status-timestamp';
+  const footerTsId = prefix === 'll' ? 'll-route-footer-timestamp' : 'erc-route-footer-timestamp';
+  const footerVersionId = prefix === 'll' ? 'll-route-footer-version' : 'erc-route-footer-version';
+  const specialsId = prefix === 'll' ? 'll-route-specials' : 'erc-route-specials';
+  const sectionsId = prefix === 'll' ? 'll-route-sections' : 'erc-route-sections';
+  const settingsDropdownId = prefix === 'll' ? 'll-route-settings-dropdown' : 'erc-settings-dropdown';
+  const swapDropdownId = prefix === 'll' ? 'll-route-swap-dropdown' : null;
+  const swapTriggerId = prefix === 'll' ? 'll-route-swap-trigger' : null;
+
+  const template = doc._registerElement(templateId, createElement('template', templateId));
+  template.content = {
+    cloneNode() {
+      return createElement('fragment', `${prefix}-fragment`);
+    },
+  };
+
+  const container = doc._registerElement('restaurant-site-wrapper', createElement('div', 'restaurant-site-wrapper'));
+  const page = createElement('main', `${prefix}-page`);
+  container.querySelector = selector => (selector === pageClass ? page : null);
+  container.appendChild = child => child;
+
+  const settingsWrapper = doc._registerSelector('[data-route-settings]', createElement('div', `${prefix}-settings-wrapper`));
+  settingsWrapper.style.display = '';
+  settingsWrapper.querySelectorAll = () => [];
+
+  if (menuNameId) doc._registerElement(menuNameId, createElement('span', menuNameId));
+  doc._registerElement(statusTsId, createElement('span', statusTsId));
+  doc._registerElement(footerTsId, createElement('span', footerTsId));
+  doc._registerElement(footerVersionId, createElement('span', footerVersionId));
+  doc._registerElement(specialsId, createElement('div', specialsId));
+  doc._registerElement(sectionsId, createElement('div', sectionsId));
+  doc._registerElement(settingsDropdownId, createElement('div', settingsDropdownId));
+  if (swapDropdownId) doc._registerElement(swapDropdownId, createElement('div', swapDropdownId));
+  if (swapTriggerId) doc._registerElement(swapTriggerId, createElement('button', swapTriggerId));
+
+  return { page, container, settingsWrapper };
+}
+
+function makeMenuState(itemsByCategory = {}, lastUpdatedTs = '1712705100000') {
+  const state = { _meta: { lastUpdatedTs } };
+  Object.entries(itemsByCategory).forEach(([categoryId, items]) => {
+    state[categoryId] = { items, lastSent: [] };
+  });
+  return state;
+}
+
+test('menu runtime delegates menu session lifecycle calls', async () => {
+  const sandbox = loadAppSandbox();
+  const calls = [];
+  sandbox.location.search = '?menu=leroys-lounge-drinks';
+
+  const runtime = sandbox.createMenuRuntime({
+    lifecycle: {
+      openPageState: async options => {
+        calls.push(['open', options]);
+        return { snapshot: { stage: 'open' } };
+      },
+      refreshPageState: async options => {
+        calls.push(['refresh', options]);
+        return { snapshot: { stage: 'refresh' } };
+      },
+      savePageDraft: async options => {
+        calls.push(['save', options]);
+        return { snapshot: { stage: 'save' } };
+      },
+      publishPageUpdate: async options => {
+        calls.push(['send', options]);
+        return { snapshot: { stage: 'send' } };
+      },
+    },
+  });
+
+  const session = runtime.openPage({ requestedMenuSlug: 'leroys-lounge-drinks' });
+  await session.open({ resolveMenu: true });
+  await session.refresh({ reason: 'poll' });
+  await session.save({ reason: 'manual' });
+  await session.sendUpdate({ preview: { hasChanges: false, diff: [] } });
+
+  assert.equal(calls.length, 4);
+  assert.equal(calls[0][0], 'open');
+  assert.equal(calls[0][1].request.search, '?menu=leroys-lounge-drinks');
+  assert.equal(calls[1][0], 'refresh');
+  assert.equal(calls[2][0], 'save');
+  assert.equal(calls[3][0], 'send');
+});
+
+test('update publisher consolidates send results, persistence, and warnings', async () => {
+  const sandbox = loadAppSandbox();
+  const diff = [
+    {
+      id: 'beer',
+      icon: '🍺',
+      label: 'Beers on Tap',
+      added: ['New Lager'],
+      removed: [],
+      eightySixed: [],
+      restored: [],
+    },
+  ];
+  const patches = [];
+  const persistCalls = [];
+
+  setState(sandbox, {
+    MENU_ID: 'menu-main',
+    _activeMenuName: 'Main Menu',
+    currentUser: { accessToken: 'token-1', uid: 'user-1' },
+    getCachedDiff: () => diff,
+    buildMenuSessionSnapshot: source => ({ source }),
+    snapshotCurrentItemsAsLastSent: () => ({ beer: [] }),
+    getCurrentFeaturedIds: () => ['feature-1'],
+    currentUserCanEditRestaurantSpecials: () => true,
+    getRestaurantSpecialConfig: () => ({ menuIds: ['menu-main', 'menu-sibling'] }),
+    persistState: async options => {
+      persistCalls.push(options);
+      return true;
+    },
+    patchMenuMetaWithCompatibility: async update => {
+      patches.push(['primary', update]);
+      return { downgradedFields: ['last_sent_featured'] };
+    },
+    patchMenuMetaForMenuWithCompatibility: async (menuId, update) => {
+      patches.push([menuId, update]);
+      return { downgradedFields: [] };
+    },
+    syncLocalMenuCache: () => false,
+    logUpdate: async () => false,
+    fetch: async () => createFetchResponse(207, {
+      results: {
+        groupme: 'ok',
+        sms: 'error:500',
+        discord: 'skipped',
+        webhook: 'skipped',
+      },
+    }),
+  });
+
+  const publisher = sandbox.createUpdatePublisher();
+  const result = await publisher.publish();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.notificationStatus.statusCode, 207);
+  assert.equal(persistCalls.length, 1);
+  assert.equal(persistCalls[0].silentFailure, true);
+  assert.ok(result.warnings.some(message => message.includes('Some notification channels failed: SMS.')));
+  assert.ok(result.warnings.some(message => message.includes('legacy metadata compatibility')));
+  assert.ok(result.warnings.some(message => message.includes('local cache')));
+  assert.ok(result.warnings.some(message => message.includes('audit log')));
+  assert.ok(patches.length >= 1);
+});
+
+test('access session service restores sessions and resolves settings access', async () => {
+  const sandbox = loadAppSandbox();
+  const refreshCalls = [];
+  const roleCalls = [];
+  const sessionChanges = [];
+
+  setState(sandbox, {
+    SUPABASE_URL: 'https://example.supabase.co',
+    SUPABASE_ANON_KEY: 'anon-key',
+    applyRole: role => roleCalls.push(role),
+    _scheduleTokenRefresh: expiresAt => refreshCalls.push(expiresAt),
+    sbGetProfile: async token => {
+      sessionChanges.push(['profile', token]);
+      return {
+        role: 'manager',
+        name: 'Taylor',
+        accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'],
+      };
+    },
+    sbRefreshToken: async refreshToken => {
+      sessionChanges.push(['refresh', refreshToken]);
+      return {
+        access_token: 'new-token',
+        refresh_token: 'new-refresh',
+        expires_in: 3600,
+        user: { id: 'user-1', email: 'taylor@example.com' },
+      };
+    },
+  });
+  sandbox.localStorage.setItem('hf_sb_access_token', 'stored-token');
+  sandbox.localStorage.setItem('hf_sb_refresh_token', 'stored-refresh');
+  sandbox.localStorage.setItem('hf_sb_expires_at', String(Date.now() + 60 * 60 * 1000));
+  sandbox.localStorage.setItem('hf_sb_uid', 'user-1');
+  sandbox.localStorage.setItem('hf_sb_email', 'taylor@example.com');
+
+  const service = sandbox.getAccessSessionService();
+  const restored = await service.restoreStoredSession();
+
+  assert.equal(restored.restored, true);
+  assert.equal(restored.source, 'stored-access');
+  assert.equal(getState(sandbox, 'currentUser').name, 'Taylor');
+  assert.equal(getState(sandbox, 'currentUser').role, 'manager');
+  assert.equal(refreshCalls.length, 1);
+  assert.equal(roleCalls[0], 'manager');
+  assert.equal(sessionChanges[0][0], 'profile');
+
+  sandbox.location.hash = '#type=recovery&access_token=recovery-token&refresh_token=recovery-refresh&expires_in=3600';
+  const recovered = await service.handleRecoveryCallback();
+  assert.equal(recovered.handled, true);
+  assert.equal(getState(sandbox, '_recoverySessionData').access_token, 'recovery-token');
+
+  sandbox.location.hash = '';
+  setState(sandbox, { _appPageMode: 'manager' });
+  sandbox.location.search = '?menu=el-roys-cantina-drinks';
+  setState(sandbox, { currentUser: {
+    role: 'manager',
+    accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'],
+  } });
+
+  const decision = sandbox.resolveRequestedSettingsRoute(sandbox.currentUser);
+  assert.equal(decision.kind, 'manager-redirect');
+  assert.equal(decision.targetPath, '/manager?menu=leroys-lounge-drinks');
+
+  setState(sandbox, { _appPageMode: 'admin' });
+  const adminDecision = sandbox.resolveRequestedSettingsRoute(sandbox.currentUser);
+  assert.equal(adminDecision.kind, 'admin-denied');
+});
+
+test('public route contract exposes a stable snapshot and switchMenu action', async () => {
+  const sandbox = loadAppSandbox();
+  const selectedMenus = [];
+  let loadCalls = 0;
+  let renderCalls = 0;
+  let applyCalls = 0;
+
+  setState(sandbox, {
+    RESTAURANT_ID: '00000000-0000-0000-0000-000000000010',
+    MENU_ID: '00000000-0000-0000-0000-000000000020',
+    MENU_TYPE: 'drinks',
+    _activeMenuName: "Leroy's Lounge Drinks",
+    _activeRestaurantName: "Leroy's Lounge",
+    _siteRestaurant: { id: '00000000-0000-0000-0000-000000000010', name: "Leroy's Lounge" },
+    currentUser: { role: 'manager', name: 'Alex', accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'] },
+    menuState: makeMenuState({
+      beer: [{ id: 'beer-1', name: 'Draft Lager', onMenu: true, visibility: 'public' }],
+    }),
+    _featuredGroups: [],
+    currentUserCanEditRestaurantSpecials: () => true,
+    getManagedCategoryDefs: () => [{ id: 'beer', title: 'Beers on Tap', icon: '🍺' }],
+    getLastUpdatedTs: () => '1712705100000',
+    selectMenu: (...args) => {
+      selectedMenus.push(args);
+    },
+    getPublicHrefForCurrentMenu: () => '/leroyslounge?menu=leroys-lounge-drinks',
+    loadActiveMenuState: async () => {
+      loadCalls += 1;
+    },
+    renderPublicViews: async () => {
+      renderCalls += 1;
+    },
+    applyDesign: () => {
+      applyCalls += 1;
+    },
+  });
+  sandbox.location.pathname = '/leroyslounge';
+  sandbox.location.search = '?menu=leroys-lounge-drinks';
+
+  const contract = sandbox.createPublicRouteContract();
+  assert.equal(contract.snapshot.activeMenuName, "Leroy's Lounge Drinks");
+  assert.equal(contract.snapshot.restaurantId, getState(sandbox, 'RESTAURANT_ID'));
+  assert.equal(contract.snapshot.menuId, getState(sandbox, 'MENU_ID'));
+  assert.equal(typeof contract.actions.switchMenu, 'function');
+
+  await contract.actions.switchMenu({
+    id: getState(sandbox, 'MENU_ID'),
+    slug: 'leroys-lounge-drinks',
+    name: "Leroy's Lounge Drinks",
+    type: 'drinks',
+    restaurantId: getState(sandbox, 'RESTAURANT_ID'),
+  });
+
+  assert.equal(selectedMenus.length, 1);
+  assert.equal(loadCalls, 1);
+  assert.equal(renderCalls, 1);
+  assert.equal(applyCalls, 1);
+});
+
+test('restaurant specials service centralizes add, matches, and confirm flows', async () => {
+  const sandbox = loadAppSandbox();
+  const requestCalls = [];
+  const refreshCalls = [];
+
+  setState(sandbox, {
+    MENU_ID: 'menu-main',
+    RESTAURANT_ID: '00000000-0000-0000-0000-000000000010',
+    currentUser: { role: 'manager', accessToken: 'token-1', accessibleMenuIds: ['00000000-0000-0000-0000-000000000020', '00000000-0000-0000-0000-000000000021'] },
+    currentUserCanEditRestaurantSpecials: () => true,
+    persistState: async () => true,
+    _dirty: true,
+    _deletedItemIds: new Set(),
+    menuState: makeMenuState({
+      beer: [{ id: 'beer-1', name: 'Draft Lager', onMenu: true, visibility: 'public' }],
+      __uncategorized__: [{ id: 'pool-1', name: 'Off Menu Special', onMenu: true, visibility: 'off_menu' }],
+    }),
+    _featuredGroups: [
+      {
+        id: 'group-1',
+        name: 'Specials',
+        slots: [
+          { id: 'slot-1', itemId: 'featured-1', item: { id: 'featured-1', name: 'House Spritz', price: '$9', visibility: 'public', eightySixed: false, desc: '', recipe: [], upcharges: [], showDescription: true, showRecipe: false } },
+        ],
+      },
+    ],
+    _restaurantSpecialsSiblingCatalog: [
+      { id: 'sibling-1', name: 'Sibling Special', cat: 'Canned & Bottled', menuId: 'menu-sibling', menuLabel: 'Drinks', onMenu: true, visibility: 'public' },
+    ],
+  });
+
+  const service = sandbox.createRestaurantSpecialsService();
+  service.request = async (action, payload = {}) => {
+    requestCalls.push([action, payload]);
+    return {};
+  };
+  service.refreshForActiveMenu = async () => {
+    refreshCalls.push('refresh');
+    return sandbox._featuredGroups;
+  };
+
+  const matches = service.getMatches('', 'sibling');
+  assert.equal(matches.length, 1);
+  assert.equal(matches[0].id, 'sibling-1');
+
+  const added = await service.addSlot({ itemId: 'beer-1' });
+  assert.equal(added.ok, true);
+  assert.equal(requestCalls[0][0], 'add');
+  assert.equal(refreshCalls.length, 1);
+
+  const confirmed = await service.confirmToday();
+  assert.equal(confirmed.ok, true);
+  assert.equal(sandbox.sessionStorage.getItem('featured_confirmed:00000000-0000-0000-0000-000000000010'), '1');
+  assert.equal(requestCalls[1][0], 'confirm');
+});
+
+test('public route contract and route renderers register and hydrate both restaurant shells', async () => {
+  const routeCases = [
+    {
+      file: path.join(__dirname, '..', 'leroyslounge', 'app.js'),
+      prefix: 'll',
+      restaurantId: '00000000-0000-0000-0000-000000000010',
+      restaurantName: "Leroy's Lounge",
+      menuId: '00000000-0000-0000-0000-000000000020',
+      menuName: "Leroy's Lounge Drinks",
+    },
+    {
+      file: path.join(__dirname, '..', 'elroyscantina', 'app.js'),
+      prefix: 'erc',
+      restaurantId: '00000000-0000-0000-0000-000000000001',
+      restaurantName: "El Roy's Cantina",
+      menuId: '00000000-0000-0000-0000-000000000002',
+      menuName: "El Roy's Cantina Drinks",
+    },
+  ];
+
+  for (const routeCase of routeCases) {
+    const sandbox = loadAppSandbox();
+    const { page, settingsWrapper } = setupRouteDom(sandbox, routeCase.prefix);
+    setState(sandbox, {
+      _siteRestaurant: { id: routeCase.restaurantId, name: routeCase.restaurantName },
+      RESTAURANT_ID: routeCase.restaurantId,
+      MENU_ID: routeCase.menuId,
+      MENU_TYPE: 'drinks',
+      _activeMenuName: routeCase.menuName,
+      _activeRestaurantName: routeCase.restaurantName,
+      _featuredGroups: [
+        {
+          id: 'group-1',
+          name: 'Specials',
+          slots: [
+            {
+              id: 'slot-1',
+              itemId: 'special-1',
+              sellNote: '',
+              item: {
+                id: 'special-1',
+                name: 'House Margarita',
+                price: '$12',
+                visibility: 'public',
+                eightySixed: false,
+                desc: 'Citrus and salt',
+                recipe: ['tequila', 'lime'],
+                upcharges: [],
+                showDescription: true,
+                showRecipe: true,
+              },
+            },
+          ],
+        },
+      ],
+      menuState: makeMenuState({
+        beer: [{ id: 'beer-1', name: 'Draft Beer', price: '$8', onMenu: true, visibility: 'public' }],
+      }),
+      currentUser: { role: 'manager', name: 'Alex', accessibleMenuIds: [routeCase.menuId] },
+      currentUserCanEditRestaurantSpecials: () => true,
+      getManagedCategoryDefs: () => [{ id: 'beer', title: 'Beers on Tap', icon: '🍺' }],
+      getLastUpdatedTs: () => '1712705100000',
+    });
+
+    loadScript(routeCase.file, sandbox);
+
+    const renderer = sandbox.__publicRouteRenderer;
+    assert.ok(renderer, `${routeCase.prefix} renderer did not register`);
+    assert.equal(renderer.restaurantId, routeCase.restaurantId);
+
+    const contract = {
+      snapshot: {
+        activeMenuName: routeCase.menuName,
+        appVersion: getState(sandbox, 'APP_VERSION'),
+        canEditRestaurantSpecials: true,
+        categoryDefs: [{ id: 'beer', title: 'Beers on Tap', icon: '🍺' }],
+        currentUser: getState(sandbox, 'currentUser'),
+        featuredGroups: getState(sandbox, '_featuredGroups'),
+        isPreview: true,
+        knownMenus: [{ id: routeCase.menuId, restaurantId: routeCase.restaurantId, type: 'drinks', name: routeCase.menuName, slug: 'test-slug' }],
+        lastUpdatedTs: '1712705100000',
+        menuId: routeCase.menuId,
+        menuState: getState(sandbox, 'menuState'),
+        menuType: 'drinks',
+        restaurantId: routeCase.restaurantId,
+        restaurantSpecials: getState(sandbox, '_featuredGroups')[0],
+        siteRestaurant: getState(sandbox, '_siteRestaurant'),
+      },
+      helpers: {
+        escHtml: value => String(value || ''),
+        formatUpdatedAt: () => 'Thu, Apr 9 at 7:25 PM',
+        getMenuTypeLabel: value => String(value || ''),
+      },
+      actions: {
+        closeDropdowns() {
+          settingsWrapper.style.display = 'none';
+        },
+        canManageMenu() {
+          return true;
+        },
+        openManager() {},
+        openAdmin() {},
+        switchMenu: async () => ({ ok: true }),
+      },
+    };
+
+    assert.equal(renderer.boot(contract), true);
+    assert.equal(renderer.render(contract), true);
+
+    const footerVersion = sandbox.document.getElementById(
+      routeCase.prefix === 'll' ? 'll-route-footer-version' : 'erc-route-footer-version'
+    );
+    const footerTimestamp = sandbox.document.getElementById(
+      routeCase.prefix === 'll' ? 'll-route-footer-timestamp' : 'erc-route-footer-timestamp'
+    );
+    const menuNameEl = routeCase.prefix === 'll'
+      ? sandbox.document.getElementById('ll-route-menu-name')
+      : null;
+    const featuredWrap = sandbox.document.getElementById(
+      routeCase.prefix === 'll' ? 'll-route-specials' : 'erc-route-specials'
+    );
+
+    assert.match(footerVersion.innerHTML, /v0\.8\.6/);
+    assert.match(footerVersion.innerHTML, /PREVIEW/);
+    assert.equal(footerTimestamp.textContent, 'Thu, Apr 9 at 7:25 PM');
+    if (menuNameEl) assert.equal(menuNameEl.textContent, routeCase.menuName);
+    assert.match(featuredWrap.innerHTML, /House Margarita/);
+    assert.equal(page.classList.contains('is-mobile-expanded') || page.classList.contains('is-mobile-compact'), true);
+  }
+});

--- a/tests/helpers/runtime.cjs
+++ b/tests/helpers/runtime.cjs
@@ -1,0 +1,351 @@
+const fs = require('node:fs');
+const path = require('node:path');
+const vm = require('node:vm');
+
+function createStorage(initial = {}) {
+  const store = new Map(Object.entries(initial));
+  return {
+    getItem(key) {
+      return store.has(key) ? store.get(key) : null;
+    },
+    setItem(key, value) {
+      store.set(String(key), String(value));
+    },
+    removeItem(key) {
+      store.delete(String(key));
+    },
+    clear() {
+      store.clear();
+    },
+    key(index) {
+      return Array.from(store.keys())[index] || null;
+    },
+    get length() {
+      return store.size;
+    },
+  };
+}
+
+function createClassList() {
+  const classes = new Set();
+  return {
+    add(...tokens) {
+      tokens.filter(Boolean).forEach(token => classes.add(token));
+    },
+    remove(...tokens) {
+      tokens.filter(Boolean).forEach(token => classes.delete(token));
+    },
+    toggle(token, force) {
+      if (force === true) {
+        classes.add(token);
+        return true;
+      }
+      if (force === false) {
+        classes.delete(token);
+        return false;
+      }
+      if (classes.has(token)) {
+        classes.delete(token);
+        return false;
+      }
+      classes.add(token);
+      return true;
+    },
+    contains(token) {
+      return classes.has(token);
+    },
+    toString() {
+      return Array.from(classes).join(' ');
+    },
+  };
+}
+
+function createElement(tagName = 'div', id = '') {
+  const attributes = new Map();
+  const element = {
+    id,
+    tagName: String(tagName || 'div').toUpperCase(),
+    innerHTML: '',
+    textContent: '',
+    value: '',
+    hidden: false,
+    className: '',
+    style: {},
+    dataset: {},
+    children: [],
+    classList: createClassList(),
+    appendChild(child) {
+      this.children.push(child);
+      return child;
+    },
+    removeChild(child) {
+      this.children = this.children.filter(entry => entry !== child);
+      return child;
+    },
+    contains() {
+      return false;
+    },
+    closest() {
+      return null;
+    },
+    focus() {},
+    scrollIntoView() {},
+    addEventListener() {},
+    removeEventListener() {},
+    querySelector() {
+      return null;
+    },
+    querySelectorAll() {
+      return [];
+    },
+    setAttribute(name, value) {
+      const stringValue = String(value);
+      attributes.set(name, stringValue);
+      if (name === 'id') this.id = stringValue;
+      if (name === 'class') this.className = stringValue;
+      if (name.startsWith('data-')) {
+        const key = name
+          .slice(5)
+          .replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+        this.dataset[key] = stringValue;
+      }
+    },
+    getAttribute(name) {
+      if (name === 'class') return this.className || '';
+      return attributes.has(name) ? attributes.get(name) : null;
+    },
+    removeAttribute(name) {
+      attributes.delete(name);
+      if (name === 'class') this.className = '';
+      if (name.startsWith('data-')) {
+        const key = name
+          .slice(5)
+          .replace(/-([a-z])/g, (_, char) => char.toUpperCase());
+        delete this.dataset[key];
+      }
+    },
+    cloneNode() {
+      const clone = createElement(tagName, id);
+      clone.innerHTML = this.innerHTML;
+      clone.textContent = this.textContent;
+      clone.value = this.value;
+      clone.hidden = this.hidden;
+      clone.className = this.className;
+      return clone;
+    },
+  };
+
+  return element;
+}
+
+function createDocument() {
+  const byId = new Map();
+  const bySelector = new Map();
+
+  const document = {
+    body: createElement('body', 'body'),
+    documentElement: createElement('html', 'html'),
+    addEventListener() {},
+    removeEventListener() {},
+    createElement(tagName) {
+      return createElement(tagName);
+    },
+    getElementById(id) {
+      if (!byId.has(id)) byId.set(id, createElement('div', id));
+      return byId.get(id);
+    },
+    querySelector(selector) {
+      const entry = bySelector.get(selector);
+      if (Array.isArray(entry)) return entry[0] || null;
+      return entry || null;
+    },
+    querySelectorAll(selector) {
+      const entry = bySelector.get(selector);
+      if (!entry) return [];
+      return Array.isArray(entry) ? entry : [entry];
+    },
+    _registerElement(id, element = createElement('div', id)) {
+      element.id = id;
+      byId.set(id, element);
+      return element;
+    },
+    _registerSelector(selector, entry) {
+      bySelector.set(selector, entry);
+      return entry;
+    },
+    _elementsById: byId,
+    _elementsBySelector: bySelector,
+  };
+
+  return document;
+}
+
+function createFetchResponse(status, body) {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => (typeof body === 'string' ? body : JSON.stringify(body)),
+  };
+}
+
+function createSandbox(overrides = {}) {
+  const document = overrides.document || createDocument();
+  const location = overrides.location || {
+    origin: 'https://example.com',
+    protocol: 'https:',
+    hostname: 'example.com',
+    pathname: '/',
+    search: '',
+    hash: '',
+    assign() {},
+  };
+  const window = {};
+
+  const sandbox = {
+    console,
+    Buffer,
+    Date,
+    JSON,
+    Map,
+    Math,
+    Number,
+    Object,
+    Promise,
+    RegExp,
+    Set,
+    String,
+    URL,
+    URLSearchParams,
+    clearTimeout,
+    document,
+    fetch: async () => createFetchResponse(200, {}),
+    history: {
+      replaceState() {},
+    },
+    localStorage: createStorage(),
+    navigator: {},
+    process: { env: {} },
+    requestAnimationFrame: cb => cb(),
+    self: window,
+    setTimeout,
+    setInterval: () => 0,
+    clearInterval,
+    sessionStorage: createStorage(),
+    window,
+    location,
+  };
+
+  sandbox.globalThis = sandbox;
+  sandbox.window = sandbox;
+  sandbox.document.defaultView = sandbox;
+  sandbox.matchMedia = () => ({
+    matches: false,
+    addEventListener() {},
+    removeEventListener() {},
+    addListener() {},
+    removeListener() {},
+  });
+  sandbox.addEventListener = () => {};
+  sandbox.removeEventListener = () => {};
+  sandbox.window.matchMedia = sandbox.matchMedia;
+  sandbox.window.location = location;
+  sandbox.window.history = sandbox.history;
+  sandbox.window.document = document;
+  sandbox.window.localStorage = sandbox.localStorage;
+  sandbox.window.sessionStorage = sandbox.sessionStorage;
+  sandbox.window.requestAnimationFrame = sandbox.requestAnimationFrame;
+  sandbox.window.setTimeout = setTimeout;
+  sandbox.window.setInterval = sandbox.setInterval;
+  sandbox.window.clearTimeout = clearTimeout;
+  sandbox.window.clearInterval = clearInterval;
+  sandbox.window.console = console;
+  sandbox.window.navigator = sandbox.navigator;
+  sandbox.window.fetch = sandbox.fetch;
+  sandbox.window.URL = URL;
+  sandbox.window.URLSearchParams = URLSearchParams;
+  sandbox.window.Buffer = Buffer;
+  sandbox.window.process = sandbox.process;
+  sandbox.window.globalThis = sandbox;
+  sandbox.window.self = sandbox.window;
+  sandbox.window.addEventListener = sandbox.addEventListener;
+  sandbox.window.removeEventListener = sandbox.removeEventListener;
+
+  Object.assign(sandbox, overrides);
+  sandbox.window = sandbox;
+  sandbox.globalThis = sandbox;
+  sandbox.self = sandbox;
+  sandbox.document.defaultView = sandbox;
+  sandbox.window.location = sandbox.location;
+  sandbox.window.history = sandbox.history;
+  sandbox.window.document = sandbox.document;
+  sandbox.window.localStorage = sandbox.localStorage;
+  sandbox.window.sessionStorage = sandbox.sessionStorage;
+  sandbox.window.requestAnimationFrame = sandbox.requestAnimationFrame;
+  sandbox.window.setTimeout = sandbox.setTimeout;
+  sandbox.window.setInterval = sandbox.setInterval;
+  sandbox.window.clearTimeout = sandbox.clearTimeout;
+  sandbox.window.clearInterval = sandbox.clearInterval;
+  sandbox.window.console = sandbox.console;
+  sandbox.window.navigator = sandbox.navigator;
+  sandbox.window.fetch = sandbox.fetch;
+  sandbox.window.URL = sandbox.URL;
+  sandbox.window.URLSearchParams = sandbox.URLSearchParams;
+  sandbox.window.Buffer = sandbox.Buffer;
+  sandbox.window.process = sandbox.process;
+  sandbox.window.globalThis = sandbox;
+  sandbox.window.self = sandbox;
+  sandbox.window.addEventListener = sandbox.addEventListener;
+  sandbox.window.removeEventListener = sandbox.removeEventListener;
+
+  sandbox.__vmContext = vm.createContext(sandbox);
+  return sandbox;
+}
+
+function loadScript(filePath, sandbox, options = {}) {
+  let source = fs.readFileSync(filePath, 'utf8');
+  if (options.stripInit) {
+    source = source.replace(/\ninit\(\);\s*$/, '\n');
+  }
+  vm.runInContext(source, sandbox.__vmContext, { filename: path.basename(filePath) });
+  return sandbox;
+}
+
+function getState(sandbox, expression) {
+  return vm.runInContext(expression, sandbox.__vmContext);
+}
+
+function setState(sandbox, updates = {}) {
+  Object.entries(updates).forEach(([name, value]) => {
+    sandbox.__testStateValue = value;
+    vm.runInContext(`${name} = globalThis.__testStateValue;`, sandbox.__vmContext);
+    delete sandbox.__testStateValue;
+  });
+  return sandbox;
+}
+
+function loadAppSandbox(overrides = {}) {
+  const sandbox = createSandbox(overrides);
+  loadScript(path.join(__dirname, '..', '..', 'app.js'), sandbox, { stripInit: true });
+  return sandbox;
+}
+
+function loadRouteSandbox(routePath, overrides = {}) {
+  const sandbox = loadAppSandbox(overrides);
+  loadScript(routePath, sandbox);
+  return sandbox;
+}
+
+module.exports = {
+  createClassList,
+  createDocument,
+  createElement,
+  createFetchResponse,
+  createSandbox,
+  createStorage,
+  getState,
+  loadAppSandbox,
+  loadRouteSandbox,
+  loadScript,
+  setState,
+};


### PR DESCRIPTION
## Summary
- land the architecture boundary refactors for menu lifecycle, publish/send, restaurant specials, and the public route renderer contract on the `v0.8.6` release branch
- add a minimal `node:test` harness with boundary coverage for the new runtime services and route contract
- fix the delayed settings-session restore path so the auth overlay closes after recovery succeeds

## Issues Addressed
- #226
- #227
- #228
- #229
- #230

## Test plan
- `node --check app.js`
- `node --test tests/architecture-boundaries.test.cjs`
- manual browser verification for:
  - manager save vs send flows
  - manager/admin access gating on settings routes
  - shared specials behavior across both menus in a restaurant
  - route-owned public menu boot, menu switching, footer metadata, and manager/admin affordances
