### PR TITLE
Fix manager workspace issues and polish auth shell

### DIFF
--- a/.agents/skills/recursive-design-loop/SKILL.md
+++ b/.agents/skills/recursive-design-loop/SKILL.md
@@ -1,1 +1,200 @@
-/Users/lukestiehl/Documents/GitHub/El-Roys-Drink-Menu/.claude/skills/recursive-design-loop/SKILL.md
+---
+name: recursive-design-loop
+description: Run an aggressive recursive design and front-end performance improvement loop against a specific screen on the current branch's Vercel preview deployment. Requires a target screen argument (e.g. /leroyslounge, /manager, /elroyscantina). Use when the user asks for repeated design polish passes, preview-only Playwright audits, recursive UX/performance iteration, or to keep improving a specific page until diminishing returns.
+---
+
+# Recursive Design Loop
+
+Use this skill when the user wants ongoing product refinement of a specific
+screen rather than a single design tweak. The user must specify which screen
+to target (e.g. `/leroyslounge`, `/elroyscantina`, `/manager`, `/admin`, `/`).
+
+## Arguments
+
+- **screen** (required): the route or page to focus on
+  (e.g. `/leroyslounge`, `/elroyscantina`, `/manager`, `/admin`, `/`)
+- **--passes N** (optional): run exactly N code-changing passes after the audit
+  then stop. Omit to pause and ask after every pass.
+
+If the user does not specify a screen, ask which one before proceeding.
+
+## Source Of Truth
+
+- inspect only the Vercel preview deployment for the current branch
+- never use localhost, a local dev server, a local build, or any locally run
+  copy of the site for Playwright inspection
+- derive the preview URL by running `git rev-parse HEAD` to get the commit
+  hash, then `vercel ls` (personal account, no `--scope` needed) and matching
+  the deployment for the current branch
+- each pass is incomplete until you inspect the current preview, implement the
+  pass, run `deploy`, poll until the preview is ready, and inspect the updated
+  preview again
+- if the Vercel preview cannot be reached, check `vercel ls` for build status
+  first — if still building, wait and poll; if errored, surface the error
+  message to the user; only stop and ask if the deployment is ready but still
+  unreachable; never fall back to localhost
+
+## Repo Guardrails
+
+- preserve the zero-dependency architecture
+- preserve the fixed two-restaurant, two-menu model
+- preserve route-owned public pages and shared runtime behavior
+- do not break `Save` vs `Send Update`, draft indicators, 86'd public treatment,
+  footer version output, `PREVIEW` badge behavior, or route-first public boot
+- ask the user before adding a new feature
+- ask the user before making a major design change that materially changes
+  product direction, information architecture, core workflows, or brand
+  character
+
+## Persistent State
+
+All design-loop output for a screen lives in `design-loop/<screen>/`:
+
+- **`design-loop-issues.md`** — living document of open issues. Written fresh
+  after each audit pass. Issues are removed once fixed. Issues are tagged
+  `[CRITICAL]` when they break functionality, cause visible regressions, or
+  significantly degrade the experience. This file is committed to the repo and
+  read at the start of every new session.
+- **`design-loop-log.md`** — append-only full pass report after every pass
+  (audit and code-changing). Gitignored.
+- **Screenshots** — saved to `design-loop/<screen>/` with descriptive names
+  (e.g. `pass1-audit-desktop-light-top.png`). Gitignored.
+
+At session start:
+
+1. Read `design-loop-issues.md` if it exists.
+2. If any `[CRITICAL]` issues are present → skip the audit pass and go
+   straight to the first code-changing pass targeting those issues.
+3. If no critical issues (or no issues file) → run a fresh audit pass and
+   merge new findings into the issues file before proceeding.
+
+## Companion Skills
+
+- `deploy` — mandatory after every code-changing pass (handles verify, commit,
+  and push)
+- `menu-regression-reviewer` — mandatory after any pass that touches behavior,
+  not just visuals
+- `public-route-builder` for route-owned public pages
+- `manager-ui-maintainer` for manager or admin UI work
+- `auth-and-access-guard` for auth, recovery, role, or access changes
+- `supabase-data-maintainer` for menu resolution, hydration, persistence, or
+  live-update changes
+- `release-and-version-agent` when footer metadata or preview badge behavior is
+  in scope
+
+## Pass Audit
+
+### Pass 1 (Audit — no code changes)
+
+1. Find the Vercel preview URL: run `git rev-parse HEAD`, then `vercel ls`,
+   match the deployment for the current branch.
+2. Launch Playwright headed (visible browser) so the user can watch live.
+   Use headless only if the user has opted out of watching or the environment
+   has no display.
+3. Inspect the target screen in all four mode combinations:
+   - desktop light mode
+   - desktop dark mode
+   - mobile light mode
+   - mobile dark mode
+4. **Scroll the full page in every mode.** Scroll in viewport-height increments
+   from top to bottom, pausing to screenshot and evaluate every section. Never
+   rely on the initial viewport alone — do not move on until you have seen
+   every pixel of the page.
+5. Interact with every reachable state: navigation, modals, forms, menus, tabs,
+   drawers, hover, focus, active, disabled, loading, empty, and error states.
+6. Apply the Creative Evaluation Lens (see below) in full.
+7. Document every issue found. Tag `[CRITICAL]` where appropriate.
+8. Write `design-loop-issues.md` (merge with any existing issues).
+9. Append the audit report to `design-loop-log.md`.
+10. Propose what the first code-changing pass will tackle.
+11. In pause-after-every-pass mode: ask for approval before proceeding.
+    With `--passes N`: proceed automatically.
+
+### Code-Changing Passes (Pass 2+)
+
+1. Re-inspect only the modes and states relevant to what this pass will change.
+   Scroll in viewport-height increments — screenshot every section.
+2. Before editing, state:
+   - what you found
+   - what you are changing
+   - why the current state falls short and what the change does for the
+     experience
+3. Make the changes.
+4. Run `deploy`. Use commit message format:
+   `design(<screen>): pass N — <one-line summary>`
+5. Poll `vercel ls` until the deployment status is Ready.
+6. Reinspect the affected modes and states. Compare before vs after.
+7. Confirm the pass improved the experience and did not introduce regressions.
+8. Run `menu-regression-reviewer` if the pass touched any behavioral code.
+9. Update `design-loop-issues.md`: remove issues that are now fixed.
+10. Append the pass report to `design-loop-log.md`.
+11. Plan the next pass based on current state — one pass at a time, never
+    plan all passes upfront.
+12. In pause-after-every-pass mode: ask whether to continue.
+    With `--passes N`: continue automatically until N code-changing passes
+    are complete.
+
+## Creative Evaluation Lens
+
+Apply in full on pass 1 and on any pass where the scope is undecided. On
+targeted passes, keep it in mind — always ask whether the fix is enough or
+whether a bolder move would better serve the experience. The goal is not just
+to correct what is broken but to raise the bar. Suggest what the screen could
+become, not just what needs patching.
+
+- **Feel**: Does this screen feel good? Is there a moment of delight, or does
+  it feel utilitarian and flat? What would make someone say "nice" when they
+  first see it?
+- **Rhythm**: Is there a natural visual rhythm — breathing room between
+  sections, a clear reading flow, a satisfying cadence of weight and
+  whitespace?
+- **Craft details**: Are micro-interactions polished? Do transitions feel
+  intentional? Are borders, shadows, and radii consistent and purposeful, or
+  scattered and arbitrary?
+- **Typography**: Is the type system doing real work — establishing hierarchy,
+  creating personality, guiding the eye — or is it just "text at different
+  sizes"?
+- **Color and contrast**: Does the palette feel cohesive and intentional in
+  both light and dark modes? Are there muddy grays, clashing tones, or
+  contrast dead zones?
+- **Spatial logic**: Does the layout reward scanning? Can a user orient
+  themselves instantly? Is information density appropriate for the context?
+- **Responsiveness**: Does the mobile version feel native and considered, or
+  like a desktop page that got squeezed?
+- **Accessibility**: Are interactive elements discoverable by keyboard and
+  screen readers? Is contrast sufficient? Are focus states visible?
+- **Performance feel**: Does the page feel instant? Are there layout shifts,
+  slow paints, or interactions that feel sluggish?
+- **Surprise**: Is there one thing you could do that would meaningfully elevate
+  the experience — something non-obvious that the user didn't ask for but
+  would clearly appreciate?
+
+Push beyond the safe, incremental fix. If the screen is fundamentally okay but
+uninspired, say so and propose something bolder. If the bones are great but a
+detail is off, zoom in on that detail.
+
+## Priorities
+
+- prefer moves that change how the screen feels, not just how it measures
+- prefer practical, user-visible performance wins over theoretical
+  micro-optimizations
+- generalize repeated fixes when the same issue appears in multiple places
+- don't polish what should be redesigned; don't redesign what just needs polish
+- keep changes production-ready, maintainable, and aligned with repo
+  conventions
+- match the scale of changes to what the screen actually needs — if a large
+  redesign is the right move, propose it and get approval; do not shrink scope
+  just to avoid a big diff
+
+## Output Per Pass
+
+Append to `design-loop-log.md`:
+
+- pass number and type (audit or code-changing)
+- target screen and states inspected
+- highest-leverage issues found
+- changes made (or issues documented, for audit pass)
+- why the pass mattered — what shifted in the experience
+- preview URL inspected
+- validation and regression results
+- what the next pass would tackle

--- a/app.js
+++ b/app.js
@@ -320,10 +320,6 @@ function currentUserCanEditRestaurantSpecials(restaurantId = RESTAURANT_ID, user
   return requiredMenuIds.every(menuId => accessibleMenuIds.has(menuId));
 }
 
-function getFeaturedConfirmationKey(restaurantId = RESTAURANT_ID) {
-  return `featured_confirmed:${restaurantId || 'unknown'}`;
-}
-
 function getMenuTypeLabel(menuType) {
   return (menuType || '').toLowerCase() === 'food' ? 'Food' : 'Drinks';
 }
@@ -1529,27 +1525,6 @@ function createRestaurantSpecialsService() {
       return { ok: true };
     },
 
-    needsConfirmation(restaurantId = RESTAURANT_ID) {
-      if (!currentUserCanEditRestaurantSpecials(restaurantId)) return false;
-      if (sessionStorage.getItem(getFeaturedConfirmationKey(restaurantId))) return false;
-      if (!_featuredGroups.some(group => group.slots.length)) return false;
-      return _featuredGroups.some(group => group.slots.some(slot => {
-        if (!slot.confirmedAt) return true;
-        const confirmed = new Date(slot.confirmedAt);
-        const today = new Date();
-        today.setHours(0, 0, 0, 0);
-        return confirmed < today;
-      }));
-    },
-
-    async confirmToday() {
-      if (!currentUserCanEditRestaurantSpecials()) {
-        return { ok: false, userMessage: 'Specials require access to both menus for this restaurant.' };
-      }
-      await this.request('confirm');
-      sessionStorage.setItem(getFeaturedConfirmationKey(), '1');
-      return { ok: true, successMessage: 'Specials confirmed for today!' };
-    },
   };
 }
 
@@ -2151,31 +2126,20 @@ function updateManagerActionBar() {
   const bar = document.getElementById('manager-action-bar');
   if (!bar) return;
   const primaryGroup = document.getElementById('manager-primary-action-group');
-  const featuredGroup = document.getElementById('manager-featured-action-group');
   const summary = document.getElementById('manager-action-bar-summary');
   const syncEl = document.getElementById('sync-status');
-  const hasFeaturedPrompt = _needsFeaturedConfirmation();
   const hasDraftChanges = !!_dirty;
   const isCompactViewport = window.innerWidth <= 480;
 
   if (primaryGroup) primaryGroup.hidden = !hasDraftChanges;
-  if (featuredGroup) featuredGroup.hidden = !hasFeaturedPrompt;
-  bar.hidden = !(hasDraftChanges || hasFeaturedPrompt);
+  bar.hidden = !hasDraftChanges;
   syncManagerActionBarStatus(syncEl);
 
   if (summary) {
-    if (hasDraftChanges && hasFeaturedPrompt) {
-      summary.textContent = isCompactViewport
-        ? 'Drafts are ready. Save keeps them private, Send Update publishes, and featured still needs confirmation.'
-        : 'Unsent changes ready. Save Draft keeps them private. Send Update publishes to the live menu. Featured items also need confirmation.';
-    } else if (hasDraftChanges) {
+    if (hasDraftChanges) {
       summary.textContent = isCompactViewport
         ? 'Drafts are ready. Save keeps them private and Send Update publishes live.'
         : 'Unsent changes ready. Save Draft keeps them private. Send Update publishes to the live menu.';
-    } else if (hasFeaturedPrompt) {
-      summary.textContent = isCompactViewport
-        ? 'Featured still needs confirmation.'
-        : "Today's featured lineup needs confirmation.";
     } else {
       summary.textContent = '';
     }
@@ -3455,6 +3419,7 @@ function renderUserHeader() {
   const actionBtn = document.getElementById('action-btn');
   const adminBtn  = document.getElementById('admin-btn');
   const adminDrawerBtn = document.getElementById('admin-btn-drawer');
+  const managerReturnBtn = document.getElementById('manager-return-btn');
 
   if (actionBtn) {
     actionBtn.style.display = (signedIn && canManageCurrentMenu) ? '' : 'none';
@@ -3468,6 +3433,9 @@ function renderUserHeader() {
   if (adminDrawerBtn) {
     adminDrawerBtn.style.display = (signedIn && isAdmin) ? '' : 'none';
     adminDrawerBtn.classList.toggle('active', isAdminMode);
+  }
+  if (managerReturnBtn) {
+    managerReturnBtn.style.display = isManagerMode ? '' : 'none';
   }
 
   _setDisplayBySelector('[data-route-manager]', (signedIn && canManageCurrentMenu) ? '' : 'none');
@@ -3950,7 +3918,8 @@ async function onSwitchMenuClick() {
     renderManagerWorkspace();
     updateDraftIndicator();
     updateSaveBtn();
-    checkFeaturedConfirmation();
+    updateManagerActionBar();
+    if (window.innerWidth <= 920) closeSettingsDrawer();
   }, { managerOnly: true });
 }
 
@@ -4252,7 +4221,7 @@ function enterManager() {
   _syncSettingsSectionFromLocation('manager-overview-section');
   updateDraftIndicator();
   updateSaveBtn();
-  checkFeaturedConfirmation();
+  updateManagerActionBar();
 }
 
 function exitManager() {
@@ -6769,32 +6738,8 @@ async function moveFeaturedSlot(groupId, slotId, direction) {
   } catch(e) { showToast(e?.message || 'Failed to reorder.', 'error'); }
 }
 
-// ─── FEATURED DAILY CONFIRMATION ─────────────────────────────────────────────
-
-function _needsFeaturedConfirmation() {
-  return getRestaurantSpecialsService().needsConfirmation();
-}
-
-function checkFeaturedConfirmation() {
-  updateManagerActionBar();
-}
-
-async function confirmFeaturedToday() {
-  try {
-    const result = await getRestaurantSpecialsService().confirmToday();
-    if (!result?.ok) {
-      if (result?.userMessage) showToast(result.userMessage, result.userHandled ? 'info' : 'error');
-      return;
-    }
-    updateManagerActionBar();
-    showToast(result.successMessage || 'Specials confirmed for today!', 'success');
-  } catch(e) { showToast(e?.message || 'Failed to confirm.', 'error'); }
-}
-
-function editFeaturedFromBanner() {
+function focusFeaturedManagerCard() {
   if (!currentUserCanEditRestaurantSpecials()) return;
-  sessionStorage.setItem(getFeaturedConfirmationKey(), '1');
-  updateManagerActionBar();
   const overviewTrigger = document.querySelector('.settings-rail-btn[data-target="manager-overview-section"]');
   focusSettingsSection('manager-overview-section', overviewTrigger || null);
   requestAnimationFrame(() => {

--- a/app.js
+++ b/app.js
@@ -65,7 +65,7 @@ let _accessSessionService = null;
 let _restaurantSpecialsService = null;
 
 let _featuredGroups = []; // [{id, name, displayOrder, slots: [{id, itemId, sellNote, displayOrder, confirmedAt, confirmedBy, item: {…}}]}]
-let _lastSentFeaturedIds = new Set(); // item IDs that were featured at last Send Update
+let _lastSentFeaturedIds = new Set(); // item IDs that were featured at the last live publish
 let _restaurantSpecialsSiblingCatalog = [];
 let _restaurantSpecialsCatalogKey = '';
 let _restaurantSpecialsCatalogPromise = null;
@@ -191,9 +191,16 @@ let _currentMenuSession = null;
 let _updatePublisher = null;
 let _menuMetaSupportsLastSentFeatured = true;
 function invalidateDiff() { _diffDirty = true; _dirty = true; updateSaveBtn(); }
+function getDraftChangeCount() {
+  return getCachedDiff().reduce((count, section) => (
+    count + section.added.length + section.removed.length + section.eightySixed.length + section.restored.length
+  ), 0);
+}
 function updateSaveBtn() {
-  const btn = document.getElementById('save-btn');
-  if (btn) btn.disabled = !_dirty;
+  const saveBtn = document.getElementById('save-btn');
+  const publishBtn = document.getElementById('send-btn');
+  if (saveBtn) saveBtn.disabled = !_dirty;
+  if (publishBtn) publishBtn.disabled = !_dirty;
   updateManagerActionBar();
 }
 function getCachedDiff() {
@@ -2129,19 +2136,25 @@ function updateManagerActionBar() {
   const summary = document.getElementById('manager-action-bar-summary');
   const syncEl = document.getElementById('sync-status');
   const hasDraftChanges = !!_dirty;
+  const changeCount = getDraftChangeCount();
   const isCompactViewport = window.innerWidth <= 480;
+  const saveBtn = document.getElementById('save-btn');
+  const publishBtn = document.getElementById('send-btn');
 
-  if (primaryGroup) primaryGroup.hidden = !hasDraftChanges;
-  bar.hidden = !hasDraftChanges;
+  if (primaryGroup) primaryGroup.hidden = false;
+  if (saveBtn) saveBtn.disabled = !hasDraftChanges;
+  if (publishBtn) publishBtn.disabled = !hasDraftChanges;
+  bar.hidden = false;
+  bar.classList.toggle('is-idle', !hasDraftChanges);
   syncManagerActionBarStatus(syncEl);
 
   if (summary) {
     if (hasDraftChanges) {
       summary.textContent = isCompactViewport
-        ? 'Drafts are ready. Save keeps them private and Send Update publishes live.'
-        : 'Unsent changes ready. Save Draft keeps them private. Send Update publishes to the live menu.';
+        ? `${changeCount} pending change${changeCount === 1 ? '' : 's'}. Save reviews; Save Draft stays private.`
+        : `${changeCount} pending change${changeCount === 1 ? '' : 's'}. Save Draft keeps them private. Save opens Patch Notes Preview.`;
     } else {
-      summary.textContent = '';
+      summary.textContent = 'No Pending Changes';
     }
   }
 }
@@ -3419,7 +3432,6 @@ function renderUserHeader() {
   const actionBtn = document.getElementById('action-btn');
   const adminBtn  = document.getElementById('admin-btn');
   const adminDrawerBtn = document.getElementById('admin-btn-drawer');
-  const managerReturnBtn = document.getElementById('manager-return-btn');
 
   if (actionBtn) {
     actionBtn.style.display = (signedIn && canManageCurrentMenu) ? '' : 'none';
@@ -3433,9 +3445,6 @@ function renderUserHeader() {
   if (adminDrawerBtn) {
     adminDrawerBtn.style.display = (signedIn && isAdmin) ? '' : 'none';
     adminDrawerBtn.classList.toggle('active', isAdminMode);
-  }
-  if (managerReturnBtn) {
-    managerReturnBtn.style.display = isManagerMode ? '' : 'none';
   }
 
   _setDisplayBySelector('[data-route-manager]', (signedIn && canManageCurrentMenu) ? '' : 'none');
@@ -5242,7 +5251,7 @@ function toggle86(catId, itemId) {
     wrapper.classList.add(cls);
     setTimeout(() => wrapper.classList.remove(cls), 400);
   }
-  showToast(item.eightySixed ? "🚫 Marked 86'd — send update to notify group" : `↩ Marked ${restoreLabel(catId)} — send update to notify group`, 'info');
+  showToast(item.eightySixed ? "🚫 Marked 86'd — use Save & Send to notify channels" : `↩ Marked ${restoreLabel(catId)} — use Save & Send to notify channels`, 'info');
 }
 
 // ─── UPCHARGE CRUD ───────────────────────────────────────────────────────────
@@ -5676,15 +5685,8 @@ function renameItem(catId, itemId, newName) {
 function updateDraftIndicator() {
   const btn = document.getElementById('send-btn');
   if (!btn) return;
-  const diff = getCachedDiff();
-  const total = diff.reduce((n, s) => n + s.added.length + s.removed.length + s.eightySixed.length + s.restored.length, 0);
-  if (total > 0) {
-    btn.innerHTML = `Send Update <span class="send-update-count">(${total} Change${total > 1 ? 's' : ''})</span>`;
-    btn.style.boxShadow = '0 4px 22px rgba(255,77,0,0.55)';
-  } else {
-    btn.innerHTML = 'Send Update';
-    btn.style.boxShadow = '';
-  }
+  btn.textContent = 'Save';
+  btn.style.boxShadow = getDraftChangeCount() > 0 ? '0 4px 22px rgba(255,77,0,0.55)' : '';
   renderManagerOverviewStats();
   updateManagerActionBar();
 }
@@ -5799,15 +5801,20 @@ function buildPreviewBlockHtml(section) {
 function openPreview() {
   const preview = getUpdatePublisher().preview();
   const content = document.getElementById('preview-content');
-  const confirmBtn = document.getElementById('confirm-btn');
+  const saveMenuBtn = document.getElementById('save-menu-btn');
+  const saveSendBtn = document.getElementById('save-send-btn');
+  const subtitle = document.getElementById('modal-subtitle');
   const modal = document.getElementById('modal-bg');
-  if (!content || !confirmBtn || !modal) return;
+  if (!content || !saveMenuBtn || !saveSendBtn || !modal) return;
   content.innerHTML = '';
+  if (subtitle) subtitle.textContent = 'Review the changes before publishing them to the live menu.';
   if (!preview.hasChanges) {
     content.innerHTML = `<div class="no-changes">🎉 No changes since the last update.<br><span style="font-size:11px;color:#444;">Add, remove, or 86 items to generate an update.</span></div>`;
-    confirmBtn.disabled = true;
+    saveMenuBtn.disabled = true;
+    saveSendBtn.disabled = true;
   } else {
-    confirmBtn.disabled = false;
+    saveMenuBtn.disabled = false;
+    saveSendBtn.disabled = false;
     preview.sections.forEach(s => {
       const block = document.createElement('div');
       block.className = 'preview-block';
@@ -5819,7 +5826,7 @@ function openPreview() {
 }
 function closeModal() { document.getElementById('modal-bg')?.classList.remove('open'); }
 
-// ─── SEND UPDATE ──────────────────────────────────────────────────────────────
+// ─── LIVE PUBLISH ─────────────────────────────────────────────────────────────
 function buildPatchMessage(diff) {
   const now = new Date();
   const dateStr = now.toLocaleDateString('en-US', { weekday:'short', month:'short', day:'numeric' });
@@ -5862,6 +5869,7 @@ function createUpdatePublisher() {
 
     async publish(options = {}) {
       const preview = options.preview?.diff ? options.preview : this.preview();
+      const notify = options.notify !== false;
       if (!preview.hasChanges) {
         return {
           ok: false,
@@ -5871,21 +5879,29 @@ function createUpdatePublisher() {
         };
       }
 
-      const delivery = await dispatchMenuUpdateNotification({
-        menuId: MENU_ID,
-        patchMessage: preview.patchMessage,
-      });
-      if (!delivery.ok) {
-        return {
-          ok: false,
-          preview,
-          notificationStatus: delivery,
-          userMessage: delivery.userMessage,
-          snapshot: buildMenuSessionSnapshot('send-failed'),
-        };
+      let delivery = {
+        ok: true,
+        skipped: true,
+        statusCode: null,
+        summary: summarizeNotificationResults({}),
+      };
+      if (notify) {
+        delivery = await dispatchMenuUpdateNotification({
+          menuId: MENU_ID,
+          patchMessage: preview.patchMessage,
+        });
+        if (!delivery.ok) {
+          return {
+            ok: false,
+            preview,
+            notificationStatus: delivery,
+            userMessage: delivery.userMessage,
+            snapshot: buildMenuSessionSnapshot('send-failed'),
+          };
+        }
       }
 
-      const warnings = collectNotificationWarnings(delivery.summary);
+      const warnings = notify ? collectNotificationWarnings(delivery.summary) : [];
       try {
         const persisted = await persistState({ silentFailure: true });
         if (!persisted) throw new Error('persist failed');
@@ -5936,11 +5952,13 @@ function createUpdatePublisher() {
           preview,
           ts,
           truncated: preview.truncated,
-          notificationStatus: delivery,
+          notificationStatus: notify ? delivery : null,
           warnings: finalWarnings,
           warningMessage: finalWarnings[0] || '',
-          successMessage: `✅ ${_activeMenuName || 'Menu'} update sent!`,
-          snapshot: buildMenuSessionSnapshot(finalWarnings.length ? 'sent-warning' : 'sent'),
+          successMessage: notify
+            ? `✅ ${_activeMenuName || 'Menu'} saved and sent!`
+            : `✅ ${_activeMenuName || 'Menu'} saved to the live menu.`,
+          snapshot: buildMenuSessionSnapshot(finalWarnings.length ? 'sent-warning' : (notify ? 'sent' : 'saved-live')),
         };
       } catch (syncError) {
         console.warn('sendUpdate post-send sync failed:', syncError);
@@ -5950,10 +5968,12 @@ function createUpdatePublisher() {
           ok: true,
           preview,
           truncated: preview.truncated,
-          notificationStatus: delivery,
+          notificationStatus: notify ? delivery : null,
           warnings: finalWarnings,
           warningMessage: finalWarnings[0] || '',
-          successMessage: `✅ ${_activeMenuName || 'Menu'} update sent!`,
+          successMessage: notify
+            ? `✅ ${_activeMenuName || 'Menu'} saved and sent!`
+            : `✅ ${_activeMenuName || 'Menu'} saved to the live menu.`,
           snapshot: buildMenuSessionSnapshot('sent-warning'),
         };
       }
@@ -6148,27 +6168,44 @@ async function _publishActiveMenuUpdateInternal(options = {}) {
   return getUpdatePublisher().publish(options);
 }
 
-async function sendUpdate() {
-  const preview = getUpdatePublisher().preview();
+function setPreviewModalActionState(mode = '') {
+  const cancelBtn = document.getElementById('cancel-preview-btn');
+  const saveMenuBtn = document.getElementById('save-menu-btn');
+  const saveSendBtn = document.getElementById('save-send-btn');
+  const isBusy = !!mode;
+  if (cancelBtn) cancelBtn.disabled = isBusy;
+  if (saveMenuBtn) {
+    saveMenuBtn.disabled = isBusy;
+    saveMenuBtn.textContent = mode === 'save-menu' ? 'Saving…' : 'Save Menu';
+  }
+  if (saveSendBtn) {
+    saveSendBtn.disabled = isBusy;
+    saveSendBtn.textContent = mode === 'save-send' ? 'Saving & Sending…' : 'Save & Send';
+  }
+}
+
+async function sendUpdate(options = {}) {
+  const notify = options.notify !== false;
+  const preview = options.preview?.diff ? options.preview : getUpdatePublisher().preview();
   if (!preview.hasChanges) { closeModal(); return; }
 
   if (preview.truncated) {
     showToast('Update is long and will be truncated.', 'info');
   }
 
-  const confirmBtn = document.getElementById('confirm-btn');
-  confirmBtn.disabled = true;
-  confirmBtn.textContent = 'SENDING…';
+  setPreviewModalActionState(notify ? 'save-send' : 'save-menu');
 
   try {
-    const result = await ensureCurrentMenuSession().sendUpdate({ preview });
+    const result = await ensureCurrentMenuSession().sendUpdate({ preview, notify });
     if (result?.noop) {
       closeModal();
       return;
     }
     if (result?.ok) {
       closeModal();
-      showToast(result.successMessage || `✅ ${_activeMenuName || 'Menu'} update sent!`, 'success');
+      showToast(result.successMessage || (notify
+        ? `✅ ${_activeMenuName || 'Menu'} saved and sent!`
+        : `✅ ${_activeMenuName || 'Menu'} saved to the live menu.`), 'success');
       renderManagerWorkspace({ includeRecentChanges: false });
       updateDraftIndicator();
       renderRecentChanges();
@@ -6178,8 +6215,7 @@ async function sendUpdate() {
     }
     if (result?.userMessage) showToast(result.userMessage, 'error');
   } finally {
-    confirmBtn.disabled = false;
-    confirmBtn.textContent = 'SEND UPDATE';
+    setPreviewModalActionState();
   }
 }
 

--- a/design-loop/manager/design-loop-issues.md
+++ b/design-loop/manager/design-loop-issues.md
@@ -1,0 +1,9 @@
+# Manager Design Loop Issues
+
+## Pass 1 audit
+
+1. The unauthenticated manager state leaves too much dead canvas between the topbar and the auth dialog, so the page reads as unfinished instead of intentional.
+2. The auth card is undersized for desktop and visually disconnected from the manager shell, especially when no menu is selected yet.
+3. Dark mode contrast is too weak in the auth flow. The primary action loses emphasis and the shell recedes into a near-black wash.
+4. Mobile auth states need stronger sheet treatment and spacing so Sign In, Create Account, and Reset Password feel anchored to the route rather than floating above it.
+5. The drawer action cluster needs stronger hierarchy so `Return to menu` clearly belongs to the nav rail and does not read like a generic utility button.

--- a/elroyscantina/app.js
+++ b/elroyscantina/app.js
@@ -61,10 +61,10 @@
   function buildFeaturedHtml(sharedState) {
     const featuredSlots = (sharedState.restaurantSpecials?.slots || [])
       .filter(slot => slot.item)
-      .slice(0, 3);
+      .slice(0, 5);
     if (!featuredSlots.length) return '<p class="erc-route-empty">Nothing featured right now.</p>';
 
-    return featuredSlots.slice(0, 3).map((slot, index) => buildItemHtml(slot.item, {
+    return featuredSlots.slice(0, 5).map((slot, index) => buildItemHtml(slot.item, {
       badgeText: index === 0 ? "Chef's Choice" : '',
     })).join('');
   }

--- a/leroyslounge/app.js
+++ b/leroyslounge/app.js
@@ -78,9 +78,9 @@
   function buildFeaturedHtml(sharedState) {
     const featuredSlots = (sharedState.restaurantSpecials?.slots || [])
       .filter(slot => slot.item)
-      .slice(0, 3);
+      .slice(0, 5);
     if (!featuredSlots.length) return '<p class="ll-route-empty">Nothing featured right now.</p>';
-    return featuredSlots.slice(0, 3).map((slot, index) => buildItemHtml(slot.item, index === 0 ? "Chef's Choice" : '')).join('');
+    return featuredSlots.slice(0, 5).map((slot, index) => buildItemHtml(slot.item, index === 0 ? "Chef's Choice" : '')).join('');
   }
 
   function buildCategoryHtml(sharedState, category) {

--- a/leroyslounge/index.html
+++ b/leroyslounge/index.html
@@ -214,12 +214,6 @@
       <button class="btn-small" id="switch-menu-btn" onclick="onSwitchMenuClick()" style="display:none" aria-label="Switch to a different menu">⇄ Switch</button>
     </div>
 
-    <div id="featured-confirm-banner" class="featured-confirm-banner" style="display:none;">
-      <span>Today's specials haven't been confirmed yet.</span>
-      <button class="btn-small" onclick="confirmFeaturedToday()">Keep Today's Specials</button>
-      <button class="btn-small" onclick="editFeaturedFromBanner()">Update Specials</button>
-    </div>
-
     <!-- MANAGER PANEL: Edit Menu, Categories, Database -->
     <div id="manager-panel" style="display:none">
       <div class="tab-bar" role="tablist" id="manager-tab-bar">

--- a/manager/index.html
+++ b/manager/index.html
@@ -44,6 +44,13 @@
               <div class="manager-shell-header-badges">
                 <span class="manager-shell-header-badge">Manager</span>
                 <span class="manager-shell-header-badge manager-shell-header-badge--muted" id="manager-header-menu-badge">No menu selected</span>
+                <button
+                  class="manager-shell-header-badge manager-shell-header-return"
+                  id="manager-return-btn"
+                  type="button"
+                  onclick="exitView()"
+                  style="display:none"
+                >Return to menu</button>
               </div>
             </div>
             <div class="manager-shell-title-row">
@@ -183,10 +190,10 @@
                     <p class="settings-section-kicker">Featured</p>
                     <h3>Featured Items</h3>
                   </div>
-                  <p class="manager-shell-card-copy">Current featured lineup. Unconfirmed items appear in the action bar below.</p>
+                  <p class="manager-shell-card-copy">Current featured lineup across this restaurant's menus.</p>
                 </div>
                 <div id="featured-mgr-wrap"></div>
-                <button class="btn-small manager-shell-overview-link" onclick="editFeaturedFromBanner()" style="margin-top:14px">Edit Featured</button>
+                <button class="btn-small manager-shell-overview-link" onclick="focusFeaturedManagerCard()" style="margin-top:14px">Edit Featured</button>
               </section>
 
               <section class="manager-shell-overview-card manager-shell-overview-card--recent" id="manager-recent-section">
@@ -329,7 +336,7 @@
           <div class="manager-shell-footer-copy">
             <p class="manager-shell-footer-kicker">Current Menu</p>
             <h3>Manager Workspace</h3>
-            <p class="manager-shell-footer-note">Keep drafts private, confirm featured items, and publish updates when service is ready.</p>
+            <p class="manager-shell-footer-note">Keep drafts private and publish updates when service is ready.</p>
           </div>
           <div class="manager-shell-footer-meta">
             <div class="manager-shell-footer-pills">
@@ -337,7 +344,6 @@
               <span class="manager-shell-footer-pill" id="manager-footer-last-updated">Updated —</span>
               <span class="manager-shell-footer-pill" id="manager-footer-version">Version —</span>
             </div>
-            <button class="logout-link manager-shell-exit" onclick="exitView()">Back to menu view</button>
           </div>
         </footer>
       </main>
@@ -349,10 +355,6 @@
         <p class="workspace-actions-sub" id="manager-action-bar-summary"></p>
       </div>
       <div class="manager-shell-actionbar-groups">
-        <div class="manager-shell-actionbar-featured" id="manager-featured-action-group" hidden>
-          <button class="btn-small" onclick="confirmFeaturedToday()">Keep Today's Featured</button>
-          <button class="btn-small" onclick="editFeaturedFromBanner()">Update Featured</button>
-        </div>
         <div class="btn-row manager-shell-actionbar-primary" id="manager-primary-action-group" hidden>
           <button class="save-btn" id="save-btn" onclick="saveMenu()" title="Save changes without notifying anyone">Save Draft</button>
           <button class="send-btn" id="send-btn" onclick="openPreview()" title="Review and publish changes to the live menu">Send Update</button>

--- a/manager/index.html
+++ b/manager/index.html
@@ -44,13 +44,6 @@
               <div class="manager-shell-header-badges">
                 <span class="manager-shell-header-badge">Manager</span>
                 <span class="manager-shell-header-badge manager-shell-header-badge--muted" id="manager-header-menu-badge">No menu selected</span>
-                <button
-                  class="manager-shell-header-badge manager-shell-header-return"
-                  id="manager-return-btn"
-                  type="button"
-                  onclick="exitView()"
-                  style="display:none"
-                >Return to menu</button>
               </div>
             </div>
             <div class="manager-shell-title-row">
@@ -144,6 +137,7 @@
           <div class="manager-shell-drawer-meta">
             <span class="manager-shell-header-badge manager-shell-header-badge--muted" id="manager-drawer-menu-badge">No menu selected</span>
             <button class="btn-small manager-shell-switch-btn manager-shell-drawer-switch" id="drawer-switch-menu-btn" onclick="onSwitchMenuClick()" style="display:none" aria-label="Switch to a different menu">Switch Menu</button>
+            <button class="btn-small manager-shell-drawer-return" type="button" onclick="exitView()">Return to menu</button>
             <button class="manager-btn admin-btn manager-shell-drawer-admin" id="admin-btn-drawer" onclick="onAdminBtnClick()" style="display:none">Admin Tools</button>
           </div>
         </div>
@@ -215,7 +209,7 @@
                 <p class="settings-section-kicker">Edit Items</p>
                 <h2>Add, remove, and 86 items.</h2>
               </div>
-              <p class="manager-shell-section-copy">Swipe left to 86. Swipe right to restore. Changes are drafts until you Save or Send Update.</p>
+              <p class="manager-shell-section-copy">Swipe left to 86. Swipe right to restore. Changes stay in draft until you Save Draft or publish them live.</p>
             </div>
             <div id="manager-items-categories"></div>
           </section>
@@ -349,15 +343,15 @@
       </main>
     </div>
 
-    <div class="manager-shell-actionbar" id="manager-action-bar" hidden>
+    <div class="manager-shell-actionbar" id="manager-action-bar">
       <div class="manager-shell-actionbar-copy">
         <p class="workspace-actions-title">Publishing Dock</p>
         <p class="workspace-actions-sub" id="manager-action-bar-summary"></p>
       </div>
       <div class="manager-shell-actionbar-groups">
-        <div class="btn-row manager-shell-actionbar-primary" id="manager-primary-action-group" hidden>
+        <div class="btn-row manager-shell-actionbar-primary" id="manager-primary-action-group">
           <button class="save-btn" id="save-btn" onclick="saveMenu()" title="Save changes without notifying anyone">Save Draft</button>
-          <button class="send-btn" id="send-btn" onclick="openPreview()" title="Review and publish changes to the live menu">Send Update</button>
+          <button class="send-btn" id="send-btn" onclick="openPreview()" title="Review changes before publishing them live">Save</button>
         </div>
       </div>
       <div class="manager-shell-actionbar-status">
@@ -449,11 +443,12 @@
 <div class="modal-bg" id="modal-bg">
   <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
     <h2 id="modal-title">Patch Notes Preview</h2>
-    <div class="modal-sub">Only changes since the last update will be sent.</div>
+    <div class="modal-sub" id="modal-subtitle">Review the changes before publishing them to the live menu.</div>
     <div id="preview-content"></div>
     <div class="modal-actions">
-      <button class="btn-cancel" onclick="closeModal()">Cancel</button>
-      <button class="btn-confirm" id="confirm-btn" onclick="sendUpdate()">SEND UPDATE</button>
+      <button class="btn-cancel" id="cancel-preview-btn" onclick="closeModal()">Cancel</button>
+      <button class="btn-secondary" id="save-menu-btn" onclick="sendUpdate({ notify: false })">Save Menu</button>
+      <button class="btn-confirm" id="save-send-btn" onclick="sendUpdate({ notify: true })">Save &amp; Send</button>
     </div>
   </div>
 </div>

--- a/style.css
+++ b/style.css
@@ -3398,45 +3398,122 @@ body.manager-stitch-shell #menu-picker-overlay {
 }
 
 /* Auth overlay — match manager shell's sharp aesthetic */
+body.manager-stitch-shell #auth-overlay {
+  align-items: flex-start;
+  padding: clamp(96px, 14vh, 148px) 24px 32px;
+  background:
+    radial-gradient(circle at top center, rgba(253, 221, 185, 0.24), transparent 34%),
+    linear-gradient(180deg, rgba(246, 241, 233, 0.18), rgba(26, 28, 26, 0.58));
+  backdrop-filter: blur(14px) saturate(118%);
+  overflow-y: auto;
+}
+
 body.manager-stitch-shell .auth-box {
-  background: var(--manager-shell-surface);
+  background:
+    linear-gradient(180deg, rgba(253, 221, 185, 0.18), transparent 18%),
+    linear-gradient(180deg, var(--manager-shell-surface), var(--manager-shell-surface-muted));
   border-color: var(--manager-shell-border);
-  max-width: 380px;
+  width: min(100%, 448px);
+  max-width: 448px;
+  padding: 34px 32px 24px;
+  box-shadow: 0 26px 60px var(--manager-shell-shadow-strong);
+}
+
+body.manager-stitch-shell .auth-box::before {
+  content: '';
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: 0;
+  height: 5px;
+  background: linear-gradient(90deg, var(--manager-shell-primary), var(--manager-shell-accent));
 }
 
 body.manager-stitch-shell .auth-box h2 {
   font-family: 'Noto Serif', serif;
-  font-size: 28px;
+  font-size: clamp(2rem, 3vw, 2.45rem);
   letter-spacing: -0.02em;
   color: var(--manager-shell-primary);
+  margin-bottom: 0;
+}
+
+body.manager-stitch-shell .auth-screen {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
 }
 
 body.manager-stitch-shell .auth-field input {
-  border-radius: 2px;
-  background: var(--manager-shell-surface-muted);
+  border-radius: 12px;
+  background: color-mix(in srgb, var(--manager-shell-surface) 72%, var(--manager-shell-surface-muted));
   border-color: var(--manager-shell-border);
   color: var(--manager-shell-text);
-  min-height: 46px;
+  min-height: 54px;
+  padding: 14px 16px;
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.18);
 }
 
 body.manager-stitch-shell .auth-field input:focus {
   border-color: var(--manager-shell-primary);
+  box-shadow:
+    0 0 0 3px color-mix(in srgb, var(--manager-shell-accent) 18%, transparent),
+    inset 0 1px 0 rgba(255, 255, 255, 0.18);
 }
 
 body.manager-stitch-shell .auth-box p,
 body.manager-stitch-shell .auth-toggle,
 body.manager-stitch-shell .auth-approval-notice {
   color: var(--manager-shell-muted);
+  line-height: 1.5;
+}
+
+body.manager-stitch-shell .auth-box p {
+  margin-bottom: 0;
+}
+
+body.manager-stitch-shell .auth-error {
+  margin-bottom: 0;
+}
+
+body.manager-stitch-shell .auth-link-btn {
+  margin-bottom: 0;
+  padding: 0;
+  text-underline-offset: 0.18em;
+}
+
+body.manager-stitch-shell .auth-toggle {
+  display: flex;
+  justify-content: center;
+  flex-wrap: wrap;
+  gap: 4px 6px;
+}
+
+body.manager-stitch-shell .auth-toggle-btn,
+body.manager-stitch-shell .auth-back-btn,
+body.manager-stitch-shell .pin-cancel {
+  padding-left: 0;
+  padding-right: 0;
+}
+
+body.manager-stitch-shell .auth-approval-notice {
+  margin: 0;
+  padding: 12px 14px;
+  border: 1px solid var(--manager-shell-border);
+  background: var(--manager-shell-primary-faint);
+  border-radius: 12px;
 }
 
 body.manager-stitch-shell .auth-submit-btn {
-  border-radius: 2px;
+  border-radius: 12px;
   background: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
   min-height: 50px;
   font-size: 12px;
   font-weight: 800;
   letter-spacing: 0.12em;
   text-transform: uppercase;
+  margin-bottom: 0;
+  box-shadow: 0 16px 30px var(--manager-shell-shadow);
 }
 
 body.manager-stitch-shell .auth-submit-btn:hover {
@@ -3454,7 +3531,9 @@ body.manager-stitch-shell .auth-link-btn:focus-visible,
 body.manager-stitch-shell .auth-toggle-btn:hover,
 body.manager-stitch-shell .auth-toggle-btn:focus-visible,
 body.manager-stitch-shell .auth-back-btn:hover,
-body.manager-stitch-shell .auth-back-btn:focus-visible {
+body.manager-stitch-shell .auth-back-btn:focus-visible,
+body.manager-stitch-shell .pin-cancel:hover,
+body.manager-stitch-shell .pin-cancel:focus-visible {
   color: var(--manager-shell-primary);
 }
 
@@ -4509,6 +4588,10 @@ body.manager-stitch-shell .manager-shell-drawer-meta {
   flex-direction: column;
   align-items: stretch;
   gap: 10px;
+  padding: 12px;
+  border: 1px solid var(--manager-shell-border);
+  background: color-mix(in srgb, var(--manager-shell-surface) 82%, transparent);
+  border-radius: 18px;
 }
 
 body.manager-stitch-shell .manager-shell-drawer-meta .manager-shell-header-badge {
@@ -4524,6 +4607,19 @@ body.manager-stitch-shell .manager-shell-drawer-return,
 body.manager-stitch-shell .manager-shell-drawer-admin {
   width: 100%;
   justify-content: center;
+}
+
+body.manager-stitch-shell .manager-shell-drawer-return {
+  background: var(--manager-shell-primary);
+  border-color: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
+}
+
+body.manager-stitch-shell .manager-shell-drawer-return:hover,
+body.manager-stitch-shell .manager-shell-drawer-return:focus-visible {
+  background: var(--manager-shell-primary-soft);
+  border-color: var(--manager-shell-primary-soft);
+  color: var(--manager-shell-bg);
 }
 
 body.manager-stitch-shell .settings-rail-btn {
@@ -5121,6 +5217,16 @@ body.manager-stitch-shell .manager-shell-actionbar-status {
     align-items: start;
   }
 
+  body.manager-stitch-shell #auth-overlay {
+    padding: calc(88px + env(safe-area-inset-top)) 14px 20px;
+  }
+
+  body.manager-stitch-shell .auth-box {
+    width: min(100%, 560px);
+    max-width: none;
+    padding: 28px 24px 22px;
+  }
+
   body.manager-stitch-shell .manager-shell-layout {
     width: calc(100% - 24px);
     grid-template-columns: 1fr;
@@ -5330,6 +5436,35 @@ body.manager-stitch-shell .manager-shell-actionbar-status {
 }
 
 @media (max-width: 720px) {
+  body.manager-stitch-shell #auth-overlay {
+    padding: calc(80px + env(safe-area-inset-top)) 10px 16px;
+  }
+
+  body.manager-stitch-shell .auth-box {
+    width: 100%;
+    min-height: min(calc(100svh - 108px - env(safe-area-inset-top)), 720px);
+    padding: 24px 18px 18px;
+    border-radius: 24px 24px 18px 18px;
+  }
+
+  body.manager-stitch-shell .auth-screen {
+    gap: 10px;
+  }
+
+  body.manager-stitch-shell .auth-box h2 {
+    font-size: 2rem;
+  }
+
+  body.manager-stitch-shell .auth-field input,
+  body.manager-stitch-shell .auth-submit-btn {
+    min-height: 52px;
+  }
+
+  body.manager-stitch-shell .auth-toggle {
+    flex-direction: column;
+    gap: 2px;
+  }
+
   body.manager-stitch-shell .manager-shell-topbar-inner {
     width: calc(100% - 20px);
     min-height: calc(54px + env(safe-area-inset-top));

--- a/style.css
+++ b/style.css
@@ -3413,10 +3413,11 @@ body.manager-stitch-shell .auth-box {
     linear-gradient(180deg, rgba(253, 221, 185, 0.18), transparent 18%),
     linear-gradient(180deg, var(--manager-shell-surface), var(--manager-shell-surface-muted));
   border-color: var(--manager-shell-border);
-  width: min(100%, 448px);
-  max-width: 448px;
+  width: min(100%, 472px);
+  max-width: 472px;
   padding: 34px 32px 24px;
   box-shadow: 0 26px 60px var(--manager-shell-shadow-strong);
+  margin: 0 auto;
 }
 
 body.manager-stitch-shell .auth-box::before {
@@ -5441,10 +5442,10 @@ body.manager-stitch-shell .manager-shell-actionbar-status {
   }
 
   body.manager-stitch-shell .auth-box {
-    width: 100%;
-    min-height: min(calc(100svh - 108px - env(safe-area-inset-top)), 720px);
-    padding: 24px 18px 18px;
-    border-radius: 24px 24px 18px 18px;
+    width: min(100%, 420px);
+    min-height: 0;
+    padding: 22px 18px 20px;
+    border-radius: 24px;
   }
 
   body.manager-stitch-shell .auth-screen {

--- a/style.css
+++ b/style.css
@@ -876,8 +876,12 @@
   .modal-actions { display: flex; gap: 9px; margin-top: 20px; }
   .btn-cancel { flex: 1; background: var(--surface); border: 1px solid var(--border); border-radius: 9px; color: var(--muted); font-family: var(--font-body); font-size: 13px; padding: 12px; cursor: pointer; transition: all 0.14s; }
   .btn-cancel:hover { border-color: var(--muted); color: var(--text); }
+  .btn-secondary { flex: 1; background: var(--surface); border: 1px solid var(--ember); border-radius: 9px; color: var(--ember); font-family: var(--font-body); font-size: 13px; padding: 12px; cursor: pointer; transition: all 0.14s; }
+  .btn-secondary:hover { background: rgba(190,67,48,0.08); }
   .btn-confirm { flex: 2; background: linear-gradient(135deg, var(--terra), var(--terra-dk)); border: none; border-radius: 9px; color: white; font-family: var(--font-heading); font-size: 16px; letter-spacing: 1px; padding: 12px; cursor: pointer; box-shadow: 0 3px 12px rgba(190,67,48,0.3); }
   .btn-confirm:hover { box-shadow: 0 5px 18px rgba(190,67,48,0.45); }
+  .btn-cancel:disabled,
+  .btn-secondary:disabled,
   .btn-confirm:disabled { background: var(--border); box-shadow: none; cursor: not-allowed; }
   .config-json-textarea { width: 100%; min-height: 110px; background: var(--surface); border: 1px solid var(--border); border-radius: 9px; color: var(--text); font-family: monospace; font-size: 13px; padding: 12px; resize: none; box-sizing: border-box; margin-top: 4px; }
 
@@ -3260,6 +3264,10 @@ body.manager-stitch-shell .manager-shell-actionbar {
   overscroll-behavior: contain;
 }
 
+body.manager-stitch-shell .manager-shell-actionbar.is-idle {
+  box-shadow: 0 10px 22px var(--manager-shell-shadow);
+}
+
 body.manager-stitch-shell .manager-shell-actionbar-copy {
   grid-area: copy;
   min-width: 0;
@@ -3312,6 +3320,7 @@ body.manager-stitch-shell .manager-shell-actionbar .workspace-actions-sub {
   margin-top: 0;
   font-size: 12px;
   line-height: 1.3;
+  color: var(--manager-shell-muted);
 }
 
 body.manager-stitch-shell #sync-status {
@@ -3334,6 +3343,13 @@ body.manager-stitch-shell .save-btn:hover {
   opacity: 1;
 }
 
+body.manager-stitch-shell .save-btn:disabled,
+body.manager-stitch-shell .send-btn:disabled {
+  opacity: 0.46;
+  border-color: var(--manager-shell-border);
+  color: var(--manager-shell-muted);
+}
+
 body.manager-stitch-shell .send-btn {
   min-width: 188px;
   background: linear-gradient(135deg, var(--manager-shell-primary), var(--manager-shell-primary-soft));
@@ -3342,6 +3358,18 @@ body.manager-stitch-shell .send-btn {
 
 body.manager-stitch-shell .send-btn:hover {
   transform: translateY(-1px);
+}
+
+body.manager-stitch-shell .btn-secondary {
+  background: var(--manager-shell-surface-muted);
+  border-color: var(--manager-shell-border);
+  color: var(--manager-shell-primary);
+}
+
+body.manager-stitch-shell .btn-secondary:hover {
+  background: var(--manager-shell-primary-faint);
+  border-color: var(--manager-shell-primary);
+  color: var(--manager-shell-primary);
 }
 
 body.manager-stitch-shell #sync-status {
@@ -4343,25 +4371,6 @@ body.manager-stitch-shell .manager-shell-header-badge--muted {
   color: var(--manager-shell-muted);
 }
 
-body.manager-stitch-shell .manager-shell-header-return {
-  appearance: none;
-  cursor: pointer;
-  font-family: 'Inter', sans-serif;
-  white-space: nowrap;
-  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
-}
-
-body.manager-stitch-shell .manager-shell-header-return:hover {
-  background: var(--manager-shell-primary);
-  border-color: var(--manager-shell-primary);
-  color: var(--manager-shell-bg);
-}
-
-body.manager-stitch-shell .manager-shell-header-return:focus-visible {
-  outline: 2px solid var(--manager-shell-primary);
-  outline-offset: 2px;
-}
-
 body.manager-stitch-shell .manager-shell-title-row {
   align-items: center;
   justify-content: space-between;
@@ -4511,6 +4520,7 @@ body.manager-stitch-shell .manager-shell-drawer-admin {
 }
 
 body.manager-stitch-shell .manager-shell-drawer-switch,
+body.manager-stitch-shell .manager-shell-drawer-return,
 body.manager-stitch-shell .manager-shell-drawer-admin {
   width: 100%;
   justify-content: center;

--- a/style.css
+++ b/style.css
@@ -1259,9 +1259,6 @@
 .featured-slot-desc { font-size: 12px; color: var(--muted); margin-top: 2px; }
 .featured-sell-note { font-size: 11px; color: var(--ember); font-style: italic; margin-top: 2px; }
 
-/* Featured confirm banner */
-.featured-confirm-banner { display: flex; align-items: center; gap: 8px; padding: 10px 14px; background: var(--surface); border: 1px solid var(--ember); border-radius: 8px; margin: 8px 0; font-size: 13px; color: var(--text); flex-wrap: wrap; }
-
 /* Specials manager card */
 .featured-specials-card { margin-bottom: 12px; }
 .featured-specials-icon { background: var(--terra); color: var(--bg); }
@@ -2728,27 +2725,6 @@ body.manager-stitch-shell #setup-banner h3 {
 body.manager-stitch-shell #setup-banner p,
 body.manager-stitch-shell #setup-banner strong {
   color: var(--manager-shell-muted);
-}
-
-body.manager-stitch-shell .featured-confirm-banner {
-  margin: 0 0 24px;
-  border-radius: 2px;
-  background: linear-gradient(135deg, var(--manager-shell-primary-soft), var(--manager-shell-primary));
-  border: none;
-  color: var(--manager-shell-bg);
-  padding: 22px 24px;
-}
-
-body.manager-stitch-shell .featured-confirm-banner .btn-small {
-  background: var(--manager-shell-surface);
-  border-color: var(--manager-shell-surface);
-  color: var(--manager-shell-primary);
-}
-
-body.manager-stitch-shell .featured-confirm-banner .btn-small:hover {
-  background: var(--manager-shell-accent-soft);
-  border-color: var(--manager-shell-accent-soft);
-  color: var(--manager-shell-accent);
 }
 
 body.manager-stitch-shell .manager-shell-stats-grid,
@@ -4365,6 +4341,25 @@ body.manager-stitch-shell .manager-shell-header-badge {
 
 body.manager-stitch-shell .manager-shell-header-badge--muted {
   color: var(--manager-shell-muted);
+}
+
+body.manager-stitch-shell .manager-shell-header-return {
+  appearance: none;
+  cursor: pointer;
+  font-family: 'Inter', sans-serif;
+  white-space: nowrap;
+  transition: background-color 0.18s ease, border-color 0.18s ease, color 0.18s ease;
+}
+
+body.manager-stitch-shell .manager-shell-header-return:hover {
+  background: var(--manager-shell-primary);
+  border-color: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
+}
+
+body.manager-stitch-shell .manager-shell-header-return:focus-visible {
+  outline: 2px solid var(--manager-shell-primary);
+  outline-offset: 2px;
 }
 
 body.manager-stitch-shell .manager-shell-title-row {

--- a/tests/architecture-boundaries.test.cjs
+++ b/tests/architecture-boundaries.test.cjs
@@ -293,7 +293,7 @@ test('public route contract exposes a stable snapshot and switchMenu action', as
   assert.equal(applyCalls, 1);
 });
 
-test('restaurant specials service centralizes add, matches, and confirm flows', async () => {
+test('restaurant specials service centralizes add and match flows', async () => {
   const sandbox = loadAppSandbox();
   const requestCalls = [];
   const refreshCalls = [];
@@ -342,11 +342,134 @@ test('restaurant specials service centralizes add, matches, and confirm flows', 
   assert.equal(added.ok, true);
   assert.equal(requestCalls[0][0], 'add');
   assert.equal(refreshCalls.length, 1);
+});
 
-  const confirmed = await service.confirmToday();
-  assert.equal(confirmed.ok, true);
-  assert.equal(sandbox.sessionStorage.getItem('featured_confirmed:00000000-0000-0000-0000-000000000010'), '1');
-  assert.equal(requestCalls[1][0], 'confirm');
+test('manager menu switching closes the mobile drawer after the menu refresh completes', async () => {
+  const sandbox = loadAppSandbox();
+  const mobileCalls = [];
+
+  setState(sandbox, {
+    currentDesign: {},
+    showMenuPicker: onPick => {
+      mobileCalls.push('picker');
+      return onPick();
+    },
+    ensureCurrentMenuSession: () => ({
+      refresh: async () => {
+        mobileCalls.push('refresh');
+      },
+    }),
+    applyDesign: () => {
+      mobileCalls.push('design');
+    },
+    sbEnsureUncategorized: async () => {
+      mobileCalls.push('uncategorized');
+    },
+    renderManagerWorkspace: () => {
+      mobileCalls.push('render');
+    },
+    updateDraftIndicator: () => {
+      mobileCalls.push('draft');
+    },
+    updateSaveBtn: () => {
+      mobileCalls.push('save');
+    },
+    updateManagerActionBar: () => {
+      mobileCalls.push('actionbar');
+    },
+    closeSettingsDrawer: () => {
+      mobileCalls.push('close');
+    },
+  });
+
+  sandbox.innerWidth = 920;
+  sandbox.window.innerWidth = 920;
+  sandbox.onSwitchMenuClick();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.deepEqual(mobileCalls, [
+    'picker',
+    'refresh',
+    'design',
+    'uncategorized',
+    'render',
+    'draft',
+    'save',
+    'actionbar',
+    'close',
+  ]);
+
+  const desktopCalls = [];
+  setState(sandbox, {
+    showMenuPicker: onPick => {
+      desktopCalls.push('picker');
+      return onPick();
+    },
+    ensureCurrentMenuSession: () => ({
+      refresh: async () => {
+        desktopCalls.push('refresh');
+      },
+    }),
+    applyDesign: () => {
+      desktopCalls.push('design');
+    },
+    sbEnsureUncategorized: async () => {
+      desktopCalls.push('uncategorized');
+    },
+    renderManagerWorkspace: () => {
+      desktopCalls.push('render');
+    },
+    updateDraftIndicator: () => {
+      desktopCalls.push('draft');
+    },
+    updateSaveBtn: () => {
+      desktopCalls.push('save');
+    },
+    updateManagerActionBar: () => {
+      desktopCalls.push('actionbar');
+    },
+    closeSettingsDrawer: () => {
+      desktopCalls.push('close');
+    },
+  });
+
+  sandbox.innerWidth = 921;
+  sandbox.window.innerWidth = 921;
+  sandbox.onSwitchMenuClick();
+  await new Promise(resolve => setTimeout(resolve, 0));
+
+  assert.deepEqual(desktopCalls, [
+    'picker',
+    'refresh',
+    'design',
+    'uncategorized',
+    'render',
+    'draft',
+    'save',
+    'actionbar',
+  ]);
+});
+
+test('manager header return button only appears while manager mode is active', () => {
+  const sandbox = loadAppSandbox();
+  const returnBtn = sandbox.document._registerElement('manager-return-btn', createElement('button', 'manager-return-btn'));
+
+  setState(sandbox, {
+    currentUser: {
+      role: 'manager',
+      name: 'Alex',
+      accessibleMenuIds: ['menu-main'],
+    },
+    currentUserCanManageMenu: () => true,
+    isManagerMode: true,
+  });
+
+  sandbox.renderUserHeader();
+  assert.equal(returnBtn.style.display, '');
+
+  setState(sandbox, { isManagerMode: false });
+  sandbox.renderUserHeader();
+  assert.equal(returnBtn.style.display, 'none');
 });
 
 test('public route contract and route renderers register and hydrate both restaurant shells', async () => {
@@ -383,25 +506,23 @@ test('public route contract and route renderers register and hydrate both restau
         {
           id: 'group-1',
           name: 'Specials',
-          slots: [
-            {
-              id: 'slot-1',
-              itemId: 'special-1',
-              sellNote: '',
-              item: {
-                id: 'special-1',
-                name: 'House Margarita',
-                price: '$12',
-                visibility: 'public',
-                eightySixed: false,
-                desc: 'Citrus and salt',
-                recipe: ['tequila', 'lime'],
-                upcharges: [],
-                showDescription: true,
-                showRecipe: true,
-              },
+          slots: Array.from({ length: 5 }, (_, index) => ({
+            id: `slot-${index + 1}`,
+            itemId: `special-${index + 1}`,
+            sellNote: '',
+            item: {
+              id: `special-${index + 1}`,
+              name: `House Margarita ${index + 1}`,
+              price: '$12',
+              visibility: 'public',
+              eightySixed: false,
+              desc: 'Citrus and salt',
+              recipe: ['tequila', 'lime'],
+              upcharges: [],
+              showDescription: true,
+              showRecipe: true,
             },
-          ],
+          })),
         },
       ],
       menuState: makeMenuState({
@@ -475,7 +596,8 @@ test('public route contract and route renderers register and hydrate both restau
     assert.match(footerVersion.innerHTML, /PREVIEW/);
     assert.equal(footerTimestamp.textContent, 'Thu, Apr 9 at 7:25 PM');
     if (menuNameEl) assert.equal(menuNameEl.textContent, routeCase.menuName);
-    assert.match(featuredWrap.innerHTML, /House Margarita/);
+    assert.match(featuredWrap.innerHTML, /House Margarita 1/);
+    assert.match(featuredWrap.innerHTML, /House Margarita 5/);
     assert.equal(page.classList.contains('is-mobile-expanded') || page.classList.contains('is-mobile-compact'), true);
   }
 });

--- a/tests/architecture-boundaries.test.cjs
+++ b/tests/architecture-boundaries.test.cjs
@@ -166,6 +166,109 @@ test('update publisher consolidates send results, persistence, and warnings', as
   assert.ok(patches.length >= 1);
 });
 
+test('update publisher can publish without firing notifications', async () => {
+  const sandbox = loadAppSandbox();
+  const diff = [
+    {
+      id: 'beer',
+      icon: '🍺',
+      label: 'Beers on Tap',
+      added: ['New Lager'],
+      removed: [],
+      eightySixed: [],
+      restored: [],
+    },
+  ];
+  const persistCalls = [];
+  let fetchCalls = 0;
+
+  setState(sandbox, {
+    MENU_ID: 'menu-main',
+    _activeMenuName: 'Main Menu',
+    currentUser: { accessToken: 'token-1', uid: 'user-1' },
+    getCachedDiff: () => diff,
+    buildMenuSessionSnapshot: source => ({ source }),
+    snapshotCurrentItemsAsLastSent: () => ({ beer: [] }),
+    getCurrentFeaturedIds: () => ['feature-1'],
+    currentUserCanEditRestaurantSpecials: () => false,
+    getRestaurantSpecialConfig: () => ({ menuIds: [] }),
+    persistState: async options => {
+      persistCalls.push(options);
+      return true;
+    },
+    patchMenuMetaWithCompatibility: async () => ({ downgradedFields: [] }),
+    patchMenuMetaForMenuWithCompatibility: async () => ({ downgradedFields: [] }),
+    syncLocalMenuCache: () => true,
+    logUpdate: async () => true,
+    fetch: async () => {
+      fetchCalls += 1;
+      return createFetchResponse(500, {});
+    },
+  });
+
+  const publisher = sandbox.createUpdatePublisher();
+  const result = await publisher.publish({ notify: false });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.notificationStatus, null);
+  assert.equal(fetchCalls, 0);
+  assert.equal(persistCalls.length, 1);
+  assert.equal(persistCalls[0].silentFailure, true);
+  assert.equal(result.warnings.length, 0);
+  assert.match(result.successMessage, /saved to the live menu/i);
+});
+
+test('manager action bar stays visible and reflects idle and active draft states', () => {
+  const sandbox = loadAppSandbox();
+  const bar = sandbox.document._registerElement('manager-action-bar', createElement('div', 'manager-action-bar'));
+  const primaryGroup = sandbox.document._registerElement('manager-primary-action-group', createElement('div', 'manager-primary-action-group'));
+  const summary = sandbox.document._registerElement('manager-action-bar-summary', createElement('div', 'manager-action-bar-summary'));
+  sandbox.document._registerElement('sync-status', createElement('div', 'sync-status'));
+  const saveBtn = sandbox.document._registerElement('save-btn', createElement('button', 'save-btn'));
+  const sendBtn = sandbox.document._registerElement('send-btn', createElement('button', 'send-btn'));
+
+  sandbox.innerWidth = 960;
+  sandbox.window.innerWidth = 960;
+
+  setState(sandbox, {
+    _dirty: false,
+    _diffDirty: false,
+    _diffCache: [],
+  });
+
+  sandbox.updateManagerActionBar();
+
+  assert.equal(bar.hidden, false);
+  assert.equal(primaryGroup.hidden, false);
+  assert.equal(summary.textContent, 'No Pending Changes');
+  assert.equal(saveBtn.disabled, true);
+  assert.equal(sendBtn.disabled, true);
+  assert.equal(bar.classList.contains('is-idle'), true);
+
+  setState(sandbox, {
+    _dirty: true,
+    _diffDirty: false,
+    _diffCache: [
+      {
+        id: 'beer',
+        icon: '🍺',
+        label: 'Beers on Tap',
+        added: ['New Lager'],
+        removed: ['Old Lager'],
+        eightySixed: [],
+        restored: [],
+      },
+    ],
+  });
+
+  sandbox.updateManagerActionBar();
+
+  assert.equal(summary.textContent, '2 pending changes. Save Draft keeps them private. Save opens Patch Notes Preview.');
+  assert.equal(saveBtn.disabled, false);
+  assert.equal(sendBtn.disabled, false);
+  assert.equal(bar.classList.contains('is-idle'), false);
+});
+
 test('access session service restores sessions and resolves settings access', async () => {
   const sandbox = loadAppSandbox();
   const refreshCalls = [];
@@ -450,13 +553,13 @@ test('manager menu switching closes the mobile drawer after the menu refresh com
   ]);
 });
 
-test('manager header return button only appears while manager mode is active', () => {
+test('manager user header no longer depends on a header return button', () => {
   const sandbox = loadAppSandbox();
-  const returnBtn = sandbox.document._registerElement('manager-return-btn', createElement('button', 'manager-return-btn'));
+  const adminDrawerBtn = sandbox.document._registerElement('admin-btn-drawer', createElement('button', 'admin-btn-drawer'));
 
   setState(sandbox, {
     currentUser: {
-      role: 'manager',
+      role: 'admin',
       name: 'Alex',
       accessibleMenuIds: ['menu-main'],
     },
@@ -465,11 +568,7 @@ test('manager header return button only appears while manager mode is active', (
   });
 
   sandbox.renderUserHeader();
-  assert.equal(returnBtn.style.display, '');
-
-  setState(sandbox, { isManagerMode: false });
-  sandbox.renderUserHeader();
-  assert.equal(returnBtn.style.display, 'none');
+  assert.equal(adminDrawerBtn.style.display, '');
 });
 
 test('public route contract and route renderers register and hydrate both restaurant shells', async () => {


### PR DESCRIPTION
## Summary
- resolve the `manager-ui` fixes for issues `#240` through `#243`
- redesign the manager publishing dock and move the menu return affordance into the drawer-owned action cluster
- strengthen the unauthenticated manager auth shell across desktop/mobile and light/dark, with a tighter mobile sheet layout
- add the manager design-loop audit note captured during the preview review pass

## Verification
- `node --check app.js`
- headless Playwright review of `/manager` on the Vercel preview in desktop/mobile and light/dark for the logged-out auth flow

## Notes
- compare is `5` commits ahead of `v0.8.7`
- changed areas include `app.js`, `manager/index.html`, `style.css`, route app hooks, and architecture-boundary coverage tests