### PR TITLE
[codex] Deepen menu session lifecycle boundary

### DIFF
--- a/app.js
+++ b/app.js
@@ -185,10 +185,7 @@ let _deletedItemIds    = new Set();  // item UUIDs to DELETE on next persistStat
 let _uncatCategoryUuid = '';         // DB UUID of the __uncategorized__ category row
 let _managerDraggedItemId = '';
 let _managerDraggedCatId = '';
-let _menuLifecycleService = null;
-let _menuRuntime = null;
 let _currentMenuSession = null;
-let _updatePublisher = null;
 let _menuMetaSupportsLastSentFeatured = true;
 function invalidateDiff() { _diffDirty = true; _dirty = true; updateSaveBtn(); }
 function updateSaveBtn() {
@@ -488,9 +485,9 @@ function buildCurrentMenuPageRequest(overrides = {}) {
   };
 }
 
-function buildMenuSessionSnapshot(source = 'live') {
+function buildMenuSessionSnapshot(source = 'live', request = buildCurrentMenuPageRequest()) {
   return {
-    request: buildCurrentMenuPageRequest(),
+    request,
     source,
     menuId: MENU_ID,
     menuType: MENU_TYPE,
@@ -505,113 +502,350 @@ function buildMenuSessionSnapshot(source = 'live') {
   };
 }
 
-function createMenuLifecycleService(ports) {
+function buildMenuSessionPreview(snapshot = buildMenuSessionSnapshot('preview')) {
+  const diff = getCachedDiff();
+  const patchMessage = diff.length ? buildPatchMessage(diff) : '';
   return {
-    async openPageState(options = {}) {
-      return ports.openPageState(options);
+    hasChanges: diff.length > 0,
+    diff,
+    sections: diff,
+    patchMessage,
+    truncated: patchMessage.length > 1000,
+    snapshot,
+  };
+}
+
+function getMenuSessionPorts() {
+  return {
+    buildRequest(overrides = {}) {
+      return buildCurrentMenuPageRequest(overrides);
     },
-    async refreshPageState(options = {}) {
-      if (options.reason === 'poll') return ports.pollPageState(options);
+    buildSnapshot(source = 'live', request = buildCurrentMenuPageRequest()) {
+      return buildMenuSessionSnapshot(source, request);
+    },
+    async resolveMenu() {
+      if (!SUPABASE_URL) return null;
+      return sbResolveMenu();
+    },
+    canLoadFromNetwork() {
+      return !!(SUPABASE_URL && MENU_ID);
+    },
+    restoreFallback({ expectedRestaurantId = '' } = {}) {
+      const fallback = restoreMenuStateFromFallback(expectedRestaurantId);
+      return {
+        source: fallback.source,
+        usedFallback: fallback.usedFallback,
+      };
+    },
+    async loadState(options = {}) {
+      return _loadActiveMenuStateInternal(options);
+    },
+    async pollState(options = {}) {
+      return _pollActiveMenuStateInternal(options);
+    },
+    now() {
+      return Date.now();
+    },
+    async persistState(options = {}) {
+      return persistState(options);
+    },
+    async patchMenuMeta(update) {
+      return patchMenuMetaWithCompatibility(update);
+    },
+    async patchMenuMetaForMenu(menuId, update) {
+      return patchMenuMetaForMenuWithCompatibility(menuId, update);
+    },
+    finalizePersistStatus(ok) {
+      finalizePersistStatus(ok);
+    },
+    commitDraft(ts) {
+      menuState._meta = { ...(menuState._meta || {}), lastUpdatedTs: ts.toString() };
+      lsSet(LS_KEYS.lastUpdated, ts.toString());
+      _dirty = false;
+      updateSaveBtn();
+      updateLastUpdatedLabel();
+      syncLocalMenuCache({ silent: true });
+    },
+    buildPreview(snapshot) {
+      return buildMenuSessionPreview(snapshot);
+    },
+    getMenuId() {
+      return MENU_ID;
+    },
+    getRestaurantId() {
+      return RESTAURANT_ID;
+    },
+    getMenuName() {
+      return _activeMenuName;
+    },
+    snapshotCurrentItemsAsLastSent() {
+      return snapshotCurrentItemsAsLastSent();
+    },
+    getCurrentFeaturedIds() {
+      return getCurrentFeaturedIds();
+    },
+    canEditRestaurantSpecials(restaurantId) {
+      return currentUserCanEditRestaurantSpecials(restaurantId);
+    },
+    getRestaurantMenuIds(restaurantId) {
+      return getRestaurantSpecialConfig(restaurantId)?.menuIds || [];
+    },
+    async dispatchNotification(payload) {
+      return dispatchMenuUpdateNotification(payload);
+    },
+    collectNotificationWarnings(summary) {
+      return collectNotificationWarnings(summary);
+    },
+    syncLocalCache(options = {}) {
+      return syncLocalMenuCache(options);
+    },
+    async logUpdate(diff, patchMessage) {
+      return logUpdate(diff, patchMessage);
+    },
+    commitPublished({ diff, ts, featuredIds }) {
+      _lastSentFeaturedIds = new Set(featuredIds);
+      applySentState(diff, ts);
+      _dirty = false;
+      updateSaveBtn();
+      updateLastUpdatedLabel();
+    },
+    dedupeWarnings(warnings = []) {
+      return dedupePublisherWarnings(warnings);
+    },
+  };
+}
+
+function createMenuSessionLifecycle(ports) {
+  const sessionPorts = ports || getMenuSessionPorts();
+  let request = sessionPorts.buildRequest();
+
+  function syncRequest(overrides = {}) {
+    request = { ...request, ...sessionPorts.buildRequest(overrides) };
+    return request;
+  }
+
+  function buildSnapshot(source = 'live') {
+    return sessionPorts.buildSnapshot(source, request);
+  }
+
+  const session = {
+    syncRequest,
+    snapshot(source = 'live') {
+      syncRequest();
+      return buildSnapshot(source);
+    },
+    async open(options = {}) {
+      const nextRequest = syncRequest(options);
+      const expectedRestaurantId = options.expectedRestaurantId || nextRequest.siteRestaurantId || '';
+
+      if (options.resolveMenu !== false) {
+        const resolution = await sessionPorts.resolveMenu({ request: nextRequest, ...options });
+        if (resolution?.redirect) return resolution;
+      }
+
+      if (!sessionPorts.canLoadFromNetwork({ request: nextRequest, ...options })) {
+        const fallback = sessionPorts.restoreFallback({ expectedRestaurantId, request: nextRequest, ...options });
+        return {
+          ok: true,
+          source: fallback.source,
+          usedFallback: fallback.usedFallback,
+          showLoadError: false,
+          snapshot: fallback.snapshot || buildSnapshot(fallback.source),
+        };
+      }
+
+      try {
+        const snapshot = await sessionPorts.loadState({
+          request: nextRequest,
+          fallbackToDefault: options.fallbackToDefault,
+          includeFeatured: options.includeFeatured,
+          persistCache: options.persistCache,
+          source: options.source || 'network',
+        });
+        return {
+          ok: true,
+          source: snapshot.source || 'network',
+          usedFallback: false,
+          showLoadError: false,
+          snapshot,
+        };
+      } catch (error) {
+        const fallback = sessionPorts.restoreFallback({ expectedRestaurantId, request: nextRequest, error, ...options });
+        return {
+          ok: false,
+          error,
+          source: fallback.source,
+          usedFallback: fallback.usedFallback,
+          showLoadError: true,
+          snapshot: fallback.snapshot || buildSnapshot(fallback.source),
+        };
+      }
+    },
+    async refresh(options = {}) {
+      const nextRequest = syncRequest(options);
+      if (options.reason === 'poll') {
+        return sessionPorts.pollState({ request: nextRequest, ...options });
+      }
       return {
         ok: true,
-        snapshot: await ports.loadPageState(options),
+        snapshot: await sessionPorts.loadState({ request: nextRequest, ...options }),
       };
     },
-    async savePageDraft(options = {}) {
-      return ports.savePageDraft(options);
+    preview() {
+      syncRequest();
+      return sessionPorts.buildPreview(buildSnapshot('preview'));
     },
-    async publishPageUpdate(options = {}) {
-      return ports.publishPageUpdate(options);
+    async saveDraft(options = {}) {
+      syncRequest(options);
+      const ts = sessionPorts.now();
+      try {
+        const persisted = await sessionPorts.persistState(options);
+        if (!persisted) {
+          return {
+            ok: false,
+            userHandled: true,
+            snapshot: buildSnapshot('save-failed'),
+          };
+        }
+        await sessionPorts.patchMenuMeta({ last_updated_ts: ts });
+        sessionPorts.commitDraft(ts);
+        return {
+          ok: true,
+          ts,
+          snapshot: buildSnapshot('saved'),
+        };
+      } catch (_) {
+        sessionPorts.finalizePersistStatus(false);
+        return {
+          ok: false,
+          userHandled: false,
+          snapshot: buildSnapshot('save-failed'),
+        };
+      }
+    },
+    async publishUpdate(options = {}) {
+      syncRequest(options);
+      const preview = options.preview?.diff ? options.preview : session.preview();
+      if (!preview.hasChanges) {
+        return {
+          ok: false,
+          noop: true,
+          preview,
+          snapshot: buildSnapshot('send-noop'),
+        };
+      }
+
+      const delivery = await sessionPorts.dispatchNotification({
+        menuId: sessionPorts.getMenuId(),
+        patchMessage: preview.patchMessage,
+      });
+      if (!delivery.ok) {
+        return {
+          ok: false,
+          preview,
+          notificationStatus: delivery,
+          userMessage: delivery.userMessage,
+          snapshot: buildSnapshot('send-failed'),
+        };
+      }
+
+      const warnings = sessionPorts.collectNotificationWarnings(delivery.summary);
+      try {
+        const persisted = await sessionPorts.persistState({ silentFailure: true });
+        if (!persisted) throw new Error('persist failed');
+
+        const ts = sessionPorts.now();
+        const lastSentState = sessionPorts.snapshotCurrentItemsAsLastSent();
+        const currentFeaturedIds = sessionPorts.getCurrentFeaturedIds();
+        const restaurantId = sessionPorts.getRestaurantId();
+        const restaurantMenuIds = sessionPorts.canEditRestaurantSpecials(restaurantId)
+          ? sessionPorts.getRestaurantMenuIds(restaurantId)
+          : [];
+        const patchResults = await Promise.all([
+          sessionPorts.patchMenuMeta({
+            last_updated_ts: ts,
+            last_sent_ts: ts,
+            last_sent_state: lastSentState,
+            last_sent_categories: preview.diff.map(section => section.id),
+            last_sent_featured: currentFeaturedIds,
+          }),
+          ...restaurantMenuIds
+            .filter(menuId => menuId && menuId !== sessionPorts.getMenuId())
+            .map(menuId => sessionPorts.patchMenuMetaForMenu(menuId, {
+              last_sent_featured: currentFeaturedIds,
+            })),
+        ]);
+        if (patchResults.some(result => (result?.downgradedFields || []).includes('last_sent_featured'))) {
+          warnings.push('Featured sync used legacy metadata compatibility on this deployment.');
+        }
+
+        sessionPorts.commitPublished({
+          diff: preview.diff,
+          ts,
+          featuredIds: currentFeaturedIds,
+        });
+
+        const cacheSynced = sessionPorts.syncLocalCache({ silent: true });
+        if (!cacheSynced) {
+          warnings.push('This device could not refresh its local cache after the send.');
+        }
+
+        const logged = await sessionPorts.logUpdate(preview.diff, preview.patchMessage);
+        if (!logged) {
+          warnings.push('The recent-changes audit log could not be written for this send.');
+        }
+
+        const finalWarnings = sessionPorts.dedupeWarnings(warnings);
+        return {
+          ok: true,
+          preview,
+          ts,
+          truncated: preview.truncated,
+          notificationStatus: delivery,
+          warnings: finalWarnings,
+          warningMessage: finalWarnings[0] || '',
+          successMessage: `✅ ${sessionPorts.getMenuName() || 'Menu'} update sent!`,
+          snapshot: buildSnapshot(finalWarnings.length ? 'sent-warning' : 'sent'),
+        };
+      } catch (syncError) {
+        console.warn('sendUpdate post-send sync failed:', syncError);
+        warnings.push('Update sent, but database sync needs attention. Refresh before sending again.');
+        const finalWarnings = sessionPorts.dedupeWarnings(warnings);
+        return {
+          ok: true,
+          preview,
+          truncated: preview.truncated,
+          notificationStatus: delivery,
+          warnings: finalWarnings,
+          warningMessage: finalWarnings[0] || '',
+          successMessage: `✅ ${sessionPorts.getMenuName() || 'Menu'} update sent!`,
+          snapshot: buildSnapshot('sent-warning'),
+        };
+      }
+    },
+    async save(options = {}) {
+      return session.saveDraft(options);
+    },
+    async sendUpdate(options = {}) {
+      return session.publishUpdate(options);
+    },
+    getSnapshot(source = 'live') {
+      return session.snapshot(source);
+    },
+    _syncRequest(nextRequest = {}) {
+      return syncRequest(nextRequest);
     },
   };
-}
 
-function createMenuRuntime({ lifecycle }) {
-  return {
-    openPage(pageRequest = {}) {
-      const session = {
-        _request: { ...pageRequest },
-        _syncRequest(nextRequest = {}) {
-          this._request = { ...this._request, ...nextRequest };
-          return this._request;
-        },
-        async open(options = {}) {
-          this._syncRequest(buildCurrentMenuPageRequest(options));
-          return lifecycle.openPageState({ request: this._request, ...options });
-        },
-        getSnapshot(source = 'live') {
-          this._syncRequest(buildCurrentMenuPageRequest());
-          return buildMenuSessionSnapshot(source);
-        },
-        update(mutator) {
-          if (typeof mutator === 'function') {
-            mutator({
-              menuState,
-              currentDesign,
-              featuredGroups: _featuredGroups,
-              menuId: MENU_ID,
-              restaurantId: RESTAURANT_ID,
-            });
-            invalidateDiff();
-          }
-          return this.getSnapshot();
-        },
-        async refresh(options = {}) {
-          this._syncRequest(buildCurrentMenuPageRequest(options));
-          return lifecycle.refreshPageState({ request: this._request, ...options });
-        },
-        async save(options = {}) {
-          this._syncRequest(buildCurrentMenuPageRequest(options));
-          return lifecycle.savePageDraft({ request: this._request, ...options });
-        },
-        async sendUpdate(options = {}) {
-          this._syncRequest(buildCurrentMenuPageRequest(options));
-          return lifecycle.publishPageUpdate({ request: this._request, ...options });
-        },
-        async switchMenu(menuRef) {
-          const requested = typeof menuRef === 'string'
-            ? (getMenuById(menuRef) || getMenuBySlug(menuRef))
-            : (menuRef?.id ? getMenuById(menuRef.id) : getMenuBySlug(menuRef?.slug || ''));
-          if (!requested) return this.getSnapshot();
-          selectMenu(
-            requested.id,
-            requested.slug,
-            requested.name,
-            requested.type,
-            requested.restaurantId
-          );
-          return this.refresh();
-        },
-      };
-      session._syncRequest(buildCurrentMenuPageRequest(pageRequest));
-      return session;
-    },
-  };
-}
-
-function getMenuLifecycleService() {
-  if (_menuLifecycleService) return _menuLifecycleService;
-  _menuLifecycleService = createMenuLifecycleService({
-    openPageState: options => _openCurrentMenuPageInternal(options),
-    loadPageState: options => _loadActiveMenuStateInternal(options),
-    pollPageState: options => _pollActiveMenuStateInternal(options),
-    savePageDraft: options => _saveActiveMenuDraftInternal(options),
-    publishPageUpdate: options => _publishActiveMenuUpdateInternal(options),
-  });
-  return _menuLifecycleService;
-}
-
-function getMenuRuntime() {
-  if (_menuRuntime) return _menuRuntime;
-  _menuRuntime = createMenuRuntime({ lifecycle: getMenuLifecycleService() });
-  return _menuRuntime;
+  return session;
 }
 
 function ensureCurrentMenuSession(overrides = {}) {
   if (!_currentMenuSession) {
-    _currentMenuSession = getMenuRuntime().openPage(buildCurrentMenuPageRequest(overrides));
+    _currentMenuSession = createMenuSessionLifecycle();
+    _currentMenuSession.syncRequest(overrides);
   } else {
-    _currentMenuSession._syncRequest(buildCurrentMenuPageRequest(overrides));
+    _currentMenuSession.syncRequest(overrides);
   }
   return _currentMenuSession;
 }
@@ -1561,56 +1795,6 @@ function getRestaurantSpecialsService() {
 
 async function refreshFeaturedForActiveMenu() {
   return getRestaurantSpecialsService().refreshForActiveMenu(RESTAURANT_ID);
-}
-
-async function _openCurrentMenuPageInternal(options = {}) {
-  const {
-    request = buildCurrentMenuPageRequest(),
-    resolveMenu = true,
-    fallbackToDefault = true,
-    includeFeatured = true,
-    persistCache = true,
-    expectedRestaurantId = request.siteRestaurantId || '',
-  } = options;
-
-  if (resolveMenu && SUPABASE_URL) await sbResolveMenu();
-
-  if (!SUPABASE_URL || !MENU_ID) {
-    const fallback = restoreMenuStateFromFallback(expectedRestaurantId);
-    return {
-      ok: true,
-      source: fallback.source,
-      usedFallback: fallback.usedFallback,
-      showLoadError: false,
-      snapshot: buildMenuSessionSnapshot(fallback.source),
-    };
-  }
-
-  try {
-    const snapshot = await _loadActiveMenuStateInternal({
-      fallbackToDefault,
-      includeFeatured,
-      persistCache,
-      source: 'network',
-    });
-    return {
-      ok: true,
-      source: snapshot.source || 'network',
-      usedFallback: false,
-      showLoadError: false,
-      snapshot,
-    };
-  } catch (error) {
-    const fallback = restoreMenuStateFromFallback(expectedRestaurantId);
-    return {
-      ok: false,
-      error,
-      source: fallback.source,
-      usedFallback: fallback.usedFallback,
-      showLoadError: true,
-      snapshot: buildMenuSessionSnapshot(fallback.source),
-    };
-  }
 }
 
 async function _loadActiveMenuStateInternal(options = {}) {
@@ -5061,42 +5245,9 @@ async function persistState(options = {}) {
   }
 }
 
-async function _saveActiveMenuDraftInternal() {
-  const ts = Date.now();
-  try {
-    const persisted = await persistState();
-    if (!persisted) {
-      return {
-        ok: false,
-        userHandled: true,
-        snapshot: buildMenuSessionSnapshot('save-failed'),
-      };
-    }
-    await patchMenuMetaWithCompatibility({ last_updated_ts: ts });
-    menuState._meta = { ...(menuState._meta || {}), lastUpdatedTs: ts.toString() };
-    lsSet(LS_KEYS.lastUpdated, ts.toString());
-    _dirty = false;
-    updateSaveBtn();
-    updateLastUpdatedLabel();
-    syncLocalMenuCache({ silent: true });
-    return {
-      ok: true,
-      ts,
-      snapshot: buildMenuSessionSnapshot('saved'),
-    };
-  } catch(e) {
-    finalizePersistStatus(false);
-    return {
-      ok: false,
-      userHandled: false,
-      snapshot: buildMenuSessionSnapshot('save-failed'),
-    };
-  }
-}
-
 async function saveMenu() {
   try {
-    const result = await ensureCurrentMenuSession().save();
+    const result = await ensureCurrentMenuSession().saveDraft();
     if (result?.ok) {
       showToast('✅ Menu saved!', 'success');
       return;
@@ -5828,7 +5979,7 @@ function buildPreviewBlockHtml(section) {
 }
 
 function openPreview() {
-  const preview = getUpdatePublisher().preview();
+  const preview = ensureCurrentMenuSession().preview();
   const content = document.getElementById('preview-content');
   const confirmBtn = document.getElementById('confirm-btn');
   const modal = document.getElementById('modal-bg');
@@ -5868,128 +6019,6 @@ function buildPatchMessage(diff) {
   });
   if (MENU_URL) lines.push(`📋 Full menu: ${MENU_URL}`);
   return lines.join('\n').trim();
-}
-
-function getUpdatePublisher() {
-  if (_updatePublisher) return _updatePublisher;
-  _updatePublisher = createUpdatePublisher();
-  return _updatePublisher;
-}
-
-function createUpdatePublisher() {
-  return {
-    preview() {
-      const diff = getCachedDiff();
-      const patchMessage = diff.length ? buildPatchMessage(diff) : '';
-      return {
-        hasChanges: diff.length > 0,
-        diff,
-        sections: diff,
-        patchMessage,
-        truncated: patchMessage.length > 1000,
-        snapshot: buildMenuSessionSnapshot('preview'),
-      };
-    },
-
-    async publish(options = {}) {
-      const preview = options.preview?.diff ? options.preview : this.preview();
-      if (!preview.hasChanges) {
-        return {
-          ok: false,
-          noop: true,
-          preview,
-          snapshot: buildMenuSessionSnapshot('send-noop'),
-        };
-      }
-
-      const delivery = await dispatchMenuUpdateNotification({
-        menuId: MENU_ID,
-        patchMessage: preview.patchMessage,
-      });
-      if (!delivery.ok) {
-        return {
-          ok: false,
-          preview,
-          notificationStatus: delivery,
-          userMessage: delivery.userMessage,
-          snapshot: buildMenuSessionSnapshot('send-failed'),
-        };
-      }
-
-      const warnings = collectNotificationWarnings(delivery.summary);
-      try {
-        const persisted = await persistState({ silentFailure: true });
-        if (!persisted) throw new Error('persist failed');
-
-        const ts = Date.now();
-        const lastSentState = snapshotCurrentItemsAsLastSent();
-        const currentFeaturedIds = getCurrentFeaturedIds();
-        const restaurantMenuIds = currentUserCanEditRestaurantSpecials(RESTAURANT_ID)
-          ? (getRestaurantSpecialConfig(RESTAURANT_ID)?.menuIds || [])
-          : [];
-        const patchResults = await Promise.all([
-          patchMenuMetaWithCompatibility({
-            last_updated_ts: ts,
-            last_sent_ts: ts,
-            last_sent_state: lastSentState,
-            last_sent_categories: preview.diff.map(section => section.id),
-            last_sent_featured: currentFeaturedIds,
-          }),
-          ...restaurantMenuIds
-            .filter(menuId => menuId && menuId !== MENU_ID)
-            .map(menuId => patchMenuMetaForMenuWithCompatibility(menuId, {
-              last_sent_featured: currentFeaturedIds,
-            })),
-        ]);
-        if (patchResults.some(result => (result?.downgradedFields || []).includes('last_sent_featured'))) {
-          warnings.push('Featured sync used legacy metadata compatibility on this deployment.');
-        }
-
-        _lastSentFeaturedIds = new Set(currentFeaturedIds);
-        applySentState(preview.diff, ts);
-        _dirty = false;
-        updateSaveBtn();
-        updateLastUpdatedLabel();
-
-        const cacheSynced = syncLocalMenuCache({ silent: true });
-        if (!cacheSynced) {
-          warnings.push('This device could not refresh its local cache after the send.');
-        }
-
-        const logged = await logUpdate(preview.diff, preview.patchMessage);
-        if (!logged) {
-          warnings.push('The recent-changes audit log could not be written for this send.');
-        }
-
-        const finalWarnings = dedupePublisherWarnings(warnings);
-        return {
-          ok: true,
-          preview,
-          ts,
-          truncated: preview.truncated,
-          notificationStatus: delivery,
-          warnings: finalWarnings,
-          warningMessage: finalWarnings[0] || '',
-          successMessage: `✅ ${_activeMenuName || 'Menu'} update sent!`,
-          snapshot: buildMenuSessionSnapshot(finalWarnings.length ? 'sent-warning' : 'sent'),
-        };
-      } catch (syncError) {
-        console.warn('sendUpdate post-send sync failed:', syncError);
-        warnings.push('Update sent, but database sync needs attention. Refresh before sending again.');
-        const finalWarnings = dedupePublisherWarnings(warnings);
-        return {
-          ok: true,
-          preview,
-          truncated: preview.truncated,
-          notificationStatus: delivery,
-          warnings: finalWarnings,
-          warningMessage: finalWarnings[0] || '',
-          successMessage: `✅ ${_activeMenuName || 'Menu'} update sent!`,
-          snapshot: buildMenuSessionSnapshot('sent-warning'),
-        };
-      }
-    },
-  };
 }
 
 function dedupePublisherWarnings(warnings = []) {
@@ -6175,12 +6204,8 @@ async function logUpdate(diff, patchMessage) {
   }
 }
 
-async function _publishActiveMenuUpdateInternal(options = {}) {
-  return getUpdatePublisher().publish(options);
-}
-
 async function sendUpdate() {
-  const preview = getUpdatePublisher().preview();
+  const preview = ensureCurrentMenuSession().preview();
   if (!preview.hasChanges) { closeModal(); return; }
 
   if (preview.truncated) {
@@ -6192,7 +6217,7 @@ async function sendUpdate() {
   confirmBtn.textContent = 'SENDING…';
 
   try {
-    const result = await ensureCurrentMenuSession().sendUpdate({ preview });
+    const result = await ensureCurrentMenuSession().publishUpdate({ preview });
     if (result?.noop) {
       closeModal();
       return;

--- a/tests/architecture-boundaries.test.cjs
+++ b/tests/architecture-boundaries.test.cjs
@@ -4,7 +4,6 @@ const test = require('node:test');
 
 const {
   createElement,
-  createFetchResponse,
   getState,
   loadAppSandbox,
   loadScript,
@@ -62,48 +61,7 @@ function makeMenuState(itemsByCategory = {}, lastUpdatedTs = '1712705100000') {
   return state;
 }
 
-test('menu runtime delegates menu session lifecycle calls', async () => {
-  const sandbox = loadAppSandbox();
-  const calls = [];
-  sandbox.location.search = '?menu=leroys-lounge-drinks';
-
-  const runtime = sandbox.createMenuRuntime({
-    lifecycle: {
-      openPageState: async options => {
-        calls.push(['open', options]);
-        return { snapshot: { stage: 'open' } };
-      },
-      refreshPageState: async options => {
-        calls.push(['refresh', options]);
-        return { snapshot: { stage: 'refresh' } };
-      },
-      savePageDraft: async options => {
-        calls.push(['save', options]);
-        return { snapshot: { stage: 'save' } };
-      },
-      publishPageUpdate: async options => {
-        calls.push(['send', options]);
-        return { snapshot: { stage: 'send' } };
-      },
-    },
-  });
-
-  const session = runtime.openPage({ requestedMenuSlug: 'leroys-lounge-drinks' });
-  await session.open({ resolveMenu: true });
-  await session.refresh({ reason: 'poll' });
-  await session.save({ reason: 'manual' });
-  await session.sendUpdate({ preview: { hasChanges: false, diff: [] } });
-
-  assert.equal(calls.length, 4);
-  assert.equal(calls[0][0], 'open');
-  assert.equal(calls[0][1].request.search, '?menu=leroys-lounge-drinks');
-  assert.equal(calls[1][0], 'refresh');
-  assert.equal(calls[2][0], 'save');
-  assert.equal(calls[3][0], 'send');
-});
-
-test('update publisher consolidates send results, persistence, and warnings', async () => {
-  const sandbox = loadAppSandbox();
+function createMenuSessionPorts(overrides = {}) {
   const diff = [
     {
       id: 'beer',
@@ -115,55 +73,233 @@ test('update publisher consolidates send results, persistence, and warnings', as
       restored: [],
     },
   ];
-  const patches = [];
-  const persistCalls = [];
 
-  setState(sandbox, {
-    MENU_ID: 'menu-main',
-    _activeMenuName: 'Main Menu',
-    currentUser: { accessToken: 'token-1', uid: 'user-1' },
-    getCachedDiff: () => diff,
-    buildMenuSessionSnapshot: source => ({ source }),
+  return {
+    buildRequest: overridesRequest => ({
+      pathname: '/leroyslounge',
+      search: '?menu=leroys-lounge-drinks',
+      pageMode: 'public',
+      actor: null,
+      siteRestaurantId: 'restaurant-main',
+      requestedMenuId: 'menu-main',
+      requestedMenuSlug: 'leroys-lounge-drinks',
+      ...overridesRequest,
+    }),
+    buildSnapshot: (source, request) => ({ source, request }),
+    resolveMenu: async () => null,
+    canLoadFromNetwork: () => true,
+    restoreFallback: ({ request }) => ({
+      source: 'cache',
+      usedFallback: true,
+      snapshot: { source: 'cache', request },
+    }),
+    loadState: async ({ request, source = 'network' }) => ({ source, request }),
+    pollState: async ({ request }) => ({
+      changed: false,
+      designChanged: false,
+      snapshot: { source: 'poll', request },
+    }),
+    now: () => 1712705100000,
+    persistState: async () => true,
+    patchMenuMeta: async () => ({ downgradedFields: [] }),
+    patchMenuMetaForMenu: async () => ({ downgradedFields: [] }),
+    finalizePersistStatus() {},
+    commitDraft() {},
+    buildPreview: snapshot => ({
+      hasChanges: true,
+      diff,
+      sections: diff,
+      patchMessage: 'Patch message',
+      truncated: false,
+      snapshot,
+    }),
+    getMenuId: () => 'menu-main',
+    getRestaurantId: () => 'restaurant-main',
+    getMenuName: () => 'Main Menu',
     snapshotCurrentItemsAsLastSent: () => ({ beer: [] }),
     getCurrentFeaturedIds: () => ['feature-1'],
-    currentUserCanEditRestaurantSpecials: () => true,
-    getRestaurantSpecialConfig: () => ({ menuIds: ['menu-main', 'menu-sibling'] }),
+    canEditRestaurantSpecials: () => true,
+    getRestaurantMenuIds: () => ['menu-main', 'menu-sibling'],
+    dispatchNotification: async () => ({
+      ok: true,
+      statusCode: 207,
+      summary: {
+        anyOk: true,
+        anyError: true,
+        failedChannels: ['sms'],
+        allSkipped: false,
+      },
+    }),
+    collectNotificationWarnings: summary => {
+      if (!summary?.anyError) return [];
+      return ['Some notification channels failed: SMS.'];
+    },
+    syncLocalCache: () => false,
+    logUpdate: async () => false,
+    commitPublished() {},
+    dedupeWarnings: warnings => Array.from(new Set(warnings.filter(Boolean))),
+    ...overrides,
+  };
+}
+
+test('menu session lifecycle handles redirect and fallback-aware open results', async () => {
+  const sandbox = loadAppSandbox();
+  const restored = [];
+  let loadCalls = 0;
+
+  const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts({
+    resolveMenu: async ({ request }) => {
+      if (request.requestedMenuSlug === 'el-roys') {
+        return { redirect: { href: '/elroyscantina?menu=el-roys-cantina-drinks' } };
+      }
+      return null;
+    },
+    canLoadFromNetwork: ({ request }) => request.requestedMenuSlug !== 'fallback-only',
+    restoreFallback: ({ expectedRestaurantId, request }) => {
+      restored.push({ expectedRestaurantId, request });
+      return {
+        source: 'cache',
+        usedFallback: true,
+        snapshot: { source: 'cache', request },
+      };
+    },
+    loadState: async ({ request, source = 'network' }) => {
+      loadCalls += 1;
+      if (request.requestedMenuSlug === 'load-fails') throw new Error('boom');
+      return { source, request };
+    },
+  }));
+
+  const redirect = await lifecycle.open({ requestedMenuSlug: 'el-roys' });
+  assert.equal(redirect.redirect.href, '/elroyscantina?menu=el-roys-cantina-drinks');
+
+  const fallback = await lifecycle.open({
+    requestedMenuSlug: 'fallback-only',
+    expectedRestaurantId: 'restaurant-main',
+  });
+  assert.equal(fallback.ok, true);
+  assert.equal(fallback.usedFallback, true);
+  assert.equal(fallback.showLoadError, false);
+  assert.equal(fallback.snapshot.source, 'cache');
+  assert.equal(restored[0].expectedRestaurantId, 'restaurant-main');
+
+  const failed = await lifecycle.open({
+    requestedMenuSlug: 'load-fails',
+    expectedRestaurantId: 'restaurant-main',
+  });
+  assert.equal(failed.ok, false);
+  assert.equal(failed.showLoadError, true);
+  assert.equal(failed.snapshot.source, 'cache');
+  assert.equal(loadCalls, 1);
+});
+
+test('menu session lifecycle routes poll and manual refreshes through one boundary', async () => {
+  const sandbox = loadAppSandbox();
+  const calls = [];
+
+  const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts({
+    loadState: async ({ request, source = 'network' }) => {
+      calls.push(['load', request.requestedMenuSlug, source]);
+      return { source, request };
+    },
+    pollState: async ({ request }) => {
+      calls.push(['poll', request.requestedMenuSlug]);
+      return {
+        changed: true,
+        designChanged: true,
+        snapshot: { source: 'poll', request },
+      };
+    },
+  }));
+
+  const pollResult = await lifecycle.refresh({ reason: 'poll', requestedMenuSlug: 'leroys-lounge-drinks' });
+  const manualResult = await lifecycle.refresh({ requestedMenuSlug: 'leroys-lounge-food', source: 'manual' });
+
+  assert.equal(pollResult.changed, true);
+  assert.equal(pollResult.designChanged, true);
+  assert.equal(pollResult.snapshot.source, 'poll');
+  assert.equal(manualResult.ok, true);
+  assert.equal(manualResult.snapshot.source, 'manual');
+  assert.deepEqual(calls, [
+    ['poll', 'leroys-lounge-drinks'],
+    ['load', 'leroys-lounge-food', 'manual'],
+  ]);
+});
+
+test('menu session lifecycle saveDraft persists and patches last-updated metadata', async () => {
+  const sandbox = loadAppSandbox();
+  const persistCalls = [];
+  const patchCalls = [];
+  const commitCalls = [];
+  const finalizeCalls = [];
+
+  const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts({
     persistState: async options => {
       persistCalls.push(options);
       return true;
     },
-    patchMenuMetaWithCompatibility: async update => {
-      patches.push(['primary', update]);
-      return { downgradedFields: ['last_sent_featured'] };
-    },
-    patchMenuMetaForMenuWithCompatibility: async (menuId, update) => {
-      patches.push([menuId, update]);
+    patchMenuMeta: async update => {
+      patchCalls.push(update);
       return { downgradedFields: [] };
     },
-    syncLocalMenuCache: () => false,
-    logUpdate: async () => false,
-    fetch: async () => createFetchResponse(207, {
-      results: {
-        groupme: 'ok',
-        sms: 'error:500',
-        discord: 'skipped',
-        webhook: 'skipped',
-      },
-    }),
-  });
+    commitDraft: ts => {
+      commitCalls.push(ts);
+    },
+    finalizePersistStatus: ok => {
+      finalizeCalls.push(ok);
+    },
+  }));
 
-  const publisher = sandbox.createUpdatePublisher();
-  const result = await publisher.publish();
+  const result = await lifecycle.saveDraft();
+
+  assert.equal(result.ok, true);
+  assert.equal(result.snapshot.source, 'saved');
+  assert.equal(persistCalls.length, 1);
+  assert.equal(patchCalls[0].last_updated_ts, 1712705100000);
+  assert.deepEqual(commitCalls, [1712705100000]);
+  assert.deepEqual(finalizeCalls, []);
+});
+
+test('menu session lifecycle publishes updates through one preview-aware boundary', async () => {
+  const sandbox = loadAppSandbox();
+  const persistCalls = [];
+  const patchCalls = [];
+  const commitCalls = [];
+
+  const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts({
+    persistState: async options => {
+      persistCalls.push(options);
+      return true;
+    },
+    patchMenuMeta: async update => {
+      patchCalls.push(['primary', update]);
+      return { downgradedFields: ['last_sent_featured'] };
+    },
+    patchMenuMetaForMenu: async (menuId, update) => {
+      patchCalls.push([menuId, update]);
+      return { downgradedFields: [] };
+    },
+    commitPublished: payload => {
+      commitCalls.push(payload);
+    },
+  }));
+
+  const preview = lifecycle.preview();
+  const result = await lifecycle.publishUpdate({ preview });
 
   assert.equal(result.ok, true);
   assert.equal(result.notificationStatus.statusCode, 207);
+  assert.equal(result.preview, preview);
   assert.equal(persistCalls.length, 1);
   assert.equal(persistCalls[0].silentFailure, true);
   assert.ok(result.warnings.some(message => message.includes('Some notification channels failed: SMS.')));
   assert.ok(result.warnings.some(message => message.includes('legacy metadata compatibility')));
   assert.ok(result.warnings.some(message => message.includes('local cache')));
   assert.ok(result.warnings.some(message => message.includes('audit log')));
-  assert.ok(patches.length >= 1);
+  assert.equal(patchCalls[0][0], 'primary');
+  assert.equal(patchCalls[1][0], 'menu-sibling');
+  assert.equal(commitCalls[0].ts, 1712705100000);
+  assert.equal(commitCalls[0].featuredIds[0], 'feature-1');
 });
 
 test('access session service restores sessions and resolves settings access', async () => {


### PR DESCRIPTION
## Summary

Deepens the menu session lifecycle into a single explicit boundary and routes open, refresh, preview, save-draft, and publish-update behavior through that one session object.

## What Changed

- replaced the split runtime/update-publisher seam in `app.js` with `createMenuSessionLifecycle()`
- moved preview, save-draft, and publish-update orchestration behind the same session boundary used for open/refresh
- removed the old runtime/update-publisher wrapper paths that duplicated lifecycle behavior
- rewrote the architecture boundary tests to target lifecycle outcomes instead of shallow delegation seams

## Why

The previous implementation split one menu-page concept across multiple shallow facades. That made the save/send/open flow harder to reason about, increased integration risk in the seams, and left the tests checking wrapper delegation more than lifecycle behavior.

## Impact

- menu page lifecycle behavior is now owned by one explicit session boundary
- callers use the same session object for open, refresh, preview, save, and publish work
- tests now exercise boundary behavior directly, which should make future refactors safer

## Validation

- `node --check app.js`
- `node --test tests/architecture-boundaries.test.cjs`

## Notes

- targets issue #238
- PR is opened as draft for review against `v0.8.7`
