### PR TITLE
Refactor runtime boundaries for publish, access policy, loader, notifications, draft ledger, and route adapters

### DIFF
--- a/app.js
+++ b/app.js
@@ -739,88 +739,17 @@ function getMenuSessionPorts() {
   };
 }
 
-function createMenuSessionLifecycle(ports) {
-  const sessionPorts = ports || getMenuSessionPorts();
-  let request = sessionPorts.buildRequest();
+function createMenuPublishService(sessionPorts, runtime = {}) {
+  const buildSnapshot = typeof runtime.buildSnapshot === 'function'
+    ? runtime.buildSnapshot
+    : (() => ({ source: 'unknown' }));
+  const buildPreview = typeof runtime.buildPreview === 'function'
+    ? runtime.buildPreview
+    : (() => sessionPorts.buildPreview(buildSnapshot('preview')));
 
-  function syncRequest(overrides = {}) {
-    request = { ...request, ...sessionPorts.buildRequest(overrides) };
-    return request;
-  }
-
-  function buildSnapshot(source = 'live') {
-    return sessionPorts.buildSnapshot(source, request);
-  }
-
-  const session = {
-    syncRequest,
-    snapshot(source = 'live') {
-      syncRequest();
-      return buildSnapshot(source);
-    },
-    async open(options = {}) {
-      const nextRequest = syncRequest(options);
-      const expectedRestaurantId = options.expectedRestaurantId || nextRequest.siteRestaurantId || '';
-
-      if (options.resolveMenu !== false) {
-        const resolution = await sessionPorts.resolveMenu({ request: nextRequest, ...options });
-        if (resolution?.redirect) return resolution;
-      }
-
-      if (!sessionPorts.canLoadFromNetwork({ request: nextRequest, ...options })) {
-        const fallback = sessionPorts.restoreFallback({ expectedRestaurantId, request: nextRequest, ...options });
-        return {
-          ok: true,
-          source: fallback.source,
-          usedFallback: fallback.usedFallback,
-          showLoadError: false,
-          snapshot: fallback.snapshot || buildSnapshot(fallback.source),
-        };
-      }
-
-      try {
-        const snapshot = await sessionPorts.loadState({
-          request: nextRequest,
-          fallbackToDefault: options.fallbackToDefault,
-          includeFeatured: options.includeFeatured,
-          persistCache: options.persistCache,
-          source: options.source || 'network',
-        });
-        return {
-          ok: true,
-          source: snapshot.source || 'network',
-          usedFallback: false,
-          showLoadError: false,
-          snapshot,
-        };
-      } catch (error) {
-        const fallback = sessionPorts.restoreFallback({ expectedRestaurantId, request: nextRequest, error, ...options });
-        return {
-          ok: false,
-          error,
-          source: fallback.source,
-          usedFallback: fallback.usedFallback,
-          showLoadError: true,
-          snapshot: fallback.snapshot || buildSnapshot(fallback.source),
-        };
-      }
-    },
-    async refresh(options = {}) {
-      const nextRequest = syncRequest(options);
-      if (options.reason === 'poll') {
-        return sessionPorts.pollState({ request: nextRequest, ...options });
-      }
-      return {
-        ok: true,
-        snapshot: await sessionPorts.loadState({ request: nextRequest, ...options }),
-      };
-    },
-    preview() {
-      syncRequest();
-      return sessionPorts.buildPreview(buildSnapshot('preview'));
-    },
+  return {
     async saveDraft(options = {}) {
-      syncRequest(options);
+      void options;
       const snapshot = buildSnapshot('draft');
       if (!snapshot.dirty) {
         return {
@@ -847,9 +776,9 @@ function createMenuSessionLifecycle(ports) {
         };
       }
     },
+
     async publishUpdate(options = {}) {
-      syncRequest(options);
-      const preview = options.preview?.sections ? options.preview : session.preview();
+      const preview = options.preview?.sections ? options.preview : buildPreview();
       const selectedChangeIds = options.selectedChangeIds || preview.notificationChanges.map(change => change.id);
       const selectedChanges = preview.notificationChanges.filter(change => selectedChangeIds.includes(change.id));
       const selectedSections = groupNotificationChangesBySection(selectedChanges);
@@ -1010,6 +939,102 @@ function createMenuSessionLifecycle(ports) {
         snapshot: buildSnapshot(finalWarnings.length ? 'publish-warning' : 'publish-complete'),
       };
     },
+  };
+}
+
+function createMenuSessionLifecycle(ports) {
+  const sessionPorts = ports || getMenuSessionPorts();
+  let request = sessionPorts.buildRequest();
+
+  function syncRequest(overrides = {}) {
+    request = { ...request, ...sessionPorts.buildRequest(overrides) };
+    return request;
+  }
+
+  function buildSnapshot(source = 'live') {
+    return sessionPorts.buildSnapshot(source, request);
+  }
+
+  const publishService = createMenuPublishService(sessionPorts, {
+    buildSnapshot,
+    buildPreview: () => sessionPorts.buildPreview(buildSnapshot('preview')),
+  });
+
+  const session = {
+    syncRequest,
+    snapshot(source = 'live') {
+      syncRequest();
+      return buildSnapshot(source);
+    },
+    async open(options = {}) {
+      const nextRequest = syncRequest(options);
+      const expectedRestaurantId = options.expectedRestaurantId || nextRequest.siteRestaurantId || '';
+
+      if (options.resolveMenu !== false) {
+        const resolution = await sessionPorts.resolveMenu({ request: nextRequest, ...options });
+        if (resolution?.redirect) return resolution;
+      }
+
+      if (!sessionPorts.canLoadFromNetwork({ request: nextRequest, ...options })) {
+        const fallback = sessionPorts.restoreFallback({ expectedRestaurantId, request: nextRequest, ...options });
+        return {
+          ok: true,
+          source: fallback.source,
+          usedFallback: fallback.usedFallback,
+          showLoadError: false,
+          snapshot: fallback.snapshot || buildSnapshot(fallback.source),
+        };
+      }
+
+      try {
+        const snapshot = await sessionPorts.loadState({
+          request: nextRequest,
+          fallbackToDefault: options.fallbackToDefault,
+          includeFeatured: options.includeFeatured,
+          persistCache: options.persistCache,
+          source: options.source || 'network',
+        });
+        return {
+          ok: true,
+          source: snapshot.source || 'network',
+          usedFallback: false,
+          showLoadError: false,
+          snapshot,
+        };
+      } catch (error) {
+        const fallback = sessionPorts.restoreFallback({ expectedRestaurantId, request: nextRequest, error, ...options });
+        return {
+          ok: false,
+          error,
+          source: fallback.source,
+          usedFallback: fallback.usedFallback,
+          showLoadError: true,
+          snapshot: fallback.snapshot || buildSnapshot(fallback.source),
+        };
+      }
+    },
+    async refresh(options = {}) {
+      const nextRequest = syncRequest(options);
+      if (options.reason === 'poll') {
+        return sessionPorts.pollState({ request: nextRequest, ...options });
+      }
+      return {
+        ok: true,
+        snapshot: await sessionPorts.loadState({ request: nextRequest, ...options }),
+      };
+    },
+    preview() {
+      syncRequest();
+      return sessionPorts.buildPreview(buildSnapshot('preview'));
+    },
+    async saveDraft(options = {}) {
+      syncRequest(options);
+      return publishService.saveDraft(options);
+    },
+    async publishUpdate(options = {}) {
+      syncRequest(options);
+      return publishService.publishUpdate(options);
+    },
     async save(options = {}) {
       return session.saveDraft(options);
     },
@@ -1037,69 +1062,89 @@ function ensureCurrentMenuSession(overrides = {}) {
   return _currentMenuSession;
 }
 
-function resolveRequestedSettingsRoute(user = currentUser) {
-  if (!user) {
-    return {
-      kind: 'auth-required',
-      pageMode: _appPageMode,
-    };
-  }
-
-  if (_appPageMode === 'admin') {
-    if (user.role !== 'admin') {
-      return {
-        kind: 'admin-denied',
-        pageMode: 'admin',
-        message: 'Admin access required for this page.',
-      };
-    }
-
-    return {
-      kind: 'admin',
-      pageMode: 'admin',
-      targetMenuId: KNOWN_MENU_ORDER.includes(MENU_ID) ? MENU_ID : (KNOWN_MENU_ORDER[0] || ''),
-    };
-  }
-
-  const requestedMenu = getRequestedMenuForSettingsPage();
-  if (!requestedMenu) {
-    return {
-      kind: 'manager-denied',
-      pageMode: 'manager',
-      message: 'No menu context available for this page.',
-    };
-  }
-
-  if (!currentUserCanManageMenu(requestedMenu.id, user)) {
-    const fallbackMenuId = getFirstAccessibleManagerMenuId(user);
-    if (fallbackMenuId) {
-      const targetPath = getManagerHrefForMenuId(fallbackMenuId);
-      if (targetPath) {
-        return {
-          kind: 'manager-redirect',
-          pageMode: 'manager',
-          targetPath,
-          menuId: fallbackMenuId,
-        };
-      }
-    }
-
-    return {
-      kind: 'manager-denied',
-      pageMode: 'manager',
-      message: 'You don\'t have manager access to this menu.',
-      targetPath: getPublicHrefForMenuId(requestedMenu.id),
-      redirectLabel: 'the public menu',
-      actionLabel: 'Return to the public menu',
-    };
-  }
+function createSettingsRoutePolicyService(deps = {}) {
+  const getPageMode = typeof deps.getPageMode === 'function' ? deps.getPageMode : (() => _appPageMode);
+  const getMenuId = typeof deps.getMenuId === 'function' ? deps.getMenuId : (() => MENU_ID);
+  const getKnownMenuOrder = typeof deps.getKnownMenuOrder === 'function' ? deps.getKnownMenuOrder : (() => KNOWN_MENU_ORDER);
+  const getRequestedMenu = typeof deps.getRequestedMenu === 'function' ? deps.getRequestedMenu : (() => getRequestedMenuForSettingsPage());
+  const canManageMenu = typeof deps.canManageMenu === 'function' ? deps.canManageMenu : ((menuId, user) => currentUserCanManageMenu(menuId, user));
+  const getFallbackMenuId = typeof deps.getFallbackMenuId === 'function' ? deps.getFallbackMenuId : (user => getFirstAccessibleManagerMenuId(user));
+  const getManagerHref = typeof deps.getManagerHrefForMenuId === 'function' ? deps.getManagerHrefForMenuId : (menuId => getManagerHrefForMenuId(menuId));
+  const getPublicHref = typeof deps.getPublicHrefForMenuId === 'function' ? deps.getPublicHrefForMenuId : (menuId => getPublicHrefForMenuId(menuId));
 
   return {
-    kind: 'manager',
-    pageMode: 'manager',
-    targetMenuId: requestedMenu.id,
-    requestedMenu,
+    decide(user = currentUser) {
+      const pageMode = getPageMode();
+      if (!user) {
+        return {
+          kind: 'auth-required',
+          pageMode,
+        };
+      }
+
+      if (pageMode === 'admin') {
+        if (user.role !== 'admin') {
+          return {
+            kind: 'admin-denied',
+            pageMode: 'admin',
+            message: 'Admin access required for this page.',
+          };
+        }
+
+        const knownMenuOrder = getKnownMenuOrder();
+        const currentMenuId = getMenuId();
+        return {
+          kind: 'admin',
+          pageMode: 'admin',
+          targetMenuId: knownMenuOrder.includes(currentMenuId) ? currentMenuId : (knownMenuOrder[0] || ''),
+        };
+      }
+
+      const requestedMenu = getRequestedMenu();
+      if (!requestedMenu) {
+        return {
+          kind: 'manager-denied',
+          pageMode: 'manager',
+          message: 'No menu context available for this page.',
+        };
+      }
+
+      if (!canManageMenu(requestedMenu.id, user)) {
+        const fallbackMenuId = getFallbackMenuId(user);
+        if (fallbackMenuId) {
+          const targetPath = getManagerHref(fallbackMenuId);
+          if (targetPath) {
+            return {
+              kind: 'manager-redirect',
+              pageMode: 'manager',
+              targetPath,
+              menuId: fallbackMenuId,
+            };
+          }
+        }
+
+        return {
+          kind: 'manager-denied',
+          pageMode: 'manager',
+          message: 'You don\'t have manager access to this menu.',
+          targetPath: getPublicHref(requestedMenu.id),
+          redirectLabel: 'the public menu',
+          actionLabel: 'Return to the public menu',
+        };
+      }
+
+      return {
+        kind: 'manager',
+        pageMode: 'manager',
+        targetMenuId: requestedMenu.id,
+        requestedMenu,
+      };
+    },
   };
+}
+
+function resolveRequestedSettingsRoute(user = currentUser) {
+  return createSettingsRoutePolicyService().decide(user);
 }
 
 function createAccessSessionService() {
@@ -2025,73 +2070,121 @@ async function refreshFeaturedForActiveMenu() {
   return getRestaurantSpecialsService().refreshForActiveMenu(RESTAURANT_ID);
 }
 
+function createMenuStateLoaderService(deps = {}) {
+  const readState = typeof deps.readState === 'function' ? deps.readState : (() => sbRead());
+  const hydrateFromState = typeof deps.hydrateFromState === 'function' ? deps.hydrateFromState : (data => hydrateState(data));
+  const applyDraftState = typeof deps.applyPersistedDraftState === 'function'
+    ? deps.applyPersistedDraftState
+    : (draftState => applyPersistedDraftState(draftState));
+  const setDefaultState = typeof deps.setDefaultState === 'function'
+    ? deps.setDefaultState
+    : (() => {
+        menuState = defaultState();
+        currentDesign = { ...DESIGN_DEFAULTS };
+        _restaurantCustomDesignEnabled = true;
+      });
+  const setDirty = typeof deps.setDirty === 'function' ? deps.setDirty : (value => { _dirty = !!value; });
+  const clearDraftChanges = typeof deps.clearDraftChanges === 'function'
+    ? deps.clearDraftChanges
+    : (() => {
+        clearDraftSaveOnlyChanges();
+        clearSharedDraftState();
+      });
+  const writeMenuCache = typeof deps.writeMenuCache === 'function'
+    ? deps.writeMenuCache
+    : (data => lsSet(LS_KEYS.menuCache, JSON.stringify(data)));
+  const refreshFeatured = typeof deps.refreshFeatured === 'function'
+    ? deps.refreshFeatured
+    : (() => refreshFeaturedForActiveMenu());
+  const buildSnapshot = typeof deps.buildSnapshot === 'function'
+    ? deps.buildSnapshot
+    : (source => buildMenuSessionSnapshot(source));
+  const getLastUpdatedTs = typeof deps.getLastUpdatedTs === 'function'
+    ? deps.getLastUpdatedTs
+    : (() => menuState._meta?.lastUpdatedTs);
+  const getCategorySnapshot = typeof deps.getCategorySnapshot === 'function'
+    ? deps.getCategorySnapshot
+    : (() => getCategoryStateSnapshot());
+  const getDesignSnapshotValue = typeof deps.getDesignSnapshot === 'function'
+    ? deps.getDesignSnapshot
+    : (() => getDesignSnapshot());
+  const getFeaturedSnapshotValue = typeof deps.getFeaturedSnapshot === 'function'
+    ? deps.getFeaturedSnapshot
+    : (() => getFeaturedSnapshot());
+
+  return {
+    async load(options = {}) {
+      const {
+        fallbackToDefault = true,
+        includeFeatured = true,
+        persistCache = true,
+        request = buildCurrentMenuPageRequest(),
+      } = options;
+      const includePersistedDraft = options.includePersistedDraft ?? (request.pageMode === 'manager' || request.pageMode === 'admin');
+      try {
+        const data = await readState();
+        if (data) {
+          hydrateFromState(data);
+          const loadedDraft = includePersistedDraft ? applyDraftState(data.meta?.draft_state || null) : false;
+          setDirty(false);
+          if (!loadedDraft) clearDraftChanges();
+          if (persistCache) writeMenuCache(data);
+        } else if (fallbackToDefault) {
+          setDefaultState();
+          setDirty(false);
+          clearDraftChanges();
+        }
+      } catch (error) {
+        if (fallbackToDefault) {
+          setDefaultState();
+          setDirty(false);
+          clearDraftChanges();
+        } else {
+          throw error;
+        }
+      }
+      if (includeFeatured) await refreshFeatured();
+      return buildSnapshot(options.source || 'network');
+    },
+
+    async poll(options = {}) {
+      void options;
+      const oldTs = getLastUpdatedTs();
+      const oldCats = getCategorySnapshot();
+      const oldDesign = getDesignSnapshotValue();
+      const oldFeatured = getFeaturedSnapshotValue();
+      const data = await readState();
+      if (!data) {
+        return {
+          changed: false,
+          designChanged: false,
+          snapshot: buildSnapshot('poll'),
+        };
+      }
+
+      hydrateFromState(data);
+      writeMenuCache(data);
+      const newTs = getLastUpdatedTs();
+      if (newTs !== oldTs) await refreshFeatured();
+
+      const afterCats = getCategorySnapshot();
+      const newDesign = getDesignSnapshotValue();
+      const newFeatured = getFeaturedSnapshotValue();
+      return {
+        changed: afterCats !== oldCats || newTs !== oldTs || newFeatured !== oldFeatured,
+        designChanged: newDesign !== oldDesign,
+        snapshot: buildSnapshot('poll'),
+      };
+    },
+  };
+}
+
 async function _loadActiveMenuStateInternal(options = {}) {
-  const {
-    fallbackToDefault = true,
-    includeFeatured = true,
-    persistCache = true,
-    request = buildCurrentMenuPageRequest(),
-  } = options;
-  const includePersistedDraft = options.includePersistedDraft ?? (request.pageMode === 'manager' || request.pageMode === 'admin');
-  try {
-    const data = await sbRead();
-    if (data) {
-      hydrateState(data);
-      const loadedDraft = includePersistedDraft ? applyPersistedDraftState(data.meta?.draft_state || null) : false;
-      _dirty = false;
-      if (!loadedDraft) clearDraftSaveOnlyChanges();
-      if (persistCache) lsSet(LS_KEYS.menuCache, JSON.stringify(data));
-    } else if (fallbackToDefault) {
-      menuState = defaultState();
-      currentDesign = { ...DESIGN_DEFAULTS };
-      _restaurantCustomDesignEnabled = true;
-      _dirty = false;
-      clearDraftSaveOnlyChanges();
-      clearSharedDraftState();
-    }
-  } catch (e) {
-    if (fallbackToDefault) {
-      menuState = defaultState();
-      currentDesign = { ...DESIGN_DEFAULTS };
-      _restaurantCustomDesignEnabled = true;
-      _dirty = false;
-      clearDraftSaveOnlyChanges();
-      clearSharedDraftState();
-    } else {
-      throw e;
-    }
-  }
-  if (includeFeatured) await refreshFeaturedForActiveMenu();
-  return buildMenuSessionSnapshot(options.source || 'network');
+  return createMenuStateLoaderService().load(options);
 }
 
 async function _pollActiveMenuStateInternal() {
-  const oldTs = menuState._meta?.lastUpdatedTs;
-  const oldCats = getCategoryStateSnapshot();
-  const oldDesign = getDesignSnapshot();
-  const oldFeatured = getFeaturedSnapshot();
-  const data = await sbRead();
-  if (!data) {
-    return {
-      changed: false,
-      designChanged: false,
-      snapshot: buildMenuSessionSnapshot('poll'),
-    };
-  }
-
-  hydrateState(data);
-  lsSet(LS_KEYS.menuCache, JSON.stringify(data));
-  const newTs = menuState._meta?.lastUpdatedTs;
-  if (newTs !== oldTs) await refreshFeaturedForActiveMenu();
-
-  const afterCats = getCategoryStateSnapshot();
-  const newDesign = getDesignSnapshot();
-  const newFeatured = getFeaturedSnapshot();
-  return {
-    changed: afterCats !== oldCats || newTs !== oldTs || newFeatured !== oldFeatured,
-    designChanged: newDesign !== oldDesign,
-    snapshot: buildMenuSessionSnapshot('poll'),
-  };
+  return createMenuStateLoaderService().poll();
 }
 
 async function loadActiveMenuState(options = {}) {
@@ -2612,45 +2705,108 @@ function renderManagerOverviewStats() {
   if (eightysixMeta) eightysixMeta.textContent = eightySixed === 1 ? "item 86'd" : "items 86'd";
 }
 
+function createDraftLedgerService(deps = {}) {
+  const isDirty = typeof deps.isDirty === 'function' ? deps.isDirty : (() => !!_dirty);
+  const hasSharedDraft = typeof deps.hasSharedDraft === 'function' ? deps.hasSharedDraft : (() => hasSharedDraftState());
+  const getDraftCount = typeof deps.getDraftChangeCount === 'function' ? deps.getDraftChangeCount : (() => getDraftChangeCount());
+  const getDiffLineCount = typeof deps.getDiffLinesCount === 'function' ? deps.getDiffLinesCount : (() => countDiffLines());
+  const getDiffSections = typeof deps.getDiffSections === 'function' ? deps.getDiffSections : (() => getCachedDiff());
+  const getSaveOnlyChanges = typeof deps.getSaveOnlyChanges === 'function' ? deps.getSaveOnlyChanges : (() => getDraftSaveOnlyChanges());
+
+  function buildLookup() {
+    return {
+      byItemId: new Set(getSaveOnlyChanges().map(change => change.itemId).filter(Boolean)),
+      byCategoryName: new Map(getDiffSections().map(section => [
+        section.id,
+        new Set([
+          ...(section.added || []),
+          ...(section.eightySixed || []),
+          ...(section.restored || []),
+        ].map(name => name.trim().toLowerCase())),
+      ])),
+    };
+  }
+
+  return {
+    buildLookup,
+    getActionBarState({ isCompactViewport = false } = {}) {
+      const hasDraftChanges = isDirty();
+      const hasShared = hasSharedDraft();
+      const hasDraftWork = hasDraftChanges || hasShared;
+      const hasPendingUpdate = !hasDraftWork && getDiffLineCount() > 0;
+      const changeCount = getDraftCount();
+      const notifyCount = hasPendingUpdate ? getDiffLineCount() : 0;
+
+      let summaryText = 'No Pending Changes';
+      if (hasDraftChanges) {
+        summaryText = isCompactViewport
+          ? `${changeCount} pending change${changeCount === 1 ? '' : 's'}. Save Draft updates the shared draft; Save publishes live.`
+          : `${changeCount} pending change${changeCount === 1 ? '' : 's'}. Save Draft updates the shared draft. Save opens Patch Notes Preview to publish live.`;
+      } else if (hasShared) {
+        summaryText = `${changeCount} saved draft change${changeCount === 1 ? ' is' : 's are'} ready to publish.`;
+      } else if (hasPendingUpdate) {
+        summaryText = `${notifyCount} update line${notifyCount === 1 ? ' is' : 's are'} live and ready to send.`;
+      }
+
+      return {
+        hasDraftChanges,
+        hasSharedDraft: hasShared,
+        hasDraftWork,
+        hasPendingUpdate,
+        changeCount,
+        summaryText,
+        publishLabel: !hasDraftWork && hasPendingUpdate ? 'Update' : 'Save',
+      };
+    },
+    getItemBadge({ item, catId, lastSentNames = null }) {
+      const is86 = !!item?.eightySixed;
+      const nameKey = String(item?.name || '').trim().toLowerCase();
+      const changeLookup = buildLookup();
+      const sectionNames = changeLookup.byCategoryName.get(catId) || new Set();
+      const hasDraftWork = isDirty() || hasSharedDraft();
+      const hasDraftTag = hasDraftWork && (changeLookup.byItemId.has(item?.id) || sectionNames.has(nameKey));
+      const hasUnsentTag = !hasDraftWork && sectionNames.has(nameKey);
+      const isNew = lastSentNames ? !lastSentNames.has(nameKey) : false;
+
+      if (hasUnsentTag) {
+        return { className: 'item-state-badge--unsent', text: 'UNSENT', label: 'Unsent update' };
+      }
+      if (hasDraftTag) {
+        return { className: 'item-state-badge--draft', text: 'DRAFT', label: 'Draft change' };
+      }
+      if (is86) {
+        return { className: 'item-state-badge--86', text: '86', label: "86'd" };
+      }
+      if (isNew) {
+        return { className: 'item-state-badge--new', text: 'NEW', label: 'New' };
+      }
+      return { className: 'item-state-badge--active', text: '', label: 'Active' };
+    },
+  };
+}
+
 function updateManagerActionBar() {
   const bar = document.getElementById('manager-action-bar');
   if (!bar) return;
   const primaryGroup = document.getElementById('manager-primary-action-group');
   const summary = document.getElementById('manager-action-bar-summary');
   const syncEl = document.getElementById('sync-status');
-  const hasDraftChanges = !!_dirty;
-  const hasSharedDraft = hasSharedDraftState();
-  const hasDraftWork = hasDraftChanges || hasSharedDraft;
-  const hasPendingUpdate = !hasDraftWork && countDiffLines() > 0;
-  const changeCount = getDraftChangeCount();
   const isCompactViewport = window.innerWidth <= 480;
+  const ledgerState = createDraftLedgerService().getActionBarState({ isCompactViewport });
   const saveBtn = document.getElementById('save-btn');
   const publishBtn = document.getElementById('send-btn');
 
   if (primaryGroup) primaryGroup.hidden = false;
-  if (saveBtn) saveBtn.disabled = !hasDraftChanges;
+  if (saveBtn) saveBtn.disabled = !ledgerState.hasDraftChanges;
   if (publishBtn) {
-    publishBtn.disabled = !hasDraftWork && !hasPendingUpdate;
-    publishBtn.textContent = !hasDraftWork && hasPendingUpdate ? 'Update' : 'Save';
+    publishBtn.disabled = !ledgerState.hasDraftWork && !ledgerState.hasPendingUpdate;
+    publishBtn.textContent = ledgerState.publishLabel;
   }
   bar.hidden = false;
-  bar.classList.toggle('is-idle', !hasDraftWork && !hasPendingUpdate);
+  bar.classList.toggle('is-idle', !ledgerState.hasDraftWork && !ledgerState.hasPendingUpdate);
   syncManagerActionBarStatus(syncEl);
 
-  if (summary) {
-    if (hasDraftChanges) {
-      summary.textContent = isCompactViewport
-        ? `${changeCount} pending change${changeCount === 1 ? '' : 's'}. Save Draft updates the shared draft; Save publishes live.`
-        : `${changeCount} pending change${changeCount === 1 ? '' : 's'}. Save Draft updates the shared draft. Save opens Patch Notes Preview to publish live.`;
-    } else if (hasSharedDraft) {
-      summary.textContent = `${changeCount} saved draft change${changeCount === 1 ? ' is' : 's are'} ready to publish.`;
-    } else if (hasPendingUpdate) {
-      const notifyCount = countDiffLines();
-      summary.textContent = `${notifyCount} update line${notifyCount === 1 ? ' is' : 's are'} live and ready to send.`;
-    } else {
-      summary.textContent = 'No Pending Changes';
-    }
-  }
+  if (summary) summary.textContent = ledgerState.summaryText;
 }
 
 function syncManagerActionBarStatus(syncEl = document.getElementById('sync-status')) {
@@ -3236,6 +3392,35 @@ async function switchPublicRouteMenu(menuRef) {
     ok: true,
     navigated: false,
     snapshot: buildPublicRouteRenderSnapshot(),
+  };
+}
+
+function createPublicRouteAdapter(contractOrMenuState, legacyState = {}, options = {}) {
+  if (contractOrMenuState?.snapshot && contractOrMenuState?.actions) return contractOrMenuState;
+
+  const snapshot = {
+    menuState: contractOrMenuState,
+    ...(legacyState || {}),
+  };
+  const helpers = {
+    escHtml,
+    formatUpdatedAt,
+    getMenuTypeLabel,
+    ...(options.helpers || {}),
+  };
+  const actionOverrides = options.actions || {};
+
+  return {
+    version: 0,
+    snapshot,
+    helpers,
+    actions: {
+      closeDropdowns: actionOverrides.closeDropdowns || (() => closeRouteDropdowns()),
+      openManager: actionOverrides.openManager || (() => onActionBtnClick()),
+      openAdmin: actionOverrides.openAdmin || (() => onAdminBtnClick()),
+      canManageMenu: actionOverrides.canManageMenu || ((menuId, user = snapshot.currentUser) => currentUserCanManageMenu(menuId, user)),
+      switchMenu: actionOverrides.switchMenu || (menu => switchPublicRouteMenu(menu)),
+    },
   };
 }
 
@@ -5104,43 +5289,8 @@ function buildItemsRowHtml(item, catId, lastSentNames) {
     </div>`;
 }
 
-function getDraftChangeLookup() {
-  return {
-    byItemId: new Set(getDraftSaveOnlyChanges().map(change => change.itemId).filter(Boolean)),
-    byCategoryName: new Map(getCachedDiff().map(section => [
-      section.id,
-      new Set([
-        ...(section.added || []),
-        ...(section.eightySixed || []),
-        ...(section.restored || []),
-      ].map(name => name.trim().toLowerCase())),
-    ])),
-  };
-}
-
 function getItemStateBadge(item, catId, lastSentNames = null) {
-  const is86 = !!item.eightySixed;
-  const nameKey = item.name.trim().toLowerCase();
-  const changeLookup = getDraftChangeLookup();
-  const sectionNames = changeLookup.byCategoryName.get(catId) || new Set();
-  const hasDraftWork = !!_dirty || hasSharedDraftState();
-  const hasDraftTag = hasDraftWork && (changeLookup.byItemId.has(item.id) || sectionNames.has(nameKey));
-  const hasUnsentTag = !hasDraftWork && sectionNames.has(nameKey);
-  const isNew = lastSentNames ? !lastSentNames.has(nameKey) : false;
-
-  if (hasUnsentTag) {
-    return { className: 'item-state-badge--unsent', text: 'UNSENT', label: 'Unsent update' };
-  }
-  if (hasDraftTag) {
-    return { className: 'item-state-badge--draft', text: 'DRAFT', label: 'Draft change' };
-  }
-  if (is86) {
-    return { className: 'item-state-badge--86', text: '86', label: "86'd" };
-  }
-  if (isNew) {
-    return { className: 'item-state-badge--new', text: 'NEW', label: 'New' };
-  }
-  return { className: 'item-state-badge--active', text: '', label: 'Active' };
+  return createDraftLedgerService().getItemBadge({ item, catId, lastSentNames });
 }
 
 function buildPricingRowHtml(item, catId) {
@@ -6565,81 +6715,100 @@ function collectNotificationWarnings(summary) {
   return warnings;
 }
 
-async function dispatchMenuUpdateNotification({ menuId, patchMessage }) {
-  const authHeaders = currentUser?.accessToken
-    ? { 'Authorization': `Bearer ${currentUser.accessToken}` }
-    : {};
+function createNotificationDeliveryService(deps = {}) {
+  const fetchImpl = typeof deps.fetchImpl === 'function' ? deps.fetchImpl : fetch;
+  const summarizeResults = typeof deps.summarizeResults === 'function'
+    ? deps.summarizeResults
+    : summarizeNotificationResults;
 
-  let response;
-  try {
-    response = await fetch('/api/send-notification', {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json', ...authHeaders },
-      body: JSON.stringify({ menu_id: menuId, text: patchMessage }),
-    });
-  } catch (_) {
-    return {
-      ok: false,
-      statusCode: 0,
-      summary: summarizeNotificationResults({}),
-      userMessage: '❌ Network error. Check connection.',
-    };
-  }
-
-  let body = {};
-  try {
-    body = await response.json();
-  } catch (_) {
-    body = {};
-  }
-
-  const summary = summarizeNotificationResults(body?.results || {});
-  if (response.status >= 200 && response.status < 300) {
-    return {
-      ok: true,
-      statusCode: response.status,
-      partial: response.status === 207,
-      results: body?.results || {},
-      summary,
-    };
-  }
-
-  if (response.status === 401) {
-    return {
-      ok: false,
-      statusCode: response.status,
-      summary,
-      userMessage: '❌ Not authorized. Please sign in.',
-    };
-  }
-
-  if (response.status === 403) {
-    return {
-      ok: false,
-      statusCode: response.status,
-      summary,
-      userMessage: '❌ Access denied. Your account role does not allow sending updates.',
-    };
-  }
-
-  if (response.status === 400 && typeof body?.error === 'string' && body.error.trim()) {
-    return {
-      ok: false,
-      statusCode: response.status,
-      summary,
-      userMessage: `❌ ${body.error.trim()}`,
-    };
-  }
-
-  const failedSummary = summary.failedChannels.length
-    ? ` Failed: ${summary.failedChannels.map(formatNotificationChannelName).join(', ')}.`
-    : '';
   return {
-    ok: false,
-    statusCode: response.status,
-    summary,
-    userMessage: `❌ Notification error. Check channel config in Admin settings.${failedSummary}`,
+    async sendMenuUpdate({ menuId, patchMessage, accessToken = '' }) {
+      const authHeaders = accessToken
+        ? { 'Authorization': `Bearer ${accessToken}` }
+        : {};
+
+      let response;
+      try {
+        response = await fetchImpl('/api/send-notification', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json', ...authHeaders },
+          body: JSON.stringify({ menu_id: menuId, text: patchMessage }),
+        });
+      } catch (_) {
+        return {
+          ok: false,
+          statusCode: 0,
+          summary: summarizeResults({}),
+          userMessage: '❌ Network error. Check connection.',
+        };
+      }
+
+      let body = {};
+      try {
+        body = await response.json();
+      } catch (_) {
+        body = {};
+      }
+
+      const summary = summarizeResults(body?.results || {});
+      const statusCode = Number(response?.status || 0);
+      const is2xx = statusCode >= 200 && statusCode < 300;
+      if (is2xx) {
+        return {
+          ok: true,
+          statusCode,
+          partial: statusCode === 207,
+          results: body?.results || {},
+          summary,
+        };
+      }
+
+      if (statusCode === 401) {
+        return {
+          ok: false,
+          statusCode,
+          summary,
+          userMessage: '❌ Not authorized. Please sign in.',
+        };
+      }
+
+      if (statusCode === 403) {
+        return {
+          ok: false,
+          statusCode,
+          summary,
+          userMessage: '❌ Access denied. Your account role does not allow sending updates.',
+        };
+      }
+
+      if (statusCode === 400 && typeof body?.error === 'string' && body.error.trim()) {
+        return {
+          ok: false,
+          statusCode,
+          summary,
+          userMessage: `❌ ${body.error.trim()}`,
+        };
+      }
+
+      const failedSummary = summary.failedChannels.length
+        ? ` Failed: ${summary.failedChannels.map(formatNotificationChannelName).join(', ')}.`
+        : '';
+      return {
+        ok: false,
+        statusCode,
+        summary,
+        userMessage: `❌ Notification error. Check channel config in Admin settings.${failedSummary}`,
+      };
+    },
   };
+}
+
+async function dispatchMenuUpdateNotification({ menuId, patchMessage }) {
+  return createNotificationDeliveryService().sendMenuUpdate({
+    menuId,
+    patchMessage,
+    accessToken: currentUser?.accessToken || '',
+  });
 }
 
 function snapshotLastSentState() {

--- a/elroyscantina/app.js
+++ b/elroyscantina/app.js
@@ -123,6 +123,9 @@
   }
 
   function resolveRouteContract(contractOrMenuState, legacyState) {
+    if (typeof window.createPublicRouteAdapter === 'function') {
+      return window.createPublicRouteAdapter(contractOrMenuState, legacyState);
+    }
     if (contractOrMenuState?.snapshot && contractOrMenuState?.actions) return contractOrMenuState;
     const snapshot = {
       menuState: contractOrMenuState,

--- a/leroyslounge/app.js
+++ b/leroyslounge/app.js
@@ -136,6 +136,9 @@
   }
 
   function resolveRouteContract(contractOrMenuState, legacyState) {
+    if (typeof window.createPublicRouteAdapter === 'function') {
+      return window.createPublicRouteAdapter(contractOrMenuState, legacyState);
+    }
     if (contractOrMenuState?.snapshot && contractOrMenuState?.actions) return contractOrMenuState;
     const snapshot = {
       menuState: contractOrMenuState,

--- a/tests/architecture-boundaries.test.cjs
+++ b/tests/architecture-boundaries.test.cjs
@@ -280,6 +280,38 @@ test('menu session lifecycle saveDraft persists and patches last-updated metadat
   assert.deepEqual(commitCalls, [1712705100000]);
 });
 
+test('menu publish service exposes draft-save and publish boundaries directly', async () => {
+  const sandbox = loadAppSandbox();
+  const patchDraftCalls = [];
+
+  const ports = createMenuSessionPorts({
+    buildSnapshot: source => ({ source, dirty: true }),
+    patchMenuDraftState: async (_snapshot, ts) => {
+      patchDraftCalls.push(ts);
+      return { downgradedFields: [] };
+    },
+    syncLocalCache: () => true,
+    logUpdate: async () => true,
+    canEditRestaurantSpecials: () => false,
+    getRestaurantMenuIds: () => [],
+  });
+
+  const service = sandbox.createMenuPublishService(ports, {
+    buildSnapshot: source => ports.buildSnapshot(source),
+    buildPreview: () => ports.buildPreview(ports.buildSnapshot('preview')),
+  });
+
+  const draftResult = await service.saveDraft();
+  assert.equal(draftResult.ok, true);
+  assert.equal(draftResult.snapshot.source, 'draft-saved');
+  assert.deepEqual(patchDraftCalls, [1712705100000]);
+
+  const publishResult = await service.publishUpdate({ notify: false });
+  assert.equal(publishResult.ok, true);
+  assert.equal(publishResult.notificationStatus, null);
+  assert.equal(publishResult.warnings.length, 0);
+});
+
 test('menu session lifecycle publishes updates through one preview-aware boundary', async () => {
   const sandbox = loadAppSandbox();
   const patchCalls = [];
@@ -330,6 +362,96 @@ test('menu session lifecycle can publish without firing notifications', async ()
   assert.equal(notificationCalls, 0);
   assert.equal(result.warnings.length, 0);
   assert.match(result.successMessage, /saved to the live menu/i);
+});
+
+test('notification delivery service normalizes API channel results', async () => {
+  const sandbox = loadAppSandbox();
+  const requests = [];
+  const service = sandbox.createNotificationDeliveryService({
+    fetchImpl: async (url, options = {}) => {
+      requests.push([url, options]);
+      return {
+        status: 207,
+        async json() {
+          return {
+            results: {
+              groupme: 'ok',
+              sms: 'error:500',
+              discord: 'skipped',
+            },
+          };
+        },
+      };
+    },
+  });
+
+  const result = await service.sendMenuUpdate({
+    menuId: 'menu-main',
+    patchMessage: 'Patch message',
+    accessToken: 'token-1',
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.partial, true);
+  assert.equal(result.statusCode, 207);
+  assert.deepEqual(Array.from(result.summary.okChannels || []), ['groupme']);
+  assert.deepEqual(Array.from(result.summary.failedChannels || []), ['sms']);
+  assert.deepEqual(Array.from(result.summary.skippedChannels || []), ['discord']);
+  assert.equal(requests.length, 1);
+  assert.equal(requests[0][0], '/api/send-notification');
+  assert.equal(requests[0][1].headers.Authorization, 'Bearer token-1');
+});
+
+test('draft ledger service provides action-bar and item badge state through one boundary', () => {
+  const sandbox = loadAppSandbox();
+  const service = sandbox.createDraftLedgerService({
+    isDirty: () => true,
+    hasSharedDraft: () => false,
+    getDraftChangeCount: () => 2,
+    getDiffLinesCount: () => 0,
+    getDiffSections: () => [{
+      id: 'beer',
+      added: ['Lager'],
+      eightySixed: [],
+      restored: [],
+    }],
+    getSaveOnlyChanges: () => [{ key: 'beer::item-1', itemId: 'item-1' }],
+  });
+
+  const actionBarState = service.getActionBarState({ isCompactViewport: false });
+  assert.equal(actionBarState.hasDraftChanges, true);
+  assert.equal(actionBarState.hasPendingUpdate, false);
+  assert.equal(actionBarState.publishLabel, 'Save');
+  assert.equal(actionBarState.summaryText, '2 pending changes. Save Draft updates the shared draft. Save opens Patch Notes Preview to publish live.');
+
+  const draftBadge = service.getItemBadge({
+    item: { id: 'item-1', name: 'Lager', eightySixed: false },
+    catId: 'beer',
+    lastSentNames: new Set(),
+  });
+  assert.equal(draftBadge.text, 'DRAFT');
+  assert.equal(draftBadge.className, 'item-state-badge--draft');
+
+  const unsentService = sandbox.createDraftLedgerService({
+    isDirty: () => false,
+    hasSharedDraft: () => false,
+    getDraftChangeCount: () => 0,
+    getDiffLinesCount: () => 1,
+    getDiffSections: () => [{
+      id: 'beer',
+      added: ['Lager'],
+      eightySixed: [],
+      restored: [],
+    }],
+    getSaveOnlyChanges: () => [],
+  });
+  const unsentBadge = unsentService.getItemBadge({
+    item: { id: 'item-1', name: 'Lager', eightySixed: false },
+    catId: 'beer',
+    lastSentNames: new Set(['lager']),
+  });
+  assert.equal(unsentBadge.text, 'UNSENT');
+  assert.equal(unsentBadge.className, 'item-state-badge--unsent');
 });
 
 test('manager action bar stays visible and reflects idle and active draft states', () => {
@@ -631,6 +753,86 @@ test('access session service restores sessions and resolves settings access', as
   assert.equal(adminDecision.kind, 'admin-denied');
 });
 
+test('settings route policy service centralizes manager and admin access decisions', () => {
+  const sandbox = loadAppSandbox();
+  const service = sandbox.createSettingsRoutePolicyService({
+    getPageMode: () => 'manager',
+    getMenuId: () => 'menu-main',
+    getKnownMenuOrder: () => ['menu-main', 'menu-other'],
+    getRequestedMenu: () => ({ id: 'menu-other' }),
+    canManageMenu: (menuId, user) => (user?.accessibleMenuIds || []).includes(menuId),
+    getFallbackMenuId: user => (user?.accessibleMenuIds || [])[0] || '',
+    getManagerHrefForMenuId: menuId => `/manager?menu=${menuId}`,
+    getPublicHrefForMenuId: menuId => `/public?menu=${menuId}`,
+  });
+
+  const redirectDecision = service.decide({
+    role: 'manager',
+    accessibleMenuIds: ['menu-main'],
+  });
+  assert.equal(redirectDecision.kind, 'manager-redirect');
+  assert.equal(redirectDecision.menuId, 'menu-main');
+  assert.equal(redirectDecision.targetPath, '/manager?menu=menu-main');
+
+  const deniedDecision = service.decide({
+    role: 'manager',
+    accessibleMenuIds: [],
+  });
+  assert.equal(deniedDecision.kind, 'manager-denied');
+  assert.equal(deniedDecision.targetPath, '/public?menu=menu-other');
+
+  const adminDenied = sandbox.createSettingsRoutePolicyService({
+    getPageMode: () => 'admin',
+    getMenuId: () => 'menu-main',
+    getKnownMenuOrder: () => ['menu-main'],
+    getRequestedMenu: () => null,
+    canManageMenu: () => false,
+    getFallbackMenuId: () => '',
+    getManagerHrefForMenuId: () => '',
+    getPublicHrefForMenuId: () => '',
+  }).decide({ role: 'manager' });
+  assert.equal(adminDenied.kind, 'admin-denied');
+});
+
+test('menu state loader service applies fallback and featured refresh through one boundary', async () => {
+  const sandbox = loadAppSandbox();
+  let fallbackCalls = 0;
+  let clearCalls = 0;
+  let featuredCalls = 0;
+
+  const service = sandbox.createMenuStateLoaderService({
+    readState: async () => {
+      throw new Error('network failed');
+    },
+    hydrateFromState: () => {},
+    applyPersistedDraftState: () => false,
+    setDefaultState: () => {
+      fallbackCalls += 1;
+    },
+    clearDraftChanges: () => {
+      clearCalls += 1;
+    },
+    writeMenuCache: () => {},
+    refreshFeatured: async () => {
+      featuredCalls += 1;
+    },
+    buildSnapshot: source => ({ source }),
+  });
+
+  const snapshot = await service.load({
+    fallbackToDefault: true,
+    includeFeatured: true,
+    persistCache: true,
+    request: { pageMode: 'public' },
+    source: 'network',
+  });
+
+  assert.equal(snapshot.source, 'network');
+  assert.equal(fallbackCalls, 1);
+  assert.equal(clearCalls, 1);
+  assert.equal(featuredCalls, 1);
+});
+
 test('public route contract exposes a stable snapshot and switchMenu action', async () => {
   const sandbox = loadAppSandbox();
   const selectedMenus = [];
@@ -677,6 +879,70 @@ test('public route contract exposes a stable snapshot and switchMenu action', as
   assert.equal(typeof contract.actions.switchMenu, 'function');
 
   await contract.actions.switchMenu({
+    id: getState(sandbox, 'MENU_ID'),
+    slug: 'leroys-lounge-drinks',
+    name: "Leroy's Lounge Drinks",
+    type: 'drinks',
+    restaurantId: getState(sandbox, 'RESTAURANT_ID'),
+  });
+
+  assert.equal(selectedMenus.length, 1);
+  assert.equal(loadCalls, 1);
+  assert.equal(renderCalls, 1);
+  assert.equal(applyCalls, 1);
+});
+
+test('public route adapter converts legacy snapshot input into a contract boundary', async () => {
+  const sandbox = loadAppSandbox();
+  const selectedMenus = [];
+  let loadCalls = 0;
+  let renderCalls = 0;
+  let applyCalls = 0;
+
+  setState(sandbox, {
+    RESTAURANT_ID: '00000000-0000-0000-0000-000000000010',
+    MENU_ID: '00000000-0000-0000-0000-000000000020',
+    MENU_TYPE: 'drinks',
+    _activeMenuName: "Leroy's Lounge Drinks",
+    _activeRestaurantName: "Leroy's Lounge",
+    _siteRestaurant: { id: '00000000-0000-0000-0000-000000000010', name: "Leroy's Lounge" },
+    currentUser: { role: 'manager', name: 'Alex', accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'] },
+    menuState: makeMenuState({
+      beer: [{ id: 'beer-1', name: 'Draft Lager', onMenu: true, visibility: 'public' }],
+    }),
+    _featuredGroups: [],
+    selectMenu: (...args) => {
+      selectedMenus.push(args);
+    },
+    getPublicHrefForCurrentMenu: () => '/leroyslounge?menu=leroys-lounge-drinks',
+    loadActiveMenuState: async () => {
+      loadCalls += 1;
+    },
+    renderPublicViews: async () => {
+      renderCalls += 1;
+    },
+    applyDesign: () => {
+      applyCalls += 1;
+    },
+  });
+  sandbox.location.pathname = '/leroyslounge';
+  sandbox.location.search = '?menu=leroys-lounge-drinks';
+
+  const adapter = sandbox.createPublicRouteAdapter(
+    getState(sandbox, 'menuState'),
+    {
+      currentUser: getState(sandbox, 'currentUser'),
+      menuId: getState(sandbox, 'MENU_ID'),
+      menuType: getState(sandbox, 'MENU_TYPE'),
+      restaurantId: getState(sandbox, 'RESTAURANT_ID'),
+    }
+  );
+
+  assert.equal(adapter.version, 0);
+  assert.equal(adapter.snapshot.menuId, getState(sandbox, 'MENU_ID'));
+  assert.equal(typeof adapter.actions.switchMenu, 'function');
+
+  await adapter.actions.switchMenu({
     id: getState(sandbox, 'MENU_ID'),
     slug: 'leroys-lounge-drinks',
     name: "Leroy's Lounge Drinks",
@@ -985,7 +1251,8 @@ test('public route contract and route renderers register and hydrate both restau
       routeCase.prefix === 'll' ? 'll-route-specials' : 'erc-route-specials'
     );
 
-    assert.match(footerVersion.innerHTML, /v0\.8\.6/);
+    const escapedVersion = String(getState(sandbox, 'APP_VERSION')).replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    assert.match(footerVersion.innerHTML, new RegExp(escapedVersion));
     assert.match(footerVersion.innerHTML, /PREVIEW/);
     assert.equal(footerTimestamp.textContent, 'Thu, Apr 9 at 7:25 PM');
     if (menuNameEl) assert.equal(menuNameEl.textContent, routeCase.menuName);


### PR DESCRIPTION
## Summary
- Extract deep boundary services in `app.js` for publish flow, settings access policy, notification delivery, draft ledger state, menu state loading/polling, and public route contract adaptation
- Delegate existing lifecycle and runtime paths to the new service boundaries without changing public behavior
- Update route-owned adapters in `leroyslounge/app.js` and `elroyscantina/app.js` to use shared `createPublicRouteAdapter` when available
- Add/expand architecture boundary tests to cover each new service boundary and keep behavior assertions interface-focused
- Make route renderer version assertion resilient to current `APP_VERSION`

## Testing
- `node --test tests/architecture-boundaries.test.cjs`
- `node --test tests/*.cjs`
- `node --check app.js && node --check leroyslounge/app.js && node --check elroyscantina/app.js`