### PR TITLE
Unify public menu routing and staff footer actions

### DIFF
--- a/app.js
+++ b/app.js
@@ -3565,6 +3565,8 @@ async function init() {
     await loadSupabaseConfig();
     const handledRecovery = await _tryHandleRecoveryCallback();
     if (!handledRecovery) await _tryRestoreSession();
+    renderUserHeader({ skipPublicRender: true });
+    syncPublicStaffFooterActions();
     return;
   }
   showAppShell();

--- a/app.js
+++ b/app.js
@@ -298,8 +298,25 @@ function sortKnownMenus(menus) {
   return [...menus].sort((a, b) => KNOWN_MENU_ORDER.indexOf(a.id) - KNOWN_MENU_ORDER.indexOf(b.id));
 }
 
-function normalizeKnownMenuSlug(slug) {
-  return LEGACY_MENU_SLUG_ALIASES[slug] || slug;
+function getMenuSlugForRestaurantType(restaurantId, menuType = 'drinks') {
+  if (!isValidRestaurant(restaurantId)) return '';
+  const normalizedType = (menuType || 'drinks').toLowerCase();
+  return knownMenuList().find(menu => (
+    menu.restaurantId === restaurantId &&
+    (menu.type || '').toLowerCase() === normalizedType
+  ))?.slug || '';
+}
+
+function normalizeKnownMenuSlug(slug, options = {}) {
+  const normalized = LEGACY_MENU_SLUG_ALIASES[slug] || slug;
+  const restaurantId = typeof options === 'string'
+    ? options
+    : options.restaurantId;
+  if (!isValidRestaurant(restaurantId)) return normalized;
+  if (normalized === 'drinks' || normalized === 'food') {
+    return getMenuSlugForRestaurantType(restaurantId, normalized) || normalized;
+  }
+  return normalized;
 }
 
 function normalizeAccessibleMenuIds(menuIds) {
@@ -476,6 +493,14 @@ function redirectToRestaurantPath(restaurantId, slug = '', message = '') {
   const safeRestaurantId = isValidRestaurant(restaurantId) ? restaurantId : RESTAURANTS.LEROYS.id;
   const path = SITE_PATHS[safeRestaurantId] || SITE_PATHS[RESTAURANTS.LEROYS.id];
   const url = new URL(path, window.location.origin);
+  const menu = getMenuBySlug(slug);
+  const publicHref = menu?.id ? getPublicHrefForMenuId(menu.id) : '';
+  if (publicHref) {
+    _clearActiveMenuContext({ clearCache: !isValidRestaurant(restaurantId) });
+    queueRedirectNotice(message);
+    navigateToPage(publicHref);
+    return false;
+  }
   if (slug) url.searchParams.set('menu', slug);
   _clearActiveMenuContext({ clearCache: !isValidRestaurant(restaurantId) });
   queueRedirectNotice(message);
@@ -545,8 +570,9 @@ function getPublicHrefForMenuId(menuId) {
     ? SITE_PATHS[menu.restaurantId]
     : getDefaultPublicPath();
   if (!menu?.slug) return basePath;
+  if ((menu.type || '').toLowerCase() === 'food') return basePath;
   const url = new URL(basePath, window.location.origin);
-  url.searchParams.set('menu', menu.slug);
+  url.searchParams.set('menu', 'drinks');
   return `${url.pathname}${url.search}`;
 }
 
@@ -612,6 +638,14 @@ function getManagerHrefForMenuId(menuId) {
   return `${url.pathname}${url.search}`;
 }
 
+function getAdminHrefForMenuId(menuId) {
+  const menu = getMenuById(menuId);
+  if (!menu?.slug) return SHARED_PAGE_PATHS.admin;
+  const url = new URL(SHARED_PAGE_PATHS.admin, window.location.origin);
+  url.searchParams.set('menu', menu.slug);
+  return `${url.pathname}${url.search}`;
+}
+
 function navigateToPage(path) {
   window.location.assign(path);
 }
@@ -672,7 +706,7 @@ function buildCurrentMenuPageRequest(overrides = {}) {
     siteRestaurantId: isValidRestaurant(siteRestaurantId) ? siteRestaurantId : '',
     requestedMenuId: overrides.requestedMenuId ?? MENU_ID,
     requestedMenuSlug: overrides.requestedMenuSlug ??
-      normalizeKnownMenuSlug(new URLSearchParams(search).get('menu') || ''),
+      normalizeKnownMenuSlug(new URLSearchParams(search).get('menu') || '', { restaurantId: siteRestaurantId }),
   };
 }
 
@@ -1610,10 +1644,10 @@ function readCachedMenuState(expectedContext = '') {
 }
 
 function getDefaultMenuForRestaurant(restaurant) {
-  if (!isValidRestaurant(restaurant?.id)) return MENUS.LEROYS_DRINKS;
+  if (!isValidRestaurant(restaurant?.id)) return MENUS.LEROYS_FOOD;
   return knownMenuList().find(menu => (
-    menu.restaurantId === restaurant.id && menu.type === 'drinks'
-  )) || MENUS.LEROYS_DRINKS;
+    menu.restaurantId === restaurant.id && menu.type === 'food'
+  )) || MENUS.LEROYS_FOOD;
 }
 
 function primeSiteRestaurantMenu(restaurant) {
@@ -1621,9 +1655,8 @@ function primeSiteRestaurantMenu(restaurant) {
   MENU_ID = preferredMenu.id;
   lsSet(LS_KEYS.menuId, MENU_ID);
   setActiveMenuContext(preferredMenu.name, preferredMenu.type, preferredMenu.restaurantId);
-  const url = new URL(location.href);
-  url.searchParams.set('menu', preferredMenu.slug);
-  history.replaceState({}, '', url.toString());
+  const href = getPublicHrefForMenuId(preferredMenu.id);
+  if (href) history.replaceState({}, '', new URL(href, window.location.origin).toString());
 }
 
 function showPickerPage() {
@@ -1693,7 +1726,7 @@ async function sbReadJsonOrThrow(url, options = {}) {
 // the hardcoded default order. Sets MENU_ID and normalizes legacy slugs.
 async function sbResolveMenu() {
   const rawSlug = new URLSearchParams(location.search).get('menu');
-  const slug = normalizeKnownMenuSlug(rawSlug);
+  const slug = normalizeKnownMenuSlug(rawSlug, { restaurantId: _siteRestaurant?.id || '' });
 
   if (slug) {
     const [menuRes, allMenusRes] = await Promise.all([
@@ -1724,10 +1757,10 @@ async function sbResolveMenu() {
         MENU_ID          = menu.id;
         if (setActiveMenuContext(menu.name || '', menu.type || 'drinks', menu.restaurant_id || '') === false) return;
         lsSet(LS_KEYS.menuId, MENU_ID);
-        if (rawSlug && rawSlug !== slug) {
-          const url = new URL(location.href);
-          url.searchParams.set('menu', slug);
-          history.replaceState({}, '', url.toString());
+        const publicHref = getPublicHrefForMenuId(menu.id);
+        const currentHref = `${window.location.pathname}${window.location.search}`;
+        if (publicHref && publicHref !== currentHref) {
+          history.replaceState({}, '', new URL(publicHref, window.location.origin).toString());
         }
         return;
       }
@@ -1761,10 +1794,10 @@ async function sbResolveMenu() {
           return;
         }
         if (setActiveMenuContext(menu.name || '', menu.type || MENU_TYPE, menu.restaurant_id || RESTAURANT_ID) === false) return;
-        if (menu.slug) {
-          const url = new URL(location.href);
-          url.searchParams.set('menu', menu.slug);
-          history.replaceState({}, '', url.toString());
+        const publicHref = getPublicHrefForMenuId(MENU_ID);
+        const currentHref = `${window.location.pathname}${window.location.search}`;
+        if (publicHref && publicHref !== currentHref) {
+          history.replaceState({}, '', new URL(publicHref, window.location.origin).toString());
         }
       } else {
         _clearActiveMenuContext({ clearCache: true });
@@ -1785,10 +1818,17 @@ async function sbResolveMenu() {
   const menus = sortKnownMenus((await res.json()).filter(menu => !menu.archived));
   _hasMultipleMenus = menus.length > 1;
 
-  let defaultMenu = menus.find(menu => menu.id === MENUS.LEROYS_DRINKS.id);
+  let defaultMenu = null;
+  if (_siteRestaurant?.id) {
+    defaultMenu = menus.find(menu => (
+      menu.restaurant_id === _siteRestaurant.id &&
+      (menu.type || '').toLowerCase() === 'food'
+    ));
+  }
   if (!defaultMenu && currentUser?.role === 'manager') {
     defaultMenu = menus.find(menu => normalizeAccessibleMenuIds(currentUser.accessibleMenuIds).includes(menu.id));
   }
+  if (!defaultMenu) defaultMenu = menus.find(menu => menu.id === MENUS.LEROYS_FOOD.id);
   if (!defaultMenu) defaultMenu = menus[0];
 
   if (defaultMenu) {
@@ -1799,9 +1839,8 @@ async function sbResolveMenu() {
       redirectToRestaurantPath(defaultMenu.restaurant_id, defaultMenu.slug || '');
       return;
     }
-    const url = new URL(location.href);
-    url.searchParams.set('menu', defaultMenu.slug);
-    history.replaceState({}, '', url.toString());
+    const href = getPublicHrefForMenuId(defaultMenu.id);
+    if (href) history.replaceState({}, '', new URL(href, window.location.origin).toString());
   }
 }
 
@@ -3521,6 +3560,11 @@ async function init() {
   const isSettingsRoute = isSettingsPage();
   if (_appPageMode === 'picker') {
     showPickerPage();
+    migrateLocalStorage();
+    loadLocalConfig();
+    await loadSupabaseConfig();
+    const handledRecovery = await _tryHandleRecoveryCallback();
+    if (!handledRecovery) await _tryRestoreSession();
     return;
   }
   showAppShell();
@@ -3626,6 +3670,10 @@ function buildPublicRouteRenderSnapshot(options = {}) {
     menuId: MENU_ID,
     menuState,
     menuType: MENU_TYPE,
+    publicFooter: buildPublicStaffFooterState(actor, {
+      menuId: MENU_ID,
+      restaurantId: RESTAURANT_ID,
+    }),
     restaurantId: RESTAURANT_ID,
     restaurantSpecials: featuredSnapshot.restaurantSpecials,
     siteRestaurant,
@@ -3686,6 +3734,8 @@ function createPublicRouteAdapter(contractOrMenuState, legacyState = {}, options
 }
 
 function createPublicRouteContract() {
+  const actor = currentUser;
+  const siteRestaurantId = _siteRestaurant?.id || '';
   return {
     version: 1,
     snapshot: buildPublicRouteRenderSnapshot({ actor, siteRestaurantId }),
@@ -3698,6 +3748,8 @@ function createPublicRouteContract() {
       closeDropdowns: () => closeRouteDropdowns(),
       openManager: () => onActionBtnClick(),
       openAdmin: () => onAdminBtnClick(),
+      openAuthOverlay: () => openAuthOverlay('signin'),
+      signOut: () => signOut(),
       canManageMenu: (menuId, user = actor) => currentUserCanManageMenu(menuId, user),
       switchMenu: menu => switchPublicRouteMenu(menu),
     },
@@ -4095,6 +4147,7 @@ function renderFooter() {
   const versionHtml = APP_VERSION +
     (IS_PREVIEW ? ' <span class="footer-preview-badge">PREVIEW</span>' : '');
   const displayName = formatMenuDisplayName(_activeMenuName, MENU_TYPE, RESTAURANT_ID);
+  const staffFooterState = buildPublicStaffFooterState();
   const publicVersionEl = document.getElementById('footer-version');
   const publicUpdatedEl = document.getElementById('footer-last-updated');
   const managerVersionEl = document.getElementById('manager-footer-version');
@@ -4115,6 +4168,95 @@ function renderFooter() {
       el.textContent = el === managerUpdatedEl ? 'Updated —' : '';
       el.title = '';
     }
+  });
+  syncPublicStaffFooterActions(staffFooterState);
+}
+
+function buildPublicStaffFooterState(user = currentUser, options = {}) {
+  const menuId = options.menuId || MENU_ID;
+  const restaurantId = options.restaurantId || RESTAURANT_ID;
+  const signedIn = !!user;
+  const canManageCurrentMenu = signedIn && (
+    menuId
+      ? currentUserCanManageMenu(menuId, user)
+      : (user?.role === 'manager' || user?.role === 'admin')
+  );
+  const isAdmin = user?.role === 'admin';
+  const links = [];
+
+  if (canManageCurrentMenu) {
+    links.push({
+      key: 'manager',
+      label: 'Manager',
+      href: getManagerHrefForMenuId(menuId),
+      action: 'navigate',
+    });
+  }
+  if (isAdmin) {
+    links.push({
+      key: 'admin',
+      label: 'Admin',
+      href: getAdminHrefForMenuId(menuId),
+      action: 'navigate',
+    });
+  }
+  if (signedIn) {
+    links.push({
+      key: 'signout',
+      label: 'Sign Out',
+      href: '',
+      action: 'signOut',
+    });
+  }
+
+  return {
+    signedIn,
+    menuId,
+    restaurantId,
+    signIn: signedIn
+      ? null
+      : {
+          key: 'signin',
+          label: 'Staff Sign-In',
+          href: '',
+          action: 'openAuthOverlay',
+        },
+    links,
+  };
+}
+
+function syncPublicStaffFooterActions(state = buildPublicStaffFooterState()) {
+  const footerWraps = document.querySelectorAll('[data-route-footer-actions], [data-route-staff-actions]');
+  const signInEls = document.querySelectorAll('[data-route-footer-signin], [data-route-staff-signin]');
+  const managerEls = document.querySelectorAll('[data-route-footer-manager], [data-route-staff-manager]');
+  const adminEls = document.querySelectorAll('[data-route-footer-admin], [data-route-staff-admin]');
+  const signOutEls = document.querySelectorAll('[data-route-footer-signout], [data-route-staff-signout]');
+  const managerLink = state.links.find(link => link.key === 'manager') || null;
+  const adminLink = state.links.find(link => link.key === 'admin') || null;
+  const signOutLink = state.links.find(link => link.key === 'signout') || null;
+
+  footerWraps.forEach(footerWrap => {
+    footerWrap.style.display = state.signedIn || state.signIn ? '' : 'none';
+  });
+  signInEls.forEach(signInEl => {
+    signInEl.style.display = state.signIn ? '' : 'none';
+    signInEl.textContent = state.signIn?.label || '';
+    signInEl.onclick = state.signIn ? () => openAuthOverlay('signin') : null;
+  });
+  managerEls.forEach(managerEl => {
+    managerEl.style.display = managerLink ? '' : 'none';
+    managerEl.textContent = managerLink?.label || '';
+    managerEl.onclick = managerLink ? () => navigateToPage(managerLink.href) : null;
+  });
+  adminEls.forEach(adminEl => {
+    adminEl.style.display = adminLink ? '' : 'none';
+    adminEl.textContent = adminLink?.label || '';
+    adminEl.onclick = adminLink ? () => navigateToPage(adminLink.href) : null;
+  });
+  signOutEls.forEach(signOutEl => {
+    signOutEl.style.display = signOutLink ? '' : 'none';
+    signOutEl.textContent = signOutLink?.label || '';
+    signOutEl.onclick = signOutLink ? () => signOut() : null;
   });
 }
 
@@ -4596,6 +4738,7 @@ function renderUserHeader(options = {}) {
       publicView?.style.display !== 'none') {
     renderPublicView();
   }
+  syncPublicStaffFooterActions();
 }
 
 function applyRole(role) {
@@ -4603,6 +4746,7 @@ function applyRole(role) {
   const pruneSection = document.getElementById('prune-section');
   if (pruneSection) pruneSection.style.display = isAdmin ? '' : 'none';
   renderUserHeader();
+  syncPublicStaffFooterActions();
 }
 
 function setActiveSettingsSection(sectionId) {
@@ -4995,9 +5139,14 @@ function selectMenu(menuId, slug, menuName, menuType, restaurantId) {
   MENU_ID       = menuId;
   setActiveMenuContext(menuName || '', menuType || 'drinks', restaurantId || '');
   lsSet(LS_KEYS.menuId, MENU_ID);
-  const url = new URL(location.href);
-  url.searchParams.set('menu', slug);
-  history.replaceState({}, '', url.toString());
+  const nextHref = _appPageMode === 'public'
+    ? getPublicHrefForMenuId(menuId)
+    : (() => {
+      const url = new URL(location.href);
+      url.searchParams.set('menu', slug);
+      return url.toString();
+    })();
+  if (nextHref) history.replaceState({}, '', nextHref);
   ensureCurrentMenuSession({
     requestedMenuId: menuId,
     requestedMenuSlug: slug,
@@ -5088,16 +5237,19 @@ function openAuthOverlay(screen) {
   _setSettingsShellPending(false);
   _authFocusBefore = document.activeElement;
   const overlay = document.getElementById('auth-overlay');
+  if (!overlay) return;
   overlay.classList.add('open');
   const noConfig = !SUPABASE_URL || !SUPABASE_ANON_KEY;
-  document.getElementById('auth-no-config').style.display = noConfig ? '' : 'none';
-  document.getElementById('auth-form-wrap').style.display = noConfig ? 'none' : '';
+  const noConfigEl = document.getElementById('auth-no-config');
+  const formWrapEl = document.getElementById('auth-form-wrap');
+  if (noConfigEl) noConfigEl.style.display = noConfig ? '' : 'none';
+  if (formWrapEl) formWrapEl.style.display = noConfig ? 'none' : '';
   if (!noConfig) renderAuthScreen(screen || 'signin');
   document.addEventListener('keydown', _authFocusTrap);
 }
 
 function closeAuthOverlay() {
-  document.getElementById('auth-overlay').classList.remove('open');
+  document.getElementById('auth-overlay')?.classList.remove('open');
   document.removeEventListener('keydown', _authFocusTrap);
   if (_authFocusBefore && typeof _authFocusBefore.focus === 'function') _authFocusBefore.focus();
   _authFocusBefore = null;
@@ -8120,24 +8272,39 @@ setInterval(() => {
     if (field) field.addEventListener('input', syncAuthUsernameAssistFields);
   });
   // Sign In: email Enter → focus password; password Enter → submit
-  document.getElementById('signin-email').addEventListener('keydown', function(e) {
-    if (e.key === 'Enter') document.getElementById('signin-password').focus();
-  });
-  document.getElementById('signin-password').addEventListener('keydown', function(e) {
-    if (e.key === 'Enter') handleSignIn();
-  });
+  const signinEmail = document.getElementById('signin-email');
+  const signinPassword = document.getElementById('signin-password');
+  const signupPassword = document.getElementById('signup-password');
+  const forgotEmail = document.getElementById('forgot-email');
+  const resetConfirm = document.getElementById('reset-confirm');
+  if (signinEmail) {
+    signinEmail.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') signinPassword?.focus();
+    });
+  }
+  if (signinPassword) {
+    signinPassword.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') handleSignIn();
+    });
+  }
   // Sign Up: password Enter → submit
-  document.getElementById('signup-password').addEventListener('keydown', function(e) {
-    if (e.key === 'Enter') handleSignUp();
-  });
+  if (signupPassword) {
+    signupPassword.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') handleSignUp();
+    });
+  }
   // Forgot: email Enter → submit
-  document.getElementById('forgot-email').addEventListener('keydown', function(e) {
-    if (e.key === 'Enter') handleForgotPassword();
-  });
+  if (forgotEmail) {
+    forgotEmail.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') handleForgotPassword();
+    });
+  }
   // Reset: confirm Enter → submit
-  document.getElementById('reset-confirm').addEventListener('keydown', function(e) {
-    if (e.key === 'Enter') handleResetPassword();
-  });
+  if (resetConfirm) {
+    resetConfirm.addEventListener('keydown', function(e) {
+      if (e.key === 'Enter') handleResetPassword();
+    });
+  }
 })();
 
 // ─── RESTAURANT & MENU MANAGEMENT ─────────────────────────────────────────────

--- a/elroyscantina/app.js
+++ b/elroyscantina/app.js
@@ -93,6 +93,70 @@
       });
   }
 
+  function buildMenuSwitchPlaceholder() {
+    return `
+      <section class="erc-section erc-route-switch-section" aria-hidden="true">
+        <div class="erc-section-head">
+          <h3 class="erc-section-title">Loading menu</h3>
+          <div class="erc-section-line"></div>
+        </div>
+        <div class="erc-route-boot-rows erc-route-switch-rows">
+          <span class="erc-route-boot-line erc-route-boot-line--wide"></span>
+          <span class="erc-route-boot-line erc-route-boot-line--mid"></span>
+          <span class="erc-route-boot-line erc-route-boot-line--narrow"></span>
+        </div>
+      </section>
+    `;
+  }
+
+  function setRouteMenuSwitchState(sharedState, targetType) {
+    const page = document.querySelector('.erc-page');
+    const main = document.getElementById('erc-route-main');
+    const sections = document.getElementById('erc-route-sections');
+    const targetMenuType = String(targetType || '').toLowerCase();
+
+    if (page) {
+      page.classList.add('is-menu-switching');
+      page.dataset.routeSwitchingMenu = targetMenuType;
+    }
+    if (main) main.setAttribute('aria-busy', 'true');
+    document.querySelectorAll('[data-route-menu-toggle]').forEach(button => {
+      const isActive = button.getAttribute('data-route-menu-toggle') === targetMenuType;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+    if (sections) sections.innerHTML = buildMenuSwitchPlaceholder(sharedState);
+  }
+
+  function clearRouteMenuSwitchState() {
+    const page = document.querySelector('.erc-page');
+    const main = document.getElementById('erc-route-main');
+    if (page) {
+      page.classList.remove('is-menu-switching');
+      delete page.dataset.routeSwitchingMenu;
+    }
+    if (main) main.removeAttribute('aria-busy');
+  }
+
+  function resetRouteScrollPosition() {
+    const main = document.getElementById('erc-route-main');
+    if (main) main.scrollTop = 0;
+    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+  }
+
+  async function switchRouteMenu(contract, menu) {
+    if (!menu?.id) return { ok: false, userHandled: true };
+    setRouteMenuSwitchState(contract.snapshot, menu.type);
+    resetRouteScrollPosition();
+    try {
+      return await contract.actions.switchMenu(menu);
+    } catch (error) {
+      clearRouteMenuSwitchState();
+      renderRoute(contract);
+      throw error;
+    }
+  }
+
   function createLegacyRouteActions(sharedState) {
     return {
       closeDropdowns: () => window.closeRouteDropdowns?.(),
@@ -192,7 +256,7 @@
         const targetType = button.getAttribute('data-route-menu-toggle');
         const menu = menus.find(entry => entry.type === targetType);
         if (!menu || menu.id === sharedState.menuId) return;
-        await contract.actions.switchMenu(menu);
+        await switchRouteMenu(contract, menu);
       };
     });
 
@@ -306,19 +370,7 @@
 
     const categoryWrap = document.getElementById('erc-route-sections');
     if (categoryWrap) {
-      categoryWrap.innerHTML = `
-        <section class="erc-section erc-route-boot-section" aria-hidden="true">
-          <div class="erc-section-head">
-            <h3 class="erc-section-title">Preparing The Menu</h3>
-            <div class="erc-section-line"></div>
-          </div>
-          <div class="erc-route-boot-rows">
-            <span class="erc-route-boot-line erc-route-boot-line--wide"></span>
-            <span class="erc-route-boot-line erc-route-boot-line--mid"></span>
-            <span class="erc-route-boot-line erc-route-boot-line--narrow"></span>
-          </div>
-        </section>
-      `;
+      categoryWrap.innerHTML = buildMenuSwitchPlaceholder();
     }
 
     bindMobileHeader(container.querySelector('.erc-page'));
@@ -365,6 +417,7 @@
       categoryWrap.innerHTML = categoriesHtml || '<p class="erc-route-empty">Nothing on the menu yet.</p>';
     }
 
+    clearRouteMenuSwitchState();
     renderHeaderState(sharedState);
     renderSettingsDropdown(contract);
     bindMenuToggles(contract);

--- a/elroyscantina/app.js
+++ b/elroyscantina/app.js
@@ -266,10 +266,9 @@
   function renderHeaderState(sharedState) {
     const signInButton = document.querySelector('[data-route-signin]');
     const userChip = document.querySelector('[data-route-user-chip]');
-    const isAuthed = !!sharedState.currentUser;
 
-    if (signInButton) signInButton.style.display = isAuthed ? 'none' : '';
-    if (userChip) userChip.style.display = isAuthed ? '' : 'none';
+    if (signInButton) signInButton.style.display = 'none';
+    if (userChip) userChip.style.display = sharedState.currentUser ? '' : 'none';
   }
 
   function addMediaListener(mql, handler) {
@@ -421,6 +420,7 @@
     renderHeaderState(sharedState);
     renderSettingsDropdown(contract);
     bindMenuToggles(contract);
+    window.syncPublicStaffFooterActions?.(sharedState.publicFooter);
     bindMobileHeader(container.querySelector('.erc-page'));
     return true;
   }

--- a/elroyscantina/index.html
+++ b/elroyscantina/index.html
@@ -39,22 +39,13 @@
         <a class="erc-skip-link" href="#erc-route-main">Skip to menu content</a>
         <header class="erc-topbar">
           <div class="erc-topbar-inner">
-            <div class="erc-brand-group">
+            <a
+              class="erc-brand-group erc-brand-link"
+              href="/"
+              aria-label="Return to the homepage"
+            >
               <h1 class="erc-brand">El Roy's Cantina</h1>
-              <a
-                class="erc-sister-link"
-                href="/leroyslounge"
-                aria-label="Open Leroy's Lounge menu"
-              >
-                <img
-                  class="erc-sister-badge"
-                  src="/assets/el-roys-cantina/cantina-badge.png"
-                  alt="Leroy's Lounge"
-                  width="495"
-                  height="335"
-                />
-              </a>
-            </div>
+            </a>
 
             <nav class="erc-menu-toggle" aria-label="Swap menu">
               <button
@@ -76,6 +67,19 @@
             </nav>
 
             <div class="erc-actions">
+              <a
+                class="erc-sister-link"
+                href="/leroyslounge"
+                aria-label="Open Leroy's Lounge menu"
+              >
+                <img
+                  class="erc-sister-badge"
+                  src="/assets/el-roys-cantina/cantina-badge.png"
+                  alt="Leroy's Lounge"
+                  width="495"
+                  height="335"
+                />
+              </a>
               <button
                 class="erc-login-btn"
                 data-route-signin
@@ -223,6 +227,12 @@
                 >
               </p>
               <p id="erc-route-footer-version" class="erc-footer-version"></p>
+              <div class="erc-footer-actions" data-route-footer-actions>
+                <button class="erc-footer-action" type="button" data-route-footer-signin>Staff Sign-In</button>
+                <button class="erc-footer-action" type="button" data-route-footer-manager style="display:none">Manager</button>
+                <button class="erc-footer-action" type="button" data-route-footer-admin style="display:none">Admin</button>
+                <button class="erc-footer-action" type="button" data-route-footer-signout style="display:none">Sign Out</button>
+              </div>
             </div>
           </div>
         </footer>
@@ -324,6 +334,12 @@
           <footer id="menu-footer">
             <span id="footer-version"></span>
             <span id="footer-last-updated"></span>
+            <div class="public-staff-actions" data-route-staff-actions>
+              <button class="public-staff-action" type="button" data-route-staff-signin>Staff Sign-In</button>
+              <button class="public-staff-action" type="button" data-route-staff-manager style="display:none">Manager</button>
+              <button class="public-staff-action" type="button" data-route-staff-admin style="display:none">Admin</button>
+              <button class="public-staff-action" type="button" data-route-staff-signout style="display:none">Sign Out</button>
+            </div>
           </footer>
         </div>
       </div>

--- a/elroyscantina/style.css
+++ b/elroyscantina/style.css
@@ -102,6 +102,11 @@ body.route-restaurant.route-restaurant--elroy {
   min-width: 0;
 }
 
+#restaurant-site-wrapper .erc-brand-link {
+  color: inherit;
+  text-decoration: none;
+}
+
 #restaurant-site-wrapper .erc-brand {
   margin: 0;
   color: var(--erc-primary);
@@ -177,6 +182,12 @@ body.route-restaurant.route-restaurant--elroy {
   align-items: center;
   gap: 0.75rem;
   transition: gap 0.22s ease, transform 0.22s ease;
+}
+
+#restaurant-site-wrapper .erc-brand-link:hover,
+#restaurant-site-wrapper .erc-brand-link:focus-visible {
+  opacity: 0.88;
+  outline: none;
 }
 
 #restaurant-site-wrapper .erc-login-btn,
@@ -576,6 +587,21 @@ body.route-restaurant.route-restaurant--elroy {
   width: min(68%, 14rem);
 }
 
+#restaurant-site-wrapper .erc-page.is-menu-switching .erc-main {
+  cursor: progress;
+}
+
+#restaurant-site-wrapper .erc-page.is-menu-switching .erc-route-switch-section {
+  min-height: 10rem;
+}
+
+#restaurant-site-wrapper .erc-page.is-menu-switching .erc-route-switch-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
 #restaurant-site-wrapper .erc-footer {
   margin-top: auto;
   background:
@@ -638,6 +664,37 @@ body.route-restaurant.route-restaurant--elroy {
   border-color: rgb(122 119 107 / 0.3);
 }
 
+#restaurant-site-wrapper .erc-footer-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+#restaurant-site-wrapper .erc-footer-action {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 0;
+  background: none;
+  color: var(--erc-muted);
+  cursor: pointer;
+  font: inherit;
+  font-size: 0.68rem;
+  font-weight: 800;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  text-decoration: underline;
+  text-underline-offset: 0.22em;
+  padding: 0;
+}
+
+#restaurant-site-wrapper .erc-footer-action:hover,
+#restaurant-site-wrapper .erc-footer-action:focus-visible {
+  color: var(--erc-primary);
+  outline: none;
+}
+
 @keyframes erc-route-boot-sheen {
   from {
     background-position: 200% 0;
@@ -672,6 +729,10 @@ body.route-restaurant.route-restaurant--elroy {
   #restaurant-site-wrapper .erc-timestamp,
   #restaurant-site-wrapper .erc-footer-meta {
     text-align: left;
+  }
+
+  #restaurant-site-wrapper .erc-footer-actions {
+    justify-content: flex-start;
   }
 }
 

--- a/index.html
+++ b/index.html
@@ -228,6 +228,136 @@
     letter-spacing: 0.2em;
     color: var(--lp-footer);
   }
+  .lp-footer-actions {
+    display: flex;
+    justify-content: center;
+    gap: 1rem;
+    flex-wrap: wrap;
+    margin-top: 0.75rem;
+  }
+  .lp-footer-action {
+    appearance: none;
+    border: 0;
+    background: none;
+    color: var(--lp-footer);
+    font-family: 'Space Grotesk', monospace;
+    font-size: 0.72rem;
+    letter-spacing: 0.16em;
+    text-transform: uppercase;
+    cursor: pointer;
+    padding: 0;
+    text-decoration: underline;
+    text-underline-offset: 0.24em;
+  }
+  .lp-footer-action:hover,
+  .lp-footer-action:focus-visible {
+    color: var(--lp-text);
+    outline: none;
+  }
+
+  #auth-overlay {
+    display: none;
+    background: rgba(0, 0, 0, 0.6);
+    position: fixed;
+    inset: 0;
+    align-items: center;
+    justify-content: center;
+    z-index: 60;
+    padding: 16px;
+  }
+  #auth-overlay.open { display: flex; }
+  .auth-box {
+    background: #f7fafc;
+    border: 1px solid rgba(45, 55, 72, 0.12);
+    border-radius: 16px;
+    padding: 36px 28px;
+    text-align: center;
+    width: 100%;
+    max-width: 340px;
+    position: relative;
+    box-shadow: 0 24px 60px rgba(0, 0, 0, 0.18);
+  }
+  .auth-box h2 {
+    font-family: 'Epilogue', sans-serif;
+    font-size: 22px;
+    letter-spacing: 0.08em;
+    margin-bottom: 5px;
+    color: #1a202c;
+  }
+  .auth-box p,
+  .auth-toggle,
+  .auth-approval-notice,
+  .auth-back-btn,
+  .pin-cancel {
+    color: #718096;
+    font-size: 12px;
+  }
+  .auth-screen-subtitle { margin-bottom: 20px; }
+  .auth-hint-msg {
+    color: #718096;
+    font-size: 12px;
+    margin-bottom: 16px;
+    padding: 10px;
+    background: rgba(0, 0, 0, 0.05);
+    border-radius: 8px;
+    line-height: 1.5;
+  }
+  .auth-field { margin-bottom: 10px; text-align: left; }
+  .auth-field input {
+    width: 100%;
+    padding: 11px 13px;
+    border: 1px solid rgba(45, 55, 72, 0.2);
+    border-radius: 9px;
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 14px;
+    background: #fff;
+    color: #1a202c;
+    outline: none;
+    transition: border-color 0.15s;
+  }
+  .auth-field input:focus { border-color: #2d3748; }
+  .auth-error {
+    color: #e74c3c;
+    font-size: 12px;
+    margin-bottom: 10px;
+    min-height: 18px;
+    text-align: left;
+  }
+  .auth-submit-btn {
+    width: 100%;
+    padding: 13px;
+    background: #2d3748;
+    color: #f7fafc;
+    border: none;
+    border-radius: 9px;
+    font-family: 'Space Grotesk', sans-serif;
+    font-size: 14px;
+    font-weight: 600;
+    letter-spacing: 0.03em;
+    cursor: pointer;
+    transition: background 0.15s;
+    margin-bottom: 12px;
+  }
+  .auth-submit-btn:hover { background: #1a202c; }
+  .auth-submit-btn:disabled { opacity: 0.6; cursor: default; }
+  .auth-toggle-btn,
+  .auth-link-btn,
+  .auth-back-btn,
+  .pin-cancel {
+    background: none;
+    border: none;
+    cursor: pointer;
+    font-family: 'Space Grotesk', sans-serif;
+  }
+  .auth-toggle-btn,
+  .auth-link-btn {
+    color: #2d3748;
+    text-decoration: underline;
+  }
+  .auth-link-btn { display: block; width: 100%; padding: 4px 0; margin-bottom: 12px; }
+  .auth-approval-notice { margin: -4px 0 10px; line-height: 1.5; opacity: 0.85; }
+  .auth-back-btn,
+  .pin-cancel { display: block; width: 100%; padding: 6px; margin-top: 10px; }
 
   /* ── Entrance animation ── */
   @keyframes lp-fade-up {
@@ -380,7 +510,93 @@
 
 <footer class="lp-footer">
   <p class="lp-footer-text">Drinks &amp; Food menus. Updated live.</p>
+  <div class="lp-footer-actions" data-route-staff-actions>
+    <button class="lp-footer-action" type="button" data-route-staff-signin>Staff Sign-In</button>
+    <button class="lp-footer-action" type="button" data-route-staff-manager style="display:none">Manager</button>
+    <button class="lp-footer-action" type="button" data-route-staff-admin style="display:none">Admin</button>
+    <button class="lp-footer-action" type="button" data-route-staff-signout style="display:none">Sign Out</button>
+  </div>
 </footer>
 
+<div id="auth-overlay">
+  <div class="auth-box" id="auth-box" role="dialog" aria-modal="true" aria-label="Sign In">
+    <div id="auth-no-config" style="display:none" class="auth-hint-msg">Supabase is not configured. Check server environment variables.</div>
+    <div id="auth-form-wrap">
+      <div id="auth-screen-signin" class="auth-screen">
+        <h2 class="auth-screen-title">SIGN IN</h2>
+        <p class="auth-screen-subtitle">Sign in to your account</p>
+        <div class="auth-field">
+          <input type="email" id="signin-email" placeholder="Email address" autocomplete="email" aria-describedby="signin-error"/>
+        </div>
+        <div class="auth-field">
+          <input type="password" id="signin-password" placeholder="Password" autocomplete="current-password" aria-describedby="signin-error"/>
+        </div>
+        <div class="auth-error" id="signin-error"></div>
+        <button class="auth-submit-btn" id="signin-submit-btn" onclick="handleSignIn()">Sign In</button>
+        <button class="auth-link-btn" onclick="renderAuthScreen('forgot')">Forgot password?</button>
+        <div class="auth-toggle">
+          <span>Don't have an account?</span>
+          <button class="auth-toggle-btn" onclick="renderAuthScreen('signup')">Sign Up</button>
+        </div>
+      </div>
+
+      <div id="auth-screen-signup" class="auth-screen" style="display:none">
+        <h2 class="auth-screen-title">CREATE ACCOUNT</h2>
+        <p class="auth-screen-subtitle">Sign up with your work email</p>
+        <div class="auth-field">
+          <input type="text" id="signup-firstname" placeholder="First name" autocomplete="given-name"
+                 aria-describedby="signup-error"
+                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-lastname').focus();}"/>
+        </div>
+        <div class="auth-field">
+          <input type="text" id="signup-lastname" placeholder="Last name" autocomplete="family-name"
+                 aria-describedby="signup-error"
+                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-email').focus();}"/>
+        </div>
+        <div class="auth-field">
+          <input type="email" id="signup-email" placeholder="Email address" autocomplete="email"
+                 aria-describedby="signup-error"
+                 onkeydown="if(event.key==='Enter'){event.preventDefault();document.getElementById('signup-password').focus();}"/>
+        </div>
+        <div class="auth-field">
+          <input type="password" id="signup-password" placeholder="Password" autocomplete="new-password"
+                 aria-describedby="signup-error"
+                 onkeydown="if(event.key==='Enter'){event.preventDefault();handleSignUp();}"/>
+        </div>
+        <div class="auth-error" id="signup-error"></div>
+        <button class="auth-submit-btn" id="signup-submit-btn" onclick="handleSignUp()">Create Account</button>
+        <p class="auth-approval-notice">New accounts require admin approval before menu access is granted.</p>
+        <button class="auth-back-btn" onclick="renderAuthScreen('signin')">← Back to Sign In</button>
+      </div>
+
+      <div id="auth-screen-forgot" class="auth-screen" style="display:none">
+        <h2 class="auth-screen-title">RESET PASSWORD</h2>
+        <p class="auth-screen-subtitle">Enter your email and we'll send a reset link</p>
+        <div class="auth-field">
+          <input type="email" id="forgot-email" placeholder="Email address" autocomplete="email" aria-describedby="forgot-error"/>
+        </div>
+        <div class="auth-error" id="forgot-error"></div>
+        <button class="auth-submit-btn" id="forgot-submit-btn" onclick="handleForgotPassword()">Send Reset Link</button>
+        <button class="auth-back-btn" onclick="renderAuthScreen('signin')">← Back to Sign In</button>
+      </div>
+
+      <div id="auth-screen-reset" class="auth-screen" style="display:none">
+        <h2 class="auth-screen-title">SET NEW PASSWORD</h2>
+        <p class="auth-screen-subtitle">Choose a new password for your account</p>
+        <div class="auth-field">
+          <input type="password" id="reset-password" placeholder="New password" autocomplete="new-password" aria-describedby="reset-error"/>
+        </div>
+        <div class="auth-field">
+          <input type="password" id="reset-confirm" placeholder="Confirm new password" autocomplete="new-password" aria-describedby="reset-error"/>
+        </div>
+        <div class="auth-error" id="reset-error"></div>
+        <button class="auth-submit-btn" id="reset-submit-btn" onclick="handleResetPassword()">Set Password</button>
+      </div>
+    </div>
+    <button class="pin-cancel" onclick="closeAuthOverlay()">Cancel</button>
+  </div>
+</div>
+
+<script src="/app.js"></script>
 </body>
 </html>

--- a/leroyslounge/app.js
+++ b/leroyslounge/app.js
@@ -307,12 +307,11 @@
   function renderHeaderState(sharedState) {
     const signInButton = document.querySelector('[data-route-signin]');
     const userChip = document.querySelector('[data-route-user-chip]');
-    const isAuthed = !!sharedState.currentUser;
 
     if (signInButton) {
-      signInButton.style.display = isAuthed ? 'none' : '';
+      signInButton.style.display = 'none';
     }
-    if (userChip) userChip.style.display = isAuthed ? '' : 'none';
+    if (userChip) userChip.style.display = sharedState.currentUser ? '' : 'none';
   }
 
   function addMediaListener(mql, handler) {
@@ -466,6 +465,7 @@
     renderSwapDropdown(contract);
     renderSettingsDropdown(contract);
     bindMenuToggles(contract);
+    window.syncPublicStaffFooterActions?.(sharedState.publicFooter);
     bindMobileHeader(container.querySelector('.ll-board-page'));
 
     return true;

--- a/leroyslounge/app.js
+++ b/leroyslounge/app.js
@@ -100,10 +100,73 @@
       .filter(menu => menu.restaurantId === restaurantId)
       .sort((a, b) => {
         if (a.type === b.type) return a.name.localeCompare(b.name);
-        if (a.type === 'drinks') return -1;
-        if (b.type === 'drinks') return 1;
+        if (a.type === 'food') return -1;
+        if (b.type === 'food') return 1;
         return a.type.localeCompare(b.type);
       });
+  }
+
+  function buildMenuSwitchPlaceholder() {
+    return `
+      <section class="ll-slat-section ll-route-switch-section" aria-hidden="true">
+        <div class="ll-slat-section-head">
+          <h2 class="ll-slat-section-title">Loading menu</h2>
+        </div>
+        <div class="ll-route-boot-rows ll-route-switch-rows">
+          <span class="ll-route-boot-line ll-route-boot-line--wide"></span>
+          <span class="ll-route-boot-line ll-route-boot-line--mid"></span>
+          <span class="ll-route-boot-line ll-route-boot-line--narrow"></span>
+        </div>
+      </section>
+    `;
+  }
+
+  function setRouteMenuSwitchState(sharedState, targetType) {
+    const page = document.querySelector('.ll-board-page');
+    const main = document.getElementById('ll-route-main');
+    const sections = document.getElementById('ll-route-sections');
+    const targetMenuType = String(targetType || '').toLowerCase();
+
+    if (page) {
+      page.classList.add('is-menu-switching');
+      page.dataset.routeSwitchingMenu = targetMenuType;
+    }
+    if (main) main.setAttribute('aria-busy', 'true');
+    document.querySelectorAll('[data-route-menu-toggle]').forEach(button => {
+      const isActive = button.getAttribute('data-route-menu-toggle') === targetMenuType;
+      button.classList.toggle('is-active', isActive);
+      button.setAttribute('aria-pressed', isActive ? 'true' : 'false');
+    });
+    if (sections) sections.innerHTML = buildMenuSwitchPlaceholder(sharedState);
+  }
+
+  function clearRouteMenuSwitchState() {
+    const page = document.querySelector('.ll-board-page');
+    const main = document.getElementById('ll-route-main');
+    if (page) {
+      page.classList.remove('is-menu-switching');
+      delete page.dataset.routeSwitchingMenu;
+    }
+    if (main) main.removeAttribute('aria-busy');
+  }
+
+  function resetRouteScrollPosition() {
+    const main = document.getElementById('ll-route-main');
+    if (main) main.scrollTop = 0;
+    window.scrollTo({ top: 0, left: 0, behavior: 'auto' });
+  }
+
+  async function switchRouteMenu(contract, menu) {
+    if (!menu?.id) return { ok: false, userHandled: true };
+    setRouteMenuSwitchState(contract.snapshot, menu.type);
+    resetRouteScrollPosition();
+    try {
+      return await contract.actions.switchMenu(menu);
+    } catch (error) {
+      clearRouteMenuSwitchState();
+      renderRoute(contract);
+      throw error;
+    }
   }
 
   function createLegacyRouteActions(sharedState) {
@@ -221,7 +284,7 @@
         const menu = menus.find(entry => entry.id === menuId);
         if (!menu) return;
         contract.actions.closeDropdowns?.();
-        await contract.actions.switchMenu(menu);
+        await switchRouteMenu(contract, menu);
       };
     });
   }
@@ -234,7 +297,7 @@
         const targetType = button.getAttribute('data-route-menu-toggle');
         const menu = menus.find(entry => entry.type === targetType);
         if (!menu || menu.id === sharedState.menuId) return;
-        await contract.actions.switchMenu(menu);
+        await switchRouteMenu(contract, menu);
       };
     });
 
@@ -247,10 +310,7 @@
     const isAuthed = !!sharedState.currentUser;
 
     if (signInButton) {
-      signInButton.disabled = isAuthed;
-      signInButton.setAttribute('aria-hidden', isAuthed ? 'true' : 'false');
-      signInButton.setAttribute('aria-label', isAuthed ? "Leroy's Lounge" : 'Sign in');
-      signInButton.classList.toggle('is-inert', isAuthed);
+      signInButton.style.display = isAuthed ? 'none' : '';
     }
     if (userChip) userChip.style.display = isAuthed ? '' : 'none';
   }
@@ -353,16 +413,7 @@
 
     const categoryWrap = document.getElementById('ll-route-sections');
     if (categoryWrap) {
-      categoryWrap.innerHTML = `
-        <section class="ll-slat-section ll-route-boot-section" aria-hidden="true">
-          <div class="ll-slat-section-head"><h2 class="ll-slat-section-title">On The Board</h2></div>
-          <div class="ll-route-boot-rows">
-            <span class="ll-route-boot-line ll-route-boot-line--wide"></span>
-            <span class="ll-route-boot-line ll-route-boot-line--mid"></span>
-            <span class="ll-route-boot-line ll-route-boot-line--narrow"></span>
-          </div>
-        </section>
-      `;
+      categoryWrap.innerHTML = buildMenuSwitchPlaceholder();
     }
 
     bindMobileHeader(container.querySelector('.ll-board-page'));
@@ -410,6 +461,7 @@
       categoryWrap.innerHTML = categoriesHtml || '<p class="ll-route-empty">Nothing on the menu yet.</p>';
     }
 
+    clearRouteMenuSwitchState();
     renderHeaderState(sharedState);
     renderSwapDropdown(contract);
     renderSettingsDropdown(contract);

--- a/leroyslounge/index.html
+++ b/leroyslounge/index.html
@@ -29,80 +29,88 @@
   <div class="ll-board-page">
     <a class="ll-skip-link" href="#ll-route-main">Skip to menu content</a>
     <header class="ll-board-topbar neon-header-full">
-      <div class="ll-board-topbar-left" aria-hidden="true"></div>
-      <div class="ll-board-topbar-center">
-        <button class="ll-board-logo-btn ll-board-logo-btn--center" data-route-signin data-route-signin-persistent type="button" onclick="openAuthOverlay()" aria-label="Sign in">
+      <div class="ll-board-topbar-left">
+        <a class="ll-board-logo-btn ll-board-logo-btn--home" href="/" aria-label="Return to the homepage">
           <img class="ll-board-logo" src="/assets/leroys-lounge/stitch-logo.png" alt="Leroy's Lounge" width="495" height="335">
-        </button>
+        </a>
       </div>
-      <div class="ll-board-topbar-right">
+      <div class="ll-board-topbar-center">
         <nav class="ll-menu-toggle" aria-label="Swap menu">
-          <button id="ll-nav-drinks"
-                  class="ll-menu-toggle-btn"
-                  type="button"
-                  data-route-menu-toggle="drinks">
-            Drinks
-          </button>
           <button id="ll-nav-food"
                   class="ll-menu-toggle-btn"
                   type="button"
                   data-route-menu-toggle="food">
             Food
           </button>
+          <button id="ll-nav-drinks"
+                  class="ll-menu-toggle-btn"
+                  type="button"
+                  data-route-menu-toggle="drinks">
+            Drinks
+          </button>
         </nav>
+      </div>
+      <div class="ll-board-topbar-right">
         <div class="ll-board-action-cluster">
-        <a class="ll-board-jump-link"
-           href="/elroyscantina"
-           aria-label="Open El Roy's Cantina menu">
-          El Roy's
-        </a>
-        <div class="ll-board-action-dropdown" data-route-dropdown data-route-menu>
-          <button id="ll-route-swap-trigger"
-                  class="ll-board-swap-trigger"
+          <a class="ll-board-jump-link"
+             href="/elroyscantina"
+             aria-label="Open El Roy's Cantina menu">
+            El Roy's
+          </a>
+          <button class="ll-board-jump-link ll-board-login-btn"
+                  data-route-signin
                   type="button"
-                  data-route-dropdown-trigger
-                  aria-haspopup="true"
-                  aria-expanded="false"
-                  aria-controls="ll-route-swap-dropdown"
-                  onclick="toggleRouteDropdown('ll-route-swap-trigger', 'll-route-swap-dropdown')">
-            Swap Menu
+                  onclick="openAuthOverlay()"
+                  aria-label="Sign in">
+            Sign In
           </button>
-          <div id="ll-route-swap-dropdown"
-               class="ll-board-route-dropdown"
-               data-route-dropdown-panel
-               hidden></div>
-        </div>
-        <div class="ll-board-action-dropdown" data-route-dropdown data-route-settings style="display:none">
-          <button id="ll-route-settings-trigger"
-                  class="ll-board-settings-trigger"
+          <div class="ll-board-action-dropdown" data-route-dropdown data-route-menu>
+            <button id="ll-route-swap-trigger"
+                    class="ll-board-swap-trigger"
+                    type="button"
+                    data-route-dropdown-trigger
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    aria-controls="ll-route-swap-dropdown"
+                    onclick="toggleRouteDropdown('ll-route-swap-trigger', 'll-route-swap-dropdown')">
+              Swap Menu
+            </button>
+            <div id="ll-route-swap-dropdown"
+                 class="ll-board-route-dropdown"
+                 data-route-dropdown-panel
+                 hidden></div>
+          </div>
+          <div class="ll-board-action-dropdown" data-route-dropdown data-route-settings style="display:none">
+            <button id="ll-route-settings-trigger"
+                    class="ll-board-settings-trigger"
+                    type="button"
+                    data-route-dropdown-trigger
+                    aria-label="Manager and admin actions"
+                    aria-haspopup="true"
+                    aria-expanded="false"
+                    aria-controls="ll-route-settings-dropdown"
+                    onclick="toggleRouteDropdown('ll-route-settings-trigger', 'll-route-settings-dropdown')">
+              <span class="material-symbols-outlined" aria-hidden="true">settings</span>
+            </button>
+            <div id="ll-route-settings-dropdown"
+                 class="ll-board-route-dropdown"
+                 data-route-dropdown-panel
+                 hidden></div>
+          </div>
+          <button class="ll-board-swap-trigger ll-route-exit-btn"
                   type="button"
-                  data-route-dropdown-trigger
-                  aria-label="Manager and admin actions"
-                  aria-haspopup="true"
-                  aria-expanded="false"
-                  aria-controls="ll-route-settings-dropdown"
-                  onclick="toggleRouteDropdown('ll-route-settings-trigger', 'll-route-settings-dropdown')">
-            <span class="material-symbols-outlined" aria-hidden="true">settings</span>
+                  data-route-manager
+                  onclick="exitView()"
+                  aria-label="Exit manager view">
+            Exit
           </button>
-          <div id="ll-route-settings-dropdown"
-               class="ll-board-route-dropdown"
-               data-route-dropdown-panel
-               hidden></div>
-        </div>
-        <button class="ll-board-swap-trigger ll-route-exit-btn"
-                type="button"
-                data-route-manager
-                onclick="exitView()"
-                aria-label="Exit manager view">
-          Exit
-        </button>
-        <button class="ll-board-swap-trigger ll-route-exit-btn"
-                type="button"
-                data-route-admin
-                onclick="exitView()"
-                aria-label="Exit admin view">
-          Exit
-        </button>
+          <button class="ll-board-swap-trigger ll-route-exit-btn"
+                  type="button"
+                  data-route-admin
+                  onclick="exitView()"
+                  aria-label="Exit admin view">
+            Exit
+          </button>
         </div>
         <div class="ll-board-userchip ll-site-userchip" data-route-user-chip style="display:none"
              onclick="toggleUserDropdown('ll-user-chip')"
@@ -142,6 +150,12 @@
     <footer class="ll-board-footer">
       <p class="ll-board-footer-updated">Menu last updated: <span id="ll-route-footer-timestamp">Awaiting first update</span></p>
       <p id="ll-route-footer-version" class="ll-board-footer-version"></p>
+      <div class="ll-board-footer-actions" data-route-footer-actions>
+        <button class="ll-board-footer-action" type="button" data-route-footer-signin>Staff Sign-In</button>
+        <button class="ll-board-footer-action" type="button" data-route-footer-manager style="display:none">Manager</button>
+        <button class="ll-board-footer-action" type="button" data-route-footer-admin style="display:none">Admin</button>
+        <button class="ll-board-footer-action" type="button" data-route-footer-signout style="display:none">Sign Out</button>
+      </div>
     </footer>
   </div>
 </template>
@@ -196,6 +210,12 @@
       <footer id="menu-footer">
         <span id="footer-version"></span>
         <span id="footer-last-updated"></span>
+        <div class="public-staff-actions" data-route-staff-actions>
+          <button class="public-staff-action" type="button" data-route-staff-signin>Staff Sign-In</button>
+          <button class="public-staff-action" type="button" data-route-staff-manager style="display:none">Manager</button>
+          <button class="public-staff-action" type="button" data-route-staff-admin style="display:none">Admin</button>
+          <button class="public-staff-action" type="button" data-route-staff-signout style="display:none">Sign Out</button>
+        </div>
       </footer>
     </div>
   </div>

--- a/leroyslounge/style.css
+++ b/leroyslounge/style.css
@@ -139,14 +139,6 @@ body.route-restaurant.route-restaurant--leroy {
   justify-content: flex-start;
 }
 
-#restaurant-site-wrapper .ll-board-topbar-left::before {
-  content: '';
-  display: block;
-  width: clamp(11rem, 16vw, 15rem);
-  height: 1px;
-  pointer-events: none;
-}
-
 #restaurant-site-wrapper .ll-board-topbar-center {
   justify-content: center;
 }
@@ -207,6 +199,12 @@ body.route-restaurant.route-restaurant--leroy {
   -webkit-tap-highlight-color: rgb(255 255 255 / 0.12);
 }
 
+#restaurant-site-wrapper .ll-board-logo-btn--home {
+  display: inline-flex;
+  align-items: center;
+  justify-content: flex-start;
+}
+
 #restaurant-site-wrapper .ll-board-logo-btn:hover,
 #restaurant-site-wrapper .ll-board-logo-btn:focus-visible {
   opacity: 0.88;
@@ -230,6 +228,11 @@ body.route-restaurant.route-restaurant--leroy {
 #restaurant-site-wrapper .ll-board-logo-btn.is-inert {
   cursor: default;
   pointer-events: none;
+}
+
+#restaurant-site-wrapper .ll-board-login-btn {
+  appearance: none;
+  -webkit-appearance: none;
 }
 
 #restaurant-site-wrapper .ll-board-action-cluster {
@@ -625,6 +628,21 @@ body.route-restaurant.route-restaurant--leroy {
   text-shadow: var(--ll-board-text-shadow);
 }
 
+#restaurant-site-wrapper .ll-board-page.is-menu-switching .ll-board-main {
+  cursor: progress;
+}
+
+#restaurant-site-wrapper .ll-board-page.is-menu-switching .ll-route-switch-section {
+  min-height: 10rem;
+}
+
+#restaurant-site-wrapper .ll-board-page.is-menu-switching .ll-route-switch-rows {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  margin-top: 0.75rem;
+}
+
 #restaurant-site-wrapper .ll-board-item-name.menu-item-name,
 #restaurant-site-wrapper .ll-board-price.menu-item-price {
   margin: 0;
@@ -825,6 +843,36 @@ body.route-restaurant.route-restaurant--leroy {
   border-color: rgb(229 226 225 / 0.2);
 }
 
+#restaurant-site-wrapper .ll-board-footer-actions {
+  display: flex;
+  gap: 12px;
+  justify-content: flex-end;
+  flex-wrap: wrap;
+  margin-top: 12px;
+}
+
+#restaurant-site-wrapper .ll-board-footer-action {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 0;
+  background: none;
+  color: rgba(255, 240, 231, 0.72);
+  cursor: pointer;
+  font: inherit;
+  font-size: 10px;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+  text-decoration: underline;
+  text-underline-offset: 0.24em;
+  padding: 0;
+}
+
+#restaurant-site-wrapper .ll-board-footer-action:hover,
+#restaurant-site-wrapper .ll-board-footer-action:focus-visible {
+  color: #fff0e7;
+  outline: none;
+}
+
 @keyframes ll-board-flicker {
   0%,
   18%,
@@ -939,8 +987,12 @@ body.route-restaurant.route-restaurant--leroy {
     text-align: left;
   }
 
+  #restaurant-site-wrapper .ll-board-footer-actions {
+    justify-content: flex-start;
+  }
+
   #restaurant-site-wrapper .ll-board-page.is-mobile-compact .ll-board-topbar {
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: auto minmax(0, 1fr) auto;
     gap: 0.5rem;
     padding-top: calc(0.5rem + var(--ll-safe-top));
     padding-bottom: 0.5rem;
@@ -949,7 +1001,6 @@ body.route-restaurant.route-restaurant--leroy {
       inset 0 0 15px var(--ll-board-red-deep);
   }
 
-  #restaurant-site-wrapper .ll-board-page.is-mobile-compact .ll-board-topbar-left,
   #restaurant-site-wrapper .ll-board-page.is-mobile-compact .ll-board-action-cluster,
   #restaurant-site-wrapper .ll-board-page.is-mobile-compact .ll-board-userchip {
     opacity: 0;
@@ -966,7 +1017,7 @@ body.route-restaurant.route-restaurant--leroy {
   }
 
   #restaurant-site-wrapper .ll-board-page.is-mobile-compact .ll-board-topbar-right {
-    grid-column: 2;
+    grid-column: 3;
     justify-content: flex-end;
     gap: 0.5rem;
   }
@@ -991,29 +1042,26 @@ body.route-restaurant.route-restaurant--leroy {
 
 @media (max-width: 640px) {
   #restaurant-site-wrapper .ll-board-topbar {
-    grid-template-columns: 1fr auto;
+    grid-template-columns: auto minmax(0, 1fr) auto;
     gap: 0.75rem;
     padding: calc(0.75rem + var(--ll-safe-top)) calc(0.75rem + var(--ll-safe-right)) 0.75rem calc(0.75rem + var(--ll-safe-left));
   }
 
   #restaurant-site-wrapper .ll-board-topbar-left {
-    display: none;
+    align-self: center;
   }
 
-  #restaurant-site-wrapper .ll-board-topbar-center,
-  #restaurant-site-wrapper .ll-board-topbar-right {
-    grid-column: 1 / -1;
+  #restaurant-site-wrapper .ll-board-topbar-center {
     justify-content: center;
   }
 
   #restaurant-site-wrapper .ll-board-topbar-right {
-    gap: 0.625rem;
+    gap: 0.5rem;
   }
 
   #restaurant-site-wrapper .ll-menu-toggle,
   #restaurant-site-wrapper .ll-board-action-cluster {
-    width: 100%;
-    justify-content: center;
+    width: auto;
   }
 
   #restaurant-site-wrapper .ll-board-jump-link,
@@ -1023,8 +1071,8 @@ body.route-restaurant.route-restaurant--leroy {
   }
 
   #restaurant-site-wrapper .ll-board-route-dropdown {
-    right: 50%;
-    transform: translateX(50%);
+    right: 0;
+    transform: none;
   }
 
   #restaurant-site-wrapper .ll-board-main {
@@ -1047,17 +1095,21 @@ body.route-restaurant.route-restaurant--leroy {
   }
 
   #restaurant-site-wrapper .ll-board-page.is-mobile-compact .ll-board-topbar {
-    grid-template-columns: auto minmax(0, 1fr);
+    grid-template-columns: auto minmax(0, 1fr) auto;
     gap: 0.5rem;
   }
 
-  #restaurant-site-wrapper .ll-board-page.is-mobile-compact .ll-board-topbar-center {
+  #restaurant-site-wrapper .ll-board-page.is-mobile-compact .ll-board-topbar-left {
     grid-column: 1;
+  }
+
+  #restaurant-site-wrapper .ll-board-page.is-mobile-compact .ll-board-topbar-center {
+    grid-column: 2;
     justify-content: flex-start;
   }
 
   #restaurant-site-wrapper .ll-board-page.is-mobile-compact .ll-board-topbar-right {
-    grid-column: 2;
+    grid-column: 3;
     width: 100%;
     justify-content: flex-end;
     gap: 0.5rem;

--- a/style.css
+++ b/style.css
@@ -1099,6 +1099,7 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
+  flex-wrap: wrap;
   padding: 16px 4px 8px;
   margin-top: 24px;
   border-top: 1px solid var(--border);
@@ -1115,6 +1116,33 @@
 #footer-last-updated {
   text-align: right;
   flex: 1;
+}
+.public-staff-actions {
+  width: 100%;
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
+  margin-top: 6px;
+}
+.public-staff-action {
+  appearance: none;
+  -webkit-appearance: none;
+  border: 0;
+  background: none;
+  color: var(--muted);
+  cursor: pointer;
+  font: inherit;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  text-decoration: underline;
+  text-underline-offset: 0.2em;
+  padding: 0;
+}
+.public-staff-action:hover,
+.public-staff-action:focus-visible {
+  color: var(--text);
+  outline: none;
 }
 .footer-preview-badge {
   display: inline-block;
@@ -2283,6 +2311,9 @@ body.admin-console-page .picker-box {
   #footer-last-updated {
     text-align: left;
     width: 100%;
+  }
+  .public-staff-actions {
+    justify-content: flex-start;
   }
   .picker-box,
   .auth-box,

--- a/tests/architecture-boundaries.test.cjs
+++ b/tests/architecture-boundaries.test.cjs
@@ -795,6 +795,165 @@ test('settings route policy service centralizes manager and admin access decisio
   assert.equal(adminDenied.kind, 'admin-denied');
 });
 
+test('public href generation uses bare restaurant routes for food and ?menu=drinks for drinks', () => {
+  const sandbox = loadAppSandbox();
+
+  assert.equal(
+    sandbox.getPublicHrefForMenuId('00000000-0000-0000-0000-000000000021'),
+    '/leroyslounge'
+  );
+  assert.equal(
+    sandbox.getPublicHrefForMenuId('00000000-0000-0000-0000-000000000020'),
+    '/leroyslounge?menu=drinks'
+  );
+  assert.equal(
+    sandbox.getPublicHrefForMenuId('00000000-0000-0000-0000-000000000003'),
+    '/elroyscantina'
+  );
+  assert.equal(
+    sandbox.getPublicHrefForMenuId('00000000-0000-0000-0000-000000000002'),
+    '/elroyscantina?menu=drinks'
+  );
+});
+
+test('sbResolveMenu defaults bare restaurant routes to that restaurant food menu', async () => {
+  const sandbox = loadAppSandbox();
+  const menus = getState(sandbox, 'MENUS');
+  const restaurants = getState(sandbox, 'RESTAURANTS');
+  const replaceCalls = [];
+  const assigned = [];
+
+  sandbox.location.pathname = '/elroyscantina';
+  sandbox.location.search = '';
+  sandbox.location.href = 'https://example.com/elroyscantina';
+  sandbox.location.assign = url => assigned.push(url);
+  sandbox.history.replaceState = (_, __, url) => replaceCalls.push(url);
+  sandbox.fetch = async url => {
+    if (String(url).includes('/rest/v1/menus?id=in.(')) {
+      return {
+        ok: true,
+        json: async () => [
+          { ...menus.LEROYS_DRINKS, restaurant_id: menus.LEROYS_DRINKS.restaurantId, archived: false },
+          { ...menus.LEROYS_FOOD, restaurant_id: menus.LEROYS_FOOD.restaurantId, archived: false },
+          { ...menus.ELROYS_DRINKS, restaurant_id: menus.ELROYS_DRINKS.restaurantId, archived: false },
+          { ...menus.ELROYS_FOOD, restaurant_id: menus.ELROYS_FOOD.restaurantId, archived: false },
+        ],
+      };
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+  sandbox.window.fetch = sandbox.fetch;
+
+  setState(sandbox, {
+    SUPABASE_URL: 'https://example.supabase.co',
+    SUPABASE_ANON_KEY: 'anon-key',
+    _siteRestaurant: restaurants.ELROYS,
+    MENU_ID: '',
+    RESTAURANT_ID: '',
+    MENU_TYPE: 'drinks',
+  });
+
+  await sandbox.sbResolveMenu();
+
+  assert.equal(getState(sandbox, 'MENU_ID'), menus.ELROYS_FOOD.id);
+  assert.equal(getState(sandbox, 'RESTAURANT_ID'), restaurants.ELROYS.id);
+  assert.equal(getState(sandbox, 'MENU_TYPE'), 'food');
+  assert.deepEqual(assigned, []);
+  assert.equal(replaceCalls.at(-1), 'https://example.com/elroyscantina');
+});
+
+test('sbResolveMenu treats ?menu=drinks as restaurant-relative public state', async () => {
+  const sandbox = loadAppSandbox();
+  const menus = getState(sandbox, 'MENUS');
+  const restaurants = getState(sandbox, 'RESTAURANTS');
+  const replaceCalls = [];
+
+  sandbox.location.pathname = '/elroyscantina';
+  sandbox.location.search = '?menu=drinks';
+  sandbox.location.href = 'https://example.com/elroyscantina?menu=drinks';
+  sandbox.history.replaceState = (_, __, url) => replaceCalls.push(url);
+  sandbox.fetch = async url => {
+    const text = String(url);
+    if (text.includes(`slug=eq.${encodeURIComponent(menus.ELROYS_DRINKS.slug)}`)) {
+      return {
+        ok: true,
+        json: async () => [{
+          id: menus.ELROYS_DRINKS.id,
+          name: menus.ELROYS_DRINKS.name,
+          type: menus.ELROYS_DRINKS.type,
+          restaurant_id: menus.ELROYS_DRINKS.restaurantId,
+        }],
+      };
+    }
+    if (text.includes('slug=eq.drinks')) {
+      return { ok: true, json: async () => [] };
+    }
+    if (text.includes('/rest/v1/menus?id=in.(')) {
+      return {
+        ok: true,
+        json: async () => [
+          { id: menus.LEROYS_DRINKS.id, archived: false },
+          { id: menus.LEROYS_FOOD.id, archived: false },
+          { id: menus.ELROYS_DRINKS.id, archived: false },
+          { id: menus.ELROYS_FOOD.id, archived: false },
+        ],
+      };
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+  sandbox.window.fetch = sandbox.fetch;
+
+  setState(sandbox, {
+    SUPABASE_URL: 'https://example.supabase.co',
+    SUPABASE_ANON_KEY: 'anon-key',
+    _siteRestaurant: restaurants.ELROYS,
+    MENU_ID: '',
+    RESTAURANT_ID: '',
+    MENU_TYPE: 'food',
+  });
+
+  await sandbox.sbResolveMenu();
+
+  assert.equal(getState(sandbox, 'MENU_ID'), menus.ELROYS_DRINKS.id);
+  assert.equal(getState(sandbox, 'RESTAURANT_ID'), restaurants.ELROYS.id);
+  assert.equal(getState(sandbox, 'MENU_TYPE'), 'drinks');
+  assert.deepEqual(replaceCalls, []);
+});
+
+test('selectMenu uses replaceState with the canonical public menu url', () => {
+  const sandbox = loadAppSandbox();
+  const menus = getState(sandbox, 'MENUS');
+  const replaceCalls = [];
+  let pushCalls = 0;
+
+  sandbox.location.pathname = '/elroyscantina';
+  sandbox.location.search = '';
+  sandbox.location.href = 'https://example.com/elroyscantina';
+  sandbox.history.replaceState = (_, __, url) => replaceCalls.push(url);
+  sandbox.history.pushState = () => {
+    pushCalls += 1;
+  };
+
+  setState(sandbox, {
+    _appPageMode: 'public',
+    closeMenuPicker: () => {},
+    updateActiveMenuBar: () => {},
+    renderUserHeader: () => {},
+    ensureCurrentMenuSession: () => {},
+  });
+
+  sandbox.selectMenu(
+    menus.ELROYS_DRINKS.id,
+    menus.ELROYS_DRINKS.slug,
+    menus.ELROYS_DRINKS.name,
+    menus.ELROYS_DRINKS.type,
+    menus.ELROYS_DRINKS.restaurantId
+  );
+
+  assert.equal(replaceCalls.at(-1), '/elroyscantina?menu=drinks');
+  assert.equal(pushCalls, 0);
+});
+
 test('menu state loader service applies fallback and featured refresh through one boundary', async () => {
   const sandbox = loadAppSandbox();
   let fallbackCalls = 0;
@@ -877,7 +1036,11 @@ test('public route contract exposes a stable snapshot and switchMenu action', as
   assert.equal(contract.snapshot.activeMenuName, "Leroy's Lounge Drinks");
   assert.equal(contract.snapshot.restaurantId, getState(sandbox, 'RESTAURANT_ID'));
   assert.equal(contract.snapshot.menuId, getState(sandbox, 'MENU_ID'));
+  assert.equal(contract.snapshot.publicFooter.signIn, null);
+  assert.equal(contract.snapshot.publicFooter.links.map(link => link.label).join(','), 'Manager,Sign Out');
   assert.equal(typeof contract.actions.switchMenu, 'function');
+  assert.equal(typeof contract.actions.openAuthOverlay, 'function');
+  assert.equal(typeof contract.actions.signOut, 'function');
 
   await contract.actions.switchMenu({
     id: getState(sandbox, 'MENU_ID'),
@@ -1263,6 +1426,92 @@ test('public route contract and route renderers register and hydrate both restau
   }
 });
 
+test('public staff footer state exposes sign-in and quiet utility links by role', () => {
+  const sandbox = loadAppSandbox();
+
+  setState(sandbox, {
+    MENU_ID: '00000000-0000-0000-0000-000000000020',
+    RESTAURANT_ID: '00000000-0000-0000-0000-000000000010',
+    currentUser: null,
+  });
+  const signedOut = sandbox.buildPublicStaffFooterState();
+  assert.equal(signedOut.signIn.label, 'Staff Sign-In');
+  assert.equal(signedOut.links.length, 0);
+
+  setState(sandbox, {
+    currentUser: {
+      role: 'manager',
+      accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'],
+    },
+  });
+  const managerState = sandbox.buildPublicStaffFooterState();
+  assert.equal(managerState.links.map(link => link.label).join(','), 'Manager,Sign Out');
+  const pickerManagerState = sandbox.buildPublicStaffFooterState(getState(sandbox, 'currentUser'), {
+    menuId: '',
+    restaurantId: '',
+  });
+  assert.equal(pickerManagerState.links.map(link => link.label).join(','), 'Manager,Sign Out');
+
+  setState(sandbox, {
+    currentUser: {
+      role: 'admin',
+      accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'],
+    },
+  });
+  const adminState = sandbox.buildPublicStaffFooterState();
+  assert.equal(adminState.links.map(link => link.label).join(','), 'Manager,Admin,Sign Out');
+  const pickerAdminState = sandbox.buildPublicStaffFooterState(getState(sandbox, 'currentUser'), {
+    menuId: '',
+    restaurantId: '',
+  });
+  assert.equal(pickerAdminState.links.map(link => link.label).join(','), 'Manager,Admin,Sign Out');
+});
+
+test('picker init bootstraps shared session state without requiring the app shell', async () => {
+  const sandbox = loadAppSandbox();
+  const calls = [];
+
+  sandbox.fetch = async url => {
+    if (String(url) === '/api/config') {
+      calls.push('config');
+      return {
+        ok: true,
+        json: async () => ({
+          supabaseUrl: 'https://example.supabase.co',
+          supabaseAnonKey: 'anon-key',
+        }),
+      };
+    }
+    throw new Error(`Unexpected fetch: ${url}`);
+  };
+  sandbox.window.fetch = sandbox.fetch;
+
+  setState(sandbox, {
+    _appPageMode: 'picker',
+    showPickerPage: () => {
+      calls.push('picker');
+    },
+    loadLocalConfig: () => {
+      calls.push('local-config');
+    },
+    _tryHandleRecoveryCallback: async () => {
+      calls.push('recovery');
+      return false;
+    },
+    _tryRestoreSession: async () => {
+      calls.push('restore');
+      return { restored: true };
+    },
+    showAppShell: () => {
+      calls.push('shell');
+    },
+  });
+
+  await sandbox.init();
+
+  assert.deepEqual(calls, ['picker', 'local-config', 'config', 'recovery', 'restore']);
+});
+
 test('menu fallback store keys snapshots by menu identity and menu type', () => {
   const sandbox = loadAppSandbox();
   const menus = getState(sandbox, 'MENUS');
@@ -1337,7 +1586,7 @@ test('menu link resolver uses per-menu configuration with canonical route fallba
   });
   assert.equal(
     sandbox.getNotificationMenuLink(),
-    'https://example.com/elroyscantina?menu=el-roys-cantina-drinks'
+    'https://example.com/elroyscantina?menu=drinks'
   );
 });
 

--- a/tests/architecture-boundaries.test.cjs
+++ b/tests/architecture-boundaries.test.cjs
@@ -1502,6 +1502,12 @@ test('picker init bootstraps shared session state without requiring the app shel
       calls.push('restore');
       return { restored: true };
     },
+    renderUserHeader: () => {
+      calls.push('render-header');
+    },
+    syncPublicStaffFooterActions: () => {
+      calls.push('sync-footer');
+    },
     showAppShell: () => {
       calls.push('shell');
     },
@@ -1509,7 +1515,7 @@ test('picker init bootstraps shared session state without requiring the app shel
 
   await sandbox.init();
 
-  assert.deepEqual(calls, ['picker', 'local-config', 'config', 'recovery', 'restore']);
+  assert.deepEqual(calls, ['picker', 'local-config', 'config', 'recovery', 'restore', 'render-header', 'sync-footer']);
 });
 
 test('menu fallback store keys snapshots by menu identity and menu type', () => {


### PR DESCRIPTION
## Summary
- normalize public menu URLs so food uses bare restaurant routes and drinks use `?menu=drinks`
- default restaurant public pages to food, smooth route-level menu switching, and keep shared route state in sync
- add shared public staff footer actions and auth overlay wiring across the picker and both restaurant pages
- extend architecture coverage for canonical public hrefs, route resolution, footer actions, and picker session bootstrap

## Testing
- Not run (not requested)