### PR TITLE
Update browser tab titles for menu, picker, and console pages

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Admin | Current Menu</title>
+<title>Admin Console</title>
 <link rel="icon" type="image/png" href="/HFLOGO.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/app.js
+++ b/app.js
@@ -1666,7 +1666,7 @@ function showPickerPage() {
   if (appShell) appShell.style.display = 'none';
   document.getElementById('auth-overlay')?.classList.remove('open');
   closeMenuPicker({ skipOnClose: true });
-  document.title = 'Choose a Restaurant | Current Menu';
+  document.title = 'Leroy\'s Lounge & El Roy\'s Cantina';
 }
 
 function showAppShell() {

--- a/elroyscantina/index.html
+++ b/elroyscantina/index.html
@@ -7,7 +7,7 @@
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
     <meta name="theme-color" content="#fcf6e8" />
-    <title>El Roy's Cantina | Current Menu</title>
+<title>Current Menu | El Roy's Cantina</title>
     <link rel="icon" type="image/png" href="/HFLOGO.png" />
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />

--- a/index.html
+++ b/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>El Roy's & Leroy's</title>
+<title>Leroy's Lounge &amp; El Roy's Cantina | Menus</title>
 <link rel="icon" type="image/png" href="HFLOGO.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/leroyslounge/index.html
+++ b/leroyslounge/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
 <meta name="theme-color" content="#d30b0b">
-<title>Leroy's Lounge | Current Menu</title>
+<title>Current Menu | Leroy's Lounge</title>
 <link rel="icon" type="image/png" href="/HFLOGO.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>

--- a/manager/index.html
+++ b/manager/index.html
@@ -3,7 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
-<title>Manager | Current Menu</title>
+<title>Manager Console</title>
 <link rel="icon" type="image/png" href="/HFLOGO.png">
 <link rel="preconnect" href="https://fonts.googleapis.com">
 <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>


### PR DESCRIPTION
## Summary
- Removed `Current Menu` from non-menu page titles in root and control surfaces (`index.html`, `manager/index.html`, `admin/index.html`).
- Standardized public menu page titles to a clearer `Current Menu | <Restaurant>` format for route pages.
- Updated root site-picker tab title fallback in `app.js` to a restaurant-combo label while preserving menu route behavior.
- Kept tab-title changes scoped to HTML/JS title assignments only, with no structural or data-layer logic changes.

## Testing
- Not run (not requested)