### PR TITLE
Refine El Roy's Cantina public route pacing and hierarchy

### DIFF
--- a/design-loop/elroyscantina/design-loop-issues.md
+++ b/design-loop/elroyscantina/design-loop-issues.md
@@ -1,9 +1,6 @@
 # El Roy's Cantina Design Loop Issues
 
-## Pass 1 audit
+No open route-design issues remain from this five-pass loop.
 
-1. The mobile header still does not settle into a clean utility bar. At the top it eats a full second row for the menu toggle and badge, and in the compact scrolled state it still sits too tall over the content instead of getting out of the way.
-2. The food state still inherits too much of the longer drinks-menu spacing, so short sections feel underfilled and the page reads as airy instead of editorial. The route needs tighter density rules when the menu is short.
-3. The light-mode 86'd treatment is still too faint. Items like `Bell's Two Hearted` and `El Roy's Skinny Margarita` lose scan priority so completely that the unavailable state becomes harder to read than the available state.
-4. Secondary dark-mode details are a little too quiet. Descriptions, supporting chips, rules, and meta labels fade enough that the page loses some of its crafted rhythm once you move below the hero.
-5. The footer closes the page politely but not memorably. On both desktop and mobile it feels lighter and less intentional than the opening brand moment, so the route tapers off instead of landing with confidence.
+Manual follow-up outside this loop:
+- Authenticated manager/admin-only states were not exercised during this public-route audit.

--- a/design-loop/elroyscantina/design-loop-issues.md
+++ b/design-loop/elroyscantina/design-loop-issues.md
@@ -2,9 +2,8 @@
 
 ## Pass 1 audit
 
-1. The hero still dominates the first viewport too aggressively, especially on desktop drinks and on the shorter food menu. `THE MENU` lands as a strong brand moment, but it creates too much dead air before the route gets to useful menu content.
-2. The mobile header does not settle into a clean utility bar. At the top it eats a full second row for the menu toggle and badge, and in the compact scrolled state it still sits too tall over the content instead of getting out of the way.
-3. The food state inherits the same spacing rhythm as the longer drinks menu, so short sections feel underfilled and the page reads as airy instead of editorial. The route needs tighter density rules when the menu is short.
-4. The light-mode 86'd treatment is still too faint. Items like `Bell's Two Hearted` and `El Roy's Skinny Margarita` lose scan priority so completely that the unavailable state becomes harder to read than the available state.
-5. Secondary dark-mode details are a little too quiet. Descriptions, supporting chips, rules, and meta labels fade enough that the page loses some of its crafted rhythm once you move below the hero.
-6. The footer closes the page politely but not memorably. On both desktop and mobile it feels lighter and less intentional than the opening brand moment, so the route tapers off instead of landing with confidence.
+1. The mobile header still does not settle into a clean utility bar. At the top it eats a full second row for the menu toggle and badge, and in the compact scrolled state it still sits too tall over the content instead of getting out of the way.
+2. The food state still inherits too much of the longer drinks-menu spacing, so short sections feel underfilled and the page reads as airy instead of editorial. The route needs tighter density rules when the menu is short.
+3. The light-mode 86'd treatment is still too faint. Items like `Bell's Two Hearted` and `El Roy's Skinny Margarita` lose scan priority so completely that the unavailable state becomes harder to read than the available state.
+4. Secondary dark-mode details are a little too quiet. Descriptions, supporting chips, rules, and meta labels fade enough that the page loses some of its crafted rhythm once you move below the hero.
+5. The footer closes the page politely but not memorably. On both desktop and mobile it feels lighter and less intentional than the opening brand moment, so the route tapers off instead of landing with confidence.

--- a/design-loop/elroyscantina/design-loop-issues.md
+++ b/design-loop/elroyscantina/design-loop-issues.md
@@ -2,6 +2,9 @@
 
 ## Pass 1 audit
 
-1. The hero stack is oversized relative to the menu body, especially on mobile and on shorter food menus. `THE MENU` creates a strong brand moment, but it also delays the first actionable menu content and makes the route feel top-heavy before the user reaches the actual list.
-2. The mobile manager/admin flyout opens directly over the hero and first content block instead of feeling anchored to a dedicated utility zone. It looks polished, but it interrupts reading flow and makes the top of the page feel crowded when opened.
-3. The light-mode 86'd treatment is too faint on menu rows. Items like `Bell's Two Hearted` and `El Roy's Skinny Margarita` fade so far into the background that the sold-out state becomes harder to scan than it should be.
+1. The hero still dominates the first viewport too aggressively, especially on desktop drinks and on the shorter food menu. `THE MENU` lands as a strong brand moment, but it creates too much dead air before the route gets to useful menu content.
+2. The mobile header does not settle into a clean utility bar. At the top it eats a full second row for the menu toggle and badge, and in the compact scrolled state it still sits too tall over the content instead of getting out of the way.
+3. The food state inherits the same spacing rhythm as the longer drinks menu, so short sections feel underfilled and the page reads as airy instead of editorial. The route needs tighter density rules when the menu is short.
+4. The light-mode 86'd treatment is still too faint. Items like `Bell's Two Hearted` and `El Roy's Skinny Margarita` lose scan priority so completely that the unavailable state becomes harder to read than the available state.
+5. Secondary dark-mode details are a little too quiet. Descriptions, supporting chips, rules, and meta labels fade enough that the page loses some of its crafted rhythm once you move below the hero.
+6. The footer closes the page politely but not memorably. On both desktop and mobile it feels lighter and less intentional than the opening brand moment, so the route tapers off instead of landing with confidence.

--- a/elroyscantina/style.css
+++ b/elroyscantina/style.css
@@ -616,30 +616,35 @@ body.route-restaurant.route-restaurant--elroy {
 
 #restaurant-site-wrapper .erc-footer {
   margin-top: auto;
+  border-top: 1px solid rgb(227 221 203 / 0.72);
   background:
     linear-gradient(
       180deg,
       rgb(252 246 232 / 0) 0%,
-      rgb(246 240 225 / 0.92) 24%,
+      rgb(246 240 225 / 0.9) 20%,
       var(--erc-surface-low) 100%
     );
-  padding: 3rem calc(2rem + var(--erc-safe-right)) calc(3rem + var(--erc-safe-bottom)) calc(2rem + var(--erc-safe-left));
+  padding: 3.4rem calc(2rem + var(--erc-safe-right)) calc(3rem + var(--erc-safe-bottom)) calc(2rem + var(--erc-safe-left));
 }
 
 #restaurant-site-wrapper .erc-footer-main {
   width: min(100%, 88rem);
   margin: 0 auto;
   display: flex;
-  align-items: center;
+  align-items: flex-end;
   justify-content: space-between;
-  gap: 2rem;
+  gap: 3rem;
+}
+
+#restaurant-site-wrapper .erc-footer-copy {
+  max-width: 24rem;
 }
 
 #restaurant-site-wrapper .erc-footer-title {
-  margin: 0 0 0.35rem;
+  margin: 0 0 0.5rem;
   color: var(--erc-primary);
   font-family: 'Newsreader', serif;
-  font-size: 2rem;
+  font-size: 2.15rem;
   font-style: italic;
 }
 
@@ -653,9 +658,14 @@ body.route-restaurant.route-restaurant--elroy {
 #restaurant-site-wrapper .erc-footer-quote {
   font-family: 'Newsreader', serif;
   font-style: italic;
+  color: var(--erc-text);
+  font-size: 1.02rem;
+  line-height: 1.45;
 }
 
 #restaurant-site-wrapper .erc-footer-meta {
+  padding-left: 1.5rem;
+  border-left: 1px solid rgb(178 173 160 / 0.34);
   text-align: right;
 }
 
@@ -678,10 +688,10 @@ body.route-restaurant.route-restaurant--elroy {
 
 #restaurant-site-wrapper .erc-footer-actions {
   display: flex;
-  gap: 12px;
+  gap: 0.7rem 1rem;
   justify-content: flex-end;
   flex-wrap: wrap;
-  margin-top: 12px;
+  margin-top: 0.9rem;
 }
 
 #restaurant-site-wrapper .erc-footer-action {
@@ -789,6 +799,13 @@ body.route-restaurant.route-restaurant--elroy {
 
   #restaurant-site-wrapper .erc-footer-actions {
     justify-content: flex-start;
+  }
+
+  #restaurant-site-wrapper .erc-footer-meta {
+    width: 100%;
+    max-width: 26rem;
+    padding-top: 0.9rem;
+    border-top: 1px solid rgb(178 173 160 / 0.3);
   }
 }
 
@@ -1055,6 +1072,7 @@ body.route-restaurant.route-restaurant--elroy {
   }
 
   #restaurant-site-wrapper .erc-footer {
+    border-top-color: rgb(129 109 82 / 0.34);
     background:
       linear-gradient(
         180deg,
@@ -1062,6 +1080,14 @@ body.route-restaurant.route-restaurant--elroy {
         rgb(21 16 12 / 0.48) 22%,
         var(--erc-surface-low) 100%
       );
+  }
+
+  #restaurant-site-wrapper .erc-footer-quote {
+    color: rgb(229 214 188 / 0.95);
+  }
+
+  #restaurant-site-wrapper .erc-footer-meta {
+    border-left-color: rgb(129 109 82 / 0.4);
   }
 
   #restaurant-site-wrapper .erc-page.is-mobile-compact .erc-topbar {

--- a/elroyscantina/style.css
+++ b/elroyscantina/style.css
@@ -459,7 +459,15 @@ body.route-restaurant.route-restaurant--elroy {
 }
 
 #restaurant-site-wrapper .erc-item.is-86d {
-  opacity: 0.5;
+  opacity: 0.78;
+}
+
+#restaurant-site-wrapper .erc-item.is-86d .erc-item-title,
+#restaurant-site-wrapper .erc-item.is-86d .erc-item-price {
+  color: rgb(146 122 93 / 1);
+  text-decoration: line-through;
+  text-decoration-color: rgb(179 27 37 / 0.4);
+  text-decoration-thickness: 1px;
 }
 
 #restaurant-site-wrapper .erc-item-row {
@@ -1022,6 +1030,28 @@ body.route-restaurant.route-restaurant--elroy {
 
   #restaurant-site-wrapper .erc-route-boot-line {
     background: linear-gradient(90deg, rgb(112 95 72 / 0.3), rgb(255 208 145 / 0.16), rgb(112 95 72 / 0.3));
+  }
+
+  #restaurant-site-wrapper .erc-section-line {
+    background: rgb(196 168 124 / 0.22);
+  }
+
+  #restaurant-site-wrapper .erc-item.is-86d .erc-item-title,
+  #restaurant-site-wrapper .erc-item.is-86d .erc-item-price {
+    color: rgb(213 190 157 / 0.88);
+    text-decoration-color: rgb(255 128 132 / 0.5);
+  }
+
+  #restaurant-site-wrapper .erc-item-desc,
+  #restaurant-site-wrapper .erc-timestamp-label,
+  #restaurant-site-wrapper .erc-footer-updated,
+  #restaurant-site-wrapper .erc-footer-version {
+    color: rgb(219 203 177 / 0.9);
+  }
+
+  #restaurant-site-wrapper .erc-upcharge-chip {
+    border-color: rgb(129 109 82 / 0.55);
+    color: rgb(236 225 207 / 0.94);
   }
 
   #restaurant-site-wrapper .erc-footer {

--- a/elroyscantina/style.css
+++ b/elroyscantina/style.css
@@ -358,7 +358,7 @@ body.route-restaurant.route-restaurant--elroy {
 #restaurant-site-wrapper .erc-main {
   width: min(100%, 64rem);
   margin: 0 auto;
-  padding: 3rem calc(1.5rem + var(--erc-safe-right)) calc(4rem + var(--erc-safe-bottom)) calc(1.5rem + var(--erc-safe-left));
+  padding: 2.35rem calc(1.5rem + var(--erc-safe-right)) calc(4rem + var(--erc-safe-bottom)) calc(1.5rem + var(--erc-safe-left));
 }
 
 #restaurant-site-wrapper #erc-route-main {
@@ -367,19 +367,19 @@ body.route-restaurant.route-restaurant--elroy {
 
 #restaurant-site-wrapper .erc-hero {
   display: flex;
-  align-items: flex-end;
+  align-items: flex-start;
   justify-content: space-between;
-  gap: 1.5rem;
-  margin-bottom: 4rem;
+  gap: clamp(1.4rem, 3vw, 2.75rem);
+  margin-bottom: 3rem;
 }
 
 #restaurant-site-wrapper .erc-kicker {
   display: block;
-  margin-bottom: 0.5rem;
+  margin-bottom: 0.35rem;
   color: var(--erc-tertiary);
-  font-size: 0.8rem;
+  font-size: 0.75rem;
   font-weight: 800;
-  letter-spacing: 0.22em;
+  letter-spacing: 0.2em;
   text-transform: uppercase;
 }
 
@@ -387,14 +387,18 @@ body.route-restaurant.route-restaurant--elroy {
   margin: 0;
   color: var(--erc-primary);
   font-family: 'Newsreader', serif;
-  font-size: clamp(4rem, 10vw, 8rem);
+  font-size: clamp(3.4rem, 7.8vw, 6.7rem);
   font-weight: 800;
-  line-height: 0.92;
+  line-height: 0.88;
   text-wrap: balance;
   transition: none;
 }
 
 #restaurant-site-wrapper .erc-timestamp {
+  flex: 0 0 min(18rem, 34vw);
+  align-self: flex-end;
+  padding: 0.95rem 0 0.2rem 1.35rem;
+  border-left: 1px solid rgb(178 173 160 / 0.38);
   text-align: right;
 }
 
@@ -403,7 +407,7 @@ body.route-restaurant.route-restaurant--elroy {
   color: var(--erc-muted);
   font-size: 0.72rem;
   font-weight: 800;
-  letter-spacing: 0.08em;
+  letter-spacing: 0.12em;
   text-transform: uppercase;
 }
 
@@ -411,7 +415,7 @@ body.route-restaurant.route-restaurant--elroy {
   margin: 0.25rem 0 0;
   color: var(--erc-primary);
   font-family: 'Newsreader', serif;
-  font-size: 1.2rem;
+  font-size: 1.12rem;
   font-style: italic;
   font-weight: 700;
 }
@@ -728,7 +732,16 @@ body.route-restaurant.route-restaurant--elroy {
 
   #restaurant-site-wrapper .erc-timestamp,
   #restaurant-site-wrapper .erc-footer-meta {
+    padding-left: 0;
+    border-left: 0;
     text-align: left;
+  }
+
+  #restaurant-site-wrapper .erc-timestamp {
+    width: 100%;
+    max-width: 26rem;
+    padding-top: 0.9rem;
+    border-top: 1px solid rgb(178 173 160 / 0.34);
   }
 
   #restaurant-site-wrapper .erc-footer-actions {
@@ -797,15 +810,16 @@ body.route-restaurant.route-restaurant--elroy {
   }
 
   #restaurant-site-wrapper .erc-main {
-    padding-top: 2rem;
+    padding-top: 1.4rem;
   }
 
   #restaurant-site-wrapper .erc-title {
-    font-size: clamp(2.8rem, 15vw, 4.25rem);
+    font-size: clamp(2.45rem, 13vw, 3.65rem);
   }
 
   #restaurant-site-wrapper .erc-hero {
-    margin-bottom: 2.5rem;
+    gap: 0.95rem;
+    margin-bottom: 1.85rem;
   }
 
   #restaurant-site-wrapper .erc-section {

--- a/elroyscantina/style.css
+++ b/elroyscantina/style.css
@@ -758,21 +758,21 @@ body.route-restaurant.route-restaurant--elroy {
   }
 
   #restaurant-site-wrapper .erc-brand-group {
-    flex-wrap: wrap;
-    gap: 0.4rem 0.75rem;
+    min-width: 0;
+    gap: 0.35rem;
   }
 
   #restaurant-site-wrapper .erc-brand {
-    font-size: 2.2rem;
+    font-size: 1.95rem;
   }
 
   #restaurant-site-wrapper .erc-sister-link {
     margin-left: 0;
-    padding-left: 0.75rem;
+    padding-left: 0.6rem;
   }
 
   #restaurant-site-wrapper .erc-sister-badge {
-    height: 2rem;
+    height: 1.7rem;
   }
 
   #restaurant-site-wrapper .erc-item-row {
@@ -781,23 +781,38 @@ body.route-restaurant.route-restaurant--elroy {
   }
 
   #restaurant-site-wrapper .erc-topbar-inner {
-    gap: 0.5rem;
+    display: grid;
+    grid-template-columns: minmax(0, 1fr) auto;
+    align-items: center;
+    gap: 0.5rem 0.75rem;
+    padding-top: calc(0.7rem + var(--erc-safe-top));
+    padding-bottom: 0.7rem;
   }
 
-  #restaurant-site-wrapper .erc-menu-toggle,
+  #restaurant-site-wrapper .erc-menu-toggle {
+    grid-column: 1 / span 1;
+    justify-self: start;
+    width: fit-content;
+  }
+
   #restaurant-site-wrapper .erc-actions {
+    grid-column: 2;
+    justify-self: end;
+    align-self: center;
     width: auto;
-  }
-
-  #restaurant-site-wrapper .erc-actions {
     justify-content: flex-end;
     flex-wrap: nowrap;
-    gap: 0.5rem;
-    margin-left: auto;
+    gap: 0.35rem;
+    margin-left: 0;
   }
 
   #restaurant-site-wrapper .erc-login-btn {
     padding: 0.55rem 0.85rem;
+  }
+
+  #restaurant-site-wrapper .erc-menu-toggle-btn {
+    padding: 0.52rem 1rem;
+    font-size: 0.75rem;
   }
 
   #restaurant-site-wrapper .erc-section-title {
@@ -836,16 +851,15 @@ body.route-restaurant.route-restaurant--elroy {
   }
 
   #restaurant-site-wrapper .erc-page.is-mobile-compact .erc-topbar-inner {
-    flex-direction: row;
+    grid-template-columns: minmax(0, 1fr) auto;
     align-items: center;
-    justify-content: space-between;
     gap: 0.6rem;
-    padding-top: calc(0.55rem + var(--erc-safe-top));
-    padding-bottom: 0.55rem;
+    padding-top: calc(0.45rem + var(--erc-safe-top));
+    padding-bottom: 0.45rem;
   }
 
   #restaurant-site-wrapper .erc-page.is-mobile-compact .erc-brand {
-    font-size: 1.7rem;
+    font-size: 1.5rem;
   }
 
   #restaurant-site-wrapper .erc-page.is-mobile-compact .erc-sister-link {
@@ -858,14 +872,16 @@ body.route-restaurant.route-restaurant--elroy {
   }
 
   #restaurant-site-wrapper .erc-page.is-mobile-compact .erc-menu-toggle {
+    grid-column: 2;
+    justify-self: end;
     width: auto;
-    max-width: 13.5rem;
+    max-width: none;
     box-shadow: 0 10px 24px rgb(139 75 0 / 0.08);
   }
 
   #restaurant-site-wrapper .erc-page.is-mobile-compact .erc-menu-toggle-btn {
-    padding: 0.48rem 1.1rem;
-    font-size: 0.74rem;
+    padding: 0.42rem 0.9rem;
+    font-size: 0.71rem;
   }
 
   #restaurant-site-wrapper .erc-page.is-mobile-compact .erc-actions {

--- a/elroyscantina/style.css
+++ b/elroyscantina/style.css
@@ -699,6 +699,41 @@ body.route-restaurant.route-restaurant--elroy {
   outline: none;
 }
 
+#restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-main {
+  padding-bottom: calc(3.25rem + var(--erc-safe-bottom));
+}
+
+#restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-hero {
+  margin-bottom: 2.3rem;
+}
+
+#restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-section {
+  margin-bottom: 2.5rem;
+}
+
+#restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-section-head {
+  margin-bottom: 1.35rem;
+}
+
+#restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-items {
+  gap: 1.45rem;
+}
+
+#restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-item-row {
+  padding-bottom: 0.22rem;
+  margin-bottom: 0.22rem;
+}
+
+#restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-item-title,
+#restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-item-price {
+  font-size: 1.22rem;
+}
+
+#restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-item-desc {
+  font-size: 0.95rem;
+  line-height: 1.45;
+}
+
 @keyframes erc-route-boot-sheen {
   from {
     background-position: 200% 0;
@@ -890,6 +925,19 @@ body.route-restaurant.route-restaurant--elroy {
 
   #restaurant-site-wrapper .erc-page.is-mobile-compact .erc-hero {
     margin-bottom: 2rem;
+  }
+
+  #restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-hero {
+    margin-bottom: 1.45rem;
+  }
+
+  #restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-section {
+    margin-bottom: 2rem;
+  }
+
+  #restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-item-title,
+  #restaurant-site-wrapper .erc-page:has(.erc-menu-toggle-btn[data-route-menu-toggle='food'][aria-pressed='true']) .erc-item-price {
+    font-size: 1.12rem;
   }
 }
 


### PR DESCRIPTION
## Summary
- tighten the El Roy's Cantina hero and first-viewport spacing so menu content appears sooner
- compact the mobile header and compact-scroll state to reduce navigation chrome
- improve food-menu density, 86'd item readability, dark-mode supporting contrast, and footer structure
- update the El Roy's design-loop issues file to reflect the completed pass set

## Testing
- `node --check app.js`
- preview-checked on Vercel across desktop/mobile and light/dark route states