### PR TITLE
Fix shared title override for dedicated route pages

### DIFF
--- a/app.js
+++ b/app.js
@@ -3311,7 +3311,10 @@ function applyDesign(design) {
   }
   const brand = (design.brandName || '').trim();
   const title = (design.menuTitle || '').trim();
-  document.title = [brand, title].filter(Boolean).join(' | ') || 'Current Menu';
+  const currentTitle = (document.title || '').trim();
+  if (currentTitle.toUpperCase() === 'CURRENT MENU') {
+    document.title = [brand, title].filter(Boolean).join(' | ') || 'Current Menu';
+  }
 }
 
 async function renderPublicViews() {


### PR DESCRIPTION
## Summary
- Updated `app.js` in `applyDesign()` to avoid unconditionally setting `document.title`.
- Added a guard so the shared design title only applies when the current tab title is still the generic `CURRENT MENU`.
- Preserved existing behavior for non-dedicated/picker flows that intentionally set their own title.

## Testing
- Not run (not requested)