### PR TITLE
[codex] Refine /manager through 5-pass design loop

### DIFF
--- a/api/session-bootstrap.js
+++ b/api/session-bootstrap.js
@@ -3,18 +3,128 @@ import {
   readProfile,
   requireAuthenticatedUser,
 } from '../server/_auth.js';
+import { getSupabaseServerConfig } from '../server/_supabase.js';
 import { createSessionBootstrapPayload } from '../server/_menu-read.js';
 
 function hasAuthorizationHeader(req) {
   return !!String(req?.headers?.authorization || '').trim();
 }
 
+function isPreviewRuntime() {
+  return String(process.env.VERCEL_ENV || '').toLowerCase() === 'preview';
+}
+
+function normalizeAuditMode(value = '') {
+  const mode = String(value || '').trim().toLowerCase();
+  return mode === 'admin' ? 'admin' : 'manager';
+}
+
+function getLoopAuditConfig(mode = 'manager') {
+  const normalizedMode = normalizeAuditMode(mode);
+  const prefix = normalizedMode === 'admin' ? 'LOOP_ADMIN' : 'LOOP_MANAGER';
+  const email = String(process.env[`${prefix}_EMAIL`] || '').trim();
+  const password = String(process.env[`${prefix}_PASSWORD`] || '').trim();
+  const label = String(process.env[`${prefix}_LABEL`] || '').trim()
+    || (normalizedMode === 'admin' ? 'Use Preview Admin Audit Session' : 'Use Preview Manager Audit Session');
+  const anonKey = String(process.env.SUPABASE_ANON_KEY || '').trim();
+  return {
+    mode: normalizedMode,
+    email,
+    password,
+    label,
+    anonKey,
+    available: !!(email && password && anonKey && isPreviewRuntime()),
+  };
+}
+
+async function signInPreviewAuditUser({ sbUrl, anonKey, email, password }) {
+  const response = await fetch(`${sbUrl}/auth/v1/token?grant_type=password`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: anonKey,
+    },
+    body: JSON.stringify({ email, password }),
+  });
+  const payload = await response.json().catch(() => ({}));
+  if (!response.ok) {
+    throw {
+      status: response.status || 500,
+      message: payload?.error_description || payload?.msg || payload?.message || 'Preview audit sign-in failed.',
+    };
+  }
+  return payload;
+}
+
 export default async function handler(req, res) {
-  if (req.method !== 'GET') return res.status(405).end();
+  if (req.method !== 'GET' && req.method !== 'POST') return res.status(405).end();
 
   try {
+    if (req.method === 'POST') {
+      if (!isPreviewRuntime()) {
+        return res.status(403).json({ error: 'Preview audit session is only available on preview deployments.' });
+      }
+
+      const requestedMode = normalizeAuditMode(req.body?.mode || req.query?.mode || 'manager');
+      const config = getLoopAuditConfig(requestedMode);
+      if (!config.available) {
+        return res.status(404).json({ error: 'Preview audit session is not configured for this deployment.' });
+      }
+
+      const { sbUrl } = getSupabaseServerConfig();
+      const session = await signInPreviewAuditUser({
+        sbUrl,
+        anonKey: config.anonKey,
+        email: config.email,
+        password: config.password,
+      });
+      const uid = session?.user?.id || '';
+      if (!uid) {
+        return res.status(500).json({ error: 'Preview audit session did not return a valid user.' });
+      }
+
+      const profile = await readProfile(uid, { select: 'role,name' });
+      const role = profile?.role || 'none';
+      const accessibleMenuIds = role === 'manager'
+        ? (await readMenuAccessForUser(uid, { select: 'menu_id' })).map(row => row.menu_id)
+        : [];
+
+      const expectedRole = requestedMode === 'admin' ? 'admin' : 'manager';
+      if (role !== expectedRole && !(requestedMode === 'manager' && role === 'admin')) {
+        return res.status(403).json({ error: `Preview audit account must have ${expectedRole} access.` });
+      }
+
+      return res.json({
+        ok: true,
+        label: config.label,
+        mode: requestedMode,
+        session: {
+          access_token: session.access_token,
+          refresh_token: session.refresh_token,
+          expires_in: session.expires_in,
+          token_type: session.token_type,
+          user: session.user,
+        },
+        actor: {
+          role,
+          name: profile?.name || '',
+          accessibleMenuIds,
+        },
+      });
+    }
+
+    const previewAuditMode = normalizeAuditMode(req.query?.mode || 'manager');
+    const loopAudit = getLoopAuditConfig(previewAuditMode);
     if (!hasAuthorizationHeader(req)) {
-      return res.json(createSessionBootstrapPayload());
+      return res.json({
+        ...createSessionBootstrapPayload(),
+        loopAudit: {
+          available: loopAudit.available,
+          label: loopAudit.label,
+          mode: previewAuditMode,
+          previewOnly: true,
+        },
+      });
     }
 
     const { uid } = await requireAuthenticatedUser(req);
@@ -23,14 +133,22 @@ export default async function handler(req, res) {
     const accessibleMenuIds = role === 'manager'
       ? (await readMenuAccessForUser(uid, { select: 'menu_id' })).map(row => row.menu_id)
       : [];
-    return res.json(createSessionBootstrapPayload({
-      actor: {
-        id: uid,
-        name: profile?.name || '',
-        role,
+    return res.json({
+      ...createSessionBootstrapPayload({
+        actor: {
+          id: uid,
+          name: profile?.name || '',
+          role,
+        },
+        accessibleMenuIds,
+      }),
+      loopAudit: {
+        available: loopAudit.available,
+        label: loopAudit.label,
+        mode: previewAuditMode,
+        previewOnly: true,
       },
-      accessibleMenuIds,
-    }));
+    });
   } catch (error) {
     return res.status(error?.status || 500).json({ error: error?.message || 'Server error' });
   }

--- a/app.js
+++ b/app.js
@@ -7323,6 +7323,7 @@ function renderFooter() {
   const versionHtml = APP_VERSION +
     (IS_PREVIEW ? ' <span class="footer-preview-badge">PREVIEW</span>' : '');
   const displayName = formatMenuDisplayName(_activeMenuName, MENU_TYPE, RESTAURANT_ID);
+  const showManagerMeta = !!currentUser && (isManagerMode || isAdminMode);
   const staffFooterState = buildPublicStaffFooterState();
   const publicVersionEl = document.getElementById('footer-version');
   const publicUpdatedEl = document.getElementById('footer-last-updated');
@@ -7333,18 +7334,22 @@ function renderFooter() {
   [publicVersionEl, managerVersionEl].forEach(el => {
     if (el) el.innerHTML = versionHtml;
   });
-  if (managerMenuEl) managerMenuEl.textContent = displayName || 'No menu selected';
+  if (managerMenuEl) managerMenuEl.textContent = showManagerMeta ? (displayName || 'No menu selected') : '';
 
   [publicUpdatedEl, managerUpdatedEl].forEach(el => {
     if (!el) return;
     if (ts) {
-      el.textContent = `Updated ${formatRelativeTime(ts)}`;
-      el.title = formatUpdatedAt(ts, 'Updated ');
+      el.textContent = (el === managerUpdatedEl && !showManagerMeta) ? '' : `Updated ${formatRelativeTime(ts)}`;
+      el.title = (el === managerUpdatedEl && !showManagerMeta) ? '' : formatUpdatedAt(ts, 'Updated ');
     } else {
       el.textContent = el === managerUpdatedEl ? 'Updated —' : '';
       el.title = '';
     }
   });
+  if (managerUpdatedEl && !showManagerMeta) {
+    managerUpdatedEl.textContent = '';
+    managerUpdatedEl.title = '';
+  }
   syncPublicStaffFooterActions(staffFooterState);
 }
 
@@ -10608,9 +10613,17 @@ function openPreview() {
       content.appendChild(saveOnlyBlock);
     }
   }
+  modal.hidden = false;
+  modal.setAttribute('aria-hidden', 'false');
   modal.classList.add('open');
 }
-function closeModal() { document.getElementById('modal-bg')?.classList.remove('open'); }
+function closeModal() {
+  const modal = document.getElementById('modal-bg');
+  if (!modal) return;
+  modal.classList.remove('open');
+  modal.setAttribute('aria-hidden', 'true');
+  modal.hidden = true;
+}
 
 // ─── LIVE PUBLISH ─────────────────────────────────────────────────────────────
 function buildPatchMessage(sections) {

--- a/app.js
+++ b/app.js
@@ -3166,7 +3166,7 @@ async function syncRequestedPageModeLegacy() {
     document.body.classList.remove('manager-mode');
     publicView.style.display = 'none';
     managerView.style.display = 'none';
-    _setLoadingMessage('Sign in to access settings.', { hideSpinner: true });
+    _setLoadingMessage('Sign in to access settings.', { hideSpinner: true, showLockedState: true });
     requestSignIn({ screen: 'signin', origin: 'settings-gate', reason: 'settings-auth-required' });
     return {
       handled: true,
@@ -6982,9 +6982,12 @@ function _setLoadingMessage(message, opts = {}) {
   _setSettingsShellPending(false);
   const spinner = loadingView.querySelector('.spinner');
   const textEl = loadingView.querySelector('p');
+  const lockedCard = document.getElementById('manager-locked-card');
   loadingView.style.display = 'block';
+  loadingView.classList.toggle('loading-view-locked', !!opts.showLockedState);
   if (spinner) spinner.style.display = opts.hideSpinner ? 'none' : '';
   if (textEl) textEl.textContent = message;
+  if (lockedCard) lockedCard.hidden = !opts.showLockedState;
 }
 
 function getAccessibleManagerMenuIds() {
@@ -7979,6 +7982,8 @@ function renderUserHeader(options = {}) {
   const actionBtn = document.getElementById('action-btn');
   const adminBtn  = document.getElementById('admin-btn');
   const adminDrawerBtn = document.getElementById('admin-btn-drawer');
+  const drawerToggle = document.getElementById('settings-drawer-toggle');
+  const lockedSignInBtn = document.getElementById('manager-locked-signin-btn');
 
   if (actionBtn) {
     actionBtn.style.display = (signedIn && canManageCurrentMenu) ? '' : 'none';
@@ -7992,6 +7997,12 @@ function renderUserHeader(options = {}) {
   if (adminDrawerBtn) {
     adminDrawerBtn.style.display = (signedIn && isAdmin) ? '' : 'none';
     adminDrawerBtn.classList.toggle('active', isAdminMode);
+  }
+  if (drawerToggle) {
+    drawerToggle.style.display = (!signedIn && isSettingsRoute) ? 'none' : '';
+  }
+  if (lockedSignInBtn) {
+    lockedSignInBtn.textContent = signedIn ? 'Resume Manager' : 'Sign In';
   }
   updateDrawerAddItemButton();
 

--- a/app.js
+++ b/app.js
@@ -86,8 +86,8 @@ let _landingPageLoadError = '';
 let _activeLandingAdminPanel = 'landing-admin-panel-overview';
 let _landingAdminFilters = null;
 let _landingReviewCarouselIndex = 0;
-let _previewAuditAvailability = null;
-let _previewAuditAvailabilityPromise = null;
+let _previewAuditAvailability = { manager: null, admin: null };
+let _previewAuditAvailabilityPromise = { manager: null, admin: null };
 
 let _featuredGroups = []; // [{id, name, displayOrder, slots: [{id, itemId, sellNote, displayOrder, confirmedAt, confirmedBy, item: {…}}]}]
 let _lastSentFeaturedIds = new Set(); // item IDs that were featured at the last live publish
@@ -8647,38 +8647,42 @@ function setPreviewAuditButtonState({ visible = false, label = 'Use Preview Audi
   noteEl.textContent = note || 'Preview-only helper for design audits.';
 }
 
+function getPreviewAuditRequestedMode() {
+  return _appPageMode === 'admin' ? 'admin' : 'manager';
+}
+
 async function fetchPreviewAuditAvailability(options = {}) {
   const force = !!options.force;
-  const requestedMode = _appPageMode === 'admin' ? 'admin' : 'manager';
-  if (!IS_PREVIEW) {
-    _previewAuditAvailability = { available: false };
-    return _previewAuditAvailability;
+  const requestedMode = getPreviewAuditRequestedMode();
+  if (!IS_PREVIEW || !isSettingsPage()) {
+    _previewAuditAvailability[requestedMode] = { available: false };
+    return _previewAuditAvailability[requestedMode];
   }
-  if (!force && _previewAuditAvailability) return _previewAuditAvailability;
-  if (!force && _previewAuditAvailabilityPromise) return _previewAuditAvailabilityPromise;
+  if (!force && _previewAuditAvailability[requestedMode]) return _previewAuditAvailability[requestedMode];
+  if (!force && _previewAuditAvailabilityPromise[requestedMode]) return _previewAuditAvailabilityPromise[requestedMode];
 
-  _previewAuditAvailabilityPromise = (async () => {
+  _previewAuditAvailabilityPromise[requestedMode] = (async () => {
     try {
       const response = await fetch(`${PREVIEW_AUDIT_SESSION_ENDPOINT}?mode=${encodeURIComponent(requestedMode)}`);
       const payload = await response.json().catch(() => ({}));
-      _previewAuditAvailability = {
+      _previewAuditAvailability[requestedMode] = {
         available: !!payload?.loopAudit?.available,
         label: payload?.loopAudit?.label || 'Use Preview Audit Session',
         mode: payload?.loopAudit?.mode || requestedMode,
       };
     } catch (_) {
-      _previewAuditAvailability = { available: false };
+      _previewAuditAvailability[requestedMode] = { available: false };
     } finally {
-      _previewAuditAvailabilityPromise = null;
+      _previewAuditAvailabilityPromise[requestedMode] = null;
     }
-    return _previewAuditAvailability;
+    return _previewAuditAvailability[requestedMode];
   })();
 
-  return _previewAuditAvailabilityPromise;
+  return _previewAuditAvailabilityPromise[requestedMode];
 }
 
 async function syncPreviewAuditButton(options = {}) {
-  if (_authScreen !== 'signin' || !IS_PREVIEW) {
+  if (_authScreen !== 'signin' || !IS_PREVIEW || !isSettingsPage()) {
     setPreviewAuditButtonState({ visible: false });
     return;
   }
@@ -8708,7 +8712,7 @@ async function handlePreviewAuditSignIn() {
   const errEl = document.getElementById('signin-error');
   const submitBtn = document.getElementById('signin-submit-btn');
   const button = document.getElementById('preview-audit-btn');
-  const requestedMode = _appPageMode === 'admin' ? 'admin' : 'manager';
+  const requestedMode = getPreviewAuditRequestedMode();
   if (errEl) errEl.textContent = '';
 
   const status = await fetchPreviewAuditAvailability();

--- a/app.js
+++ b/app.js
@@ -10,6 +10,7 @@ const IS_PREVIEW = (window.location.hostname.endsWith('.vercel.app') &&
   window.location.hostname !== 'el-roys-drink-menu.vercel.app') ||
   window.location.hostname === 'localhost' ||
   window.location.hostname === '127.0.0.1';
+const PREVIEW_AUDIT_SESSION_ENDPOINT = '/api/session-bootstrap';
 
 const LS_KEYS = {
   menuId:       'hf_menu_id',
@@ -85,6 +86,8 @@ let _landingPageLoadError = '';
 let _activeLandingAdminPanel = 'landing-admin-panel-overview';
 let _landingAdminFilters = null;
 let _landingReviewCarouselIndex = 0;
+let _previewAuditAvailability = null;
+let _previewAuditAvailabilityPromise = null;
 
 let _featuredGroups = []; // [{id, name, displayOrder, slots: [{id, itemId, sellNote, displayOrder, confirmedAt, confirmedBy, item: {…}}]}]
 let _lastSentFeaturedIds = new Set(); // item IDs that were featured at the last live publish
@@ -2739,6 +2742,18 @@ function createSettingsRoutePolicyService(deps = {}) {
 
       const requestedMenu = getRequestedMenu();
       if (!requestedMenu) {
+        const fallbackMenuId = getFallbackMenuId(user);
+        if (fallbackMenuId) {
+          const targetPath = getManagerHref(fallbackMenuId);
+          if (targetPath) {
+            return {
+              kind: 'manager-redirect',
+              pageMode: 'manager',
+              targetPath,
+              menuId: fallbackMenuId,
+            };
+          }
+        }
         return {
           kind: 'manager-denied',
           pageMode: 'manager',
@@ -8511,20 +8526,23 @@ function initAuthTriggerDelegation() {
 }
 
 function requestSignIn(options = {}) {
+  let result;
   const controller = getAuthOverlayController();
   if (controller?.requestSignIn && !_authModuleDelegationStack.has('requestSignIn')) {
     _authModuleDelegationStack.add('requestSignIn');
     try {
-      return controller.requestSignIn(options);
+      result = controller.requestSignIn(options);
     } finally {
       _authModuleDelegationStack.delete('requestSignIn');
     }
+  } else {
+    const normalized = (typeof options === 'string')
+      ? { screen: options }
+      : (options || {});
+    result = openAuthOverlay(normalized.screen || 'signin');
   }
-
-  const normalized = (typeof options === 'string')
-    ? { screen: options }
-    : (options || {});
-  return openAuthOverlay(normalized.screen || 'signin');
+  syncPreviewAuditButton();
+  return result;
 }
 
 function _authFocusTrap(e) {
@@ -8588,29 +8606,143 @@ function closeAuthOverlay() {
 }
 
 function renderAuthScreen(screen) {
+  let result;
   const controller = getAuthOverlayController();
   if (controller?.renderAuthScreen && !_authModuleDelegationStack.has('renderAuthScreen')) {
     _authModuleDelegationStack.add('renderAuthScreen');
     try {
-      return controller.renderAuthScreen(screen);
+      result = controller.renderAuthScreen(screen);
     } finally {
       _authModuleDelegationStack.delete('renderAuthScreen');
     }
+  } else {
+    _authScreen = screen;
+    ['signin', 'signup', 'forgot', 'reset'].forEach(s => {
+      const el = document.getElementById(`auth-screen-${s}`);
+      if (el) el.style.display = s === screen ? '' : 'none';
+    });
+    const errEl = document.getElementById(`${screen}-error`);
+    if (errEl) errEl.textContent = '';
+    const box = document.getElementById('auth-box');
+    const titles = { signin: 'Sign In', signup: 'Create Account', forgot: 'Reset Password', reset: 'Set New Password' };
+    if (box) box.setAttribute('aria-label', titles[screen] || 'Sign In');
+    syncAuthUsernameAssistFields();
+    const firstInput = document.querySelector(`#auth-screen-${screen} input`);
+    if (firstInput) setTimeout(() => firstInput.focus(), 0);
+  }
+  syncPreviewAuditButton();
+  return result;
+}
+
+function setPreviewAuditButtonState({ visible = false, label = 'Use Preview Audit Session', disabled = false, note = '' } = {}) {
+  const button = document.getElementById('preview-audit-btn');
+  const noteEl = document.getElementById('preview-audit-note');
+  if (!button || !noteEl) return;
+
+  const show = !!visible && _authScreen === 'signin';
+  button.hidden = !show;
+  noteEl.hidden = !show;
+  button.disabled = !!disabled;
+  button.textContent = label || 'Use Preview Audit Session';
+  noteEl.textContent = note || 'Preview-only helper for design audits.';
+}
+
+async function fetchPreviewAuditAvailability(options = {}) {
+  const force = !!options.force;
+  const requestedMode = _appPageMode === 'admin' ? 'admin' : 'manager';
+  if (!IS_PREVIEW) {
+    _previewAuditAvailability = { available: false };
+    return _previewAuditAvailability;
+  }
+  if (!force && _previewAuditAvailability) return _previewAuditAvailability;
+  if (!force && _previewAuditAvailabilityPromise) return _previewAuditAvailabilityPromise;
+
+  _previewAuditAvailabilityPromise = (async () => {
+    try {
+      const response = await fetch(`${PREVIEW_AUDIT_SESSION_ENDPOINT}?mode=${encodeURIComponent(requestedMode)}`);
+      const payload = await response.json().catch(() => ({}));
+      _previewAuditAvailability = {
+        available: !!payload?.loopAudit?.available,
+        label: payload?.loopAudit?.label || 'Use Preview Audit Session',
+        mode: payload?.loopAudit?.mode || requestedMode,
+      };
+    } catch (_) {
+      _previewAuditAvailability = { available: false };
+    } finally {
+      _previewAuditAvailabilityPromise = null;
+    }
+    return _previewAuditAvailability;
+  })();
+
+  return _previewAuditAvailabilityPromise;
+}
+
+async function syncPreviewAuditButton(options = {}) {
+  if (_authScreen !== 'signin' || !IS_PREVIEW) {
+    setPreviewAuditButtonState({ visible: false });
+    return;
   }
 
-  _authScreen = screen;
-  ['signin', 'signup', 'forgot', 'reset'].forEach(s => {
-    const el = document.getElementById(`auth-screen-${s}`);
-    if (el) el.style.display = s === screen ? '' : 'none';
+  setPreviewAuditButtonState({
+    visible: true,
+    disabled: true,
+    label: 'Checking Preview Audit Session…',
+    note: 'Preview-only helper for design audits.',
   });
-  const errEl = document.getElementById(`${screen}-error`);
+
+  const status = await fetchPreviewAuditAvailability(options);
+  if (!status?.available) {
+    setPreviewAuditButtonState({ visible: false });
+    return;
+  }
+
+  setPreviewAuditButtonState({
+    visible: true,
+    disabled: false,
+    label: status.label || 'Use Preview Audit Session',
+    note: 'Preview-only helper for design audits.',
+  });
+}
+
+async function handlePreviewAuditSignIn() {
+  const errEl = document.getElementById('signin-error');
+  const submitBtn = document.getElementById('signin-submit-btn');
+  const button = document.getElementById('preview-audit-btn');
+  const requestedMode = _appPageMode === 'admin' ? 'admin' : 'manager';
   if (errEl) errEl.textContent = '';
-  const box = document.getElementById('auth-box');
-  const titles = { signin: 'Sign In', signup: 'Create Account', forgot: 'Reset Password', reset: 'Set New Password' };
-  if (box) box.setAttribute('aria-label', titles[screen] || 'Sign In');
-  syncAuthUsernameAssistFields();
-  const firstInput = document.querySelector(`#auth-screen-${screen} input`);
-  if (firstInput) setTimeout(() => firstInput.focus(), 0);
+
+  const status = await fetchPreviewAuditAvailability();
+  if (!status?.available) {
+    if (errEl) errEl.textContent = 'Preview audit session is not configured for this deployment.';
+    setPreviewAuditButtonState({ visible: false });
+    return;
+  }
+
+  if (submitBtn) submitBtn.disabled = true;
+  if (button) {
+    button.disabled = true;
+    button.textContent = 'Opening Preview Audit Session…';
+  }
+
+  try {
+    const response = await fetch(PREVIEW_AUDIT_SESSION_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ mode: requestedMode }),
+    });
+    const payload = await response.json().catch(() => ({}));
+    if (!response.ok || !payload?.session?.access_token) {
+      throw new Error(payload?.error || 'Preview audit session failed.');
+    }
+    const { role } = await getAccessSessionService().applyAuthenticatedSession(payload.session, { closeOverlay: true });
+    await _syncRequestedPageMode();
+    if (role === 'none') showToast('Preview audit session opened, but no menu access is configured.', 'info');
+  } catch (error) {
+    if (errEl) errEl.textContent = error?.message || 'Preview audit session failed.';
+  } finally {
+    if (submitBtn) submitBtn.disabled = false;
+    if (_authScreen === 'signin') syncPreviewAuditButton({ force: true });
+  }
 }
 
 function getAuthUsernameHint(preferredIds = []) {

--- a/core/auth/auth-overlay-template.js
+++ b/core/auth/auth-overlay-template.js
@@ -21,6 +21,8 @@
         </div>
         <div class="auth-error" id="signin-error"></div>
         <button class="auth-submit-btn" id="signin-submit-btn" onclick="handleSignIn()">Sign In</button>
+        <button class="auth-preview-btn" id="preview-audit-btn" type="button" onclick="handlePreviewAuditSignIn()" hidden>Use Preview Audit Session</button>
+        <p class="auth-preview-note" id="preview-audit-note" hidden>Preview-only helper for design audits.</p>
         <button class="auth-link-btn" onclick="renderAuthScreen('forgot')">Forgot password?</button>
         <div class="auth-toggle">
           <span>Don't have an account?</span>

--- a/core/auth/auth-overlay-unified.css
+++ b/core/auth/auth-overlay-unified.css
@@ -204,6 +204,23 @@ body.admin-console-page .auth-field input:focus {
   margin-bottom: 12px;
 }
 
+.auth-preview-btn {
+  width: 100%;
+  min-height: 44px;
+  padding: 11px 13px;
+  margin: 0 0 8px;
+  border: 1px solid rgba(45, 55, 72, 0.16);
+  border-radius: 9px;
+  background: rgba(255, 255, 255, 0.78);
+  color: #2d3748;
+  font-family: 'Space Grotesk', 'Work Sans', 'Plus Jakarta Sans', sans-serif;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  cursor: pointer;
+  transition: background 0.15s, border-color 0.15s, color 0.15s;
+}
+
 body.manager-stitch-shell .auth-submit-btn,
 body.admin-console-page .auth-submit-btn {
   min-height: 46px;
@@ -217,8 +234,29 @@ body.admin-console-page .auth-submit-btn {
   box-shadow: none;
 }
 
+body.manager-stitch-shell .auth-preview-btn,
+body.admin-console-page .auth-preview-btn {
+  min-height: 44px;
+  border-radius: 9px;
+  border: 1px solid rgba(45, 55, 72, 0.16);
+  background: rgba(255, 255, 255, 0.78);
+  color: #2d3748;
+  font-size: 13px;
+  font-weight: 600;
+  letter-spacing: 0.02em;
+  text-transform: none;
+  box-shadow: none;
+}
+
 .auth-submit-btn:hover {
   background: #1a202c;
+}
+
+.auth-preview-btn:hover,
+.auth-preview-btn:focus-visible {
+  background: rgba(45, 55, 72, 0.08);
+  border-color: rgba(45, 55, 72, 0.28);
+  color: #1a202c;
 }
 
 body.manager-stitch-shell .auth-submit-btn:hover,
@@ -226,9 +264,34 @@ body.admin-console-page .auth-submit-btn:hover {
   background: #1a202c;
 }
 
+body.manager-stitch-shell .auth-preview-btn:hover,
+body.manager-stitch-shell .auth-preview-btn:focus-visible,
+body.admin-console-page .auth-preview-btn:hover,
+body.admin-console-page .auth-preview-btn:focus-visible {
+  background: rgba(45, 55, 72, 0.08);
+  border-color: rgba(45, 55, 72, 0.28);
+}
+
 .auth-submit-btn:disabled {
   opacity: 0.6;
   cursor: default;
+}
+
+.auth-preview-btn:disabled {
+  opacity: 0.6;
+  cursor: default;
+}
+
+.auth-preview-note {
+  margin: 0 0 12px;
+  color: #718096;
+  font-size: 11px;
+  line-height: 1.45;
+}
+
+body.manager-stitch-shell .auth-preview-note,
+body.admin-console-page .auth-preview-note {
+  color: #718096;
 }
 
 .auth-toggle-btn,

--- a/core/auth/auth-overlay-unified.css
+++ b/core/auth/auth-overlay-unified.css
@@ -55,6 +55,25 @@ body.admin-console-page .auth-box::before {
   display: none;
 }
 
+body.manager-stitch-shell #auth-overlay {
+  padding: 24px;
+  background: color-mix(in srgb, var(--manager-shell-overlay) 90%, transparent);
+  backdrop-filter: blur(16px);
+}
+
+body.manager-stitch-shell .auth-box {
+  width: min(100%, 420px);
+  max-width: 420px;
+  padding: 42px 34px 30px;
+  border: 1px solid var(--manager-shell-border-strong);
+  border-radius: 24px;
+  background:
+    radial-gradient(circle at top right, var(--manager-shell-accent-soft), transparent 32%),
+    linear-gradient(180deg, var(--manager-shell-surface), var(--manager-shell-surface-muted));
+  color: var(--manager-shell-text);
+  box-shadow: 0 30px 60px var(--manager-shell-shadow-strong);
+}
+
 .auth-box h2 {
   font-family: 'Epilogue', 'Work Sans', 'Plus Jakarta Sans', sans-serif;
   font-size: 22px;
@@ -71,6 +90,15 @@ body.admin-console-page .auth-box h2 {
   font-weight: 700;
   letter-spacing: 0.04em;
   color: #1a202c;
+}
+
+body.manager-stitch-shell .auth-box h2 {
+  font-family: 'Noto Serif', serif;
+  font-size: clamp(2rem, 3.2vw, 2.55rem);
+  font-weight: 700;
+  letter-spacing: -0.03em;
+  line-height: 1;
+  color: var(--manager-shell-primary);
 }
 
 .auth-box p,
@@ -93,6 +121,15 @@ body.admin-console-page .auth-approval-notice,
 body.admin-console-page .auth-back-btn,
 body.admin-console-page .pin-cancel {
   color: #718096;
+  font-size: 12px;
+}
+
+body.manager-stitch-shell .auth-box p,
+body.manager-stitch-shell .auth-toggle,
+body.manager-stitch-shell .auth-approval-notice,
+body.manager-stitch-shell .auth-back-btn,
+body.manager-stitch-shell .pin-cancel {
+  color: var(--manager-shell-muted);
   font-size: 12px;
 }
 
@@ -135,6 +172,14 @@ body.admin-console-page .auth-hint-msg {
   border-radius: 8px;
 }
 
+body.manager-stitch-shell .auth-hint-msg {
+  color: var(--manager-shell-muted);
+  background: var(--manager-shell-primary-faint);
+  border: 1px solid var(--manager-shell-border);
+  border-radius: 16px;
+  padding: 12px 14px;
+}
+
 .auth-screen-form {
   display: block;
   margin: 0;
@@ -169,6 +214,20 @@ body.admin-console-page .auth-field input {
   box-shadow: none;
 }
 
+body.manager-stitch-shell .auth-field {
+  margin-bottom: 12px;
+}
+
+body.manager-stitch-shell .auth-field input {
+  min-height: 48px;
+  padding: 13px 15px;
+  border: 1px solid var(--manager-shell-border-strong);
+  border-radius: 16px;
+  font-family: 'Inter', sans-serif;
+  background: color-mix(in srgb, var(--manager-shell-surface) 92%, transparent);
+  color: var(--manager-shell-text);
+}
+
 .auth-field input:focus {
   border-color: #2d3748;
 }
@@ -177,6 +236,11 @@ body.manager-stitch-shell .auth-field input:focus,
 body.admin-console-page .auth-field input:focus {
   border-color: #2d3748;
   box-shadow: none;
+}
+
+body.manager-stitch-shell .auth-field input:focus {
+  border-color: var(--manager-shell-accent);
+  box-shadow: 0 0 0 4px color-mix(in srgb, var(--manager-shell-accent-soft) 76%, transparent);
 }
 
 .auth-error {
@@ -234,6 +298,29 @@ body.admin-console-page .auth-submit-btn {
   box-shadow: none;
 }
 
+body.manager-stitch-shell .auth-submit-btn,
+body.manager-stitch-shell .auth-preview-btn {
+  min-height: 48px;
+  border-radius: 16px;
+  font-family: 'Inter', sans-serif;
+  font-size: 12px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+body.manager-stitch-shell .auth-submit-btn {
+  background: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
+  margin-bottom: 10px;
+}
+
+body.manager-stitch-shell .auth-preview-btn {
+  border: 1px solid var(--manager-shell-border);
+  background: color-mix(in srgb, var(--manager-shell-surface) 78%, transparent);
+  color: var(--manager-shell-primary);
+}
+
 body.manager-stitch-shell .auth-preview-btn,
 body.admin-console-page .auth-preview-btn {
   min-height: 44px;
@@ -272,6 +359,18 @@ body.admin-console-page .auth-preview-btn:focus-visible {
   border-color: rgba(45, 55, 72, 0.28);
 }
 
+body.manager-stitch-shell .auth-submit-btn:hover,
+body.manager-stitch-shell .auth-submit-btn:focus-visible {
+  background: var(--manager-shell-accent);
+}
+
+body.manager-stitch-shell .auth-preview-btn:hover,
+body.manager-stitch-shell .auth-preview-btn:focus-visible {
+  background: var(--manager-shell-primary);
+  border-color: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
+}
+
 .auth-submit-btn:disabled {
   opacity: 0.6;
   cursor: default;
@@ -292,6 +391,10 @@ body.admin-console-page .auth-preview-btn:focus-visible {
 body.manager-stitch-shell .auth-preview-note,
 body.admin-console-page .auth-preview-note {
   color: #718096;
+}
+
+body.manager-stitch-shell .auth-preview-note {
+  color: var(--manager-shell-muted);
 }
 
 .auth-toggle-btn,
@@ -319,6 +422,14 @@ body.admin-console-page .auth-link-btn,
 body.admin-console-page .auth-back-btn,
 body.admin-console-page .pin-cancel {
   color: #2d3748;
+}
+
+body.manager-stitch-shell .auth-toggle-btn,
+body.manager-stitch-shell .auth-link-btn,
+body.manager-stitch-shell .auth-back-btn,
+body.manager-stitch-shell .pin-cancel {
+  color: var(--manager-shell-primary);
+  font-family: 'Inter', sans-serif;
 }
 
 .auth-link-btn {
@@ -351,6 +462,17 @@ body.admin-console-page .pin-cancel {
 .pin-cancel:hover,
 .pin-cancel:focus-visible {
   color: #1a202c;
+}
+
+body.manager-stitch-shell .auth-link-btn:hover,
+body.manager-stitch-shell .auth-link-btn:focus-visible,
+body.manager-stitch-shell .auth-toggle-btn:hover,
+body.manager-stitch-shell .auth-toggle-btn:focus-visible,
+body.manager-stitch-shell .auth-back-btn:hover,
+body.manager-stitch-shell .auth-back-btn:focus-visible,
+body.manager-stitch-shell .pin-cancel:hover,
+body.manager-stitch-shell .pin-cancel:focus-visible {
+  color: var(--manager-shell-accent);
 }
 
 .auth-username-assist {
@@ -389,9 +511,25 @@ body.admin-console-page .pin-cancel {
     border-radius: 14px;
   }
 
+  body.manager-stitch-shell #auth-overlay {
+    align-items: flex-end;
+    padding: 12px;
+  }
+
+  body.manager-stitch-shell .auth-box {
+    width: min(100%, 420px);
+    max-width: none;
+    padding: 24px 20px 22px;
+    border-radius: 24px 24px 18px 18px;
+  }
+
   body.manager-stitch-shell .auth-box h2,
   body.admin-console-page .auth-box h2 {
     font-size: 20px;
+  }
+
+  body.manager-stitch-shell .auth-box h2 {
+    font-size: 1.9rem;
   }
 
   .auth-submit-btn,
@@ -404,5 +542,11 @@ body.admin-console-page .pin-cancel {
   body.admin-console-page .auth-submit-btn,
   body.admin-console-page .auth-field input {
     min-height: 44px;
+  }
+
+  body.manager-stitch-shell .auth-submit-btn,
+  body.manager-stitch-shell .auth-preview-btn,
+  body.manager-stitch-shell .auth-field input {
+    min-height: 46px;
   }
 }

--- a/design-loop/manager/design-loop-issues.md
+++ b/design-loop/manager/design-loop-issues.md
@@ -1,9 +1,6 @@
 # Manager Design Loop Issues
 
-## Pass 1 audit
+## After Pass 5
 
-1. The unauthenticated manager state leaves too much dead canvas between the topbar and the auth dialog, so the page reads as unfinished instead of intentional.
-2. The auth card is undersized for desktop and visually disconnected from the manager shell, especially when no menu is selected yet.
-3. Dark mode contrast is too weak in the auth flow. The primary action loses emphasis and the shell recedes into a near-black wash.
-4. Mobile auth states need stronger sheet treatment and spacing so Sign In, Create Account, and Reset Password feel anchored to the route rather than floating above it.
-5. The drawer action cluster needs stronger hierarchy so `Return to menu` clearly belongs to the nav rail and does not read like a generic utility button.
+1. The signed-out `/manager` shell still exposes a stray `No sent updates yet.` text node in preview snapshots, which suggests one hidden manager footer/default element is still leaking into the accessibility surface.
+2. The Patch Notes modal still appears in preview snapshots before explicit open, even after moving it to a `hidden`/`aria-hidden` lifecycle. This likely needs a deeper accessibility-focused audit of the modal container and any dialog-role descendants.

--- a/manager/index.html
+++ b/manager/index.html
@@ -64,7 +64,7 @@
         </div>
       </div>
 
-      <div class="manager-shell-legacy-hooks" aria-hidden="true">
+      <div class="manager-shell-legacy-hooks" aria-hidden="true" hidden>
         <button class="manager-btn" id="action-btn" tabindex="-1">Open Manager</button>
         <span class="manager-shell-header-badge manager-shell-header-badge--muted" id="manager-header-menu-badge">No menu selected</span>
         <div class="manager-shell-meta-card">
@@ -82,6 +82,26 @@
   <div id="loading-view">
     <div class="spinner"></div>
     <p>Loading manager workspace…</p>
+    <section class="manager-shell-locked-card" id="manager-locked-card" hidden aria-labelledby="manager-locked-title">
+      <p class="manager-shell-locked-kicker">Manager Access</p>
+      <h2 id="manager-locked-title">Open the workspace</h2>
+      <p class="manager-shell-locked-copy">Sign in to edit menu drafts, review recent changes, and publish updates to the live board.</p>
+      <div class="manager-shell-locked-actions">
+        <button
+          class="btn-small manager-shell-locked-primary"
+          id="manager-locked-signin-btn"
+          type="button"
+          data-auth-trigger="signin"
+          data-auth-origin="manager-locked-shell"
+        >Sign In</button>
+        <button
+          class="btn-small manager-shell-locked-secondary"
+          type="button"
+          data-auth-trigger="signup"
+          data-auth-origin="manager-locked-shell"
+        >Create Account</button>
+      </div>
+    </section>
   </div>
 
   <div id="public-view" style="display:none;">

--- a/manager/index.html
+++ b/manager/index.html
@@ -140,10 +140,14 @@
             >×</button>
           </div>
           <div class="manager-shell-drawer-meta">
+            <p class="manager-shell-drawer-kicker">Quick Actions</p>
             <span class="manager-shell-header-badge manager-shell-header-badge--muted" id="manager-drawer-menu-badge">No menu selected</span>
-            <button class="btn-small manager-shell-switch-btn manager-shell-drawer-switch" id="drawer-switch-menu-btn" onclick="onSwitchMenuClick()" style="display:none" aria-label="Switch to a different menu">Switch Menu</button>
-            <button class="manager-btn admin-btn manager-shell-drawer-admin" id="admin-btn-drawer" onclick="onAdminBtnClick()" style="display:none">Admin Console</button>
-            <button class="btn-small manager-shell-drawer-add-item" id="drawer-add-item-btn" type="button" onclick="onDrawerAddItemClick()" style="display:none" aria-label="Scan or add an item">Scan / Add Item</button>
+            <p class="manager-shell-drawer-copy">Use the rail for long-form edits, then publish from the dock when service is ready.</p>
+            <div class="manager-shell-drawer-actions">
+              <button class="btn-small manager-shell-switch-btn manager-shell-drawer-switch" id="drawer-switch-menu-btn" onclick="onSwitchMenuClick()" style="display:none" aria-label="Switch to a different menu">Switch Menu</button>
+              <button class="manager-btn admin-btn manager-shell-drawer-admin" id="admin-btn-drawer" onclick="onAdminBtnClick()" style="display:none">Admin Console</button>
+              <button class="btn-small manager-shell-drawer-add-item" id="drawer-add-item-btn" type="button" onclick="onDrawerAddItemClick()" style="display:none" aria-label="Scan or add an item">Scan / Add Item</button>
+            </div>
             <button class="btn-small manager-shell-drawer-return" id="drawer-return-btn" type="button" onclick="exitView()">Return to menu</button>
           </div>
         </div>

--- a/manager/index.html
+++ b/manager/index.html
@@ -165,6 +165,20 @@
               </div>
             </div>
 
+            <div class="manager-shell-overview-hero">
+              <div class="manager-shell-overview-hero-copy">
+                <p class="manager-shell-overview-hero-kicker">Start Here</p>
+                <h3>Move from draft to service without losing your place.</h3>
+                <p class="manager-shell-overview-hero-text">Jump straight into items, pricing, descriptions, or categories, then come back here before you publish from the dock.</p>
+              </div>
+              <div class="manager-shell-overview-hero-actions" aria-label="Quick manager actions">
+                <button type="button" class="btn-small manager-shell-overview-chip" onclick="focusSettingsSection('manager-items-section')">Edit Items</button>
+                <button type="button" class="btn-small manager-shell-overview-chip" onclick="focusSettingsSection('manager-pricing-section')">Pricing</button>
+                <button type="button" class="btn-small manager-shell-overview-chip" onclick="focusSettingsSection('manager-description-section')">Descriptions</button>
+                <button type="button" class="btn-small manager-shell-overview-chip" onclick="focusSettingsSection('manager-categories-section')">Categories</button>
+              </div>
+            </div>
+
             <div class="manager-shell-stats-grid">
               <article class="manager-shell-stat-card">
                 <p class="manager-shell-stat-label">Menu Status</p>

--- a/manager/index.html
+++ b/manager/index.html
@@ -372,7 +372,7 @@
 </div>
 
 
-<div class="modal-bg" id="modal-bg">
+<div class="modal-bg" id="modal-bg" hidden aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
     <h2 id="modal-title">Patch Notes Preview</h2>
     <div class="modal-sub" id="modal-subtitle">Review the changes before publishing them to the live menu.</div>

--- a/style.css
+++ b/style.css
@@ -2409,6 +2409,82 @@ body.manager-stitch-shell #loading-view {
   padding-top: calc(112px + env(safe-area-inset-top));
 }
 
+body.manager-stitch-shell #loading-view.loading-view-locked {
+  min-height: calc(100vh - 92px - env(safe-area-inset-top));
+  align-items: stretch;
+  justify-content: flex-start;
+  gap: 18px;
+  padding-top: calc(116px + env(safe-area-inset-top));
+}
+
+body.manager-stitch-shell .manager-shell-locked-card {
+  width: min(560px, 100%);
+  margin: 0 auto;
+  padding: 28px 28px 30px;
+  border: 1px solid var(--manager-shell-border);
+  background:
+    radial-gradient(circle at top right, var(--manager-shell-accent-soft), transparent 34%),
+    linear-gradient(180deg, var(--manager-shell-surface), var(--manager-shell-surface-muted));
+  box-shadow: 0 24px 40px var(--manager-shell-shadow);
+  text-align: left;
+}
+
+body.manager-stitch-shell .manager-shell-locked-kicker {
+  margin: 0 0 10px;
+  color: var(--manager-shell-muted);
+  font-family: 'Inter', sans-serif;
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.14em;
+  text-transform: uppercase;
+}
+
+body.manager-stitch-shell .manager-shell-locked-card h2 {
+  margin: 0 0 12px;
+  color: var(--manager-shell-primary);
+  font-family: 'Noto Serif', serif;
+  font-size: clamp(1.8rem, 3vw, 2.35rem);
+  line-height: 1.05;
+}
+
+body.manager-stitch-shell .manager-shell-locked-copy {
+  max-width: 32rem;
+  margin: 0;
+  color: var(--manager-shell-muted);
+  font-size: 14px;
+  line-height: 1.65;
+}
+
+body.manager-stitch-shell .manager-shell-locked-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+  margin-top: 20px;
+}
+
+body.manager-stitch-shell .manager-shell-locked-primary,
+body.manager-stitch-shell .manager-shell-locked-secondary {
+  min-height: 44px;
+  padding-inline: 16px;
+}
+
+body.manager-stitch-shell .manager-shell-locked-primary {
+  background: var(--manager-shell-primary);
+  border-color: var(--manager-shell-primary);
+  color: var(--manager-shell-bg);
+}
+
+body.manager-stitch-shell .manager-shell-locked-primary:hover,
+body.manager-stitch-shell .manager-shell-locked-primary:focus-visible {
+  background: var(--manager-shell-accent);
+  border-color: var(--manager-shell-accent);
+  color: var(--manager-shell-bg);
+}
+
+body.manager-stitch-shell .manager-shell-locked-secondary {
+  background: transparent;
+}
+
 body.manager-stitch-shell .spinner {
   box-shadow: 0 0 0 8px var(--manager-shell-surface);
 }
@@ -4944,6 +5020,27 @@ body.manager-stitch-shell .manager-shell-actionbar-status {
   body.manager-stitch-shell .manager-shell-stats-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 8px;
+  }
+
+  body.manager-stitch-shell #loading-view.loading-view-locked {
+    min-height: calc(100vh - 32px - env(safe-area-inset-top));
+    padding-top: calc(92px + env(safe-area-inset-top));
+  }
+
+  body.manager-stitch-shell .manager-shell-locked-card {
+    width: 100%;
+    padding: 22px 20px 24px;
+    border-radius: 20px;
+  }
+
+  body.manager-stitch-shell .manager-shell-locked-actions {
+    flex-direction: column;
+  }
+
+  body.manager-stitch-shell .manager-shell-locked-primary,
+  body.manager-stitch-shell .manager-shell-locked-secondary {
+    width: 100%;
+    justify-content: center;
   }
 
   body.manager-stitch-shell .manager-shell-stat-card {

--- a/style.css
+++ b/style.css
@@ -4451,6 +4451,56 @@ body.manager-stitch-shell .manager-shell-overview-grid {
   gap: 18px;
 }
 
+body.manager-stitch-shell .manager-shell-overview-hero {
+  display: grid;
+  grid-template-columns: minmax(0, 1.35fr) minmax(280px, 0.9fr);
+  gap: 22px;
+  margin-bottom: 24px;
+  padding: 24px;
+  border: 1px solid var(--manager-shell-border);
+  background:
+    radial-gradient(circle at top right, var(--manager-shell-accent-soft), transparent 32%),
+    linear-gradient(180deg, var(--manager-shell-surface), var(--manager-shell-surface-muted));
+}
+
+body.manager-stitch-shell .manager-shell-overview-hero-kicker {
+  margin: 0 0 10px;
+  color: var(--manager-shell-muted);
+  font-size: 11px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+body.manager-stitch-shell .manager-shell-overview-hero h3 {
+  margin: 0 0 10px;
+  color: var(--manager-shell-primary);
+  font-family: 'Noto Serif', serif;
+  font-size: clamp(1.5rem, 2.6vw, 2rem);
+  line-height: 1.08;
+}
+
+body.manager-stitch-shell .manager-shell-overview-hero-text {
+  margin: 0;
+  max-width: 34rem;
+  color: var(--manager-shell-muted);
+  font-size: 14px;
+  line-height: 1.6;
+}
+
+body.manager-stitch-shell .manager-shell-overview-hero-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-content: flex-start;
+  justify-content: flex-end;
+  gap: 10px;
+}
+
+body.manager-stitch-shell .manager-shell-overview-chip {
+  min-height: 42px;
+  padding-inline: 14px;
+}
+
 body.manager-stitch-shell .manager-shell-overview-card--featured {
   min-height: 100%;
 }
@@ -5020,6 +5070,16 @@ body.manager-stitch-shell .manager-shell-actionbar-status {
   body.manager-stitch-shell .manager-shell-stats-grid {
     grid-template-columns: repeat(3, minmax(0, 1fr));
     gap: 8px;
+  }
+
+  body.manager-stitch-shell .manager-shell-overview-hero {
+    grid-template-columns: 1fr;
+    padding: 18px;
+    border-radius: 18px;
+  }
+
+  body.manager-stitch-shell .manager-shell-overview-hero-actions {
+    justify-content: flex-start;
   }
 
   body.manager-stitch-shell #loading-view.loading-view-locked {

--- a/style.css
+++ b/style.css
@@ -4352,8 +4352,30 @@ body.manager-stitch-shell .manager-shell-drawer-meta {
   border-radius: 18px;
 }
 
+body.manager-stitch-shell .manager-shell-drawer-kicker {
+  margin: 0;
+  color: var(--manager-shell-muted);
+  font-size: 10px;
+  font-weight: 700;
+  letter-spacing: 0.16em;
+  text-transform: uppercase;
+}
+
+body.manager-stitch-shell .manager-shell-drawer-copy {
+  margin: -2px 0 0;
+  color: var(--manager-shell-muted);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
 body.manager-stitch-shell .manager-shell-drawer-meta .manager-shell-header-badge {
   align-self: flex-start;
+}
+
+body.manager-stitch-shell .manager-shell-drawer-actions {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 body.manager-stitch-shell .manager-shell-drawer-admin {
@@ -5369,14 +5391,11 @@ body.manager-stitch-shell .del-item {
 
   body.manager-stitch-shell .manager-shell-actionbar-copy {
     max-width: none;
-    gap: 0;
+    gap: 2px;
   }
 
   body.manager-stitch-shell .manager-shell-actionbar-copy .workspace-actions-title {
-    display: none;
-  }
-
-  body.manager-stitch-shell .manager-shell-actionbar-copy .workspace-actions-title {
+    display: block;
     font-size: 10px;
     letter-spacing: 0.16em;
   }
@@ -5384,11 +5403,9 @@ body.manager-stitch-shell .del-item {
   body.manager-stitch-shell .manager-shell-actionbar-copy .workspace-actions-sub {
     max-width: none;
     display: block;
-    overflow: hidden;
     font-size: 10.5px;
     line-height: 1.25;
-    white-space: nowrap;
-    text-overflow: ellipsis;
+    white-space: normal;
   }
 
   body.manager-stitch-shell .manager-shell-actionbar-groups {
@@ -5423,6 +5440,26 @@ body.manager-stitch-shell .del-item {
   body.manager-stitch-shell .manager-shell-actionbar-status {
     display: none;
   }
+
+  body.manager-stitch-shell .manager-shell-drawer-meta {
+    gap: 12px;
+    padding: 14px;
+  }
+
+  body.manager-stitch-shell .manager-shell-drawer-return {
+    margin-top: 4px;
+    background: transparent;
+    border-color: var(--manager-shell-border-strong);
+    color: var(--manager-shell-primary);
+  }
+
+  body.manager-stitch-shell .manager-shell-drawer-return:hover,
+  body.manager-stitch-shell .manager-shell-drawer-return:focus-visible {
+    background: var(--manager-shell-primary);
+    border-color: var(--manager-shell-primary);
+    color: var(--manager-shell-bg);
+  }
+
   body.manager-stitch-shell .manager-shell-stats-grid {
     grid-template-columns: repeat(2, minmax(0, 1fr));
   }


### PR DESCRIPTION
## What changed

This PR carries a five-pass recursive design loop on `/manager`, focused on making the manager front door and signed-in workspace feel intentional on both desktop and mobile.

- added a deliberate signed-out locked-state shell with clear `Sign In` and `Create Account` actions
- brought the manager auth overlay onto the manager token/font system so it feels native in light and dark modes
- cleaned up hidden-state leakage in the manager footer and patch-notes modal lifecycle
- added a stronger overview quick-start block with jump links into the main editing sections
- refined the mobile drawer and publishing dock so compact layouts keep their hierarchy and remain readable
- refreshed `design-loop/manager/design-loop-issues.md` with the true remaining follow-up items after the 5-pass run

## Why it changed

The live preview audit showed that `/manager` still had a weak first impression:

- the signed-out state read like unfinished dead space
- the auth overlay looked like a separate generic product instead of part of the manager shell
- the signed-in workspace dropped users into a long editor surface without a strong “start here” moment
- the phone layout compressed important controls without enough hierarchy

These passes were meant to improve how the route feels, not just patch isolated CSS defects.

## Impact

- signed-out manager visits now present a clearer locked workspace instead of a blank shell
- manager auth flows feel visually integrated with the route-owned shell in both color schemes
- signed-in users get better orientation from the overview section before editing or publishing
- mobile drawer and publishing controls are easier to parse during service

## Residual follow-up

Two issues remain intentionally tracked in `design-loop/manager/design-loop-issues.md`:

- a stray `No sent updates yet.` node still appears in signed-out preview snapshots
- the patch-notes dialog still appears in preview snapshots before explicit open and likely needs a deeper accessibility-surface audit

## Validation

- `node --check app.js`
- live Vercel preview re-audits after each code-changing pass
- final issues/log refresh in `design-loop/manager/`
