### PR TITLE
[codex] Fix manager save status after quiet save

### DIFF
--- a/api/manager.js
+++ b/api/manager.js
@@ -40,7 +40,7 @@ function parsePublishBody(req) {
   const body = parseRequestBody(req);
   return {
     body,
-    menuId: String(body?.menu_id || '').trim(),
+    menuId: String(body?.menu_id || parseMenuId(req) || '').trim(),
     action: String(body?.action || '').trim().toLowerCase(),
   };
 }
@@ -104,6 +104,7 @@ export default async function handler(req, res) {
         return res.status(200).json(await saveSharedDraftCommand(req));
       case 'save_live':
         return res.status(200).json(await saveLiveMenuCommand(req));
+      case 'save_quietly':
       case 'preview_publish':
       case 'publish': {
         const { body, menuId, action: bodyAction } = parsePublishBody(req);
@@ -115,10 +116,12 @@ export default async function handler(req, res) {
         const result = await command({
           actor,
           menuId,
-          mode: String(body?.mode || '').trim(),
+          mode: action === 'save_quietly' ? 'save' : String(body?.mode || '').trim(),
           source: String(body?.source || '').trim(),
           snapshot: body?.snapshot || {},
-          selectedChangeIds: Array.isArray(body?.selected_change_ids) ? body.selected_change_ids : null,
+          selectedChangeIds: Array.isArray(body?.selected_change_ids)
+            ? body.selected_change_ids
+            : (Array.isArray(body?.selected_group_ids) ? body.selected_group_ids : null),
           legacySelectedSections: Array.isArray(body?.selected_sections) ? body.selected_sections : [],
           expectedLiveRevision: body?.expected_live_revision ?? null,
           expectedDraftRevision: body?.expected_draft_revision ?? null,

--- a/api/manager.js
+++ b/api/manager.js
@@ -125,6 +125,7 @@ export default async function handler(req, res) {
           legacySelectedSections: Array.isArray(body?.selected_sections) ? body.selected_sections : [],
           expectedLiveRevision: body?.expected_live_revision ?? null,
           expectedDraftRevision: body?.expected_draft_revision ?? null,
+          expectedNotificationRevision: body?.expected_notification_revision ?? null,
         });
         return res.status(200).json(result);
       }

--- a/app.js
+++ b/app.js
@@ -5359,7 +5359,6 @@ async function requestPublishPreviewThroughApi() {
     menu_id: MENU_ID,
     snapshot: buildPublishSnapshotPayload(),
     expected_live_revision: menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null,
-    expected_draft_revision: draftEnvelope?.baseLastSentRevision ?? null,
     expected_notification_revision: draftEnvelope?.baseLastSentRevision ?? null,
   }, {
     headers: getAuthorizedApiHeaders(),
@@ -5377,7 +5376,6 @@ async function publishMenuThroughApi({ mode, selectedChangeIds = [] }) {
     snapshot: buildPublishSnapshotPayload(),
     selected_change_ids: Array.isArray(selectedChangeIds) ? selectedChangeIds : [],
     expected_live_revision: menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null,
-    expected_draft_revision: draftEnvelope?.baseLastSentRevision ?? null,
     expected_notification_revision: draftEnvelope?.baseLastSentRevision ?? null,
   }, {
     headers: getAuthorizedApiHeaders(),
@@ -5829,6 +5827,9 @@ function withMenuStateLoaderDefaults(deps = {}) {
     getFeaturedSnapshot: typeof deps.getFeaturedSnapshot === 'function'
       ? deps.getFeaturedSnapshot
       : (() => getFeaturedSnapshot()),
+    syncLocalDraftDirtyState: typeof deps.syncLocalDraftDirtyState === 'function'
+      ? deps.syncLocalDraftDirtyState
+      : (() => syncLocalDraftDirtyState()),
     isDirty: typeof deps.isDirty === 'function'
       ? deps.isDirty
       : (() => !!_dirty),
@@ -5876,6 +5877,7 @@ function createMenuStateLoaderService(deps = {}) {
   const getCategorySnapshot = resolvedDeps.getCategorySnapshot;
   const getDesignSnapshotValue = resolvedDeps.getDesignSnapshot;
   const getFeaturedSnapshotValue = resolvedDeps.getFeaturedSnapshot;
+  const syncDraftDirtyState = resolvedDeps.syncLocalDraftDirtyState;
   const readStoredLocalDraft = resolvedDeps.readStoredLocalDraftEnvelope;
   const buildCurrentDraftEnvelope = resolvedDeps.buildCurrentLocalDraftEnvelope;
   const applyLocalDraft = resolvedDeps.applyLocalDraftEnvelope;
@@ -5899,14 +5901,20 @@ function createMenuStateLoaderService(deps = {}) {
           const localDraftEnvelope = includePersistedDraft ? readStoredLocalDraft() : null;
           const loadedDraft = includePersistedDraft
             ? (localDraftEnvelope
-                ? !!applyLocalDraft(localDraftEnvelope, { markDirty: true })
+                ? !!applyLocalDraft(localDraftEnvelope, { markDirty: false })
                 : !!applyDraftState(null))
             : false;
           if (loadedDraft) {
             setLocalDraftBaseSnapshot(localDraftEnvelope?.baseSnapshot || getServerLiveSnapshot());
-            setDirty(true);
+            if (syncDraftDirtyState()) {
+              setDirty(true);
+            } else {
+              clearCurrentDraft();
+              setDirty(false);
+              clearDraftChanges();
+            }
           } else {
-            clearCurrentDraft({ clearStorage: false });
+            clearCurrentDraft(localDraftEnvelope ? {} : { clearStorage: false });
             setDirty(false);
             clearDraftChanges();
           }
@@ -5953,7 +5961,14 @@ function createMenuStateLoaderService(deps = {}) {
       hydrateFromState(data);
       const usedWorkspaceRestaurantTools = applyWorkspaceRestaurantTools(data);
       if (activeDraftEnvelope?.draftSnapshot) {
-        applyLocalDraft(activeDraftEnvelope, { markDirty: true });
+        const reappliedDraft = applyLocalDraft(activeDraftEnvelope, { markDirty: false });
+        if (reappliedDraft && syncDraftDirtyState()) {
+          setDirty(true);
+        } else {
+          clearCurrentDraft();
+          setDirty(false);
+          clearDraftChanges();
+        }
       } else {
         clearCurrentDraft({ clearStorage: false });
         setDirty(false);
@@ -6351,7 +6366,11 @@ function applyLocalDraftEnvelope(envelope = null, options = {}) {
   const applied = applyPersistedDraftState(normalized.draftSnapshot);
   if (!applied) return false;
   setLocalDraftBaseSnapshot(normalized.baseSnapshot || getServerLiveSnapshot());
-  _dirty = options.markDirty !== false;
+  if (options.markDirty === false) {
+    _dirty = false;
+  } else {
+    _dirty = hasActualLocalDraftChanges();
+  }
   return true;
 }
 

--- a/app.js
+++ b/app.js
@@ -16,6 +16,7 @@ const LS_KEYS = {
   menuId:       'hf_menu_id',
   menuUrl:      'hf_menu_url',
   menuCache:    'hf_menu_cache',
+  menuDraftClientId: 'hf_menu_draft_client_id',
   lastUpdated:  'hf_last_updated_ts',
   accessToken:  'hf_sb_access_token',
   refreshToken: 'hf_sb_refresh_token',
@@ -975,6 +976,9 @@ let _hasSharedDraft = false;
 let _sharedDraftSavedTs = '';
 let _sharedDraftSavedBy = null;
 let _sharedDraftSource = '';
+let _serverLiveSnapshot = null;
+let _localDraftBaseSnapshot = null;
+let _localDraftPersistTimer = null;
 let _previewModalState = null;
 let _previewSelectionState = {};
 let _lastAddItemCategoryId = '';
@@ -997,7 +1001,12 @@ function createAddItemModalState(overrides = {}) {
   };
 }
 let _addItemModalState = createAddItemModalState();
-function invalidateDiff() { _diffDirty = true; _dirty = true; updateSaveBtn(); }
+function invalidateDiff() {
+  _diffDirty = true;
+  _dirty = true;
+  scheduleCurrentLocalDraftPersistence();
+  updateSaveBtn();
+}
 function countDiffLines(diff = getCachedDiff()) {
   return (diff || []).reduce((count, section) => (
     count + (section.added?.length || 0) +
@@ -1055,6 +1064,116 @@ function setSharedDraftState(savedTs = '', details = {}) {
     _sharedDraftSource = String(nextDetails.source || '').trim();
   }
 }
+function isMenuWorkspacePage() {
+  return _appPageMode === 'manager' || _appPageMode === 'admin';
+}
+function getMenuDraftClientId() {
+  let clientId = localStorage.getItem(LS_KEYS.menuDraftClientId) || '';
+  if (!clientId) {
+    clientId = uid();
+    try {
+      localStorage.setItem(LS_KEYS.menuDraftClientId, clientId);
+    } catch (_) {
+      return clientId;
+    }
+  }
+  return clientId;
+}
+function getLocalDraftStorageKey({ userId = currentUser?.uid || '', menuId = MENU_ID, clientId = getMenuDraftClientId() } = {}) {
+  const normalizedUserId = String(userId || '').trim();
+  const normalizedMenuId = String(menuId || '').trim();
+  const normalizedClientId = String(clientId || '').trim();
+  if (!normalizedUserId || !normalizedMenuId || !normalizedClientId) return '';
+  return `hf_menu_local_draft::${normalizedUserId}::${normalizedMenuId}::${normalizedClientId}`;
+}
+function clearLocalDraftPersistTimer() {
+  if (_localDraftPersistTimer) {
+    clearTimeout(_localDraftPersistTimer);
+    _localDraftPersistTimer = null;
+  }
+}
+function normalizeLocalDraftEnvelope(candidate = null) {
+  if (!candidate || typeof candidate !== 'object' || Array.isArray(candidate)) return null;
+  const userId = String(candidate.userId || '').trim();
+  const menuId = String(candidate.menuId || '').trim();
+  const clientId = String(candidate.clientId || '').trim();
+  const draftSnapshot = candidate.draftSnapshot && typeof candidate.draftSnapshot === 'object'
+    ? cloneJsonCompatible(candidate.draftSnapshot, null)
+    : (Array.isArray(candidate.cats)
+        ? {
+            cats: cloneJsonCompatible(candidate.cats, []),
+            save_only_changes: cloneJsonCompatible(candidate.saveOnlyChanges || candidate.save_only_changes || [], []),
+            featured_groups: cloneJsonCompatible(candidate.featured_groups || [], []),
+          }
+        : null);
+  if (!userId || !menuId || !clientId || !draftSnapshot) return null;
+  const baseSnapshot = candidate.baseSnapshot && typeof candidate.baseSnapshot === 'object'
+    ? cloneJsonCompatible(candidate.baseSnapshot, null)
+    : null;
+  return {
+    version: Number(candidate.version || 2) || 2,
+    userId,
+    menuId,
+    clientId,
+    savedAt: Number(candidate.savedAt || Date.now()),
+    baseLiveRevision: candidate.baseLiveRevision == null ? null : Number(candidate.baseLiveRevision),
+    baseLastSentRevision: candidate.baseLastSentRevision == null ? null : Number(candidate.baseLastSentRevision),
+    baseSnapshot,
+    draftSnapshot,
+  };
+}
+function readStoredLocalDraftEnvelope(options = {}) {
+  const storageKey = getLocalDraftStorageKey(options);
+  if (!storageKey) return null;
+  try {
+    const raw = localStorage.getItem(storageKey);
+    if (!raw) return null;
+    return normalizeLocalDraftEnvelope(JSON.parse(raw));
+  } catch (_) {
+    return null;
+  }
+}
+function writeStoredLocalDraftEnvelope(envelope = null, options = {}) {
+  const storageKey = getLocalDraftStorageKey(options);
+  if (!storageKey) return null;
+  try {
+    if (!envelope) {
+      localStorage.removeItem(storageKey);
+      return null;
+    }
+    const normalized = normalizeLocalDraftEnvelope(envelope);
+    if (!normalized) {
+      localStorage.removeItem(storageKey);
+      return null;
+    }
+    localStorage.setItem(storageKey, JSON.stringify(normalized));
+    return normalized;
+  } catch (_) {
+    return null;
+  }
+}
+function clearStoredLocalDraftEnvelope(options = {}) {
+  return writeStoredLocalDraftEnvelope(null, options);
+}
+function setServerLiveSnapshot(snapshot = null) {
+  _serverLiveSnapshot = snapshot && typeof snapshot === 'object'
+    ? cloneJsonCompatible(snapshot, null)
+    : null;
+}
+function getServerLiveSnapshot() {
+  return cloneJsonCompatible(_serverLiveSnapshot, null);
+}
+function setLocalDraftBaseSnapshot(snapshot = null) {
+  _localDraftBaseSnapshot = snapshot && typeof snapshot === 'object'
+    ? cloneJsonCompatible(snapshot, null)
+    : null;
+}
+function getLocalDraftBaseSnapshot() {
+  return cloneJsonCompatible(_localDraftBaseSnapshot || _serverLiveSnapshot, null);
+}
+function clearLocalDraftBaseSnapshot() {
+  _localDraftBaseSnapshot = null;
+}
 function upsertDraftSaveOnlyChange(change) {
   if (!change?.key) return null;
   const nextChange = {
@@ -1072,6 +1191,7 @@ function upsertDraftSaveOnlyChange(change) {
 function markSaveOnlyDraftChange(change) {
   upsertDraftSaveOnlyChange(change);
   _dirty = true;
+  scheduleCurrentLocalDraftPersistence();
   updateSaveBtn();
 }
 function getDraftChangeCount() {
@@ -1080,29 +1200,86 @@ function getDraftChangeCount() {
 function isSharedDraftClearable({ hasLocalDraft = !!_dirty, hasSharedDraft = hasSharedDraftState(), changeCount = getDraftChangeCount() } = {}) {
   return !!hasSharedDraft && !hasLocalDraft && Number(changeCount || 0) === 0;
 }
+function getMenuActionState({ isCompactViewport = false } = {}) {
+  const hasLocalDraft = syncLocalDraftDirtyState();
+  const notificationCount = countDiffLines();
+  const saveOnlyCount = getDraftSaveOnlyChanges().length;
+  const hasNotificationChanges = notificationCount > 0;
+  const hasSaveOnlyChanges = saveOnlyCount > 0;
+  const hasChanges = hasNotificationChanges || hasSaveOnlyChanges;
+  const hasPendingServerQueue = !hasLocalDraft && hasNotificationChanges;
+
+  if (hasLocalDraft) {
+    const summaryText = hasNotificationChanges
+      ? (isCompactViewport
+          ? `${getDraftChangeCount()} pending change${getDraftChangeCount() === 1 ? '' : 's'}. Save quietly or review the send queue.`
+          : `${getDraftChangeCount()} pending change${getDraftChangeCount() === 1 ? '' : 's'}. Save Quietly writes live without sending. Save & Send reviews the queue before notifying.`)
+      : `${saveOnlyCount || getDraftChangeCount()} quiet change${(saveOnlyCount || getDraftChangeCount()) === 1 ? '' : 's'} ready to save.`;
+    return {
+      hasLocalDraft,
+      hasPendingServerQueue,
+      hasNotificationChanges,
+      hasSaveOnlyChanges,
+      hasChanges,
+      summaryText,
+      saveLabel: hasNotificationChanges ? 'Save Quietly' : 'Save',
+      saveDisabled: !hasChanges,
+      publishLabel: 'Save & Send',
+      publishDisabled: !hasNotificationChanges,
+      showDiscard: true,
+    };
+  }
+
+  if (hasPendingServerQueue) {
+    return {
+      hasLocalDraft,
+      hasPendingServerQueue,
+      hasNotificationChanges,
+      hasSaveOnlyChanges,
+      hasChanges,
+      summaryText: `${notificationCount} update line${notificationCount === 1 ? ' is' : 's are'} live and ready to send.`,
+      saveLabel: '',
+      saveDisabled: true,
+      publishLabel: 'Send',
+      publishDisabled: false,
+      showDiscard: false,
+    };
+  }
+
+  return {
+    hasLocalDraft,
+    hasPendingServerQueue,
+    hasNotificationChanges,
+    hasSaveOnlyChanges,
+    hasChanges,
+    summaryText: 'No pending changes',
+    saveLabel: 'Save',
+    saveDisabled: true,
+    publishLabel: 'Send',
+    publishDisabled: true,
+    showDiscard: false,
+  };
+}
 function updateSaveBtn() {
   const saveBtn = document.getElementById('save-btn');
   const publishBtn = document.getElementById('send-btn');
-  const hasLocalDraft = !!_dirty;
-  const hasSharedDraft = hasSharedDraftState();
-  const changeCount = getDraftChangeCount();
-  const hasClearableSharedDraft = isSharedDraftClearable({
-    hasLocalDraft,
-    hasSharedDraft,
-    changeCount,
-  });
-  const hasPublishableDraftWork = hasLocalDraft || (hasSharedDraft && !hasClearableSharedDraft);
-  const hasPendingUpdate = !hasLocalDraft && !hasSharedDraft && countDiffLines() > 0;
+  const discardBtn = document.getElementById('discard-draft-btn');
+  const actionState = getMenuActionState();
   if (saveBtn) {
-    saveBtn.disabled = !hasLocalDraft && !hasClearableSharedDraft;
-    saveBtn.textContent = hasClearableSharedDraft ? 'Clear Draft' : 'Save Draft';
-    saveBtn.title = hasClearableSharedDraft
-      ? 'Remove the saved draft because it already matches the live menu'
-      : 'Save changes without notifying anyone';
+    saveBtn.disabled = !!actionState.saveDisabled;
+    saveBtn.textContent = actionState.saveLabel || 'Save';
+    saveBtn.hidden = !actionState.saveLabel;
+    saveBtn.title = actionState.hasLocalDraft
+      ? 'Save the live menu without notifying anyone yet'
+      : '';
   }
   if (publishBtn) {
-    publishBtn.disabled = !hasPublishableDraftWork && !hasPendingUpdate;
-    publishBtn.textContent = !hasPublishableDraftWork && hasPendingUpdate ? 'Update' : 'Save';
+    publishBtn.disabled = !!actionState.publishDisabled;
+    publishBtn.textContent = actionState.publishLabel;
+  }
+  if (discardBtn) {
+    discardBtn.hidden = !actionState.showDiscard;
+    discardBtn.disabled = !actionState.showDiscard;
   }
   updateManagerActionBar();
 }
@@ -2146,9 +2323,8 @@ function buildCurrentMenuPageRequest(overrides = {}) {
 function buildMenuSessionSnapshot(source = 'live', request = buildCurrentMenuPageRequest()) {
   const notifyDiff = getCachedDiff();
   const saveOnlyChanges = getDraftSaveOnlyChanges();
-  const hasLocalDraft = !!_dirty;
-  const hasSharedDraft = hasSharedDraftState();
-  const hasPendingUpdate = !hasLocalDraft && !hasSharedDraft && countDiffLines(notifyDiff) > 0;
+  const hasLocalDraft = syncLocalDraftDirtyState();
+  const hasPendingUpdate = !hasLocalDraft && countDiffLines(notifyDiff) > 0;
   return {
     request,
     source,
@@ -2161,11 +2337,11 @@ function buildMenuSessionSnapshot(source = 'live', request = buildCurrentMenuPag
     currentDesign,
     featuredGroups: _featuredGroups,
     dirty: hasLocalDraft,
-    hasSharedDraft,
+    hasSharedDraft: false,
     draftSavedTs: getDraftSavedTs(),
     saveOnlyChanges,
     notifyDiff,
-    status: hasLocalDraft ? 'DRAFTING' : (hasSharedDraft ? 'DRAFTED' : (hasPendingUpdate ? 'LIVE | UNSENT' : 'LIVE')),
+    status: hasLocalDraft ? 'DRAFTING' : (hasPendingUpdate ? 'LIVE | UNSENT' : 'LIVE'),
     hasMultipleMenus: _hasMultipleMenus,
   };
 }
@@ -2177,12 +2353,11 @@ function buildMenuSessionPreview(snapshot = buildMenuSessionSnapshot('preview'))
   const saveOnlyChanges = snapshot.saveOnlyChanges || getDraftSaveOnlyChanges();
   const patchMessage = notificationChanges.length ? buildPatchMessage(sections) : '';
   const hasLocalDraft = !!snapshot.dirty;
-  const hasSharedDraft = !!snapshot.hasSharedDraft;
-  const mode = (hasLocalDraft || hasSharedDraft) ? 'save' : (notificationChanges.length ? 'update-only' : 'save');
+  const mode = hasLocalDraft ? 'save-and-send' : (notificationChanges.length ? 'send' : 'save');
   return {
     hasChanges: notificationChanges.length > 0 || saveOnlyChanges.length > 0,
     hasLocalDraft,
-    hasSharedDraft,
+    hasSharedDraft: false,
     hasNotificationChanges: notificationChanges.length > 0,
     hasSaveOnlyChanges: saveOnlyChanges.length > 0,
     diff,
@@ -2288,11 +2463,25 @@ function getMenuSessionPorts() {
       const selectedChangeIds = Array.isArray(options.selectedChangeIds)
         ? options.selectedChangeIds
         : (providedPreview?.notificationChanges || []).map(change => change.id);
-      const mode = options.mode || ((providedPreview?.mode === 'update-only')
-        ? (options.notify === false ? 'save' : 'update-only')
-        : (options.notify === false ? 'save' : 'save-and-update'));
+      const mode = options.mode || (((providedPreview?.mode === 'send') || (providedPreview?.mode === 'update-only'))
+        ? (options.notify === false ? 'save' : 'send')
+        : (options.notify === false ? 'save' : 'save-and-send'));
       const apiResult = await publishMenuThroughApi({ mode, selectedChangeIds });
       if (!apiResult.ok) {
+        if (apiResult.status === 409 && apiResult.payload?.code === 'revision_conflict' && syncLocalDraftDirtyState()) {
+          const reloadResult = await reloadLatestWorkspaceIntoLocalDraft();
+          if (reloadResult.reloaded) {
+            return {
+              ok: false,
+              preview: providedPreview,
+              userHandled: true,
+              userMessage: reloadResult.requiresReview
+                ? 'The live menu changed while you were drafting. Your draft was reloaded on top of the latest live data so you can review the overlap before saving again.'
+                : 'The live menu changed while you were drafting. Your non-overlapping local draft was automatically reapplied on top of the latest live data.',
+              snapshot: buildMenuSessionSnapshot('publish-conflict-reloaded'),
+            };
+          }
+        }
         return {
           ok: false,
           preview: providedPreview,
@@ -2307,25 +2496,25 @@ function getMenuSessionPorts() {
       if (mode === 'save') {
         menuState._meta = { ...(menuState._meta || {}), lastUpdatedTs: String(ts) };
         lsSet(LS_KEYS.lastUpdated, String(ts));
-        _dirty = false;
         clearDraftSaveOnlyChanges();
         clearSharedDraftState();
+        clearCurrentLocalDraft();
         updateSaveBtn();
         updateLastUpdatedLabel();
-      } else if (result.notificationStatus?.partial || (mode === 'save-and-update' && result.notificationStatus && result.notificationStatus.ok === false)) {
+      } else if (result.notificationStatus?.partial || (mode === 'save-and-send' && result.notificationStatus && result.notificationStatus.ok === false)) {
         menuState._meta = { ...(menuState._meta || {}), lastUpdatedTs: String(ts) };
         lsSet(LS_KEYS.lastUpdated, String(ts));
-        _dirty = false;
         clearDraftSaveOnlyChanges();
         clearSharedDraftState();
+        clearCurrentLocalDraft();
         updateSaveBtn();
         updateLastUpdatedLabel();
-      } else if (mode === 'save-and-update' || mode === 'update-only') {
+      } else if (mode === 'save-and-send' || mode === 'send') {
         _lastSentFeaturedIds = new Set(getCurrentFeaturedIds());
         applySentState(Array.isArray(canonicalPreview?.diff) ? canonicalPreview.diff : [], ts);
-        _dirty = false;
         clearDraftSaveOnlyChanges();
         clearSharedDraftState();
+        clearCurrentLocalDraft();
         updateSaveBtn();
         updateLastUpdatedLabel();
       }
@@ -2345,17 +2534,17 @@ function getMenuSessionPorts() {
       updateSaveBtn();
     },
     clearDraft() {
-      _dirty = false;
       clearDraftSaveOnlyChanges();
       clearSharedDraftState();
+      clearCurrentLocalDraft();
       updateSaveBtn();
     },
     commitLiveSave(ts) {
       menuState._meta = { ...(menuState._meta || {}), lastUpdatedTs: String(ts) };
       lsSet(LS_KEYS.lastUpdated, String(ts));
-      _dirty = false;
       clearDraftSaveOnlyChanges();
       clearSharedDraftState();
+      clearCurrentLocalDraft();
       updateSaveBtn();
       updateLastUpdatedLabel();
     },
@@ -2395,9 +2584,9 @@ function getMenuSessionPorts() {
     commitPublished({ diff, ts, featuredIds }) {
       _lastSentFeaturedIds = new Set(featuredIds);
       applySentState(diff, ts);
-      _dirty = false;
       clearDraftSaveOnlyChanges();
       clearSharedDraftState();
+      clearCurrentLocalDraft();
       updateSaveBtn();
       updateLastUpdatedLabel();
     },
@@ -2435,61 +2624,39 @@ function createMenuPublishService(sessionPorts, runtime = {}) {
   const buildPreview = typeof runtime.buildPreview === 'function'
     ? runtime.buildPreview
     : (() => sessionPorts.buildPreview(buildSnapshot('preview')));
+  const buildSaveDraftNoop = (preview, source = 'draft-noop') => ({
+    ok: false,
+    noop: true,
+    preview,
+    snapshot: buildSnapshot(source),
+  });
 
-  return {
+  const service = {
     async saveDraft(options = {}) {
-      void options;
       const snapshot = buildSnapshot('draft');
-      const changeCount = countDiffLines(snapshot.notifyDiff || []) + (Array.isArray(snapshot.saveOnlyChanges) ? snapshot.saveOnlyChanges.length : 0);
-      const hasClearableSharedDraft = isSharedDraftClearable({
-        hasLocalDraft: !!snapshot.dirty,
-        hasSharedDraft: !!snapshot.hasSharedDraft,
-        changeCount,
+      const preview = options.preview?.sections ? options.preview : buildPreview();
+      const hasLocalDraft = !!snapshot.dirty || !!preview?.hasLocalDraft;
+      const hasChanges = !!preview?.hasChanges;
+
+      if (!hasLocalDraft || !hasChanges) {
+        return buildSaveDraftNoop(preview);
+      }
+
+      if (typeof sessionPorts.publishMenuUpdate === 'function') {
+        return sessionPorts.publishMenuUpdate({
+          ...options,
+          preview,
+          mode: 'save',
+          notify: false,
+        });
+      }
+
+      return service.publishUpdate({
+        ...options,
+        preview,
+        mode: 'save',
+        notify: false,
       });
-      if (!snapshot.dirty) {
-        if (hasClearableSharedDraft) {
-          const ts = sessionPorts.now();
-          try {
-            await sessionPorts.patchMenuDraftState(null, ts);
-            sessionPorts.clearDraft?.();
-            return {
-              ok: true,
-              cleared: true,
-              ts,
-              snapshot: buildSnapshot('draft-cleared'),
-            };
-          } catch (error) {
-            return {
-              ok: false,
-              userHandled: false,
-              userMessage: error?.message || 'Draft clear failed.',
-              snapshot: buildSnapshot('draft-clear-failed'),
-            };
-          }
-        }
-        return {
-          ok: false,
-          noop: true,
-          snapshot: buildSnapshot('draft-noop'),
-        };
-      }
-      const ts = sessionPorts.now();
-      try {
-        await sessionPorts.patchMenuDraftState(buildPersistedDraftStateSnapshot(ts), ts);
-        sessionPorts.commitDraft(ts);
-        return {
-          ok: true,
-          ts,
-          snapshot: buildSnapshot('draft-saved'),
-        };
-      } catch (error) {
-        return {
-          ok: false,
-          userHandled: false,
-          userMessage: error?.message || 'Draft save failed.',
-          snapshot: buildSnapshot('draft-save-failed'),
-        };
-      }
     },
 
     async publishUpdate(options = {}) {
@@ -2501,9 +2668,9 @@ function createMenuPublishService(sessionPorts, runtime = {}) {
       const selectedChanges = preview.notificationChanges.filter(change => selectedChangeIds.includes(change.id));
       const selectedSections = groupNotificationChangesBySection(selectedChanges);
       const patchMessage = selectedSections.length ? buildPatchMessage(selectedSections) : '';
-      const mode = options.mode || (preview.mode === 'update-only'
-        ? (options.notify === false ? 'save' : 'update-only')
-        : (options.notify === false ? 'save' : 'save-and-update'));
+      const mode = options.mode || ((preview.mode === 'send' || preview.mode === 'update-only')
+        ? (options.notify === false ? 'save' : 'send')
+        : (options.notify === false ? 'save' : 'save-and-send'));
       if (!preview.hasChanges) {
         return {
           ok: false,
@@ -2537,7 +2704,7 @@ function createMenuPublishService(sessionPorts, runtime = {}) {
         if (!cacheSynced) warnings.push('This device could not refresh its local cache after the live save.');
       }
 
-      const shouldNotify = (mode === 'save-and-update' || mode === 'update-only') && selectedSections.length > 0;
+      const shouldNotify = (mode === 'save-and-send' || mode === 'send') && selectedSections.length > 0;
       let delivery = {
         ok: true,
         skipped: !shouldNotify,
@@ -2580,7 +2747,7 @@ function createMenuPublishService(sessionPorts, runtime = {}) {
 
       if (shouldNotify) warnings.push(...sessionPorts.collectNotificationWarnings(delivery.summary));
 
-      if (mode === 'save-and-update' || mode === 'update-only') {
+      if (mode === 'save-and-send' || mode === 'send') {
         const ts = liveSaveTs || sessionPorts.now();
         const lastSentState = sessionPorts.snapshotCurrentItemsAsLastSent();
         const currentFeaturedIds = sessionPorts.getCurrentFeaturedIds();
@@ -2648,10 +2815,12 @@ function createMenuPublishService(sessionPorts, runtime = {}) {
         warnings: finalWarnings,
         warningMessage: finalWarnings[0] || '',
         successMessage: `✅ ${sessionPorts.getMenuName() || 'Menu'} saved to the live menu.`,
-        snapshot: buildSnapshot(finalWarnings.length ? 'publish-warning' : 'publish-complete'),
+        snapshot: buildSnapshot(finalWarnings.length ? 'publish-warning' : 'saved-live'),
       };
     },
   };
+
+  return service;
 }
 
 function createMenuSessionLifecycle(ports) {
@@ -5169,11 +5338,14 @@ async function saveLiveMenuThroughApi(snapshot) {
 }
 
 function buildPublishSnapshotPayload() {
+  const draftEnvelope = buildCurrentLocalDraftEnvelope();
   return {
     ...buildMenuCacheSnapshot(),
     preview_context: {
       dirty: !!_dirty,
-      has_shared_draft: hasSharedDraftState(),
+      has_shared_draft: false,
+      base_live_revision: draftEnvelope?.baseLiveRevision ?? null,
+      base_last_sent_revision: draftEnvelope?.baseLastSentRevision ?? null,
       save_only_changes: getDraftSaveOnlyChanges(),
     },
   };
@@ -5181,12 +5353,14 @@ function buildPublishSnapshotPayload() {
 
 async function requestPublishPreviewThroughApi() {
   if (!MENU_ID || !getAuthorizedApiHeaders().Authorization) return { ok: false, fallbackable: false };
+  const draftEnvelope = buildCurrentLocalDraftEnvelope();
   return postApiJson('/api/manager', {
     action: 'preview_publish',
     menu_id: MENU_ID,
     snapshot: buildPublishSnapshotPayload(),
     expected_live_revision: menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null,
-    expected_draft_revision: getDraftSavedTs() || null,
+    expected_draft_revision: draftEnvelope?.baseLastSentRevision ?? null,
+    expected_notification_revision: draftEnvelope?.baseLastSentRevision ?? null,
   }, {
     headers: getAuthorizedApiHeaders(),
   });
@@ -5194,6 +5368,7 @@ async function requestPublishPreviewThroughApi() {
 
 async function publishMenuThroughApi({ mode, selectedChangeIds = [] }) {
   if (!MENU_ID || !getAuthorizedApiHeaders().Authorization) return { ok: false, fallbackable: true };
+  const draftEnvelope = buildCurrentLocalDraftEnvelope();
   return postApiJson('/api/manager', {
     action: 'publish',
     menu_id: MENU_ID,
@@ -5202,7 +5377,8 @@ async function publishMenuThroughApi({ mode, selectedChangeIds = [] }) {
     snapshot: buildPublishSnapshotPayload(),
     selected_change_ids: Array.isArray(selectedChangeIds) ? selectedChangeIds : [],
     expected_live_revision: menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null,
-    expected_draft_revision: getDraftSavedTs() || null,
+    expected_draft_revision: draftEnvelope?.baseLastSentRevision ?? null,
+    expected_notification_revision: draftEnvelope?.baseLastSentRevision ?? null,
   }, {
     headers: getAuthorizedApiHeaders(),
   });
@@ -5336,12 +5512,12 @@ function hydrateState({ cats, meta, restaurant }) {
     if (meta.last_sent_featured) _lastSentFeaturedIds = new Set(meta.last_sent_featured);
   }
   clearSharedDraftState();
+  setServerLiveSnapshot(buildMenuCacheSnapshot());
 }
 
 function applyPersistedDraftState(draftState = {}) {
   const cats = Array.isArray(draftState?.cats) ? draftState.cats : [];
   if (!cats.length) {
-    clearSharedDraftState();
     return false;
   }
 
@@ -5385,11 +5561,15 @@ function applyPersistedDraftState(draftState = {}) {
   }
 
   menuState._meta = liveMeta;
-  _draftSaveOnlyChanges = new Map((Array.isArray(draftState?.saveOnlyChanges) ? draftState.saveOnlyChanges : [])
+  const saveOnlyChanges = Array.isArray(draftState?.saveOnlyChanges)
+    ? draftState.saveOnlyChanges
+    : (Array.isArray(draftState?.save_only_changes) ? draftState.save_only_changes : []);
+  _draftSaveOnlyChanges = new Map(saveOnlyChanges
     .filter(change => change?.key)
     .map(change => [change.key, change]));
-  setSharedDraftState(draftState.savedAt || draftState.saved_at || '');
-  _dirty = false;
+  if (Array.isArray(draftState?.featured_groups)) {
+    _featuredGroups = normalizeWorkspaceFeaturedGroups(draftState.featured_groups);
+  }
   return true;
 }
 
@@ -5626,6 +5806,7 @@ function withMenuStateLoaderDefaults(deps = {}) {
       : (() => {
           clearDraftSaveOnlyChanges();
           clearSharedDraftState();
+          clearCurrentLocalDraft({ clearStorage: false });
         }),
     writeMenuCache: typeof deps.writeMenuCache === 'function'
       ? deps.writeMenuCache
@@ -5648,6 +5829,21 @@ function withMenuStateLoaderDefaults(deps = {}) {
     getFeaturedSnapshot: typeof deps.getFeaturedSnapshot === 'function'
       ? deps.getFeaturedSnapshot
       : (() => getFeaturedSnapshot()),
+    isDirty: typeof deps.isDirty === 'function'
+      ? deps.isDirty
+      : (() => !!_dirty),
+    readStoredLocalDraftEnvelope: typeof deps.readStoredLocalDraftEnvelope === 'function'
+      ? deps.readStoredLocalDraftEnvelope
+      : (() => readStoredLocalDraftEnvelope()),
+    buildCurrentLocalDraftEnvelope: typeof deps.buildCurrentLocalDraftEnvelope === 'function'
+      ? deps.buildCurrentLocalDraftEnvelope
+      : (() => buildCurrentLocalDraftEnvelope()),
+    applyLocalDraftEnvelope: typeof deps.applyLocalDraftEnvelope === 'function'
+      ? deps.applyLocalDraftEnvelope
+      : ((envelope, options = {}) => applyLocalDraftEnvelope(envelope, options)),
+    clearCurrentLocalDraft: typeof deps.clearCurrentLocalDraft === 'function'
+      ? deps.clearCurrentLocalDraft
+      : ((options = {}) => clearCurrentLocalDraft(options)),
   };
 }
 
@@ -5680,6 +5876,11 @@ function createMenuStateLoaderService(deps = {}) {
   const getCategorySnapshot = resolvedDeps.getCategorySnapshot;
   const getDesignSnapshotValue = resolvedDeps.getDesignSnapshot;
   const getFeaturedSnapshotValue = resolvedDeps.getFeaturedSnapshot;
+  const readStoredLocalDraft = resolvedDeps.readStoredLocalDraftEnvelope;
+  const buildCurrentDraftEnvelope = resolvedDeps.buildCurrentLocalDraftEnvelope;
+  const applyLocalDraft = resolvedDeps.applyLocalDraftEnvelope;
+  const clearCurrentDraft = resolvedDeps.clearCurrentLocalDraft;
+  const isDraftDirty = resolvedDeps.isDirty;
 
   return {
     async load(options = {}) {
@@ -5695,20 +5896,18 @@ function createMenuStateLoaderService(deps = {}) {
         if (data) {
           hydrateFromState(data);
           const usedWorkspaceRestaurantTools = applyWorkspaceRestaurantTools(data);
-          const workspaceSharedDraft = data?.workspace?.sharedDraft && typeof data.workspace.sharedDraft === 'object'
-            ? data.workspace.sharedDraft
-            : null;
-          const loadedDraft = includePersistedDraft ? applyDraftState(data.meta?.draft_state || null) : false;
-          setDirty(false);
-          if (includePersistedDraft && workspaceSharedDraft?.exists) {
-            const sharedDraftSavedAt = workspaceSharedDraft.savedAt || workspaceSharedDraft.saved_at || data.meta?.draft_saved_ts || '';
-            if (sharedDraftSavedAt) {
-              setSharedDraftState({
-                ...workspaceSharedDraft,
-                savedAt: sharedDraftSavedAt,
-              });
-            }
-          } else if (!loadedDraft) {
+          const localDraftEnvelope = includePersistedDraft ? readStoredLocalDraft() : null;
+          const loadedDraft = includePersistedDraft
+            ? (localDraftEnvelope
+                ? !!applyLocalDraft(localDraftEnvelope, { markDirty: true })
+                : !!applyDraftState(null))
+            : false;
+          if (loadedDraft) {
+            setLocalDraftBaseSnapshot(localDraftEnvelope?.baseSnapshot || getServerLiveSnapshot());
+            setDirty(true);
+          } else {
+            clearCurrentDraft({ clearStorage: false });
+            setDirty(false);
             clearDraftChanges();
           }
           if (persistCache) writeMenuCache(data);
@@ -5750,13 +5949,15 @@ function createMenuStateLoaderService(deps = {}) {
         };
       }
 
+      const activeDraftEnvelope = isDraftDirty() ? buildCurrentDraftEnvelope() : readStoredLocalDraft();
       hydrateFromState(data);
       const usedWorkspaceRestaurantTools = applyWorkspaceRestaurantTools(data);
-      const workspaceSharedDraft = data?.workspace?.sharedDraft && typeof data.workspace.sharedDraft === 'object'
-        ? data.workspace.sharedDraft
-        : null;
-      if (workspaceSharedDraft?.exists) {
-        setSharedDraftState(workspaceSharedDraft);
+      if (activeDraftEnvelope?.draftSnapshot) {
+        applyLocalDraft(activeDraftEnvelope, { markDirty: true });
+      } else {
+        clearCurrentDraft({ clearStorage: false });
+        setDirty(false);
+        clearDraftChanges();
       }
       writeMenuCache(data);
       const newTs = getLastUpdatedTs();
@@ -5889,11 +6090,354 @@ function buildMenuCacheSnapshot() {
 }
 
 function buildPersistedDraftStateSnapshot(savedAt = Date.now()) {
+  const snapshot = buildMenuCacheSnapshot();
   return {
-    version: 1,
+    ...snapshot,
     savedAt,
-    cats: buildMenuCacheSnapshot().cats,
     saveOnlyChanges: getDraftSaveOnlyChanges(),
+  };
+}
+
+function normalizeDraftDocumentSnapshot(snapshot = {}) {
+  const normalized = snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot)
+    ? cloneJsonCompatible(snapshot, {})
+    : {};
+  return {
+    context: normalized.context && typeof normalized.context === 'object' ? normalized.context : null,
+    cats: Array.isArray(normalized.cats) ? normalized.cats : [],
+    meta: normalized.meta && typeof normalized.meta === 'object' ? normalized.meta : {},
+    restaurant: normalized.restaurant && typeof normalized.restaurant === 'object' ? normalized.restaurant : null,
+    featured_groups: Array.isArray(normalized.featured_groups) ? normalized.featured_groups : [],
+    save_only_changes: Array.isArray(normalized.save_only_changes)
+      ? normalized.save_only_changes
+      : (Array.isArray(normalized.saveOnlyChanges) ? normalized.saveOnlyChanges : []),
+  };
+}
+
+function stripDraftDocumentForComparison(snapshot = {}) {
+  const normalized = normalizeDraftDocumentSnapshot(snapshot);
+  return {
+    cats: normalized.cats,
+    featured_groups: normalized.featured_groups,
+    save_only_changes: normalized.save_only_changes,
+  };
+}
+
+function areDraftDocumentsEqual(left, right) {
+  return JSON.stringify(stripDraftDocumentForComparison(left)) === JSON.stringify(stripDraftDocumentForComparison(right));
+}
+
+function buildSnapshotItemStateMap(snapshot = {}) {
+  const map = new Map();
+  normalizeDraftDocumentSnapshot(snapshot).cats.forEach(category => {
+    const categoryKey = String(category?.key || '').trim();
+    (Array.isArray(category?.items) ? category.items : []).forEach(item => {
+      const itemId = String(item?.id || '').trim();
+      if (!itemId) return;
+      map.set(itemId, {
+        item: cloneJsonCompatible(item, {}),
+        categoryKey,
+      });
+    });
+  });
+  return map;
+}
+
+function buildSnapshotCategoryStateMap(snapshot = {}) {
+  const map = new Map();
+  normalizeDraftDocumentSnapshot(snapshot).cats.forEach(category => {
+    const key = String(category?.key || '').trim();
+    if (!key || key === UNCATEGORIZED_ID) return;
+    const nextCategory = cloneJsonCompatible(category, {});
+    nextCategory.items = [];
+    map.set(key, nextCategory);
+  });
+  return map;
+}
+
+function buildSnapshotDelta(baseSnapshot = null, updatedSnapshot = null) {
+  const baseItems = buildSnapshotItemStateMap(baseSnapshot);
+  const updatedItems = buildSnapshotItemStateMap(updatedSnapshot);
+  const baseCategories = buildSnapshotCategoryStateMap(baseSnapshot);
+  const updatedCategories = buildSnapshotCategoryStateMap(updatedSnapshot);
+  const itemIds = new Set([...baseItems.keys(), ...updatedItems.keys()]);
+  const categoryKeys = new Set([...baseCategories.keys(), ...updatedCategories.keys()]);
+  const itemChanges = new Map();
+  const categoryChanges = new Map();
+
+  itemIds.forEach(itemId => {
+    const baseState = baseItems.get(itemId) || null;
+    const updatedState = updatedItems.get(itemId) || null;
+    if (JSON.stringify(baseState) === JSON.stringify(updatedState)) return;
+    const relatedCategoryKeys = new Set();
+    if (baseState?.categoryKey) relatedCategoryKeys.add(baseState.categoryKey);
+    if (updatedState?.categoryKey) relatedCategoryKeys.add(updatedState.categoryKey);
+    itemChanges.set(itemId, {
+      state: updatedState,
+      relatedCategoryKeys,
+    });
+  });
+
+  categoryKeys.forEach(key => {
+    const baseCategory = baseCategories.get(key) || null;
+    const updatedCategory = updatedCategories.get(key) || null;
+    if (JSON.stringify(baseCategory) === JSON.stringify(updatedCategory)) return;
+    categoryChanges.set(key, updatedCategory);
+  });
+
+  const baseFeatured = normalizeDraftDocumentSnapshot(baseSnapshot).featured_groups;
+  const updatedFeatured = normalizeDraftDocumentSnapshot(updatedSnapshot).featured_groups;
+  return {
+    itemChanges,
+    categoryChanges,
+    featuredGroupsChanged: JSON.stringify(baseFeatured) !== JSON.stringify(updatedFeatured),
+  };
+}
+
+function buildLocalDraftOverlapSummary(baseSnapshot = null, localSnapshot = null, remoteSnapshot = null) {
+  if (!localSnapshot) return { labels: [], usedFallback: false };
+  if (!baseSnapshot) return { labels: [], usedFallback: true };
+
+  const localDelta = buildSnapshotDelta(baseSnapshot, localSnapshot);
+  const remoteDelta = buildSnapshotDelta(baseSnapshot, remoteSnapshot);
+  const localDocument = normalizeDraftDocumentSnapshot(localSnapshot);
+  const remoteDocument = normalizeDraftDocumentSnapshot(remoteSnapshot);
+  const baseDocument = normalizeDraftDocumentSnapshot(baseSnapshot);
+  const labels = new Set();
+
+  [...localDelta.itemChanges.keys()].filter(itemId => remoteDelta.itemChanges.has(itemId)).forEach(itemId => {
+    const itemName = localDocument.cats.flatMap(category => category.items || []).find(item => item.id === itemId)?.name
+      || remoteDocument.cats.flatMap(category => category.items || []).find(item => item.id === itemId)?.name
+      || baseDocument.cats.flatMap(category => category.items || []).find(item => item.id === itemId)?.name
+      || itemId;
+    labels.add(itemName);
+  });
+
+  [...localDelta.categoryChanges.keys()].filter(key => remoteDelta.categoryChanges.has(key)).forEach(key => {
+    const categoryLabel = (localDelta.categoryChanges.get(key)?.label || '')
+      || (remoteDelta.categoryChanges.get(key)?.label || '')
+      || (baseDocument.cats.find(category => category.key === key)?.label || key);
+    labels.add(`Category: ${categoryLabel}`);
+  });
+
+  if (localDelta.featuredGroupsChanged && remoteDelta.featuredGroupsChanged) {
+    labels.add('Featured items');
+  }
+
+  return {
+    labels: Array.from(labels).sort(),
+    usedFallback: false,
+  };
+}
+
+function sortDraftDocumentInPlace(snapshot = {}) {
+  snapshot.cats = (Array.isArray(snapshot.cats) ? snapshot.cats : []).sort((left, right) => (
+    Number(left?.display_order || 0) - Number(right?.display_order || 0)
+  ));
+  snapshot.cats.forEach(category => {
+    category.items = (Array.isArray(category.items) ? category.items : []).sort((left, right) => (
+      Number(left?.display_order || 0) - Number(right?.display_order || 0)
+    ));
+  });
+  snapshot.featured_groups = (Array.isArray(snapshot.featured_groups) ? snapshot.featured_groups : []).sort((left, right) => (
+    Number(left?.display_order || 0) - Number(right?.display_order || 0)
+  ));
+  return snapshot;
+}
+
+function applyCategoryChangeToDraftDocument(snapshot = {}, key = '', categoryState = null) {
+  if (!key || key === UNCATEGORIZED_ID) return snapshot;
+  const existingCategory = (Array.isArray(snapshot.cats) ? snapshot.cats : []).find(category => category.key === key) || null;
+  snapshot.cats = (Array.isArray(snapshot.cats) ? snapshot.cats : []).filter(category => category.key !== key);
+  if (!categoryState) return snapshot;
+  snapshot.cats.push({
+    ...cloneJsonCompatible(categoryState, {}),
+    items: Array.isArray(existingCategory?.items) ? existingCategory.items : [],
+  });
+  return snapshot;
+}
+
+function applyItemChangeToDraftDocument(snapshot = {}, itemId = '', change = {}) {
+  if (!itemId) return snapshot;
+  snapshot.cats = (Array.isArray(snapshot.cats) ? snapshot.cats : []).map(category => ({
+    ...category,
+    items: (Array.isArray(category.items) ? category.items : []).filter(item => item.id !== itemId),
+  }));
+  if (!change?.state) return snapshot;
+
+  const nextCategoryKey = change.state.categoryKey;
+  const nextCategory = snapshot.cats.find(category => category.key === nextCategoryKey);
+  if (!nextCategory) return snapshot;
+  nextCategory.items.push(cloneJsonCompatible(change.state.item, {}));
+  return snapshot;
+}
+
+function mergeLocalDraftSnapshots({
+  baseSnapshot = null,
+  localSnapshot = null,
+  remoteSnapshot = null,
+  strategy = 'keep-local',
+} = {}) {
+  const baseDocument = normalizeDraftDocumentSnapshot(baseSnapshot);
+  const localDocument = normalizeDraftDocumentSnapshot(localSnapshot);
+  const remoteDocument = normalizeDraftDocumentSnapshot(remoteSnapshot);
+  const localDelta = buildSnapshotDelta(baseDocument, localDocument);
+  const remoteDelta = buildSnapshotDelta(baseDocument, remoteDocument);
+  const merged = normalizeDraftDocumentSnapshot(remoteDocument);
+  const remoteItemIds = new Set(remoteDelta.itemChanges.keys());
+  const remoteCategoryKeys = new Set(remoteDelta.categoryChanges.keys());
+
+  Array.from(localDelta.categoryChanges.entries())
+    .sort((left, right) => (
+      Number(left[1]?.display_order || Number.MAX_SAFE_INTEGER) - Number(right[1]?.display_order || Number.MAX_SAFE_INTEGER)
+    ))
+    .forEach(([key, categoryState]) => {
+      if (strategy === 'update-local' && remoteCategoryKeys.has(key)) return;
+      applyCategoryChangeToDraftDocument(merged, key, categoryState);
+    });
+
+  Array.from(localDelta.itemChanges.entries())
+    .sort(([leftId], [rightId]) => leftId.localeCompare(rightId))
+    .forEach(([itemId, change]) => {
+      const hasRemoteItemConflict = remoteItemIds.has(itemId);
+      const hasRemoteCategoryConflict = Array.from(change.relatedCategoryKeys || []).some(key => remoteCategoryKeys.has(key));
+      if (strategy === 'update-local' && (hasRemoteItemConflict || hasRemoteCategoryConflict)) return;
+      applyItemChangeToDraftDocument(merged, itemId, change);
+    });
+
+  if (localDelta.featuredGroupsChanged && !(strategy === 'update-local' && remoteDelta.featuredGroupsChanged)) {
+    merged.featured_groups = cloneJsonCompatible(localDocument.featured_groups, []);
+  }
+
+  merged.context = remoteDocument.context;
+  merged.meta = remoteDocument.meta;
+  merged.restaurant = remoteDocument.restaurant;
+  merged.save_only_changes = cloneJsonCompatible(localDocument.save_only_changes, []);
+  return sortDraftDocumentInPlace(merged);
+}
+
+function buildCurrentLocalDraftEnvelope(savedAt = Date.now()) {
+  const userId = String(currentUser?.uid || '').trim();
+  const menuId = String(MENU_ID || '').trim();
+  if (!userId || !menuId) return null;
+  const baseSnapshot = getLocalDraftBaseSnapshot() || getServerLiveSnapshot() || buildPersistedDraftStateSnapshot(savedAt);
+  return normalizeLocalDraftEnvelope({
+    version: 2,
+    userId,
+    menuId,
+    clientId: getMenuDraftClientId(),
+    savedAt,
+    baseLiveRevision: baseSnapshot?.meta?.last_updated_ts ?? menuState._meta?.lastUpdatedTs ?? null,
+    baseLastSentRevision: baseSnapshot?.meta?.last_sent_ts ?? menuState._meta?.lastSentTs ?? null,
+    baseSnapshot,
+    draftSnapshot: buildPersistedDraftStateSnapshot(savedAt),
+  });
+}
+
+function hasActualLocalDraftChanges() {
+  const baseSnapshot = getLocalDraftBaseSnapshot();
+  if (!baseSnapshot) return !!_dirty;
+  return !areDraftDocumentsEqual(baseSnapshot, buildPersistedDraftStateSnapshot());
+}
+
+function syncLocalDraftDirtyState() {
+  _dirty = hasActualLocalDraftChanges();
+  return _dirty;
+}
+
+function applyLocalDraftEnvelope(envelope = null, options = {}) {
+  const normalized = normalizeLocalDraftEnvelope(envelope);
+  if (!normalized?.draftSnapshot) return false;
+  const applied = applyPersistedDraftState(normalized.draftSnapshot);
+  if (!applied) return false;
+  setLocalDraftBaseSnapshot(normalized.baseSnapshot || getServerLiveSnapshot());
+  _dirty = options.markDirty !== false;
+  return true;
+}
+
+function persistCurrentLocalDraft(options = {}) {
+  if (!isMenuWorkspacePage()) return null;
+  clearLocalDraftPersistTimer();
+  syncLocalDraftDirtyState();
+  if (!_dirty) {
+    clearStoredLocalDraftEnvelope();
+    clearLocalDraftBaseSnapshot();
+    return null;
+  }
+  if (!_localDraftBaseSnapshot) {
+    setLocalDraftBaseSnapshot(getServerLiveSnapshot() || buildPersistedDraftStateSnapshot());
+  }
+  return writeStoredLocalDraftEnvelope(buildCurrentLocalDraftEnvelope(options.savedAt || Date.now()));
+}
+
+function scheduleCurrentLocalDraftPersistence(options = {}) {
+  if (!isMenuWorkspacePage()) return null;
+  if (options.immediate) return persistCurrentLocalDraft(options);
+  clearLocalDraftPersistTimer();
+  _localDraftPersistTimer = setTimeout(() => {
+    _localDraftPersistTimer = null;
+    persistCurrentLocalDraft();
+  }, 250);
+  return null;
+}
+
+function clearCurrentLocalDraft(options = {}) {
+  clearLocalDraftPersistTimer();
+  if (options.clearStorage !== false) clearStoredLocalDraftEnvelope();
+  clearLocalDraftBaseSnapshot();
+  if (options.resetDirty !== false) _dirty = false;
+}
+
+async function reloadLatestWorkspaceIntoLocalDraft() {
+  const currentEnvelope = buildCurrentLocalDraftEnvelope();
+  if (!currentEnvelope?.draftSnapshot) return { ok: false, reloaded: false };
+
+  const workspace = await readMenuWorkspaceThroughApi({ menuId: MENU_ID, includeRestaurantTools: true });
+  if (!workspace) return { ok: false, reloaded: false };
+
+  hydrateState(workspace);
+  applyWorkspaceRestaurantTools(workspace);
+  const remoteSnapshot = getServerLiveSnapshot() || buildPersistedDraftStateSnapshot();
+  const overlap = buildLocalDraftOverlapSummary(currentEnvelope.baseSnapshot, currentEnvelope.draftSnapshot, remoteSnapshot);
+  let strategy = 'keep-local';
+  let requiresReview = false;
+
+  if (overlap.labels.length) {
+    requiresReview = true;
+    const keepLocal = confirm([
+      'Another client updated this menu while you were drafting.',
+      '',
+      `Overlapping changes: ${overlap.labels.join(', ')}`,
+      '',
+      'Press OK to keep your local versions for those overlaps, or Cancel to adopt the latest live versions for them before reviewing again.'
+    ].join('\n'));
+    strategy = keepLocal ? 'keep-local' : 'update-local';
+  }
+
+  const mergedDraftSnapshot = mergeLocalDraftSnapshots({
+    baseSnapshot: currentEnvelope.baseSnapshot,
+    localSnapshot: currentEnvelope.draftSnapshot,
+    remoteSnapshot,
+    strategy,
+  });
+  const nextEnvelope = {
+    ...currentEnvelope,
+    baseSnapshot: remoteSnapshot,
+    baseLiveRevision: remoteSnapshot?.meta?.last_updated_ts ?? null,
+    baseLastSentRevision: remoteSnapshot?.meta?.last_sent_ts ?? null,
+    draftSnapshot: mergedDraftSnapshot,
+    savedAt: Date.now(),
+  };
+  applyLocalDraftEnvelope(nextEnvelope, { markDirty: true });
+  writeStoredLocalDraftEnvelope(nextEnvelope);
+  renderManagerWorkspace({ includeRecentChanges: false });
+  updateDraftIndicator();
+
+  return {
+    ok: true,
+    reloaded: true,
+    requiresReview,
+    overlapLabels: overlap.labels,
   };
 }
 
@@ -6141,15 +6685,8 @@ function renderManagerOverviewStats() {
     total + (menuState[cat.id]?.items || []).filter(item => item.onMenu !== false && item.eightySixed).length
   ), 0);
   const draftCount = getDraftChangeCount();
-  const hasLocalDraft = !!_dirty;
-  const hasSharedDraft = hasSharedDraftState();
-  const hasClearableSharedDraft = isSharedDraftClearable({
-    hasLocalDraft,
-    hasSharedDraft,
-    changeCount: draftCount,
-  });
-  const sharedDraftInfo = getSharedDraftInfo();
-  const notifyCount = !hasSharedDraft && !hasLocalDraft ? countDiffLines() : 0;
+  const hasLocalDraft = syncLocalDraftDirtyState();
+  const notifyCount = !hasLocalDraft ? countDiffLines() : 0;
   const statusValue = document.getElementById('manager-overview-status-value');
   const statusMeta = document.getElementById('manager-overview-status-meta');
   const activeValue = document.getElementById('manager-overview-active-value');
@@ -6157,19 +6694,10 @@ function renderManagerOverviewStats() {
   const eightysixValue = document.getElementById('manager-overview-86-value');
   const eightysixMeta = document.getElementById('manager-overview-86-meta');
 
-  if (statusValue) statusValue.textContent = hasLocalDraft ? 'Drafting' : (hasSharedDraft ? 'Drafted' : (notifyCount > 0 ? 'Live | Unsent' : 'Live'));
+  if (statusValue) statusValue.textContent = hasLocalDraft ? 'Drafting' : (notifyCount > 0 ? 'Live | Unsent' : 'Live');
   if (statusMeta) {
     if (hasLocalDraft) {
-      statusMeta.textContent = hasSharedDraft
-        ? `${draftCount} pending change${draftCount === 1 ? '' : 's'} on top of the saved draft`
-        : `${draftCount} pending change${draftCount === 1 ? '' : 's'}`;
-    } else if (hasSharedDraft) {
-      const sourceLabel = formatHistorySourceLabel(sharedDraftInfo.source);
-      const actorLabel = sharedDraftInfo.savedBy?.name ? ` by ${sharedDraftInfo.savedBy.name}` : '';
-      const sourceSuffix = sourceLabel ? ` via ${sourceLabel}` : '';
-      statusMeta.textContent = hasClearableSharedDraft
-        ? `Saved draft matches the live menu${actorLabel}${sourceSuffix}. Clear Draft removes it.`
-        : `${draftCount} saved draft change${draftCount === 1 ? '' : 's'} ready to publish${actorLabel}${sourceSuffix}`;
+      statusMeta.textContent = `${draftCount} pending change${draftCount === 1 ? '' : 's'} on this device.`;
     } else if (notifyCount > 0) {
       statusMeta.textContent = `${notifyCount} update line${notifyCount === 1 ? '' : 's'} ready to send`;
     } else {
@@ -6184,7 +6712,6 @@ function renderManagerOverviewStats() {
 
 function createDraftLedgerService(deps = {}) {
   const isDirty = typeof deps.isDirty === 'function' ? deps.isDirty : (() => !!_dirty);
-  const hasSharedDraft = typeof deps.hasSharedDraft === 'function' ? deps.hasSharedDraft : (() => hasSharedDraftState());
   const getDraftCount = typeof deps.getDraftChangeCount === 'function' ? deps.getDraftChangeCount : (() => getDraftChangeCount());
   const getDiffLineCount = typeof deps.getDiffLinesCount === 'function' ? deps.getDiffLinesCount : (() => countDiffLines());
   const getDiffSections = typeof deps.getDiffSections === 'function' ? deps.getDiffSections : (() => getCachedDiff());
@@ -6207,43 +6734,72 @@ function createDraftLedgerService(deps = {}) {
   return {
     buildLookup,
     getActionBarState({ isCompactViewport = false } = {}) {
-      const hasDraftChanges = isDirty();
-      const hasShared = hasSharedDraft();
-      const changeCount = getDraftCount();
-      const hasClearableSharedDraft = isSharedDraftClearable({
-        hasLocalDraft: hasDraftChanges,
-        hasSharedDraft: hasShared,
-        changeCount,
-      });
-      const hasDraftWork = hasDraftChanges || hasShared;
-      const hasPublishableDraftWork = hasDraftChanges || (hasShared && !hasClearableSharedDraft);
-      const hasPendingUpdate = !hasDraftChanges && !hasShared && getDiffLineCount() > 0;
-      const notifyCount = hasPendingUpdate ? getDiffLineCount() : 0;
-
-      let summaryText = 'No Pending Changes';
-      if (hasDraftChanges) {
-        summaryText = isCompactViewport
-          ? `${changeCount} pending change${changeCount === 1 ? '' : 's'}. Save Draft updates the shared draft; Save publishes live.`
-          : `${changeCount} pending change${changeCount === 1 ? '' : 's'}. Save Draft updates the shared draft. Save opens Patch Notes Preview to publish live.`;
-      } else if (hasClearableSharedDraft) {
-        summaryText = 'Saved draft matches the live menu. Clear Draft removes it.';
-      } else if (hasShared) {
-        summaryText = `${changeCount} saved draft change${changeCount === 1 ? ' is' : 's are'} ready to publish.`;
-      } else if (hasPendingUpdate) {
-        summaryText = `${notifyCount} update line${notifyCount === 1 ? ' is' : 's are'} live and ready to send.`;
-      }
-
+      const draftCount = getDraftCount();
+      const notificationCount = getDiffLineCount();
+      const saveOnlyCount = getSaveOnlyChanges().length;
+      const hasLocalDraft = !!isDirty();
+      const hasNotificationChanges = notificationCount > 0;
+      const hasSaveOnlyChanges = saveOnlyCount > 0;
+      const hasChanges = hasNotificationChanges || hasSaveOnlyChanges;
+      const actionState = hasLocalDraft
+        ? {
+            hasLocalDraft,
+            hasPendingServerQueue: false,
+            hasNotificationChanges,
+            hasSaveOnlyChanges,
+            hasChanges,
+            summaryText: hasNotificationChanges
+              ? (isCompactViewport
+                  ? `${draftCount} pending change${draftCount === 1 ? '' : 's'}. Save quietly or review the send queue.`
+                  : `${draftCount} pending change${draftCount === 1 ? '' : 's'}. Save Quietly writes live without sending. Save & Send reviews the queue before notifying.`)
+              : `${saveOnlyCount || draftCount} quiet change${(saveOnlyCount || draftCount) === 1 ? '' : 's'} ready to save.`,
+            saveLabel: hasNotificationChanges ? 'Save Quietly' : 'Save',
+            saveDisabled: !hasChanges,
+            publishLabel: 'Save & Send',
+            publishDisabled: !hasNotificationChanges,
+            showDiscard: true,
+          }
+        : (hasNotificationChanges
+            ? {
+                hasLocalDraft,
+                hasPendingServerQueue: true,
+                hasNotificationChanges,
+                hasSaveOnlyChanges,
+                hasChanges,
+                summaryText: `${notificationCount} update line${notificationCount === 1 ? ' is' : 's are'} live and ready to send.`,
+                saveLabel: '',
+                saveDisabled: true,
+                publishLabel: 'Send',
+                publishDisabled: false,
+                showDiscard: false,
+              }
+            : {
+                hasLocalDraft,
+                hasPendingServerQueue: false,
+                hasNotificationChanges,
+                hasSaveOnlyChanges,
+                hasChanges,
+                summaryText: 'No pending changes',
+                saveLabel: 'Save',
+                saveDisabled: true,
+                publishLabel: 'Send',
+                publishDisabled: true,
+                showDiscard: false,
+              });
       return {
-        hasDraftChanges,
-        hasSharedDraft: hasShared,
-        hasClearableSharedDraft,
-        hasDraftWork,
-        hasPublishableDraftWork,
-        hasPendingUpdate,
-        changeCount,
-        summaryText,
-        saveLabel: hasClearableSharedDraft ? 'Clear Draft' : 'Save Draft',
-        publishLabel: !hasPublishableDraftWork && hasPendingUpdate ? 'Update' : 'Save',
+        hasDraftChanges: actionState.hasLocalDraft,
+        hasSharedDraft: false,
+        hasClearableSharedDraft: false,
+        hasDraftWork: actionState.hasLocalDraft,
+        hasPublishableDraftWork: actionState.hasLocalDraft && actionState.hasNotificationChanges,
+        hasPendingUpdate: actionState.hasPendingServerQueue,
+        changeCount: getDraftCount(),
+        summaryText: actionState.summaryText,
+        saveLabel: actionState.saveLabel,
+        publishLabel: actionState.publishLabel,
+        showDiscard: actionState.showDiscard,
+        saveDisabled: actionState.saveDisabled,
+        publishDisabled: actionState.publishDisabled,
       };
     },
     getItemBadge({ item, catId, lastSentNames = null }) {
@@ -6251,16 +6807,15 @@ function createDraftLedgerService(deps = {}) {
       const nameKey = String(item?.name || '').trim().toLowerCase();
       const changeLookup = buildLookup();
       const sectionNames = changeLookup.byCategoryName.get(catId) || new Set();
-      const hasDraftWork = isDirty() || hasSharedDraft();
-      const hasDraftTag = hasDraftWork && (changeLookup.byItemId.has(item?.id) || sectionNames.has(nameKey));
-      const hasUnsentTag = !hasDraftWork && sectionNames.has(nameKey);
+      const hasDraftTag = isDirty() && (changeLookup.byItemId.has(item?.id) || sectionNames.has(nameKey));
+      const hasUnsentTag = sectionNames.has(nameKey);
       const isNew = lastSentNames ? !lastSentNames.has(nameKey) : false;
 
-      if (hasUnsentTag) {
-        return { className: 'item-state-badge--unsent', text: 'UNSENT', label: 'Unsent update' };
-      }
       if (hasDraftTag) {
         return { className: 'item-state-badge--draft', text: 'DRAFT', label: 'Draft change' };
+      }
+      if (hasUnsentTag) {
+        return { className: 'item-state-badge--unsent', text: 'UNSENT', label: 'Unsent update' };
       }
       if (is86) {
         return { className: 'item-state-badge--86', text: '86', label: "86'd" };
@@ -6295,21 +6850,25 @@ function updateManagerActionBar() {
   const ledgerState = createDraftLedgerService().getActionBarState({ isCompactViewport });
   const saveBtn = document.getElementById('save-btn');
   const publishBtn = document.getElementById('send-btn');
+  const discardBtn = document.getElementById('discard-draft-btn');
 
   if (primaryGroup) primaryGroup.hidden = false;
   if (saveBtn) {
-    saveBtn.disabled = !ledgerState.hasDraftChanges && !ledgerState.hasClearableSharedDraft;
-    saveBtn.textContent = ledgerState.saveLabel;
-    saveBtn.title = ledgerState.hasClearableSharedDraft
-      ? 'Remove the saved draft because it already matches the live menu'
-      : 'Save changes without notifying anyone';
+    saveBtn.disabled = !!ledgerState.saveDisabled;
+    saveBtn.textContent = ledgerState.saveLabel || 'Save';
+    saveBtn.hidden = !ledgerState.saveLabel;
+    saveBtn.title = ledgerState.hasDraftChanges ? 'Save the live menu without notifying anyone yet' : '';
   }
   if (publishBtn) {
-    publishBtn.disabled = !ledgerState.hasPublishableDraftWork && !ledgerState.hasPendingUpdate;
+    publishBtn.disabled = !!ledgerState.publishDisabled;
     publishBtn.textContent = ledgerState.publishLabel;
   }
+  if (discardBtn) {
+    discardBtn.hidden = !ledgerState.showDiscard;
+    discardBtn.disabled = !ledgerState.showDiscard;
+  }
   bar.hidden = false;
-  bar.classList.toggle('is-idle', !ledgerState.hasPublishableDraftWork && !ledgerState.hasPendingUpdate && !ledgerState.hasClearableSharedDraft);
+  bar.classList.toggle('is-idle', ledgerState.saveDisabled && ledgerState.publishDisabled && !ledgerState.showDiscard);
   syncManagerActionBarStatus(syncEl);
 
   if (summary) summary.textContent = ledgerState.summaryText;
@@ -6647,9 +7206,17 @@ async function saveCategoryEdit(catId) {
   const ph    = document.getElementById('ce-ph-'    + catId)?.value.trim() || '';
   cat.icon = icon; cat.title = title; cat.sub = sub; cat.placeholder = ph;
   toggleCategoryEdit(catId);
-  await persistState();
+  markSaveOnlyDraftChange({
+    key: `category:${catId}:copy`,
+    label: `Updated category details for ${title}`,
+    message: `Updated category details for ${title}`,
+    sectionId: catId,
+    kind: 'category-copy',
+  });
+  invalidateDiff();
+  updateDraftIndicator();
   refreshAllViews();
-  showToast('✅ Category updated!', 'success');
+  showToast('✅ Category draft updated.', 'success');
 }
 
 async function moveCategoryUp(catId) {
@@ -6657,7 +7224,15 @@ async function moveCategoryUp(catId) {
   const idx = CATEGORY_DEFS.findIndex(c => c.id === catId);
   if (idx <= 0) return;
   [CATEGORY_DEFS[idx-1], CATEGORY_DEFS[idx]] = [CATEGORY_DEFS[idx], CATEGORY_DEFS[idx-1]];
-  await persistState();
+  markSaveOnlyDraftChange({
+    key: `category:${catId}:move`,
+    label: `Reordered categories`,
+    message: `Reordered categories`,
+    sectionId: catId,
+    kind: 'category-order',
+  });
+  invalidateDiff();
+  updateDraftIndicator();
   refreshAllViews();
 }
 
@@ -6666,7 +7241,15 @@ async function moveCategoryDown(catId) {
   const idx = CATEGORY_DEFS.findIndex(c => c.id === catId);
   if (idx < 0 || idx >= CATEGORY_DEFS.length - 1) return;
   [CATEGORY_DEFS[idx], CATEGORY_DEFS[idx+1]] = [CATEGORY_DEFS[idx+1], CATEGORY_DEFS[idx]];
-  await persistState();
+  markSaveOnlyDraftChange({
+    key: `category:${catId}:move`,
+    label: `Reordered categories`,
+    message: `Reordered categories`,
+    sectionId: catId,
+    kind: 'category-order',
+  });
+  invalidateDiff();
+  updateDraftIndicator();
   refreshAllViews();
 }
 
@@ -6689,9 +7272,9 @@ async function deleteCategory(catId) {
   CATEGORY_DEFS = CATEGORY_DEFS.filter(c => c.id !== catId);
   delete menuState[catId];
   invalidateDiff();
-  await persistState();
+  updateDraftIndicator();
   refreshAllViews();
-  showToast('✅ Category deleted.', 'success');
+  showToast('✅ Category moved into draft changes.', 'success');
 }
 
 function toggleAddCategoryForm() {
@@ -6724,9 +7307,17 @@ async function confirmAddCategory() {
   document.getElementById('catmgr-add-form').style.display = 'none';
   const btn = document.getElementById('show-add-cat-btn');
   if (btn) btn.textContent = '+ Add Category';
-  await persistState();
+  markSaveOnlyDraftChange({
+    key: `category:${id}:add`,
+    label: `Added category ${title}`,
+    message: `Added category ${title}`,
+    sectionId: id,
+    kind: 'category-add',
+  });
+  invalidateDiff();
+  updateDraftIndicator();
   refreshAllViews();
-  showToast(`✅ Category "${title}" added!`, 'success');
+  showToast(`✅ Category "${title}" added to the draft.`, 'success');
 }
 
 // ─── INIT ─────────────────────────────────────────────────────────────────────
@@ -9953,26 +10544,26 @@ async function persistState(options = {}) {
 }
 
 async function saveMenu() {
-  try {
-    const result = await ensureCurrentMenuSession().saveDraft();
-    if (result?.noop) return;
-    if (result?.ok) {
-      showToast(result?.cleared
-        ? `✅ ${_activeMenuName || 'Menu'} draft cleared.`
-        : `✅ ${_activeMenuName || 'Menu'} draft saved.`, 'success');
-      renderManagerWorkspace({ includeRecentChanges: false });
-      updateDraftIndicator();
-      return;
+  const actionState = getMenuActionState();
+  if (!actionState.hasLocalDraft) {
+    if (actionState.hasPendingServerQueue) {
+      await openPreview();
     }
-    if (result?.userHandled) return;
-    if (result?.userMessage) {
-      showToast(`⚠️ ${result.userMessage}`, 'error');
-      return;
-    }
-  } catch (_) {
-    finalizePersistStatus(false);
+    return;
   }
-  showToast('⚠️ Draft save failed.', 'error');
+  await sendUpdate({ notify: false });
+}
+
+async function discardLocalDraft() {
+  if (!syncLocalDraftDirtyState()) return;
+  if (!confirm('Discard this device-only draft and return to the current live menu?')) return;
+  clearDraftSaveOnlyChanges();
+  clearCurrentLocalDraft();
+  closeModal();
+  await loadActiveMenuState({ includePersistedDraft: false, source: 'discard' });
+  renderManagerWorkspace({ includeRecentChanges: false });
+  updateDraftIndicator();
+  showToast(`✅ ${_activeMenuName || 'Menu'} draft discarded.`, 'success');
 }
 
 function addItem(catId) {
@@ -10397,7 +10988,16 @@ async function addIngredient(catId, itemId) {
   const btn = document.querySelector('#wrapper-' + itemId + ' .recipe-btn');
   if (btn) btn.classList.toggle('has-recipe', item.recipe.length > 0);
   input.focus();
-  await persistState();
+  markSaveOnlyDraftChange({
+    key: `recipe:${catId}:${itemId}`,
+    label: `Updated recipe for ${item.name}`,
+    message: `Updated recipe for ${item.name}`,
+    sectionId: catId,
+    itemId,
+    kind: 'recipe',
+  });
+  invalidateDiff();
+  updateDraftIndicator();
 }
 
 async function removeIngredient(catId, itemId, idx) {
@@ -10407,7 +11007,16 @@ async function removeIngredient(catId, itemId, idx) {
   renderRecipeIngredients(catId, itemId);
   const btn = document.querySelector('#wrapper-' + itemId + ' .recipe-btn');
   if (btn) btn.classList.toggle('has-recipe', item.recipe.length > 0);
-  await persistState();
+  markSaveOnlyDraftChange({
+    key: `recipe:${catId}:${itemId}`,
+    label: `Updated recipe for ${item.name}`,
+    message: `Updated recipe for ${item.name}`,
+    sectionId: catId,
+    itemId,
+    kind: 'recipe',
+  });
+  invalidateDiff();
+  updateDraftIndicator();
 }
 
 function handleIngredientKeydown(event, catId, itemId) {
@@ -10424,7 +11033,16 @@ async function saveDesc(catId, itemId, val) {
     markSectionsStale(_activeManagerSection);
     const btn = document.querySelector('#wrapper-' + itemId + ' .desc-btn');
     if (btn) btn.classList.toggle('has-desc', !!desc);
-    await persistState();
+    markSaveOnlyDraftChange({
+      key: `desc:${catId}:${itemId}`,
+      label: `Updated description for ${item.name}`,
+      message: `Updated description for ${item.name}`,
+      sectionId: catId,
+      itemId,
+      kind: 'description',
+    });
+    invalidateDiff();
+    updateDraftIndicator();
     _flashSaved(document.querySelector(`#desc-input-${itemId}`));
   }
 }
@@ -10437,7 +11055,16 @@ async function saveItemVisibilityFlag(catId, itemId, field, checked, sourceEl = 
   if (!!item[normalizedField] === nextValue) return;
   item[normalizedField] = nextValue;
   syncDescriptionSummary(itemId, item);
-  await persistState();
+  markSaveOnlyDraftChange({
+    key: `visibility:${normalizedField}:${catId}:${itemId}`,
+    label: `Updated ${normalizedField === 'showRecipe' ? 'recipe' : 'description'} visibility for ${item.name}`,
+    message: `Updated ${normalizedField === 'showRecipe' ? 'recipe' : 'description'} visibility for ${item.name}`,
+    sectionId: catId,
+    itemId,
+    kind: normalizedField,
+  });
+  invalidateDiff();
+  updateDraftIndicator();
   if (sourceEl?.closest) _flashSaved(sourceEl.closest('.desc-visibility-toggle'));
 }
 
@@ -10456,6 +11083,7 @@ async function savePrice(catId, itemId, val) {
       itemId,
       kind: 'price',
     });
+    updateDraftIndicator();
     _flashSaved(document.querySelector(`#pricing-wrapper-${itemId} .price-input`) || document.querySelector(`#wrapper-${itemId} .price-input`));
   }
 }
@@ -10683,7 +11311,23 @@ function computeDiff() {
   return results;
 }
 
-function renderPreviewModal(preview) {
+function buildPreviewDecisionGroups(preview = {}) {
+  const notificationChanges = Array.isArray(preview.notificationChanges) ? preview.notificationChanges : [];
+  return {
+    selectedSections: groupNotificationChangesBySection(notificationChanges.filter(change => _previewSelectionState[change.id] !== false)),
+    clearSections: groupNotificationChangesBySection(notificationChanges.filter(change => _previewSelectionState[change.id] === false)),
+    saveOnlyChanges: Array.isArray(preview.saveOnlyChanges) ? preview.saveOnlyChanges : [],
+  };
+}
+
+function renderPreviewSectionGroup(title, sections, options = {}) {
+  if (!Array.isArray(sections) || !sections.length) return '';
+  return `<div class="preview-group-title">${escHtml(title)}</div>${sections.map(section => (
+    `<div class="preview-block">${buildPreviewBlockHtml(section, options)}</div>`
+  )).join('')}`;
+}
+
+function renderPreviewModal(preview, options = {}) {
   const content = document.getElementById('preview-content');
   const saveMenuBtn = document.getElementById('save-menu-btn');
   const saveSendBtn = document.getElementById('save-send-btn');
@@ -10691,35 +11335,37 @@ function renderPreviewModal(preview) {
   const modal = document.getElementById('modal-bg');
   if (!content || !saveMenuBtn || !saveSendBtn || !modal) return;
   _previewModalState = preview;
-  _previewSelectionState = Object.fromEntries((preview.notificationChanges || []).map(change => [change.id, true]));
-  content.innerHTML = '';
-  if (subtitle) {
-    subtitle.textContent = preview.mode === 'update-only'
-      ? 'These lines are already live. Choose which ones to send now.'
-      : 'Review the changes before publishing them to the live menu.';
+  if (!options.preserveSelection) {
+    _previewSelectionState = Object.fromEntries((preview.notificationChanges || []).map(change => [change.id, true]));
   }
-  saveMenuBtn.style.display = preview.mode === 'update-only' ? 'none' : '';
-  saveMenuBtn.disabled = !(preview.hasLocalDraft || preview.hasSharedDraft);
-  saveMenuBtn.textContent = 'Save Menu';
-  saveSendBtn.textContent = preview.mode === 'update-only' ? 'Send Update' : 'Save & Update';
+  content.innerHTML = '';
+  const isSendOnly = preview.mode === 'send' || preview.mode === 'update-only';
+  const decisionGroups = buildPreviewDecisionGroups(preview);
+  if (subtitle) {
+    subtitle.textContent = isSendOnly
+      ? 'These changes are already live. Checked rows will send now, and unchecked rows will clear without sending.'
+      : (preview.hasNotificationChanges
+          ? 'Checked rows will send now, unchecked rows will clear without sending, and quiet changes will save live only.'
+          : 'These changes will save live without sending notifications.');
+  }
+  saveMenuBtn.style.display = isSendOnly ? 'none' : '';
+  saveMenuBtn.disabled = !preview.hasLocalDraft;
+  saveMenuBtn.textContent = preview.hasNotificationChanges ? 'Save Quietly' : 'Save';
+  saveSendBtn.style.display = preview.hasNotificationChanges ? '' : 'none';
+  saveSendBtn.textContent = isSendOnly ? 'Send' : 'Save & Send';
   saveSendBtn.disabled = !preview.hasNotificationChanges;
   if (!preview.hasChanges) {
     content.innerHTML = `<div class="no-changes">🎉 No changes since the last update.<br><span style="font-size:11px;color:#444;">Add, remove, or 86 items to generate an update.</span></div>`;
     saveMenuBtn.disabled = true;
     saveSendBtn.disabled = true;
   } else {
-    preview.sections.forEach(s => {
-      const block = document.createElement('div');
-      block.className = 'preview-block';
-      block.innerHTML = buildPreviewBlockHtml(s, { selectable: true });
-      content.appendChild(block);
-    });
-    if (preview.saveOnlyChanges?.length) {
-      const saveOnlyBlock = document.createElement('div');
-      saveOnlyBlock.className = 'preview-block';
-      saveOnlyBlock.innerHTML = buildSaveOnlyPreviewBlockHtml(preview.saveOnlyChanges);
-      content.appendChild(saveOnlyBlock);
-    }
+    content.innerHTML = [
+      renderPreviewSectionGroup('Will Send', decisionGroups.selectedSections, { selectable: true }),
+      renderPreviewSectionGroup('Will Clear Without Sending', decisionGroups.clearSections, { selectable: true }),
+      decisionGroups.saveOnlyChanges.length
+        ? `<div class="preview-block">${buildSaveOnlyPreviewBlockHtml(decisionGroups.saveOnlyChanges).replace('Quiet Live Changes', 'Will Save Only')}</div>`
+        : '',
+    ].filter(Boolean).join('');
   }
   modal.hidden = false;
   modal.setAttribute('aria-hidden', 'false');
@@ -10799,6 +11445,7 @@ function serializeNotificationSectionsForLog(sections = []) {
 
 function setPreviewChangeSelected(changeId, checked) {
   _previewSelectionState[changeId] = !!checked;
+  if (_previewModalState) renderPreviewModal(_previewModalState, { preserveSelection: true });
 }
 
 function getSelectedPreviewChangeIds() {
@@ -10814,7 +11461,7 @@ function buildPreviewBlockHtml(section, options = {}) {
     (section.changes || []).forEach(change => {
       const lineClass = change.kind === 'removed' || change.kind === 'eightySixed' ? 'remove' : 'add';
       if (selectable) {
-        html += `<label class="preview-line ${lineClass}"><input type="checkbox" checked onchange="setPreviewChangeSelected('${escHtml(change.id)}',this.checked)"/><span>${change.kind === 'eightySixed' ? '🚫' : change.kind === 'removed' ? '❌' : change.kind === 'restored' ? '↩' : '✅'}</span> ${escHtml(change.text)}</label>`;
+        html += `<label class="preview-line ${lineClass}"><input type="checkbox" ${_previewSelectionState[change.id] !== false ? 'checked' : ''} onchange="setPreviewChangeSelected('${escHtml(change.id)}',this.checked)"/><span>${change.kind === 'eightySixed' ? '🚫' : change.kind === 'removed' ? '❌' : change.kind === 'restored' ? '↩' : '✅'}</span> ${escHtml(change.text)}</label>`;
       } else {
         html += `<div class="preview-line ${lineClass}"><span>${change.kind === 'eightySixed' ? '🚫' : change.kind === 'removed' ? '❌' : change.kind === 'restored' ? '↩' : '✅'}</span> ${escHtml(change.text)}</div>`;
       }
@@ -11024,13 +11671,17 @@ function setPreviewModalActionState(mode = '') {
   if (cancelBtn) cancelBtn.disabled = isBusy;
   if (saveMenuBtn) {
     saveMenuBtn.disabled = isBusy;
-    saveMenuBtn.textContent = mode === 'save-menu' ? 'Saving…' : 'Save Menu';
+    saveMenuBtn.textContent = mode === 'save-menu'
+      ? 'Saving…'
+      : ((_previewModalState?.hasNotificationChanges ? 'Save Quietly' : 'Save'));
   }
   if (saveSendBtn) {
     saveSendBtn.disabled = isBusy;
     saveSendBtn.textContent = mode === 'send-update'
       ? 'Sending…'
-      : (mode === 'save-send' ? 'Saving & Sending…' : ((_previewModalState?.mode === 'update-only') ? 'Send Update' : 'Save & Update'));
+      : (mode === 'save-send'
+          ? 'Saving & Sending…'
+          : (((_previewModalState?.mode === 'send') || (_previewModalState?.mode === 'update-only')) ? 'Send' : 'Save & Send'));
   }
 }
 
@@ -11059,8 +11710,8 @@ async function sendUpdate(options = {}) {
   const selectedChangeIds = getSelectedPreviewChangeIds();
   const mode = options.notify === false
     ? 'save'
-    : (preview.mode === 'update-only' ? 'update-only' : 'save-and-update');
-  setPreviewModalActionState(mode === 'save' ? 'save-menu' : (mode === 'update-only' ? 'send-update' : 'save-send'));
+    : ((preview.mode === 'send' || preview.mode === 'update-only') ? 'send' : 'save-and-send');
+  setPreviewModalActionState(mode === 'save' ? 'save-menu' : (mode === 'send' ? 'send-update' : 'save-send'));
 
   try {
     const result = await ensureCurrentMenuSession().publishUpdate({ preview, mode, selectedChangeIds });

--- a/app.js
+++ b/app.js
@@ -2499,6 +2499,7 @@ function getMenuSessionPorts() {
         clearDraftSaveOnlyChanges();
         clearSharedDraftState();
         clearCurrentLocalDraft();
+        setServerLiveSnapshot(buildMenuCacheSnapshot());
         updateSaveBtn();
         updateLastUpdatedLabel();
       } else if (result.notificationStatus?.partial || (mode === 'save-and-send' && result.notificationStatus && result.notificationStatus.ok === false)) {
@@ -2507,6 +2508,7 @@ function getMenuSessionPorts() {
         clearDraftSaveOnlyChanges();
         clearSharedDraftState();
         clearCurrentLocalDraft();
+        setServerLiveSnapshot(buildMenuCacheSnapshot());
         updateSaveBtn();
         updateLastUpdatedLabel();
       } else if (mode === 'save-and-send' || mode === 'send') {
@@ -2515,6 +2517,7 @@ function getMenuSessionPorts() {
         clearDraftSaveOnlyChanges();
         clearSharedDraftState();
         clearCurrentLocalDraft();
+        setServerLiveSnapshot(buildMenuCacheSnapshot());
         updateSaveBtn();
         updateLastUpdatedLabel();
       }
@@ -3087,7 +3090,7 @@ function buildManagerWorkspaceModuleDeps() {
     getCategoryDefs: () => CATEGORY_DEFS,
     getMenuState: () => menuState,
     getDraftChangeCount: () => getDraftChangeCount(),
-    isDirty: () => !!_dirty,
+    isDirty: () => syncLocalDraftDirtyState(),
     hasSharedDraft: () => hasSharedDraftState(),
     countDiffLines: () => countDiffLines(),
     createDraftLedgerService: () => createDraftLedgerService(),
@@ -6730,7 +6733,7 @@ function renderManagerOverviewStats() {
 }
 
 function createDraftLedgerService(deps = {}) {
-  const isDirty = typeof deps.isDirty === 'function' ? deps.isDirty : (() => !!_dirty);
+  const isDirty = typeof deps.isDirty === 'function' ? deps.isDirty : (() => syncLocalDraftDirtyState());
   const getDraftCount = typeof deps.getDraftChangeCount === 'function' ? deps.getDraftChangeCount : (() => getDraftChangeCount());
   const getDiffLineCount = typeof deps.getDiffLinesCount === 'function' ? deps.getDiffLinesCount : (() => countDiffLines());
   const getDiffSections = typeof deps.getDiffSections === 'function' ? deps.getDiffSections : (() => getCachedDiff());
@@ -10563,6 +10566,7 @@ async function persistState(options = {}) {
 }
 
 async function saveMenu() {
+  await flushFocusedManagerEditor();
   const actionState = getMenuActionState();
   if (!actionState.hasLocalDraft) {
     if (actionState.hasPendingServerQueue) {
@@ -11393,6 +11397,7 @@ function renderPreviewModal(preview, options = {}) {
 
 // ─── PREVIEW MODAL ────────────────────────────────────────────────────────────
 async function openPreview() {
+  await flushFocusedManagerEditor();
   const content = document.getElementById('preview-content');
   const saveMenuBtn = document.getElementById('save-menu-btn');
   const saveSendBtn = document.getElementById('save-send-btn');
@@ -11704,7 +11709,19 @@ function setPreviewModalActionState(mode = '') {
   }
 }
 
+async function flushFocusedManagerEditor() {
+  const activeEl = document.activeElement;
+  if (!activeEl || activeEl === document.body || typeof activeEl.blur !== 'function') return false;
+  const tagName = String(activeEl.tagName || '').toUpperCase();
+  const isEditableField = tagName === 'INPUT' || tagName === 'TEXTAREA' || tagName === 'SELECT' || !!activeEl.isContentEditable;
+  if (!isEditableField) return false;
+  activeEl.blur();
+  await Promise.resolve();
+  return true;
+}
+
 async function sendUpdate(options = {}) {
+  await flushFocusedManagerEditor();
   let preview = options.preview?.sections ? options.preview : _previewModalState;
   if (!preview) {
     const previewResult = await requestPublishPreviewThroughApi();

--- a/core/data/menu-state-loader.js
+++ b/core/data/menu-state-loader.js
@@ -8,9 +8,6 @@
   function createMenuStateLoaderServiceImpl(deps = {}) {
     const readState = typeof deps.readState === 'function' ? deps.readState : (() => globalScope.sbRead?.());
     const hydrateFromState = typeof deps.hydrateFromState === 'function' ? deps.hydrateFromState : (data => globalScope.hydrateState?.(data));
-    const applyDraftState = typeof deps.applyPersistedDraftState === 'function'
-      ? deps.applyPersistedDraftState
-      : (draftState => globalScope.applyPersistedDraftState?.(draftState));
     const setDefaultState = typeof deps.setDefaultState === 'function'
       ? deps.setDefaultState
       : (() => globalScope.resetMenuStateToDefaults?.());
@@ -57,6 +54,9 @@
     const getFeaturedSnapshotValue = typeof deps.getFeaturedSnapshot === 'function'
       ? deps.getFeaturedSnapshot
       : (() => globalScope.getFeaturedSnapshot?.());
+    const syncLocalDraftDirtyState = typeof deps.syncLocalDraftDirtyState === 'function'
+      ? deps.syncLocalDraftDirtyState
+      : (() => globalScope.syncLocalDraftDirtyState?.());
 
     return {
       async load(options = {}) {
@@ -71,17 +71,25 @@
           const data = await readState({ request, source: options.source || 'network', options });
           if (data) {
             hydrateFromState(data);
+            const persistedDraftEnvelope = includePersistedDraft ? readStoredLocalDraftEnvelope() : null;
             let loadedDraft = false;
             if (includePersistedDraft) {
-              const persistedDraftEnvelope = readStoredLocalDraftEnvelope();
               if (persistedDraftEnvelope) {
-                loadedDraft = !!applyLocalDraftEnvelope(persistedDraftEnvelope, { markDirty: true });
-              } else if (data?.meta?.draft_state) {
-                loadedDraft = !!applyDraftState(data.meta.draft_state || null);
+                loadedDraft = !!applyLocalDraftEnvelope(persistedDraftEnvelope, { markDirty: false });
+              }
+              if (loadedDraft) {
+                const hasLocalDraft = !!syncLocalDraftDirtyState();
+                if (hasLocalDraft) {
+                  setDirty(true);
+                } else {
+                  clearCurrentLocalDraft();
+                  setDirty(false);
+                  clearDraftChanges();
+                }
               }
             }
             if (!loadedDraft) {
-              clearCurrentLocalDraft({ clearStorage: false });
+              clearCurrentLocalDraft(persistedDraftEnvelope ? {} : { clearStorage: false });
               setDirty(false);
               clearDraftChanges();
             }
@@ -125,9 +133,11 @@
           : readStoredLocalDraftEnvelope();
         hydrateFromState(data);
         if (activeDraftEnvelope) {
-          const reappliedDraft = applyLocalDraftEnvelope(activeDraftEnvelope, { markDirty: true });
-          if (!reappliedDraft) {
-            clearCurrentLocalDraft({ clearStorage: false });
+          const reappliedDraft = applyLocalDraftEnvelope(activeDraftEnvelope, { markDirty: false });
+          if (reappliedDraft && syncLocalDraftDirtyState()) {
+            setDirty(true);
+          } else {
+            clearCurrentLocalDraft(reappliedDraft ? {} : { clearStorage: false });
             setDirty(false);
             clearDraftChanges();
           }

--- a/core/data/menu-state-loader.js
+++ b/core/data/menu-state-loader.js
@@ -21,6 +21,21 @@
           globalScope.clearDraftSaveOnlyChanges?.();
           globalScope.clearSharedDraftState?.();
         });
+    const isDirty = typeof deps.isDirty === 'function'
+      ? deps.isDirty
+      : (() => !!globalScope._dirty);
+    const readStoredLocalDraftEnvelope = typeof deps.readStoredLocalDraftEnvelope === 'function'
+      ? deps.readStoredLocalDraftEnvelope
+      : (() => globalScope.readStoredLocalDraftEnvelope?.());
+    const buildCurrentLocalDraftEnvelope = typeof deps.buildCurrentLocalDraftEnvelope === 'function'
+      ? deps.buildCurrentLocalDraftEnvelope
+      : (() => globalScope.buildCurrentLocalDraftEnvelope?.());
+    const applyLocalDraftEnvelope = typeof deps.applyLocalDraftEnvelope === 'function'
+      ? deps.applyLocalDraftEnvelope
+      : ((envelope, options = {}) => globalScope.applyLocalDraftEnvelope?.(envelope, options));
+    const clearCurrentLocalDraft = typeof deps.clearCurrentLocalDraft === 'function'
+      ? deps.clearCurrentLocalDraft
+      : ((options = {}) => globalScope.clearCurrentLocalDraft?.(options));
     const writeMenuCache = typeof deps.writeMenuCache === 'function'
       ? deps.writeMenuCache
       : (() => {});
@@ -56,9 +71,20 @@
           const data = await readState({ request, source: options.source || 'network', options });
           if (data) {
             hydrateFromState(data);
-            const loadedDraft = includePersistedDraft ? applyDraftState(data.meta?.draft_state || null) : false;
-            setDirty(false);
-            if (!loadedDraft) clearDraftChanges();
+            let loadedDraft = false;
+            if (includePersistedDraft) {
+              const persistedDraftEnvelope = readStoredLocalDraftEnvelope();
+              if (persistedDraftEnvelope) {
+                loadedDraft = !!applyLocalDraftEnvelope(persistedDraftEnvelope, { markDirty: true });
+              } else if (data?.meta?.draft_state) {
+                loadedDraft = !!applyDraftState(data.meta.draft_state || null);
+              }
+            }
+            if (!loadedDraft) {
+              clearCurrentLocalDraft({ clearStorage: false });
+              setDirty(false);
+              clearDraftChanges();
+            }
             if (persistCache) writeMenuCache(data);
           } else if (fallbackToDefault) {
             setDefaultState();
@@ -94,7 +120,22 @@
           };
         }
 
+        const activeDraftEnvelope = isDirty()
+          ? buildCurrentLocalDraftEnvelope()
+          : readStoredLocalDraftEnvelope();
         hydrateFromState(data);
+        if (activeDraftEnvelope) {
+          const reappliedDraft = applyLocalDraftEnvelope(activeDraftEnvelope, { markDirty: true });
+          if (!reappliedDraft) {
+            clearCurrentLocalDraft({ clearStorage: false });
+            setDirty(false);
+            clearDraftChanges();
+          }
+        } else {
+          clearCurrentLocalDraft({ clearStorage: false });
+          setDirty(false);
+          clearDraftChanges();
+        }
         writeMenuCache(data);
         const newTs = getLastUpdatedTs();
         if (newTs !== oldTs) await refreshFeatured();

--- a/core/session/publish-service.js
+++ b/core/session/publish-service.js
@@ -32,66 +32,45 @@
           ), 0);
       return diffLineCount + saveOnlyChanges.length;
     };
-    const isSharedDraftClearable = snapshot => {
-      const changeCount = resolveDraftChangeCount(snapshot);
-      if (typeof globalScope.isSharedDraftClearable === 'function') {
-        return globalScope.isSharedDraftClearable({
-          hasLocalDraft: !!snapshot?.dirty,
-          hasSharedDraft: !!snapshot?.hasSharedDraft,
-          changeCount,
-        });
-      }
-      return !!snapshot?.hasSharedDraft && !snapshot?.dirty && changeCount === 0;
-    };
+    const buildSaveDraftNoop = (preview, snapshot, source = 'draft-noop') => ({
+      ok: false,
+      noop: true,
+      preview,
+      snapshot: buildSnapshot(source),
+    });
 
     return {
       async saveDraft(options = {}) {
-        void options;
         const snapshot = buildSnapshot('draft');
-        if (!snapshot.dirty) {
-          if (isSharedDraftClearable(snapshot)) {
-            const ts = sessionPorts.now();
-            try {
-              await sessionPorts.patchMenuDraftState(null, ts);
-              sessionPorts.clearDraft?.();
-              return {
-                ok: true,
-                cleared: true,
-                ts,
-                snapshot: buildSnapshot('draft-cleared'),
-              };
-            } catch (error) {
-              return {
-                ok: false,
-                userHandled: false,
-                userMessage: error?.message || 'Draft clear failed.',
-                snapshot: buildSnapshot('draft-clear-failed'),
-              };
-            }
-          }
-          return {
-            ok: false,
-            noop: true,
-            snapshot: buildSnapshot('draft-noop'),
-          };
+        const preview = options.preview?.sections ? options.preview : buildPreview();
+        const hasLocalDraft = !!snapshot?.dirty || !!preview?.hasLocalDraft;
+        const hasChanges = !!preview?.hasChanges || resolveDraftChangeCount(snapshot) > 0;
+
+        if (!hasLocalDraft || !hasChanges) {
+          return buildSaveDraftNoop(preview, snapshot);
         }
-        const ts = sessionPorts.now();
-        try {
-          await sessionPorts.patchMenuDraftState(globalScope.buildPersistedDraftStateSnapshot(ts), ts);
-          sessionPorts.commitDraft(ts);
-          return {
-            ok: true,
-            ts,
-            snapshot: buildSnapshot('draft-saved'),
-          };
-        } catch (error) {
-          return {
-            ok: false,
-            userHandled: false,
-            userMessage: error?.message || 'Draft save failed.',
-            snapshot: buildSnapshot('draft-save-failed'),
-          };
+
+        const request = {
+          ...options,
+          preview,
+          mode: 'save',
+          notify: false,
+        };
+
+        if (typeof sessionPorts.publishMenuUpdate === 'function') {
+          return sessionPorts.publishMenuUpdate(request);
         }
+        if (fallbackService && typeof fallbackService.publishUpdate === 'function') {
+          return fallbackService.publishUpdate(request);
+        }
+
+        return {
+          ok: false,
+          userHandled: false,
+          userMessage: 'Publish service is unavailable.',
+          preview,
+          snapshot: buildSnapshot('save-unavailable'),
+        };
       },
 
       async publishUpdate(options = {}) {

--- a/core/ui/manager/open-food-facts.js
+++ b/core/ui/manager/open-food-facts.js
@@ -54,12 +54,17 @@
       if (!response || response.status === 404 || !response.ok) return null;
 
       const payload = await response.json();
-      const name = cleanText(payload?.name);
+      const product = payload?.status === 1 && payload?.product
+        ? payload.product
+        : (payload?.product && typeof payload.product === 'object' ? payload.product : null);
+      const name = cleanText(payload?.name)
+        || cleanText(product?.product_name_en || product?.product_name)
+        || cleanText(product?.brands);
       if (!name) return null;
 
       return {
         name,
-        description: cleanText(payload?.description) || buildDescription(payload?.product || {}),
+        description: cleanText(payload?.description) || buildDescription(product || {}),
       };
     } catch (_) {
       return null;

--- a/core/ui/manager/workspace.js
+++ b/core/ui/manager/workspace.js
@@ -11,7 +11,9 @@
     const getCategoryDefs = typeof deps.getCategoryDefs === 'function' ? deps.getCategoryDefs : (() => []);
     const getMenuState = typeof deps.getMenuState === 'function' ? deps.getMenuState : (() => ({}));
     const getDraftChangeCount = typeof deps.getDraftChangeCount === 'function' ? deps.getDraftChangeCount : (() => 0);
-    const isDirty = typeof deps.isDirty === 'function' ? deps.isDirty : (() => false);
+    const isDirty = typeof deps.isDirty === 'function'
+      ? deps.isDirty
+      : (() => !!globalScope.syncLocalDraftDirtyState?.());
     const countDiffLines = typeof deps.countDiffLines === 'function' ? deps.countDiffLines : (() => 0);
     const createDraftLedgerService = typeof deps.createDraftLedgerService === 'function'
       ? deps.createDraftLedgerService

--- a/core/ui/manager/workspace.js
+++ b/core/ui/manager/workspace.js
@@ -12,7 +12,6 @@
     const getMenuState = typeof deps.getMenuState === 'function' ? deps.getMenuState : (() => ({}));
     const getDraftChangeCount = typeof deps.getDraftChangeCount === 'function' ? deps.getDraftChangeCount : (() => 0);
     const isDirty = typeof deps.isDirty === 'function' ? deps.isDirty : (() => false);
-    const hasSharedDraft = typeof deps.hasSharedDraft === 'function' ? deps.hasSharedDraft : (() => false);
     const countDiffLines = typeof deps.countDiffLines === 'function' ? deps.countDiffLines : (() => 0);
     const createDraftLedgerService = typeof deps.createDraftLedgerService === 'function'
       ? deps.createDraftLedgerService
@@ -46,8 +45,7 @@
       ), 0);
       const draftCount = getDraftChangeCount();
       const hasLocalDraft = !!isDirty();
-      const hasShared = hasSharedDraft();
-      const notifyCount = !hasShared && !hasLocalDraft ? countDiffLines() : 0;
+      const notifyCount = !hasLocalDraft ? countDiffLines() : 0;
       const statusValue = documentRef.getElementById('manager-overview-status-value');
       const statusMeta = documentRef.getElementById('manager-overview-status-meta');
       const activeValue = documentRef.getElementById('manager-overview-active-value');
@@ -55,16 +53,10 @@
       const eightysixValue = documentRef.getElementById('manager-overview-86-value');
       const eightysixMeta = documentRef.getElementById('manager-overview-86-meta');
 
-      if (statusValue) statusValue.textContent = hasLocalDraft ? 'Drafting' : (hasShared ? 'Drafted' : (notifyCount > 0 ? 'Live | Unsent' : 'Live'));
+      if (statusValue) statusValue.textContent = hasLocalDraft ? 'Drafting' : (notifyCount > 0 ? 'Live | Unsent' : 'Live');
       if (statusMeta) {
         if (hasLocalDraft) {
-          statusMeta.textContent = hasShared
-            ? `${draftCount} pending change${draftCount === 1 ? '' : 's'} on top of the saved draft`
-            : `${draftCount} pending change${draftCount === 1 ? '' : 's'}`;
-        } else if (hasShared) {
-          statusMeta.textContent = ledgerState.hasClearableSharedDraft
-            ? 'Saved draft matches the live menu. Clear Draft removes it.'
-            : `${draftCount} saved draft change${draftCount === 1 ? '' : 's'} ready to publish`;
+          statusMeta.textContent = `${draftCount} pending change${draftCount === 1 ? '' : 's'} on this device.`;
         } else if (notifyCount > 0) {
           statusMeta.textContent = `${notifyCount} update line${notifyCount === 1 ? '' : 's'} ready to send`;
         } else {
@@ -93,21 +85,25 @@
       const ledgerState = createDraftLedgerService().getActionBarState({ isCompactViewport });
       const saveBtn = documentRef.getElementById('save-btn');
       const publishBtn = documentRef.getElementById('send-btn');
+      const discardBtn = documentRef.getElementById('discard-draft-btn');
 
       if (primaryGroup) primaryGroup.hidden = false;
       if (saveBtn) {
-        saveBtn.disabled = !ledgerState.hasDraftChanges && !ledgerState.hasClearableSharedDraft;
-        saveBtn.textContent = ledgerState.saveLabel;
-        saveBtn.title = ledgerState.hasClearableSharedDraft
-          ? 'Remove the saved draft because it already matches the live menu'
-          : 'Save changes without notifying anyone';
+        saveBtn.disabled = !!ledgerState.saveDisabled;
+        saveBtn.textContent = ledgerState.saveLabel || 'Save';
+        saveBtn.hidden = !ledgerState.saveLabel;
+        saveBtn.title = ledgerState.hasDraftChanges ? 'Save the live menu without notifying anyone yet' : '';
       }
       if (publishBtn) {
-        publishBtn.disabled = !ledgerState.hasPublishableDraftWork && !ledgerState.hasPendingUpdate;
+        publishBtn.disabled = !!ledgerState.publishDisabled;
         publishBtn.textContent = ledgerState.publishLabel;
       }
+      if (discardBtn) {
+        discardBtn.hidden = !ledgerState.showDiscard;
+        discardBtn.disabled = !ledgerState.showDiscard;
+      }
       bar.hidden = false;
-      bar.classList.toggle('is-idle', !ledgerState.hasPublishableDraftWork && !ledgerState.hasPendingUpdate && !ledgerState.hasClearableSharedDraft);
+      bar.classList.toggle('is-idle', ledgerState.saveDisabled && ledgerState.publishDisabled && !ledgerState.showDiscard);
       syncManagerActionBarStatus(syncEl);
 
       if (summary) summary.textContent = ledgerState.summaryText;

--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -22,18 +22,18 @@ enum EditorRefreshStrategy {
 }
 
 enum RemoteMenuUpdateKind: Equatable {
-  case sharedDraft
+  case queueState
   case liveMenu
-  case liveAndDraft
+  case liveAndQueue
 
   var title: String {
     switch self {
-    case .sharedDraft:
-      return "Shared Draft Updated"
+    case .queueState:
+      return "Unsent Queue Updated"
     case .liveMenu:
       return "Live Menu Updated"
-    case .liveAndDraft:
-      return "Live Menu And Draft Updated"
+    case .liveAndQueue:
+      return "Live Menu And Queue Updated"
     }
   }
 }
@@ -108,7 +108,7 @@ final class AppModel {
   var currentMenuId: String?
   var selectedPreviewChangeIDs: Set<String> = []
   var editorRefreshRequirement: EditorRefreshRequirement?
-  var editorHasSharedDraft = false
+  var editorHasServerUnsentChanges = false
   var editorDirty = false
   var editorHasLiveChanges = false
 
@@ -160,49 +160,44 @@ final class AppModel {
 
   var hasLiveMenuChanges: Bool { editorHasLiveChanges }
 
+  var hasServerUnsentChanges: Bool { editorHasServerUnsentChanges }
+
+  var menuStatusLabel: String {
+    if hasLocalDraftChanges {
+      return "Drafting"
+    }
+    return hasServerUnsentChanges ? "Live | Unsent" : "Live"
+  }
+
   var canMutateRemoteEditorState: Bool {
     isAuthenticated && currentEditorWorkspace != nil && editorRefreshRequirement == nil
   }
 
-  var canSaveDraftRemotely: Bool {
-    canMutateRemoteEditorState &&
-      (editorCapabilities?.canSaveDraft ?? false) &&
-      (hasLocalDraftChanges || showClearSharedDraft)
+  var canDiscardLocalDraft: Bool {
+    canMutateRemoteEditorState && hasLocalDraftChanges
   }
 
-  var canSaveLiveRemotely: Bool {
+  var canSaveQuietlyRemotely: Bool {
     canMutateRemoteEditorState &&
       (editorCapabilities?.canSaveLiveMenu ?? false) &&
       hasLiveMenuChanges
   }
 
+  var canSaveLiveRemotely: Bool {
+    canSaveQuietlyRemotely
+  }
+
   var canLoadPublishPreview: Bool {
     canMutateRemoteEditorState &&
       (editorCapabilities?.canPublishUpdates ?? false) &&
-      hasLiveMenuChanges
+      (hasLiveMenuChanges || hasServerUnsentChanges)
   }
 
   var canPublishRemotely: Bool {
     canMutateRemoteEditorState &&
       (editorCapabilities?.canPublishUpdates ?? false) &&
       currentEditorPreview != nil &&
-      hasLiveMenuChanges
-  }
-
-  var editorSharedDraftSummary: String? {
-    guard let sharedDraft = currentEditorWorkspace?.workspace.sharedDraft, sharedDraft.exists else { return nil }
-    var parts: [String] = []
-    if let savedBy = sharedDraft.savedBy?.name, !savedBy.isEmpty {
-      parts.append("Saved by \(savedBy)")
-    }
-    if let source = sharedDraft.source.nilIfBlank {
-      parts.append(source == "ios_app" ? "from iOS" : "from \(source.replacingOccurrences(of: "_", with: " "))")
-    }
-    return parts.isEmpty ? nil : parts.joined(separator: " • ")
-  }
-
-  var showClearSharedDraft: Bool {
-    editorHasSharedDraft && !hasLocalDraftChanges && !hasLiveMenuChanges
+      (hasLiveMenuChanges || hasServerUnsentChanges)
   }
 
   func start() async {
@@ -277,7 +272,7 @@ final class AppModel {
     currentToolsHistories = [:]
     currentMenuId = nil
     editorRefreshRequirement = nil
-    editorHasSharedDraft = false
+    editorHasServerUnsentChanges = false
     editorDirty = false
     editorHasLiveChanges = false
     draftBaselineDocumentData = nil
@@ -421,12 +416,14 @@ final class AppModel {
           let workspace = currentEditorWorkspace,
           let snapshot = editorSnapshot() else { return }
 
-    await run("Building Preview") { model in
+    let operationLabel = hasLiveMenuChanges ? "Building Save & Send Preview" : "Building Send Preview"
+    await run(operationLabel) { model in
+      let expectedBaselineRevision = model.expectedNotificationBaselineRevision(for: workspace)
       let response = try await model.services.publish.preview(
         menuId: menuId,
         snapshot: snapshot,
         expectedLiveRevision: workspace.workspace.revisions.liveRevision,
-        expectedDraftRevision: workspace.workspace.revisions.draftRevision,
+        expectedDraftRevision: expectedBaselineRevision,
         accessToken: accessToken,
         source: "ios_app"
       )
@@ -443,7 +440,9 @@ final class AppModel {
           let workspace = currentEditorWorkspace,
           let snapshot = editorSnapshot() else { return }
 
-    await run("Publishing Updates") { model in
+    let operationLabel = hasLiveMenuChanges ? "Saving And Sending" : "Sending Updates"
+    await run(operationLabel) { model in
+      let expectedBaselineRevision = model.expectedNotificationBaselineRevision(for: workspace)
       let preview: MenuPreviewPayload?
       if let existing = model.currentEditorPreview {
         preview = existing
@@ -452,79 +451,63 @@ final class AppModel {
           menuId: menuId,
           snapshot: snapshot,
           expectedLiveRevision: workspace.workspace.revisions.liveRevision,
-          expectedDraftRevision: workspace.workspace.revisions.draftRevision,
+          expectedDraftRevision: expectedBaselineRevision,
           accessToken: accessToken,
           source: "ios_app"
         ).preview
+        model.currentEditorPreview = preview
+        if model.selectedPreviewChangeIDs.isEmpty {
+          model.selectedPreviewChangeIDs = Set(preview?.selectionDefaults ?? [])
+        }
       }
 
-      let selection = Array(model.selectedPreviewChangeIDs.isEmpty ? Set(preview?.selectionDefaults ?? []) : model.selectedPreviewChangeIDs)
-      _ = try await model.services.publish.publish(
+      let selection = Array(model.selectedPreviewChangeIDs)
+      let response = try await model.services.publish.publish(
         menuId: menuId,
         snapshot: snapshot,
         selectedChangeIds: selection,
         expectedLiveRevision: workspace.workspace.revisions.liveRevision,
-        expectedDraftRevision: workspace.workspace.revisions.draftRevision,
+        expectedDraftRevision: expectedBaselineRevision,
         accessToken: accessToken,
         source: "ios_app"
       )
-      model.notice = AppNotice(tone: .success, title: "Published", message: "The live menu and notifications were updated from iOS.")
+      let hasNotificationChanges = preview?.hasNotificationChanges ?? false
+      var title = "Saved Quietly"
+      var message = "The live menu was saved with no notification-ready queue items."
+      if hasNotificationChanges {
+        if selection.isEmpty {
+          title = model.hasLiveMenuChanges ? "Saved And Cleared" : "Queue Cleared"
+          message = "Unchecked queue groups were cleared without sending notifications."
+        } else {
+          title = model.hasLiveMenuChanges ? "Saved And Sent" : "Sent"
+          message = "Selected queue groups were sent to notification channels."
+        }
+      }
+      if let successMessage = response.successMessage?.nilIfBlank {
+        message = successMessage
+      }
+      model.notice = AppNotice(tone: .success, title: title, message: message)
       await model.loadEditor(menuId: menuId)
     }
   }
 
-  func saveRemoteDraft() async {
-    guard canSaveDraftRemotely,
-          let menuId = currentMenuId,
-          let accessToken = authSession?.accessToken,
-          let workspace = currentEditorWorkspace,
-          let snapshot = editorSnapshot() else { return }
-
-    await run(showClearSharedDraft ? "Clearing Draft" : "Saving Draft") { model in
-      let response = model.showClearSharedDraft
-        ? try await model.services.draft.clear(
-            menuId: menuId,
-            expectedDraftRevision: workspace.workspace.revisions.draftRevision,
-            accessToken: accessToken,
-            source: "ios_app"
-          )
-        : try await model.services.draft.save(
-            menuId: menuId,
-            snapshot: snapshot,
-            expectedDraftRevision: workspace.workspace.revisions.draftRevision,
-            accessToken: accessToken,
-            source: "ios_app"
-          )
-
-      let currentDocument = try model.requireCurrentEditorDocument()
-      let liveDocument = try model.currentLiveBaselineDocument() ?? currentDocument
-      let nextSharedDraft = response.sharedDraft ?? SharedDraftInfo(exists: false, savedAt: nil, savedBy: nil, source: "")
-      model.currentEditorWorkspace?.workspace.hasSharedDraft = response.hasSharedDraft
-      model.currentEditorWorkspace?.workspace.sharedDraft = nextSharedDraft
-      model.currentEditorWorkspace?.workspace.revisions.draftRevision = response.savedAt
-      model.currentEditorWorkspace?.meta.draftState = response.hasSharedDraft ? model.jsonValue(for: currentDocument) : nil
-      model.currentEditorWorkspace?.meta.draftSavedTs = response.savedAt
-      model.currentEditorWorkspace?.meta.draftSavedByUserId = response.hasSharedDraft ? model.authSession?.userID : nil
-      model.currentEditorWorkspace?.meta.draftSavedByName = response.hasSharedDraft ? model.authSession?.name : nil
-      model.currentEditorWorkspace?.meta.draftSavedSource = response.hasSharedDraft ? "ios_app" : nil
-      model.editorHasSharedDraft = response.hasSharedDraft
-      model.rebaselineCurrentEditorToServer(
-        liveDocument: liveDocument,
-        sharedDraftDocument: response.hasSharedDraft
-          ? currentDocument
-          : liveDocument,
-        revisions: model.currentEditorWorkspace?.workspace.revisions,
-        hasSharedDraft: response.hasSharedDraft,
-        sharedDraft: nextSharedDraft
-      )
-      model.notice = AppNotice(
-        tone: .success,
-        title: response.hasSharedDraft ? "Draft Saved" : "Draft Cleared",
-        message: response.hasSharedDraft
-          ? "The shared draft now matches your current iPhone edits."
-          : "The shared draft marker has been removed from the server."
-      )
+  func discardLocalDraft() {
+    guard canDiscardLocalDraft else { return }
+    guard let baselineDocument = (try? draftBaselineEditorDocument()) ?? (try? currentLiveBaselineDocument()) else {
+      return
     }
+    var restored = baselineDocument
+    restored.normalizeIdentifiersForRuntime()
+    currentEditorDocument = restored
+    updateEditorStateFlags(for: restored)
+    currentEditorPreview = nil
+    selectedPreviewChangeIDs = []
+    persistOfflineDraftIfNeeded()
+    notice = AppNotice(
+      tone: .neutral,
+      title: "Draft Discarded",
+      message: "Local edits on this device were removed. The shared server queue was not changed."
+    )
   }
 
   func saveLiveMenu() async {
@@ -534,29 +517,27 @@ final class AppModel {
           let workspace = currentEditorWorkspace,
           let snapshot = editorSnapshot() else { return }
 
-    await run("Saving Live Menu") { model in
+    await run("Saving Quietly") { model in
       var currentDocument = try model.requireCurrentEditorDocument()
+      let expectedBaselineRevision = model.expectedNotificationBaselineRevision(for: workspace)
       let response = try await model.services.liveSave.save(
         menuId: menuId,
         snapshot: snapshot,
         expectedLiveRevision: workspace.workspace.revisions.liveRevision,
-        expectedDraftRevision: workspace.workspace.revisions.draftRevision,
+        expectedDraftRevision: expectedBaselineRevision,
         accessToken: accessToken
       )
-      if model.editorHasSharedDraft {
-        _ = try await model.services.draft.clear(
-          menuId: menuId,
-          expectedDraftRevision: workspace.workspace.revisions.draftRevision,
-          accessToken: accessToken,
-          source: "ios_app"
-        )
+      if let currentRevisions = response.currentRevisions {
+        model.currentEditorWorkspace?.workspace.revisions = currentRevisions
       }
       if let ts = response.ts {
         currentDocument.meta.lastUpdatedTs = ts
-        model.currentEditorWorkspace?.workspace.revisions.liveRevision = ts
-        model.currentEditorDocument = currentDocument
         model.currentEditorWorkspace?.meta.lastUpdatedTs = ts
+        if model.currentEditorWorkspace?.workspace.revisions.liveRevision == nil {
+          model.currentEditorWorkspace?.workspace.revisions.liveRevision = ts
+        }
       }
+      model.currentEditorDocument = currentDocument
       model.currentEditorWorkspace?.workspace.hasSharedDraft = false
       model.currentEditorWorkspace?.workspace.sharedDraft = SharedDraftInfo(exists: false, savedAt: nil, savedBy: nil, source: "")
       model.currentEditorWorkspace?.workspace.revisions.draftRevision = nil
@@ -567,12 +548,10 @@ final class AppModel {
       model.currentEditorWorkspace?.meta.draftSavedSource = nil
       model.rebaselineCurrentEditorToServer(
         liveDocument: currentDocument,
-        sharedDraftDocument: currentDocument,
-        revisions: model.currentEditorWorkspace?.workspace.revisions,
-        hasSharedDraft: false,
-        sharedDraft: SharedDraftInfo(exists: false, savedAt: nil, savedBy: nil, source: "")
+        serverDocument: currentDocument,
+        revisions: model.currentEditorWorkspace?.workspace.revisions
       )
-      model.notice = AppNotice(tone: .success, title: "Live Menu Saved", message: "The live menu now matches the current native editor state.")
+      model.notice = AppNotice(tone: .success, title: "Saved Quietly", message: "The live menu was updated without sending notifications.")
     }
   }
 
@@ -623,7 +602,7 @@ final class AppModel {
       }
 
       let remoteLiveDocument = EditableMenuDocument(workspace: freshWorkspace)
-      let remoteDocument = model.sharedDraftEditorDocument(from: freshWorkspace, liveDocument: remoteLiveDocument)
+      let remoteDocument = model.serverWorkspaceDocument(from: freshWorkspace, liveDocument: remoteLiveDocument)
       let nextDocument: EditableMenuDocument
       if let localDraft = requirement.localDraft {
         nextDocument = model.mergeLocalDraft(
@@ -746,7 +725,7 @@ final class AppModel {
 
   private func editorSnapshot() -> MenuSnapshotPayload? {
     guard let document = currentEditorDocument else { return nil }
-    return document.makeSnapshot(hasUnsavedChanges: editorDirty, hasSharedDraft: editorHasSharedDraft)
+    return document.makeSnapshot(hasUnsavedChanges: editorDirty, hasServerUnsentChanges: editorHasServerUnsentChanges)
   }
 
   private func restoreOfflineDraftIfNeeded() throws {
@@ -770,8 +749,10 @@ final class AppModel {
     guard let envelope = maybeEnvelope else { return }
 
     let revisions = workspace.workspace.revisions
+    let serverBaselineRevision = expectedNotificationBaselineRevision(for: workspace)
+    let localBaselineRevision = envelope.baseNotificationBaselineRevision ?? envelope.baseDraftRevision
     let matchesServer = envelope.baseLiveRevision == revisions.liveRevision &&
-      envelope.baseDraftRevision == revisions.draftRevision
+      localBaselineRevision == serverBaselineRevision
 
     if matchesServer {
       var normalized = envelope.document
@@ -799,14 +780,17 @@ final class AppModel {
           workspace: WorkspaceState(
             actor: workspace.workspace.actor,
             accessibleMenuIds: workspace.workspace.accessibleMenuIds,
-            hasSharedDraft: envelope.baseDraftRevision != nil,
+            hasSharedDraft: false,
             sharedDraft: workspace.workspace.sharedDraft,
+            menuStatus: workspace.workspace.menuStatus,
+            hasUnsentChanges: workspace.workspace.hasUnsentChanges,
             permissions: workspace.workspace.permissions,
             capabilities: workspace.workspace.capabilities,
             revisions: WorkspaceRevisions(
               liveRevision: envelope.baseLiveRevision,
               draftRevision: envelope.baseDraftRevision,
-              lastSentRevision: workspace.workspace.revisions.lastSentRevision
+              lastSentRevision: workspace.workspace.revisions.lastSentRevision,
+              notificationBaselineRevision: localBaselineRevision
             )
           ),
           capabilities: workspace.capabilities
@@ -830,11 +814,13 @@ final class AppModel {
       let envelope = LocalDraftEnvelope(
         userId: session.userID,
         menuId: document.menuId,
+        clientScopeId: offlineDraftStore.clientScopeId,
         restaurantId: document.restaurantId,
         menuName: currentMenuRecord?.name ?? document.context.menuType.capitalized,
         savedAt: .now,
         baseLiveRevision: workspace.workspace.revisions.liveRevision,
         baseDraftRevision: workspace.workspace.revisions.draftRevision,
+        baseNotificationBaselineRevision: expectedNotificationBaselineRevision(for: workspace),
         baseDocument: baseDocument,
         document: document
       )
@@ -852,11 +838,13 @@ final class AppModel {
     return LocalDraftEnvelope(
       userId: session.userID,
       menuId: document.menuId,
+      clientScopeId: offlineDraftStore.clientScopeId,
       restaurantId: document.restaurantId,
       menuName: currentMenuRecord?.name ?? document.context.menuType.capitalized,
       savedAt: .now,
       baseLiveRevision: workspace.workspace.revisions.liveRevision,
       baseDraftRevision: workspace.workspace.revisions.draftRevision,
+      baseNotificationBaselineRevision: expectedNotificationBaselineRevision(for: workspace),
       baseDocument: try? draftBaselineEditorDocument(),
       document: document
     )
@@ -867,37 +855,37 @@ final class AppModel {
     history: HistoryPayload?,
     document: EditableMenuDocument? = nil
   ) throws {
-    let liveDocument = EditableMenuDocument(workspace: workspace)
-    let sharedDraftDocument = sharedDraftEditorDocument(from: workspace, liveDocument: liveDocument)
-    currentEditorWorkspace = workspace
+    var normalizedWorkspace = workspace
+    if normalizedWorkspace.workspace.revisions.notificationBaselineRevision == nil {
+      normalizedWorkspace.workspace.revisions.notificationBaselineRevision = normalizedWorkspace.meta.lastSentTs
+        ?? normalizedWorkspace.workspace.revisions.lastSentRevision
+        ?? normalizedWorkspace.workspace.revisions.draftRevision
+    }
+    let liveDocument = EditableMenuDocument(workspace: normalizedWorkspace)
+    let serverDocument = serverWorkspaceDocument(from: normalizedWorkspace, liveDocument: liveDocument)
+    currentEditorWorkspace = normalizedWorkspace
     currentEditorHistory = history
-    currentEditorDocument = document ?? sharedDraftDocument
-    try setEditorBaselines(liveDocument: liveDocument, sharedDraftDocument: sharedDraftDocument)
+    currentEditorDocument = document ?? serverDocument
+    try setEditorBaselines(liveDocument: liveDocument, serverDocument: serverDocument)
     currentEditorPreview = nil
     selectedPreviewChangeIDs = []
-    editorHasSharedDraft = workspace.workspace.hasSharedDraft
+    editorHasServerUnsentChanges = serverHasUnsentChanges(in: normalizedWorkspace)
     editorRefreshRequirement = nil
     currentPublicMenu = nil
-    updateEditorStateFlags(for: currentEditorDocument ?? sharedDraftDocument)
+    updateEditorStateFlags(for: currentEditorDocument ?? serverDocument)
   }
 
   private func rebaselineCurrentEditorToServer(
     liveDocument: EditableMenuDocument,
-    sharedDraftDocument: EditableMenuDocument,
-    revisions: WorkspaceRevisions?,
-    hasSharedDraft: Bool,
-    sharedDraft: SharedDraftInfo?
+    serverDocument: EditableMenuDocument,
+    revisions: WorkspaceRevisions?
   ) {
     guard let currentEditorDocument else { return }
-    try? setEditorBaselines(liveDocument: liveDocument, sharedDraftDocument: sharedDraftDocument)
+    try? setEditorBaselines(liveDocument: liveDocument, serverDocument: serverDocument)
     if let revisions {
       currentEditorWorkspace?.workspace.revisions = revisions
     }
-    currentEditorWorkspace?.workspace.hasSharedDraft = hasSharedDraft
-    if let sharedDraft {
-      currentEditorWorkspace?.workspace.sharedDraft = sharedDraft
-    }
-    editorHasSharedDraft = hasSharedDraft
+    editorHasServerUnsentChanges = serverHasUnsentChanges(in: currentEditorWorkspace)
     editorRefreshRequirement = nil
     updateEditorStateFlags(for: currentEditorDocument)
     currentEditorPreview = nil
@@ -913,7 +901,7 @@ final class AppModel {
     mergeBaseDocument: EditableMenuDocument?
   ) -> EditorRefreshRequirement {
     let remoteLiveDocument = EditableMenuDocument(workspace: freshWorkspace)
-    let remoteDocument = sharedDraftEditorDocument(from: freshWorkspace, liveDocument: remoteLiveDocument)
+    let remoteDocument = serverWorkspaceDocument(from: freshWorkspace, liveDocument: remoteLiveDocument)
     let baseDocument = mergeBaseDocument ?? localDraft?.baseDocument
     let overlap = buildOverlapLabels(
       base: baseDocument,
@@ -981,11 +969,6 @@ final class AppModel {
     try encoder.encode(document)
   }
 
-  private func jsonValue(for document: EditableMenuDocument) -> JSONValue? {
-    guard let data = try? documentData(for: document) else { return nil }
-    return try? JSONDecoder().decode(JSONValue.self, from: data)
-  }
-
   private func requireCurrentEditorDocument() throws -> EditableMenuDocument {
     guard let currentEditorDocument else {
       throw NSError(domain: "AppModel", code: 1, userInfo: [NSLocalizedDescriptionKey: "The editor is not loaded yet."])
@@ -993,12 +976,13 @@ final class AppModel {
     return currentEditorDocument
   }
 
-  private func setEditorBaselines(liveDocument: EditableMenuDocument, sharedDraftDocument: EditableMenuDocument) throws {
+  private func setEditorBaselines(liveDocument: EditableMenuDocument, serverDocument: EditableMenuDocument) throws {
     liveBaselineDocumentData = try documentData(for: liveDocument)
-    draftBaselineDocumentData = try documentData(for: sharedDraftDocument)
+    draftBaselineDocumentData = try documentData(for: serverDocument)
   }
 
-  private func sharedDraftEditorDocument(from workspace: MenuWorkspacePayload, liveDocument: EditableMenuDocument) -> EditableMenuDocument {
+  private func serverWorkspaceDocument(from workspace: MenuWorkspacePayload, liveDocument: EditableMenuDocument) -> EditableMenuDocument {
+    // Legacy fallback only while server payloads are transitioning away from shared drafts.
     guard workspace.workspace.hasSharedDraft else { return liveDocument }
     guard let draftState = workspace.meta.draftState,
           let document = decodeEditorDocument(from: draftState) else {
@@ -1012,6 +996,35 @@ final class AppModel {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
     return try? decoder.decode(EditableMenuDocument.self, from: data)
+  }
+
+  private func expectedNotificationBaselineRevision(for workspace: MenuWorkspacePayload) -> Int? {
+    workspace.workspace.revisions.notificationBaselineRevision
+      ?? workspace.workspace.revisions.lastSentRevision
+      ?? workspace.meta.lastSentTs
+      ?? workspace.workspace.revisions.draftRevision
+  }
+
+  private func serverHasUnsentChanges(in workspace: MenuWorkspacePayload?) -> Bool {
+    guard let workspace else { return false }
+    if let hasUnsentChanges = workspace.workspace.hasUnsentChanges {
+      return hasUnsentChanges
+    }
+    let normalizedStatus = workspace.workspace.menuStatus
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased()
+    if normalizedStatus.contains("unsent") {
+      return true
+    }
+    if normalizedStatus == "live" {
+      return false
+    }
+    let liveRevision = workspace.workspace.revisions.liveRevision ?? workspace.meta.lastUpdatedTs
+    let baselineRevision = expectedNotificationBaselineRevision(for: workspace)
+    if let liveRevision, let baselineRevision {
+      return liveRevision != baselineRevision
+    }
+    return workspace.workspace.hasSharedDraft
   }
 
   private func updateEditorStateFlags(for document: EditableMenuDocument) {
@@ -1076,15 +1089,19 @@ private func messageForRefreshCompletion(
 
 private func classifyRemoteUpdateKind(previous: WorkspaceRevisions, next: WorkspaceRevisions) -> RemoteMenuUpdateKind {
   let liveChanged = previous.liveRevision != next.liveRevision
-  let draftChanged = previous.draftRevision != next.draftRevision
-  switch (liveChanged, draftChanged) {
+  let queueChanged = queueRevision(for: previous) != queueRevision(for: next)
+  switch (liveChanged, queueChanged) {
   case (true, true):
-    return .liveAndDraft
+    return .liveAndQueue
   case (true, false):
     return .liveMenu
   case (false, true), (false, false):
-    return .sharedDraft
+    return .queueState
   }
+}
+
+private func queueRevision(for revisions: WorkspaceRevisions) -> Int? {
+  revisions.notificationBaselineRevision ?? revisions.lastSentRevision ?? revisions.draftRevision
 }
 
 private func buildOverlapLabels(

--- a/ios/ElRoysManagerApp/Clients/BackendClients.swift
+++ b/ios/ElRoysManagerApp/Clients/BackendClients.swift
@@ -163,6 +163,7 @@ private struct LiveSaveRequest: Encodable {
   var snapshot: MenuSnapshotPayload
   var expectedLiveRevision: Int?
   var expectedDraftRevision: Int?
+  var expectedNotificationBaselineRevision: Int?
 }
 
 private struct PublishRequest: Encodable {
@@ -173,6 +174,7 @@ private struct PublishRequest: Encodable {
   var selectedChangeIds: [String]?
   var expectedLiveRevision: Int?
   var expectedDraftRevision: Int?
+  var expectedNotificationBaselineRevision: Int?
 }
 
 private struct SpecialsRequest: Encodable {
@@ -513,7 +515,8 @@ final class LiveSaveClient: LiveSaveClienting {
         menuId: menuId,
         snapshot: snapshot,
         expectedLiveRevision: expectedLiveRevision,
-        expectedDraftRevision: expectedDraftRevision
+        expectedDraftRevision: expectedDraftRevision,
+        expectedNotificationBaselineRevision: expectedDraftRevision
       )
     )
   }
@@ -538,7 +541,8 @@ final class PublishClient: PublishClienting {
         source: source,
         selectedChangeIds: nil,
         expectedLiveRevision: expectedLiveRevision,
-        expectedDraftRevision: expectedDraftRevision
+        expectedDraftRevision: expectedDraftRevision,
+        expectedNotificationBaselineRevision: expectedDraftRevision
       )
     )
   }
@@ -555,7 +559,8 @@ final class PublishClient: PublishClienting {
         source: source,
         selectedChangeIds: selectedChangeIds,
         expectedLiveRevision: expectedLiveRevision,
-        expectedDraftRevision: expectedDraftRevision
+        expectedDraftRevision: expectedDraftRevision,
+        expectedNotificationBaselineRevision: expectedDraftRevision
       )
     )
   }

--- a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
@@ -10,6 +10,7 @@ struct MenuEditorScreen: View {
   @State private var showingItemSheet = false
   @State private var renameTarget: MenuCategoryPayload?
   @State private var renameText = ""
+  @State private var showingDiscardDraftConfirm = false
 
   private var theme: MenuEditorTheme {
     .theme(for: menu)
@@ -31,8 +32,8 @@ struct MenuEditorScreen: View {
             menuAccent: menuAccent,
             hasLocalDraftChanges: model.hasLocalDraftChanges,
             hasLiveMenuChanges: model.hasLiveMenuChanges,
-            hasSharedDraft: model.editorHasSharedDraft,
-            sharedDraftSummary: model.editorSharedDraftSummary
+            hasServerUnsentChanges: model.hasServerUnsentChanges,
+            menuStatusLabel: model.menuStatusLabel
           )
 
           if let notice = model.notice {
@@ -46,9 +47,9 @@ struct MenuEditorScreen: View {
             menuAccent: menuAccent,
             onAddItem: presentNewItem,
             onAddCategory: { showingAddCategory = true },
-            onSaveDraft: saveDraft,
-            onSaveLive: saveLive,
-            onSendUpdate: loadSendPreview
+            onSaveQuietly: saveQuietly,
+            onSendUpdate: loadSendPreview,
+            onDiscardDraft: { showingDiscardDraftConfirm = true }
           )
 
           if let preview = model.currentEditorPreview {
@@ -159,6 +160,14 @@ struct MenuEditorScreen: View {
       }
       Button("Cancel", role: .cancel) {}
     }
+    .alert("Discard Local Draft?", isPresented: $showingDiscardDraftConfirm) {
+      Button("Discard Draft", role: .destructive) {
+        model.discardLocalDraft()
+      }
+      Button("Keep Editing", role: .cancel) {}
+    } message: {
+      Text("This only removes unsaved edits from this device and does not modify the shared server queue.")
+    }
   }
 
   private func presentNewItem() {
@@ -174,11 +183,7 @@ struct MenuEditorScreen: View {
     }
   }
 
-  private func saveDraft() {
-    Task { await model.saveRemoteDraft() }
-  }
-
-  private func saveLive() {
+  private func saveQuietly() {
     Task { await model.saveLiveMenu() }
   }
 
@@ -258,8 +263,8 @@ private struct PublishPreviewCard: View {
   let onPublish: () -> Void
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 10) {
-      Text("Send Update Preview")
+    VStack(alignment: .leading, spacing: 12) {
+      Text(previewTitle)
         .font(EditorTypography.display(20, weight: .bold))
         .foregroundStyle(theme.titleText)
       if !preview.patchMessage.isEmpty {
@@ -267,33 +272,92 @@ private struct PublishPreviewCard: View {
           .font(EditorTypography.body(14))
           .foregroundStyle(theme.subtleText)
       }
-      ForEach(Array(preview.sections.enumerated()), id: \.offset) { _, section in
+
+      if preview.hasNotificationChanges {
         VStack(alignment: .leading, spacing: 6) {
-          Text(section.label)
+          Text("Will Send")
             .font(EditorTypography.body(14, weight: .bold))
             .foregroundStyle(theme.titleText)
-          ForEach(Array(section.changes.enumerated()), id: \.offset) { _, change in
-            Toggle(isOn: Binding(
-              get: { model.selectedPreviewChangeIDs.contains(change.id) },
-              set: { model.updatePreviewSelection(change.id, selected: $0) }
-            )) {
-              Text(change.text)
+          ForEach(Array(preview.sections.enumerated()), id: \.offset) { _, section in
+            VStack(alignment: .leading, spacing: 6) {
+              Text(section.label)
+                .font(EditorTypography.body(13, weight: .semibold))
+                .foregroundStyle(theme.subtleText)
+              ForEach(Array(section.changes.enumerated()), id: \.offset) { _, change in
+                Toggle(isOn: Binding(
+                  get: { model.selectedPreviewChangeIDs.contains(change.id) },
+                  set: { model.updatePreviewSelection(change.id, selected: $0) }
+                )) {
+                  Text(change.text)
+                    .font(EditorTypography.body(13))
+                    .foregroundStyle(theme.bodyText)
+                }
+                .tint(menuAccent)
+              }
+            }
+          }
+        }
+        .padding(12)
+        .background(theme.itemRowFill, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+
+        if !uncheckedChanges.isEmpty {
+          VStack(alignment: .leading, spacing: 6) {
+            Text("Will Clear Without Sending")
+              .font(EditorTypography.body(14, weight: .bold))
+              .foregroundStyle(theme.titleText)
+            ForEach(Array(uncheckedChanges.enumerated()), id: \.offset) { _, change in
+              Text("\(change.sectionLabel): \(change.text)")
                 .font(EditorTypography.body(13))
                 .foregroundStyle(theme.bodyText)
             }
-            .tint(menuAccent)
+          }
+          .padding(12)
+          .background(theme.itemRowFill, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        }
+      }
+
+      if !preview.saveOnlyChanges.isEmpty {
+        VStack(alignment: .leading, spacing: 6) {
+          Text("Will Save Only")
+            .font(EditorTypography.body(14, weight: .bold))
+            .foregroundStyle(theme.titleText)
+          ForEach(Array(preview.saveOnlyChanges.enumerated()), id: \.offset) { _, change in
+            Text(change.label.nilIfBlank ?? change.message)
+              .font(EditorTypography.body(13))
+              .foregroundStyle(theme.bodyText)
           }
         }
         .padding(12)
         .background(theme.itemRowFill, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
       }
-      Button("Save And Send") {
+
+      Button(actionButtonTitle) {
         onPublish()
       }
       .buttonStyle(PrimaryGlassButtonStyle())
       .disabled(!model.canPublishRemotely)
     }
     .menuEditorSurface(colors: [theme.previewTop, theme.previewBottom], border: theme.previewBorder)
+  }
+
+  private var previewTitle: String {
+    if !preview.hasNotificationChanges {
+      return "Save Preview"
+    }
+    return model.hasLocalDraftChanges ? "Save & Send Preview" : "Send Preview"
+  }
+
+  private var actionButtonTitle: String {
+    if !preview.hasNotificationChanges {
+      return "Save"
+    }
+    return model.hasLocalDraftChanges ? "Save & Send" : "Send"
+  }
+
+  private var uncheckedChanges: [PreviewChange] {
+    preview.sections
+      .flatMap(\.changes)
+      .filter { !model.selectedPreviewChangeIDs.contains($0.id) }
   }
 }
 
@@ -303,8 +367,8 @@ private struct MenuEditorHeaderCard: View {
   let menuAccent: Color
   let hasLocalDraftChanges: Bool
   let hasLiveMenuChanges: Bool
-  let hasSharedDraft: Bool
-  let sharedDraftSummary: String?
+  let hasServerUnsentChanges: Bool
+  let menuStatusLabel: String
 
   var body: some View {
     VStack(alignment: .leading, spacing: 14) {
@@ -333,6 +397,11 @@ private struct MenuEditorHeaderCard: View {
 
       HStack(alignment: .top, spacing: 10) {
         MenuEditorBadge(
+          label: menuStatusLabel,
+          fill: hasServerUnsentChanges ? menuAccent.opacity(0.16) : theme.successAccent.opacity(0.18),
+          text: hasServerUnsentChanges ? menuAccent : theme.successAccent
+        )
+        MenuEditorBadge(
           label: hasLocalDraftChanges ? "Drafting locally" : "No local drafts",
           fill: hasLocalDraftChanges ? theme.warningAccent.opacity(0.18) : theme.neutralAccent.opacity(0.16),
           text: hasLocalDraftChanges ? theme.warningAccent : theme.neutralAccent
@@ -342,19 +411,6 @@ private struct MenuEditorHeaderCard: View {
           fill: hasLiveMenuChanges ? menuAccent.opacity(0.16) : theme.successAccent.opacity(0.18),
           text: hasLiveMenuChanges ? menuAccent : theme.successAccent
         )
-        if hasSharedDraft {
-          MenuEditorBadge(
-            label: "Shared draft on server",
-            fill: menuAccent.opacity(0.16),
-            text: menuAccent
-          )
-        }
-      }
-
-      if let sharedDraftSummary {
-        Text(sharedDraftSummary)
-          .font(EditorTypography.body(13))
-          .foregroundStyle(theme.subtleText)
       }
 
       Text(workflowSummary)
@@ -365,16 +421,19 @@ private struct MenuEditorHeaderCard: View {
   }
 
   private var workflowSummary: String {
-    if hasLiveMenuChanges && hasLocalDraftChanges {
-      return "Your working copy is ahead of both the shared draft and the live menu."
-    }
-    if hasLiveMenuChanges && hasSharedDraft {
-      return "This menu is showing the saved shared draft. Save Menu or Send Update to promote it live."
+    if hasLocalDraftChanges && hasServerUnsentChanges {
+      return "This device has unsaved local edits, and the server queue still has unsent menu changes."
     }
     if hasLocalDraftChanges {
-      return "Your edits are only on this device until you save a shared draft or push them live."
+      return "Your draft is local to this device until you Save Quietly or Save & Send."
     }
-    return "This editor is aligned with the current shared draft and live menu state."
+    if hasServerUnsentChanges {
+      return "The menu is live with unsent queue work. Use Send to notify channels or clear remaining queue groups."
+    }
+    if hasLiveMenuChanges {
+      return "Your working copy differs from live. Save Quietly to stage it live without sending."
+    }
+    return "Live state and notification baseline are aligned."
   }
 }
 
@@ -400,9 +459,9 @@ private struct MenuEditorActionPanel: View {
   let menuAccent: Color
   let onAddItem: () -> Void
   let onAddCategory: () -> Void
-  let onSaveDraft: () -> Void
-  let onSaveLive: () -> Void
+  let onSaveQuietly: () -> Void
   let onSendUpdate: () -> Void
+  let onDiscardDraft: () -> Void
 
   var body: some View {
     VStack(alignment: .leading, spacing: 14) {
@@ -423,52 +482,49 @@ private struct MenuEditorActionPanel: View {
       }
 
       HStack(spacing: 12) {
-        Button(action: onSaveDraft) {
+        Button(action: onSaveQuietly) {
           MenuEditorActionLabel(
-            title: "Save Draft",
-            subtitle: model.hasLocalDraftChanges ? "Push the working copy to the shared draft" : "No local draft changes",
-            icon: "square.and.arrow.down.fill",
-            accent: theme.neutralAccent
-          )
-        }
-        .buttonStyle(.plain)
-        .disabled(!model.canSaveDraftRemotely)
-
-        Button(action: onSaveLive) {
-          MenuEditorActionLabel(
-            title: "Save Menu",
-            subtitle: model.hasLiveMenuChanges ? "Update the live menu without sending" : "Live menu already matches",
+            title: "Save Quietly",
+            subtitle: model.hasLiveMenuChanges ? "Save live without sending notifications" : "Live menu already matches",
             icon: "checkmark.seal.fill",
             accent: theme.successAccent
           )
         }
         .buttonStyle(.plain)
-        .disabled(!model.canSaveLiveRemotely)
-      }
+        .disabled(!model.canSaveQuietlyRemotely)
 
-      HStack(spacing: 12) {
         Button(action: onSendUpdate) {
           MenuEditorActionLabel(
-            title: "Send Update",
-            subtitle: model.currentEditorPreview == nil ? "Review the outgoing update before sending" : "Preview loaded below",
+            title: model.hasLocalDraftChanges ? "Save & Send" : "Send",
+            subtitle: model.currentEditorPreview == nil
+              ? (model.hasLocalDraftChanges
+                  ? "Save live, then choose what to send or clear"
+                  : "Choose which unsent queue groups to send or clear")
+              : "Preview loaded below",
             icon: "paperplane.fill",
             accent: menuAccent
           )
         }
         .buttonStyle(.plain)
         .disabled(!model.canLoadPublishPreview)
+      }
+
+      HStack(spacing: 12) {
+        Button(action: onDiscardDraft) {
+          MenuEditorActionLabel(
+            title: "Discard Draft",
+            subtitle: model.hasLocalDraftChanges ? "Remove local edits on this device" : "No local draft to discard",
+            icon: "trash.fill",
+            accent: theme.warningAccent
+          )
+        }
+        .buttonStyle(.plain)
+        .disabled(!model.canDiscardLocalDraft)
 
         NavigationLink(value: AppDestination.routePreview(menu)) {
           MenuEditorActionLabel(title: "Exact Route", subtitle: "See the true public route", icon: "safari.fill", accent: theme.neutralAccent)
         }
         .buttonStyle(.plain)
-      }
-
-      if model.showClearSharedDraft {
-        Button("Clear Shared Draft", action: onSaveDraft)
-          .font(EditorTypography.body(13, weight: .bold))
-          .foregroundStyle(theme.warningAccent)
-          .buttonStyle(.plain)
       }
     }
     .menuEditorSurface(colors: [theme.panelTop, theme.panelBottom], border: theme.panelBorder)

--- a/ios/ElRoysManagerApp/Models/AppModels.swift
+++ b/ios/ElRoysManagerApp/Models/AppModels.swift
@@ -77,6 +77,22 @@ private extension KeyedDecodingContainer {
   }
 }
 
+private extension Array {
+  mutating func moveItems(fromOffsets source: IndexSet, toOffset destination: Int) {
+    let validOffsets = source.sorted().filter { indices.contains($0) }
+    guard !validOffsets.isEmpty else { return }
+
+    let movingItems = validOffsets.map { self[$0] }
+    for index in validOffsets.reversed() {
+      remove(at: index)
+    }
+
+    let removedBeforeDestination = validOffsets.filter { $0 < destination }.count
+    let insertionIndex = Swift.max(0, Swift.min(destination - removedBeforeDestination, count))
+    insert(contentsOf: movingItems, at: insertionIndex)
+  }
+}
+
 enum AppEnvironmentName: String, Codable {
   case production = "Production"
   case preview = "Preview"
@@ -334,6 +350,54 @@ struct WorkspaceRevisions: Codable, Equatable {
   var liveRevision: Int?
   var draftRevision: Int?
   var lastSentRevision: Int?
+  var notificationBaselineRevision: Int?
+
+  enum CodingKeys: String, CodingKey {
+    case liveRevision
+    case draftRevision
+    case lastSentRevision
+    case notificationBaselineRevision
+    case notificationRevision
+    case baselineRevision
+  }
+
+  init(
+    liveRevision: Int?,
+    draftRevision: Int?,
+    lastSentRevision: Int?,
+    notificationBaselineRevision: Int? = nil
+  ) {
+    self.liveRevision = liveRevision
+    self.draftRevision = draftRevision
+    self.lastSentRevision = lastSentRevision
+    self.notificationBaselineRevision = notificationBaselineRevision ?? lastSentRevision ?? draftRevision
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let liveRevision = try container.decodeIfPresent(Int.self, forKey: .liveRevision)
+    let draftRevision = try container.decodeIfPresent(Int.self, forKey: .draftRevision)
+    let lastSentRevision = try container.decodeIfPresent(Int.self, forKey: .lastSentRevision)
+    let notificationBaselineRevision = try container.decodeIfPresent(Int.self, forKey: .notificationBaselineRevision)
+      ?? (try container.decodeIfPresent(Int.self, forKey: .notificationRevision))
+      ?? (try container.decodeIfPresent(Int.self, forKey: .baselineRevision))
+      ?? lastSentRevision
+      ?? draftRevision
+    self.init(
+      liveRevision: liveRevision,
+      draftRevision: draftRevision,
+      lastSentRevision: lastSentRevision,
+      notificationBaselineRevision: notificationBaselineRevision
+    )
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encodeIfPresent(liveRevision, forKey: .liveRevision)
+    try container.encodeIfPresent(draftRevision, forKey: .draftRevision)
+    try container.encodeIfPresent(lastSentRevision, forKey: .lastSentRevision)
+    try container.encodeIfPresent(notificationBaselineRevision, forKey: .notificationBaselineRevision)
+  }
 }
 
 struct WorkspaceState: Codable, Equatable {
@@ -341,6 +405,8 @@ struct WorkspaceState: Codable, Equatable {
   var accessibleMenuIds: [String]
   var hasSharedDraft: Bool
   var sharedDraft: SharedDraftInfo
+  var menuStatus: String
+  var hasUnsentChanges: Bool?
   var permissions: WorkspacePermissions
   var capabilities: WorkspaceCapabilities
   var revisions: WorkspaceRevisions
@@ -350,6 +416,12 @@ struct WorkspaceState: Codable, Equatable {
     case accessibleMenuIds
     case hasSharedDraft
     case sharedDraft
+    case menuStatus
+    case publishStatus
+    case status
+    case hasUnsentChanges
+    case hasPendingUpdate
+    case hasNotificationQueue
     case permissions
     case capabilities
     case revisions
@@ -360,6 +432,8 @@ struct WorkspaceState: Codable, Equatable {
     accessibleMenuIds: [String],
     hasSharedDraft: Bool,
     sharedDraft: SharedDraftInfo,
+    menuStatus: String = "",
+    hasUnsentChanges: Bool? = nil,
     permissions: WorkspacePermissions,
     capabilities: WorkspaceCapabilities,
     revisions: WorkspaceRevisions
@@ -368,6 +442,8 @@ struct WorkspaceState: Codable, Equatable {
     self.accessibleMenuIds = accessibleMenuIds
     self.hasSharedDraft = hasSharedDraft
     self.sharedDraft = sharedDraft
+    self.menuStatus = menuStatus
+    self.hasUnsentChanges = hasUnsentChanges
     self.permissions = permissions
     self.capabilities = capabilities
     self.revisions = revisions
@@ -379,10 +455,20 @@ struct WorkspaceState: Codable, Equatable {
       SharedDraftInfo.self,
       forKey: .sharedDraft
     ) ?? SharedDraftInfo(exists: false, savedAt: nil, savedBy: nil, source: "")
+    let menuStatusPrimary = try container.decodeIfPresent(String.self, forKey: .menuStatus)
+    let menuStatusLegacy = try container.decodeIfPresent(String.self, forKey: .publishStatus)
+    let menuStatusFallback = try container.decodeIfPresent(String.self, forKey: .status)
+    let menuStatus = menuStatusPrimary ?? menuStatusLegacy ?? menuStatusFallback ?? ""
+    let unsentPrimary = try container.decodeIfPresent(Bool.self, forKey: .hasUnsentChanges)
+    let unsentLegacy = try container.decodeIfPresent(Bool.self, forKey: .hasPendingUpdate)
+    let unsentFallback = try container.decodeIfPresent(Bool.self, forKey: .hasNotificationQueue)
+    let hasUnsentChanges = unsentPrimary ?? unsentLegacy ?? unsentFallback
     self.actor = try container.decodeIfPresent(ActorProfile.self, forKey: .actor)
     self.accessibleMenuIds = (try? container.decode([String].self, forKey: .accessibleMenuIds)) ?? []
     self.hasSharedDraft = try container.decodeIfPresent(Bool.self, forKey: .hasSharedDraft) ?? sharedDraft.exists
     self.sharedDraft = sharedDraft
+    self.menuStatus = menuStatus
+    self.hasUnsentChanges = hasUnsentChanges
     self.permissions = try container.decodeIfPresent(
       WorkspacePermissions.self,
       forKey: .permissions
@@ -406,7 +492,20 @@ struct WorkspaceState: Codable, Equatable {
       includesRestaurantTools: false
     )
     self.revisions = try container.decodeIfPresent(WorkspaceRevisions.self, forKey: .revisions)
-      ?? WorkspaceRevisions(liveRevision: nil, draftRevision: nil, lastSentRevision: nil)
+      ?? WorkspaceRevisions(liveRevision: nil, draftRevision: nil, lastSentRevision: nil, notificationBaselineRevision: nil)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encodeIfPresent(actor, forKey: .actor)
+    try container.encode(accessibleMenuIds, forKey: .accessibleMenuIds)
+    try container.encode(hasSharedDraft, forKey: .hasSharedDraft)
+    try container.encode(sharedDraft, forKey: .sharedDraft)
+    try container.encode(menuStatus, forKey: .menuStatus)
+    try container.encodeIfPresent(hasUnsentChanges, forKey: .hasUnsentChanges)
+    try container.encode(permissions, forKey: .permissions)
+    try container.encode(capabilities, forKey: .capabilities)
+    try container.encode(revisions, forKey: .revisions)
   }
 }
 
@@ -973,6 +1072,8 @@ struct HistoryLogEntry: Codable, Equatable, Hashable, Identifiable {
   var menuId: String
   var userId: String
   var userName: String
+  var operationId: String?
+  var eventType: String?
   var diff: [JSONValue]
   var message: String
   var source: String
@@ -984,6 +1085,8 @@ struct HistoryLogEntry: Codable, Equatable, Hashable, Identifiable {
     case menuId
     case userId
     case userName
+    case operationId
+    case eventType
     case diff
     case message
     case source
@@ -996,6 +1099,8 @@ struct HistoryLogEntry: Codable, Equatable, Hashable, Identifiable {
     menuId: String,
     userId: String,
     userName: String,
+    operationId: String?,
+    eventType: String?,
     diff: [JSONValue],
     message: String,
     source: String,
@@ -1006,6 +1111,8 @@ struct HistoryLogEntry: Codable, Equatable, Hashable, Identifiable {
     self.menuId = menuId
     self.userId = userId
     self.userName = userName
+    self.operationId = operationId
+    self.eventType = eventType
     self.diff = diff
     self.message = message
     self.source = source
@@ -1019,6 +1126,8 @@ struct HistoryLogEntry: Codable, Equatable, Hashable, Identifiable {
     self.menuId = try container.decodeString(forKey: .menuId)
     self.userId = try container.decodeString(forKey: .userId)
     self.userName = try container.decodeString(forKey: .userName)
+    self.operationId = try container.decodeIfPresent(String.self, forKey: .operationId)
+    self.eventType = try container.decodeIfPresent(String.self, forKey: .eventType)
     self.diff = (try? container.decode([JSONValue].self, forKey: .diff)) ?? []
     self.message = try container.decodeString(forKey: .message)
     self.source = try container.decodeString(forKey: .source)
@@ -1077,8 +1186,10 @@ struct PreviewMetadata: Codable, Equatable {
 
 struct MenuPreviewPayload: Codable, Equatable {
   var mode: String
+  var menuStatus: String
   var hasChanges: Bool
   var hasLocalDraft: Bool
+  var hasUnsentChanges: Bool
   var hasSharedDraft: Bool
   var hasNotificationChanges: Bool
   var hasSaveOnlyChanges: Bool
@@ -1090,6 +1201,74 @@ struct MenuPreviewPayload: Codable, Equatable {
   var truncated: Bool
   var selectionDefaults: [String]
   var metadata: PreviewMetadata
+
+  enum CodingKeys: String, CodingKey {
+    case mode
+    case menuStatus
+    case hasChanges
+    case hasLocalDraft
+    case hasUnsentChanges
+    case hasPendingUpdate
+    case hasSharedDraft
+    case hasNotificationChanges
+    case hasSaveOnlyChanges
+    case diff
+    case sections
+    case notificationChanges
+    case saveOnlyChanges
+    case patchMessage
+    case truncated
+    case selectionDefaults
+    case metadata
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.mode = try container.decodeString(forKey: .mode)
+    self.hasChanges = try container.decodeBool(forKey: .hasChanges)
+    self.hasLocalDraft = try container.decodeBool(forKey: .hasLocalDraft)
+    let sharedDraftFallback = try container.decodeBool(forKey: .hasSharedDraft)
+    let unsentPrimary = try container.decodeIfPresent(Bool.self, forKey: .hasUnsentChanges)
+    let unsentFallback = try container.decodeIfPresent(Bool.self, forKey: .hasPendingUpdate)
+    self.hasUnsentChanges = unsentPrimary ?? unsentFallback ?? sharedDraftFallback
+    self.hasSharedDraft = sharedDraftFallback
+    self.hasNotificationChanges = try container.decodeBool(forKey: .hasNotificationChanges)
+    self.hasSaveOnlyChanges = try container.decodeBool(forKey: .hasSaveOnlyChanges)
+    self.diff = try container.decodeArray([PreviewDiffSection].self, forKey: .diff)
+    self.sections = try container.decodeArray([PreviewSection].self, forKey: .sections)
+    self.notificationChanges = try container.decodeArray([PreviewChange].self, forKey: .notificationChanges)
+    self.saveOnlyChanges = try container.decodeArray([SaveOnlyChange].self, forKey: .saveOnlyChanges)
+    self.patchMessage = try container.decodeString(forKey: .patchMessage)
+    self.truncated = try container.decodeBool(forKey: .truncated)
+    self.selectionDefaults = try container.decodeArray([String].self, forKey: .selectionDefaults)
+    self.metadata = try container.decodeIfPresent(PreviewMetadata.self, forKey: .metadata)
+      ?? PreviewMetadata(serverOwned: false, contract: "", currentFeaturedIds: [])
+    let decodedStatus = try container.decodeIfPresent(String.self, forKey: .menuStatus)?
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+    self.menuStatus = (decodedStatus?.isEmpty == false)
+      ? (decodedStatus ?? "")
+      : (self.hasUnsentChanges ? "Live | Unsent" : "Live")
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(mode, forKey: .mode)
+    try container.encode(menuStatus, forKey: .menuStatus)
+    try container.encode(hasChanges, forKey: .hasChanges)
+    try container.encode(hasLocalDraft, forKey: .hasLocalDraft)
+    try container.encode(hasUnsentChanges, forKey: .hasUnsentChanges)
+    try container.encode(hasSharedDraft, forKey: .hasSharedDraft)
+    try container.encode(hasNotificationChanges, forKey: .hasNotificationChanges)
+    try container.encode(hasSaveOnlyChanges, forKey: .hasSaveOnlyChanges)
+    try container.encode(diff, forKey: .diff)
+    try container.encode(sections, forKey: .sections)
+    try container.encode(notificationChanges, forKey: .notificationChanges)
+    try container.encode(saveOnlyChanges, forKey: .saveOnlyChanges)
+    try container.encode(patchMessage, forKey: .patchMessage)
+    try container.encode(truncated, forKey: .truncated)
+    try container.encode(selectionDefaults, forKey: .selectionDefaults)
+    try container.encode(metadata, forKey: .metadata)
+  }
 }
 
 struct NotificationStatus: Codable, Equatable {
@@ -1137,8 +1316,48 @@ struct MenuSnapshotContext: Codable, Equatable {
 
 struct SnapshotPreviewContext: Codable, Equatable {
   var dirty: Bool
+  var hasUnsentChanges: Bool
   var hasSharedDraft: Bool
   var saveOnlyChanges: [SaveOnlyChange]
+
+  enum CodingKeys: String, CodingKey {
+    case dirty
+    case hasUnsentChanges
+    case hasPendingUpdate
+    case hasSharedDraft
+    case saveOnlyChanges
+  }
+
+  init(
+    dirty: Bool,
+    hasUnsentChanges: Bool,
+    hasSharedDraft: Bool,
+    saveOnlyChanges: [SaveOnlyChange]
+  ) {
+    self.dirty = dirty
+    self.hasUnsentChanges = hasUnsentChanges
+    self.hasSharedDraft = hasSharedDraft
+    self.saveOnlyChanges = saveOnlyChanges
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let hasSharedDraft = try container.decodeBool(forKey: .hasSharedDraft)
+    self.dirty = try container.decodeBool(forKey: .dirty)
+    let unsentPrimary = try container.decodeIfPresent(Bool.self, forKey: .hasUnsentChanges)
+    let unsentFallback = try container.decodeIfPresent(Bool.self, forKey: .hasPendingUpdate)
+    self.hasUnsentChanges = unsentPrimary ?? unsentFallback ?? hasSharedDraft
+    self.hasSharedDraft = hasSharedDraft
+    self.saveOnlyChanges = try container.decodeArray([SaveOnlyChange].self, forKey: .saveOnlyChanges)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(dirty, forKey: .dirty)
+    try container.encode(hasUnsentChanges, forKey: .hasUnsentChanges)
+    try container.encode(hasSharedDraft, forKey: .hasSharedDraft)
+    try container.encode(saveOnlyChanges, forKey: .saveOnlyChanges)
+  }
 }
 
 struct MenuSnapshotPayload: Codable, Equatable {
@@ -1154,16 +1373,93 @@ struct MenuSnapshotPayload: Codable, Equatable {
 struct LocalDraftEnvelope: Codable, Equatable, Identifiable {
   var userId: String
   var menuId: String
+  var clientScopeId: String
   var restaurantId: String
   var menuName: String
   var savedAt: Date
   var baseLiveRevision: Int?
   var baseDraftRevision: Int?
+  var baseNotificationBaselineRevision: Int?
   var baseDocument: EditableMenuDocument?
   var document: EditableMenuDocument
 
   var id: String {
-    "\(userId)::\(menuId)"
+    "\(userId)::\(menuId)::\(clientScopeId)"
+  }
+
+  enum CodingKeys: String, CodingKey {
+    case userId
+    case menuId
+    case clientScopeId
+    case clientId
+    case restaurantId
+    case menuName
+    case savedAt
+    case baseLiveRevision
+    case baseDraftRevision
+    case baseNotificationBaselineRevision
+    case baseDocument
+    case document
+  }
+
+  init(
+    userId: String,
+    menuId: String,
+    clientScopeId: String,
+    restaurantId: String,
+    menuName: String,
+    savedAt: Date,
+    baseLiveRevision: Int?,
+    baseDraftRevision: Int?,
+    baseNotificationBaselineRevision: Int?,
+    baseDocument: EditableMenuDocument?,
+    document: EditableMenuDocument
+  ) {
+    self.userId = userId
+    self.menuId = menuId
+    self.clientScopeId = clientScopeId
+    self.restaurantId = restaurantId
+    self.menuName = menuName
+    self.savedAt = savedAt
+    self.baseLiveRevision = baseLiveRevision
+    self.baseDraftRevision = baseDraftRevision
+    self.baseNotificationBaselineRevision = baseNotificationBaselineRevision
+    self.baseDocument = baseDocument
+    self.document = document
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let baseDraftRevision = try container.decodeIfPresent(Int.self, forKey: .baseDraftRevision)
+    self.userId = try container.decodeString(forKey: .userId)
+    self.menuId = try container.decodeString(forKey: .menuId)
+    let scopeFromPrimary = try container.decodeIfPresent(String.self, forKey: .clientScopeId)
+    let scopeFromFallback = try container.decodeIfPresent(String.self, forKey: .clientId)
+    self.clientScopeId = scopeFromPrimary ?? scopeFromFallback ?? "legacy"
+    self.restaurantId = try container.decodeString(forKey: .restaurantId)
+    self.menuName = try container.decodeString(forKey: .menuName)
+    self.savedAt = try container.decodeIfPresent(Date.self, forKey: .savedAt) ?? .distantPast
+    self.baseLiveRevision = try container.decodeIfPresent(Int.self, forKey: .baseLiveRevision)
+    self.baseDraftRevision = baseDraftRevision
+    self.baseNotificationBaselineRevision = try container.decodeIfPresent(Int.self, forKey: .baseNotificationBaselineRevision)
+      ?? baseDraftRevision
+    self.baseDocument = try container.decodeIfPresent(EditableMenuDocument.self, forKey: .baseDocument)
+    self.document = try container.decode(EditableMenuDocument.self, forKey: .document)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(userId, forKey: .userId)
+    try container.encode(menuId, forKey: .menuId)
+    try container.encode(clientScopeId, forKey: .clientScopeId)
+    try container.encode(restaurantId, forKey: .restaurantId)
+    try container.encode(menuName, forKey: .menuName)
+    try container.encode(savedAt, forKey: .savedAt)
+    try container.encodeIfPresent(baseLiveRevision, forKey: .baseLiveRevision)
+    try container.encodeIfPresent(baseDraftRevision, forKey: .baseDraftRevision)
+    try container.encodeIfPresent(baseNotificationBaselineRevision, forKey: .baseNotificationBaselineRevision)
+    try container.encodeIfPresent(baseDocument, forKey: .baseDocument)
+    try container.encode(document, forKey: .document)
   }
 }
 
@@ -1295,7 +1591,7 @@ struct EditableMenuDocument: Codable, Equatable {
 
   mutating func moveVisibleCategories(from source: IndexSet, to destination: Int) {
     var regular = visibleCategories
-    regular.move(fromOffsets: source, toOffset: destination)
+    regular.moveItems(fromOffsets: source, toOffset: destination)
     let uncategorized = cats.first(where: { $0.key == Self.uncategorizedKey })
     cats = regular + (uncategorized.map { [$0] } ?? [])
     renumberCategories()
@@ -1395,7 +1691,7 @@ struct EditableMenuDocument: Codable, Equatable {
     renumberCategories()
   }
 
-  func makeSnapshot(hasUnsavedChanges: Bool, hasSharedDraft: Bool) -> MenuSnapshotPayload {
+  func makeSnapshot(hasUnsavedChanges: Bool, hasServerUnsentChanges: Bool) -> MenuSnapshotPayload {
     MenuSnapshotPayload(
       context: context,
       cats: orderedSnapshotCategories(),
@@ -1405,7 +1701,8 @@ struct EditableMenuDocument: Codable, Equatable {
       saveOnlyChanges: [],
       previewContext: SnapshotPreviewContext(
         dirty: hasUnsavedChanges,
-        hasSharedDraft: hasSharedDraft,
+        hasUnsentChanges: hasServerUnsentChanges,
+        hasSharedDraft: hasServerUnsentChanges,
         saveOnlyChanges: []
       )
     )

--- a/ios/ElRoysManagerApp/Storage/OfflineDraftStore.swift
+++ b/ios/ElRoysManagerApp/Storage/OfflineDraftStore.swift
@@ -1,6 +1,7 @@
 import Foundation
 
 protocol OfflineDraftStoring {
+  var clientScopeId: String { get }
   func loadDraft(userId: String, menuId: String) throws -> LocalDraftEnvelope?
   func saveDraft(_ envelope: LocalDraftEnvelope) throws
   func removeDraft(userId: String, menuId: String) throws
@@ -8,22 +9,36 @@ protocol OfflineDraftStoring {
 }
 
 final class OfflineDraftStore: OfflineDraftStoring {
+  private static let clientScopeDefaultsKey = "ElRoysManagerClientScopeID"
+
   private let rootURL: URL
+  let clientScopeId: String
   private let decoder = JSONDecoder()
   private let encoder = JSONEncoder()
 
-  init(fileManager: FileManager = .default) {
+  init(
+    fileManager: FileManager = .default,
+    userDefaults: UserDefaults = .standard,
+    clientScopeId: String? = nil
+  ) {
     let appSupport = fileManager.urls(for: .applicationSupportDirectory, in: .userDomainMask).first
       ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
     self.rootURL = appSupport.appendingPathComponent("ElRoysManagerDrafts", isDirectory: true)
+    self.clientScopeId = Self.resolveClientScopeId(userDefaults: userDefaults, explicitValue: clientScopeId)
     decoder.dateDecodingStrategy = .iso8601
     encoder.dateEncodingStrategy = .iso8601
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     try? fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true, attributes: nil)
   }
 
-  init(rootURL: URL, fileManager: FileManager = .default) {
+  init(
+    rootURL: URL,
+    fileManager: FileManager = .default,
+    userDefaults: UserDefaults = .standard,
+    clientScopeId: String? = nil
+  ) {
     self.rootURL = rootURL
+    self.clientScopeId = Self.resolveClientScopeId(userDefaults: userDefaults, explicitValue: clientScopeId)
     decoder.dateDecodingStrategy = .iso8601
     encoder.dateEncodingStrategy = .iso8601
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
@@ -31,21 +46,44 @@ final class OfflineDraftStore: OfflineDraftStoring {
   }
 
   func loadDraft(userId: String, menuId: String) throws -> LocalDraftEnvelope? {
-    let url = draftURL(userId: userId, menuId: menuId)
-    guard FileManager.default.fileExists(atPath: url.path) else { return nil }
-    let data = try Data(contentsOf: url)
-    return try decoder.decode(LocalDraftEnvelope.self, from: data)
+    let scopedURL = draftURL(userId: userId, menuId: menuId, clientScopeId: clientScopeId)
+    if FileManager.default.fileExists(atPath: scopedURL.path) {
+      let data = try Data(contentsOf: scopedURL)
+      var decoded = try decoder.decode(LocalDraftEnvelope.self, from: data)
+      if decoded.clientScopeId != clientScopeId {
+        decoded.clientScopeId = clientScopeId
+        try saveDraft(decoded)
+      }
+      return decoded
+    }
+
+    let legacyURL = legacyDraftURL(userId: userId, menuId: menuId)
+    guard FileManager.default.fileExists(atPath: legacyURL.path) else { return nil }
+    let data = try Data(contentsOf: legacyURL)
+    var legacyDraft = try decoder.decode(LocalDraftEnvelope.self, from: data)
+    legacyDraft.clientScopeId = clientScopeId
+    try saveDraft(legacyDraft)
+    try? FileManager.default.removeItem(at: legacyURL)
+    return legacyDraft
   }
 
   func saveDraft(_ envelope: LocalDraftEnvelope) throws {
-    let data = try encoder.encode(envelope)
-    try data.write(to: draftURL(userId: envelope.userId, menuId: envelope.menuId), options: .atomic)
+    var scoped = envelope
+    scoped.clientScopeId = clientScopeId
+    let data = try encoder.encode(scoped)
+    try data.write(to: draftURL(userId: scoped.userId, menuId: scoped.menuId, clientScopeId: clientScopeId), options: .atomic)
+    try? FileManager.default.removeItem(at: legacyDraftURL(userId: scoped.userId, menuId: scoped.menuId))
   }
 
   func removeDraft(userId: String, menuId: String) throws {
-    let url = draftURL(userId: userId, menuId: menuId)
-    guard FileManager.default.fileExists(atPath: url.path) else { return }
-    try FileManager.default.removeItem(at: url)
+    let scopedURL = draftURL(userId: userId, menuId: menuId, clientScopeId: clientScopeId)
+    if FileManager.default.fileExists(atPath: scopedURL.path) {
+      try FileManager.default.removeItem(at: scopedURL)
+    }
+    let legacyURL = legacyDraftURL(userId: userId, menuId: menuId)
+    if FileManager.default.fileExists(atPath: legacyURL.path) {
+      try FileManager.default.removeItem(at: legacyURL)
+    }
   }
 
   func loadAllDrafts() throws -> [LocalDraftEnvelope] {
@@ -56,11 +94,38 @@ final class OfflineDraftStore: OfflineDraftStoring {
       .sorted { $0.savedAt > $1.savedAt }
   }
 
-  private func draftURL(userId: String, menuId: String) -> URL {
+  private func draftURL(userId: String, menuId: String, clientScopeId: String) -> URL {
+    rootURL.appendingPathComponent("\(sanitize(userId))__\(sanitize(menuId))__\(sanitize(clientScopeId)).json", isDirectory: false)
+  }
+
+  private func legacyDraftURL(userId: String, menuId: String) -> URL {
     rootURL.appendingPathComponent("\(sanitize(userId))__\(sanitize(menuId)).json", isDirectory: false)
   }
 
   private func sanitize(_ value: String) -> String {
     value.replacingOccurrences(of: "/", with: "_")
+  }
+
+  private static func resolveClientScopeId(
+    userDefaults: UserDefaults,
+    explicitValue: String?
+  ) -> String {
+    if let explicitValue {
+      let trimmed = explicitValue.trimmingCharacters(in: .whitespacesAndNewlines)
+      if !trimmed.isEmpty {
+        return trimmed
+      }
+    }
+
+    if let existing = userDefaults.string(forKey: clientScopeDefaultsKey)?
+      .trimmingCharacters(in: .whitespacesAndNewlines),
+       !existing.isEmpty
+    {
+      return existing
+    }
+
+    let created = UUID().uuidString.lowercased()
+    userDefaults.set(created, forKey: clientScopeDefaultsKey)
+    return created
   }
 }

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -159,15 +159,17 @@ final class MenuDocumentTests: XCTestCase {
   func testOfflineDraftStoreRoundTripsByUserAndMenu() throws {
     let rootURL = FileManager.default.temporaryDirectory
       .appendingPathComponent(UUID().uuidString, isDirectory: true)
-    let store = OfflineDraftStore(rootURL: rootURL)
+    let store = OfflineDraftStore(rootURL: rootURL, clientScopeId: "ios-phone")
     let envelope = LocalDraftEnvelope(
       userId: "staff-1",
       menuId: "menu-drinks",
+      clientScopeId: "ios-phone",
       restaurantId: "leroys-lounge",
       menuName: "Drinks",
       savedAt: Date(timeIntervalSince1970: 1234),
       baseLiveRevision: 8,
       baseDraftRevision: 9,
+      baseNotificationBaselineRevision: 7,
       baseDocument: EditableMenuDocument(workspace: makeWorkspace()),
       document: EditableMenuDocument(workspace: makeWorkspace())
     )
@@ -178,6 +180,31 @@ final class MenuDocumentTests: XCTestCase {
 
     try store.removeDraft(userId: "staff-1", menuId: "menu-drinks")
     XCTAssertNil(try store.loadDraft(userId: "staff-1", menuId: "menu-drinks"))
+  }
+
+  func testOfflineDraftStoreScopesDraftsByClientDevice() throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let phoneStore = OfflineDraftStore(rootURL: rootURL, clientScopeId: "ios-phone")
+    let tabletStore = OfflineDraftStore(rootURL: rootURL, clientScopeId: "ios-tablet")
+    let envelope = LocalDraftEnvelope(
+      userId: "staff-1",
+      menuId: "menu-drinks",
+      clientScopeId: "ios-phone",
+      restaurantId: "leroys-lounge",
+      menuName: "Drinks",
+      savedAt: Date(timeIntervalSince1970: 1234),
+      baseLiveRevision: 8,
+      baseDraftRevision: 9,
+      baseNotificationBaselineRevision: 7,
+      baseDocument: EditableMenuDocument(workspace: makeWorkspace()),
+      document: EditableMenuDocument(workspace: makeWorkspace())
+    )
+
+    try phoneStore.saveDraft(envelope)
+
+    XCTAssertNotNil(try phoneStore.loadDraft(userId: "staff-1", menuId: "menu-drinks"))
+    XCTAssertNil(try tabletStore.loadDraft(userId: "staff-1", menuId: "menu-drinks"))
   }
 
   func testCompactFeaturedItemProjectionDecodesWithDefaults() throws {
@@ -310,6 +337,51 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(payload.restaurantTools?.siblingCatalog.first?.visibility, "off_menu")
   }
 
+  func testWorkspacePayloadDecodesQueueStatusFields() throws {
+    let data = Data("""
+    {
+      "cats": [],
+      "meta": {
+        "last_updated_ts": 200,
+        "last_sent_ts": 150
+      },
+      "context": {
+        "kind": "menu-workspace",
+        "menu": {
+          "id": "menu",
+          "slug": "drinks",
+          "name": "Drinks",
+          "type": "drinks",
+          "restaurant_id": "leroys-lounge"
+        }
+      },
+      "workspace": {
+        "menu_status": "Live | Unsent",
+        "has_unsent_changes": true,
+        "accessible_menu_ids": ["menu"],
+        "shared_draft": { "exists": false },
+        "permissions": { "can_manage": true },
+        "capabilities": {
+          "can_save_draft": true,
+          "can_save_live_menu": true,
+          "can_publish_updates": true
+        },
+        "revisions": {
+          "live_revision": 200,
+          "notification_baseline_revision": 150
+        }
+      }
+    }
+    """.utf8)
+
+    let payload = try JSONDecoder.backend.decode(MenuWorkspacePayload.self, from: data)
+
+    XCTAssertEqual(payload.workspace.menuStatus, "Live | Unsent")
+    XCTAssertEqual(payload.workspace.hasUnsentChanges, true)
+    XCTAssertEqual(payload.workspace.revisions.liveRevision, 200)
+    XCTAssertEqual(payload.workspace.revisions.notificationBaselineRevision, 150)
+  }
+
   func testHistoryPayloadDecodesWhenSourceFieldsAreMissing() throws {
     let data = Data("""
     {
@@ -344,6 +416,44 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(payload.logs[0].source, "")
     XCTAssertTrue(payload.capabilities.includesMessage)
     XCTAssertFalse(payload.capabilities.includesSource)
+  }
+
+  func testHistoryPayloadDecodesOperationMetadata() throws {
+    let data = Data("""
+    {
+      "logs": [
+        {
+          "id": "log-1",
+          "menu_id": "menu",
+          "user_id": "user-1",
+          "user_name": "Alex",
+          "operation_id": "op-42",
+          "event_type": "send_failed",
+          "diff": [],
+          "message": "Delivery failed",
+          "source": "ios_app",
+          "created_at": "2026-04-14T06:00:00.000Z"
+        }
+      ],
+      "context": {
+        "kind": "menu-history"
+      },
+      "history": {
+        "days": 7,
+        "limit": 25,
+        "count": 1,
+        "scope": "menu"
+      },
+      "capabilities": {
+        "can_read_history": true
+      }
+    }
+    """.utf8)
+
+    let payload = try JSONDecoder.backend.decode(HistoryPayload.self, from: data)
+
+    XCTAssertEqual(payload.logs.first?.operationId, "op-42")
+    XCTAssertEqual(payload.logs.first?.eventType, "send_failed")
   }
 
   func testDraftCommandResponseDecodesServerShape() throws {
@@ -421,6 +531,8 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(payload.selectedChangeIds, ["beer::added::ipa"])
     XCTAssertEqual(payload.preview?.metadata.contract, "menu-publish-preview.v1")
     XCTAssertEqual(payload.preview?.metadata.currentFeaturedIds, ["item-1"])
+    XCTAssertEqual(payload.preview?.menuStatus, "Live | Unsent")
+    XCTAssertEqual(payload.preview?.hasUnsentChanges, true)
   }
 
   @MainActor
@@ -469,7 +581,7 @@ final class MenuDocumentTests: XCTestCase {
   }
 
   @MainActor
-  func testSaveDraftRebaselinesLocalStateAndClearsOfflineDraft() async {
+  func testDiscardLocalDraftRestoresServerStateAndClearsOfflineDraft() async {
     let offlineStore = TestOfflineDraftStore()
     let sessionStore = TestSessionStore()
     let workspaceClient = StubWorkspaceClient(payloads: [makeWorkspace(categories: [
@@ -486,21 +598,6 @@ final class MenuDocumentTests: XCTestCase {
         items: [makeItem(id: "item-1", name: "Pilsner")]
       )
     ])])
-    let draftClient = StubDraftClient(
-      saveResponse: DraftCommandResponse(
-        ok: true,
-        status: "draft_saved",
-        menuId: "menu",
-        savedAt: 22,
-        hasSharedDraft: true,
-        sharedDraft: SharedDraftInfo(
-          exists: true,
-          savedAt: 22,
-          savedBy: SharedDraftSavedBy(id: "staff-1", name: "Alex"),
-          source: "ios_app"
-        )
-      )
-    )
     let model = AppModel(
       environment: AppEnvironment(
         name: .preview,
@@ -510,8 +607,7 @@ final class MenuDocumentTests: XCTestCase {
       ),
       services: makeServices(
         workspaceClient: workspaceClient,
-        historyClient: StubHistoryClient(payload: makeHistoryPayload()),
-        draftClient: draftClient
+        historyClient: StubHistoryClient(payload: makeHistoryPayload())
       ),
       sessionStore: sessionStore,
       offlineDraftStore: offlineStore
@@ -523,15 +619,14 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertTrue(model.editorDirty)
     XCTAssertNotNil(offlineStore.draft)
 
-    await model.saveRemoteDraft()
+    model.discardLocalDraft()
 
     XCTAssertFalse(model.editorDirty)
-    XCTAssertTrue(model.editorHasLiveChanges)
+    XCTAssertFalse(model.editorHasLiveChanges)
     XCTAssertNil(model.editorRefreshRequirement)
     XCTAssertNil(offlineStore.draft)
-    XCTAssertTrue(model.editorHasSharedDraft)
-    XCTAssertTrue(model.canSaveLiveRemotely)
-    XCTAssertEqual(model.currentEditorWorkspace?.workspace.revisions.draftRevision, 22)
+    XCTAssertEqual(model.currentEditorDocument?.category(for: "beer")?.label, "Beer")
+    XCTAssertEqual(model.notice?.title, "Draft Discarded")
   }
 
   @MainActor
@@ -594,13 +689,14 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(model.currentEditorDocument?.itemRecord(for: "item-1")?.item.name, "House Pilsner")
     XCTAssertFalse(model.editorDirty)
     XCTAssertTrue(model.editorHasLiveChanges)
-    XCTAssertTrue(model.editorHasSharedDraft)
+    XCTAssertTrue(model.hasServerUnsentChanges)
     XCTAssertTrue(model.canSaveLiveRemotely)
     XCTAssertTrue(model.canLoadPublishPreview)
+    XCTAssertEqual(model.menuStatusLabel, "Live | Unsent")
   }
 
   @MainActor
-  func testSaveLiveMenuClearsSharedDraftAndRebaselinesBothBaselines() async throws {
+  func testSaveQuietlyRebaselinesAndKeepsQueueStateForLaterSend() async throws {
     let offlineStore = TestOfflineDraftStore()
     let sessionStore = TestSessionStore()
     let baseWorkspace = makeWorkspace(categories: [
@@ -640,16 +736,6 @@ final class MenuDocumentTests: XCTestCase {
       ),
       revisions: WorkspaceRevisions(liveRevision: 10, draftRevision: 22, lastSentRevision: 10)
     )
-    let draftClient = StubDraftClient(
-      clearResponse: DraftCommandResponse(
-        ok: true,
-        status: "draft_cleared",
-        menuId: "menu",
-        savedAt: nil,
-        hasSharedDraft: false,
-        sharedDraft: SharedDraftInfo(exists: false, savedAt: nil, savedBy: nil, source: "")
-      )
-    )
     let liveSaveClient = StubLiveSaveClient(
       response: PublishResponse(
         ok: true,
@@ -674,7 +760,6 @@ final class MenuDocumentTests: XCTestCase {
       services: makeServices(
         workspaceClient: StubWorkspaceClient(payloads: [workspace]),
         historyClient: StubHistoryClient(payload: makeHistoryPayload()),
-        draftClient: draftClient,
         liveSaveClient: liveSaveClient
       ),
       sessionStore: sessionStore,
@@ -684,20 +769,71 @@ final class MenuDocumentTests: XCTestCase {
 
     await model.loadEditor(menuId: "menu")
 
-    XCTAssertTrue(model.editorHasSharedDraft)
+    XCTAssertTrue(model.hasServerUnsentChanges)
     XCTAssertTrue(model.editorHasLiveChanges)
 
     await model.saveLiveMenu()
 
     XCTAssertFalse(model.editorDirty)
     XCTAssertFalse(model.editorHasLiveChanges)
-    XCTAssertFalse(model.editorHasSharedDraft)
-    XCTAssertFalse(model.showClearSharedDraft)
+    XCTAssertTrue(model.hasServerUnsentChanges)
     XCTAssertFalse(model.canSaveLiveRemotely)
     XCTAssertEqual(liveSaveClient.saveCallCount, 1)
-    XCTAssertEqual(draftClient.clearCallCount, 1)
     XCTAssertEqual(model.currentEditorWorkspace?.workspace.revisions.liveRevision, 44)
     XCTAssertNil(offlineStore.draft)
+    XCTAssertEqual(model.notice?.title, "Saved Quietly")
+  }
+
+  @MainActor
+  func testLiveUnsentStatusEnablesSendWithoutLocalDraft() async throws {
+    let workspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      revisions: WorkspaceRevisions(
+        liveRevision: 30,
+        draftRevision: nil,
+        lastSentRevision: 20,
+        notificationBaselineRevision: 20
+      ),
+      menuStatus: "Live | Unsent",
+      hasUnsentChanges: true
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [workspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload())
+      ),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+
+    XCTAssertFalse(model.hasLocalDraftChanges)
+    XCTAssertFalse(model.hasLiveMenuChanges)
+    XCTAssertTrue(model.hasServerUnsentChanges)
+    XCTAssertEqual(model.menuStatusLabel, "Live | Unsent")
+    XCTAssertTrue(model.canLoadPublishPreview)
+    XCTAssertFalse(model.canSaveQuietlyRemotely)
   }
 
   @MainActor
@@ -1044,11 +1180,13 @@ final class MenuDocumentTests: XCTestCase {
     offlineStore.draft = LocalDraftEnvelope(
       userId: "staff-1",
       menuId: "menu",
+      clientScopeId: offlineStore.clientScopeId,
       restaurantId: "leroys-lounge",
       menuName: "Drinks",
       savedAt: Date(timeIntervalSince1970: 1234),
       baseLiveRevision: 10,
       baseDraftRevision: 2,
+      baseNotificationBaselineRevision: 2,
       baseDocument: staleBase,
       document: malformedDocument
     )
@@ -1087,7 +1225,9 @@ final class MenuDocumentTests: XCTestCase {
     meta: MenuMetaPayload = MenuMetaPayload(),
     hasSharedDraft: Bool = false,
     sharedDraft: SharedDraftInfo? = nil,
-    revisions: WorkspaceRevisions = WorkspaceRevisions(liveRevision: 10, draftRevision: nil, lastSentRevision: 10)
+    revisions: WorkspaceRevisions = WorkspaceRevisions(liveRevision: 10, draftRevision: nil, lastSentRevision: 10, notificationBaselineRevision: 10),
+    menuStatus: String = "",
+    hasUnsentChanges: Bool? = nil
   ) -> MenuWorkspacePayload {
     let resolvedSharedDraft = sharedDraft ?? SharedDraftInfo(
       exists: hasSharedDraft,
@@ -1106,6 +1246,8 @@ final class MenuDocumentTests: XCTestCase {
         accessibleMenuIds: ["menu"],
         hasSharedDraft: hasSharedDraft || resolvedSharedDraft.exists,
         sharedDraft: resolvedSharedDraft,
+        menuStatus: menuStatus,
+        hasUnsentChanges: hasUnsentChanges,
         permissions: WorkspacePermissions(canManage: true, canAdmin: false, canEditRestaurantSpecials: false, canReadRestaurantTools: false),
         capabilities: WorkspaceCapabilities(
           canSaveDraft: true,
@@ -1218,6 +1360,7 @@ private enum TestError: LocalizedError {
 }
 
 private final class TestOfflineDraftStore: OfflineDraftStoring {
+  var clientScopeId: String = "test-device"
   var draft: LocalDraftEnvelope?
   var loadError: Error?
   var savedEnvelopes: [LocalDraftEnvelope] = []
@@ -1303,19 +1446,19 @@ private final class StubBootstrapClient: BootstrapClienting {
 }
 
 private final class StubAuthClient: AuthClienting {
-  func signIn(config: BootstrapConfig, email: String, password: String) async throws -> AuthSession {
+  func signIn(email: String, password: String) async throws -> AuthSession {
     throw TestError.message("Unused in this test")
   }
 
-  func signUp(config: BootstrapConfig, email: String, password: String, name: String) async throws -> AuthSession {
+  func signUp(email: String, password: String, name: String) async throws -> AuthSession {
     throw TestError.message("Unused in this test")
   }
 
-  func refresh(config: BootstrapConfig, session: AuthSession) async throws -> AuthSession {
+  func refresh(session: AuthSession) async throws -> AuthSession {
     throw TestError.message("Unused in this test")
   }
 
-  func sendReset(config: BootstrapConfig, email: String, redirectTo: URL) async throws {
+  func sendReset(email: String, redirectTo: URL) async throws {
     throw TestError.message("Unused in this test")
   }
 }
@@ -1421,7 +1564,7 @@ private final class StubPreviewClient: PreviewClienting {
 }
 
 private final class StubProductLookupClient: ProductLookupClienting {
-  func lookup(upc: String) async throws -> ProductLookupResult {
+  func lookup(upc: String, accessToken: String) async throws -> ProductLookupResult {
     throw TestError.message("Unused in this test")
   }
 }

--- a/manager/index.html
+++ b/manager/index.html
@@ -243,7 +243,7 @@
                 <h2>Add, remove, and 86 items.</h2>
               </div>
               <div class="manager-shell-section-actions">
-                <p class="manager-shell-section-copy">Swipe left to 86. Swipe right to restore. Changes stay in draft until you Save Draft or publish them live.</p>
+                <p class="manager-shell-section-copy">Swipe left to 86. Swipe right to restore. Changes stay on this device until you save them live or send the queue.</p>
                 <button type="button" class="btn-small manager-add-item-launch" id="manager-add-item-btn" onclick="openAddItemModal({ mode: 'manual' })" style="display:none">Add Item(s)</button>
               </div>
             </div>
@@ -387,8 +387,9 @@
       </div>
       <div class="manager-shell-actionbar-groups">
         <div class="btn-row manager-shell-actionbar-primary" id="manager-primary-action-group">
-          <button class="save-btn" id="save-btn" onclick="saveMenu()" title="Save changes without notifying anyone">Save Draft</button>
-          <button class="send-btn" id="send-btn" onclick="openPreview()" title="Review changes before publishing them live">Save</button>
+          <button class="save-btn" id="save-btn" onclick="saveMenu()" title="Save changes without notifying anyone">Save</button>
+          <button class="send-btn" id="send-btn" onclick="openPreview()" title="Review changes before publishing them live">Send</button>
+          <button class="btn-small" id="discard-draft-btn" onclick="discardLocalDraft()" hidden>Discard Draft</button>
         </div>
       </div>
       <div class="manager-shell-actionbar-status">
@@ -401,8 +402,8 @@
 
 <div class="modal-bg" id="modal-bg" hidden aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
-    <h2 id="modal-title">Patch Notes Preview</h2>
-    <div class="modal-sub" id="modal-subtitle">Review the changes before publishing them to the live menu.</div>
+    <h2 id="modal-title">Send Preview</h2>
+    <div class="modal-sub" id="modal-subtitle">Review how these changes will save, send, or clear.</div>
     <div id="preview-content"></div>
     <div class="modal-actions">
       <button class="btn-cancel" id="cancel-preview-btn" onclick="closeModal()">Cancel</button>

--- a/server/_menu-history.js
+++ b/server/_menu-history.js
@@ -72,6 +72,8 @@ export function normalizeHistoryLogEntry(entry = {}, options = {}) {
     diff: Array.isArray(entry?.diff) ? entry.diff : [],
     message: String(entry?.message || '').trim(),
     source: String(entry?.source || '').trim(),
+    operation_id: String(entry?.operation_id || '').trim(),
+    event_type: String(entry?.event_type || '').trim(),
     created_at: String(entry?.created_at || ''),
     ...(includeMenu ? { menu: entry?.menu && typeof entry.menu === 'object' ? entry.menu : null } : {}),
   };
@@ -95,12 +97,31 @@ export function createMenuHistoryPayload({
   limit = 25,
   scope = 'menu',
   includesSource = false,
+  includesOperationId = false,
+  includesEventType = false,
 } = {}) {
   const normalizedScope = normalizeHistoryScope(scope);
   const normalizedLogs = (Array.isArray(logs) ? logs : [])
     .map(entry => normalizeHistoryLogEntry(entry, { includeMenu: normalizedScope === 'restaurant' }));
+  const operationGroups = new Map();
+  normalizedLogs.forEach(entry => {
+    const operationId = String(entry?.operation_id || '').trim() || `legacy:${entry.id}`;
+    if (!operationGroups.has(operationId)) {
+      operationGroups.set(operationId, {
+        operation_id: operationId,
+        created_at: entry.created_at,
+        menu_id: entry.menu_id,
+        event_count: 0,
+        events: [],
+      });
+    }
+    const operation = operationGroups.get(operationId);
+    operation.events.push(entry);
+    operation.event_count += 1;
+  });
   return {
     logs: normalizedLogs,
+    operations: Array.from(operationGroups.values()),
     context: {
       kind: normalizedScope === 'restaurant' ? 'restaurant-history' : 'menu-history',
       menu: menu || null,
@@ -113,15 +134,21 @@ export function createMenuHistoryPayload({
       count: normalizedLogs.length,
       scope: normalizedScope,
       partial: false,
+      operationCount: operationGroups.size,
     },
     capabilities: {
       canReadHistory: true,
       includesMessage: true,
       includesSource: !!includesSource,
+      includesOperationId: !!includesOperationId,
+      includesEventType: !!includesEventType,
+      includesOperationGrouping: !!includesOperationId,
     },
     compatibility: {
-      contract: 'menu-history.v2',
+      contract: 'menu-history.v3',
       sourceStamped: !!includesSource,
+      operationGrouping: !!includesOperationId,
+      typedEvents: !!includesEventType,
     },
   };
 }
@@ -131,6 +158,12 @@ async function fetchJsonOrThrow(url, fallbackMessage) {
   if (response.ok) return response.json();
   const payload = await readJsonSafe(response);
   throw { status: 500, message: getApiErrorMessage(payload, fallbackMessage) };
+}
+
+function isMissingColumnIssue(error, columnName) {
+  const message = `${error?.error || error?.message || error?.hint || error?.details || ''}`.toLowerCase();
+  return message.includes(columnName.toLowerCase()) &&
+    (message.includes('column') || message.includes('schema cache'));
 }
 
 async function readAuthorizedHistoryActor(req, menuId) {
@@ -153,36 +186,49 @@ async function readAuthorizedHistoryActor(req, menuId) {
 
 async function readHistoryLogsForMenuIds(menuIds = [], { days = 7, limit = 25, includeSource = true } = {}) {
   const safeMenuIds = Array.isArray(menuIds) ? menuIds.filter(Boolean) : [];
-  if (!safeMenuIds.length) return { logs: [], includesSource: false };
+  if (!safeMenuIds.length) {
+    return {
+      logs: [],
+      includesSource: false,
+      includesOperationId: false,
+      includesEventType: false,
+    };
+  }
   const { sbUrl } = getSupabaseServerConfig();
   const sinceIso = new Date(Date.now() - (normalizeHistoryDays(days) * 24 * 60 * 60 * 1000)).toISOString();
   const menuFilter = safeMenuIds.length === 1
     ? `menu_id=eq.${safeMenuIds[0]}`
     : `menu_id=in.(${safeMenuIds.join(',')})`;
   const baseUrl = `${sbUrl}/rest/v1/update_log?${menuFilter}&created_at=gte.${encodeURIComponent(sinceIso)}&order=created_at.desc&limit=${normalizeHistoryLimit(limit)}`;
-  const withSourceSelect = 'id,menu_id,user_id,user_name,diff,message,source,created_at';
-  const fallbackSelect = 'id,menu_id,user_id,user_name,diff,message,created_at';
+  const requiredFields = ['id', 'menu_id', 'user_id', 'user_name', 'diff', 'message', 'created_at'];
+  const optionalFields = [
+    ...(includeSource ? ['source'] : []),
+    'operation_id',
+    'event_type',
+  ];
+  const disabledFields = new Set();
 
-  const readRows = async select => fetchJsonOrThrow(
-    `${baseUrl}&select=${select}`,
-    'Failed to load menu history'
-  );
-
-  if (!includeSource) {
-    const logs = await readRows(fallbackSelect);
-    return { logs, includesSource: false };
-  }
-
-  try {
-    const logs = await readRows(withSourceSelect);
-    return { logs, includesSource: true };
-  } catch (error) {
-    const message = `${error?.message || ''}`.toLowerCase();
-    if (!message.includes('source') || (!message.includes('column') && !message.includes('schema cache'))) {
-      throw error;
+  while (true) {
+    const select = [...requiredFields, ...optionalFields.filter(field => !disabledFields.has(field))].join(',');
+    try {
+      const logs = await fetchJsonOrThrow(
+        `${baseUrl}&select=${select}`,
+        'Failed to load menu history'
+      );
+      return {
+        logs,
+        includesSource: includeSource && !disabledFields.has('source'),
+        includesOperationId: !disabledFields.has('operation_id'),
+        includesEventType: !disabledFields.has('event_type'),
+      };
+    } catch (error) {
+      const missingField = optionalFields.find(field => (
+        !disabledFields.has(field) &&
+        isMissingColumnIssue(error, field)
+      ));
+      if (!missingField) throw error;
+      disabledFields.add(missingField);
     }
-    const logs = await readRows(fallbackSelect);
-    return { logs, includesSource: false };
   }
 }
 
@@ -216,6 +262,8 @@ export async function readMenuHistoryForRequest(req) {
       limit,
       scope,
       includesSource: historyResult.includesSource,
+      includesOperationId: historyResult.includesOperationId,
+      includesEventType: historyResult.includesEventType,
     });
   }
 
@@ -234,5 +282,7 @@ export async function readMenuHistoryForRequest(req) {
     limit,
     scope: 'menu',
     includesSource: historyResult.includesSource,
+    includesOperationId: historyResult.includesOperationId,
+    includesEventType: historyResult.includesEventType,
   });
 }

--- a/server/_menu-publish.js
+++ b/server/_menu-publish.js
@@ -486,16 +486,18 @@ async function buildCanonicalPreviewForMenu({
 function assertPublishRevisions({
   expectedLiveRevision,
   expectedDraftRevision,
+  expectedNotificationRevision,
   meta,
   menuId,
 }) {
   const currentRevisions = readRevisionState(meta);
+  const notificationBaselineRevision = expectedNotificationRevision ?? expectedDraftRevision ?? null;
   assertExpectedRevision(expectedLiveRevision, meta?.last_updated_ts || null, 'live_revision', {
     menuId,
     command: 'menu-publish.v2',
     currentRevisions,
   });
-  assertExpectedRevision(expectedDraftRevision, meta?.draft_saved_ts || null, 'draft_revision', {
+  assertExpectedRevision(notificationBaselineRevision, meta?.last_sent_ts || null, 'notification_revision', {
     menuId,
     command: 'menu-publish.v2',
     currentRevisions,
@@ -552,6 +554,7 @@ export async function previewMenuUpdateForMenu({
   snapshot = {},
   expectedLiveRevision = null,
   expectedDraftRevision = null,
+  expectedNotificationRevision = null,
 }) {
   void actor;
   void source;
@@ -564,6 +567,7 @@ export async function previewMenuUpdateForMenu({
   const currentRevisions = assertPublishRevisions({
     expectedLiveRevision,
     expectedDraftRevision,
+    expectedNotificationRevision,
     meta,
     menuId,
   });
@@ -596,6 +600,7 @@ export async function publishMenuUpdateForMenu({
   legacySelectedSections = [],
   expectedLiveRevision = null,
   expectedDraftRevision = null,
+  expectedNotificationRevision = null,
 }) {
   const knownMenu = getKnownMenuById(menuId);
   if (!knownMenu) {
@@ -606,6 +611,7 @@ export async function publishMenuUpdateForMenu({
   const currentRevisions = assertPublishRevisions({
     expectedLiveRevision,
     expectedDraftRevision,
+    expectedNotificationRevision,
     meta,
     menuId,
   });

--- a/server/_menu-publish.js
+++ b/server/_menu-publish.js
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import { getRestaurantSpecialConfig } from './_auth.js';
 import {
   MAX_NOTIFICATION_TEXT_LENGTH,
@@ -18,9 +20,16 @@ import {
   getSupabaseServerConfig,
   serviceHeaders,
 } from './_supabase.js';
-import { getKnownMenuById } from './_menu-read.js';
+import {
+  getKnownMenuById,
+  readCurrentFeaturedIdsForRestaurant,
+} from './_menu-read.js';
+import {
+  buildCategoryQueueState,
+  normalizeName,
+} from './_menu-queue.js';
 
-const PREVIEW_CONTRACT = 'menu-publish-preview.v1';
+const PREVIEW_CONTRACT = 'menu-publish-preview.v2';
 
 function summarizeSkippedNotification() {
   return {
@@ -56,49 +65,6 @@ function createNotificationStatus(delivery, shouldNotify) {
   };
 }
 
-function snapshotLastSentState(snapshot = {}) {
-  const cats = Array.isArray(snapshot?.cats) ? snapshot.cats : [];
-  return Object.fromEntries(cats.map(category => [
-    category.key,
-    (Array.isArray(category.items) ? category.items : []).map(item => ({
-      id: item.id,
-      name: item.name || '',
-      desc: item.desc || '',
-      recipe: Array.isArray(item.recipe) ? item.recipe : [],
-      price: item.price || '',
-      eightySixed: !!item.is_eighty_sixed,
-      onMenu: item.on_menu !== false,
-      visibility: item.visibility || 'public',
-      upcharges: Array.isArray(item.upcharges) ? item.upcharges : [],
-      showDescription: item.show_description !== false,
-      showRecipe: !!item.show_recipe,
-    })),
-  ]));
-}
-
-async function readCurrentFeaturedIdsForRestaurant(restaurantId = '') {
-  const config = getRestaurantSpecialConfig(restaurantId);
-  if (!config?.canonicalId) return [];
-
-  const { sbUrl } = getSupabaseServerConfig();
-  const groupRes = await fetch(
-    `${sbUrl}/rest/v1/featured_groups?canonical_id=eq.${encodeURIComponent(config.canonicalId)}&select=id&limit=1`,
-    { headers: serviceHeaders() }
-  );
-  if (!groupRes.ok) return [];
-  const groups = await groupRes.json();
-  const groupId = groups?.[0]?.id;
-  if (!groupId) return [];
-
-  const slotsRes = await fetch(
-    `${sbUrl}/rest/v1/featured_slots?featured_group_id=eq.${groupId}&select=item_id`,
-    { headers: serviceHeaders() }
-  );
-  if (!slotsRes.ok) return [];
-  const slots = await slotsRes.json();
-  return (slots || []).map(slot => slot.item_id).filter(Boolean);
-}
-
 function collectNotificationWarnings(summary = {}) {
   if (summary.allSkipped) return ['No notification channels were enabled for this menu.'];
   if (summary.anyOk && summary.anyError) {
@@ -107,18 +73,18 @@ function collectNotificationWarnings(summary = {}) {
   return [];
 }
 
-function normalizeName(value) {
-  return String(value || '').replace(/[\r\n]+/g, ' ').trim();
-}
-
-function createPreviewChangeId(sectionId, kind, name) {
-  return `${sectionId}::${kind}::${encodeURIComponent(String(name || '').trim().toLowerCase())}`;
-}
-
-function readRestoreLabel(section = {}) {
-  return String(section?.label || '').toLowerCase().includes('tap')
-    ? 'Back on Tap'
-    : 'Back in Stock';
+function snapshotLastSentState(snapshot = {}) {
+  const cats = Array.isArray(snapshot?.cats) ? snapshot.cats : [];
+  return Object.fromEntries(cats.map(category => [
+    category.key,
+    (Array.isArray(category.items) ? category.items : []).map(item => ({
+      id: item.id,
+      name: item.name || '',
+      eightySixed: !!item.is_eighty_sixed,
+      onMenu: item.on_menu !== false,
+      visibility: item.visibility || 'public',
+    })),
+  ]));
 }
 
 function readSnapshotPreviewContext(snapshot = {}) {
@@ -138,162 +104,25 @@ function readSnapshotPreviewContext(snapshot = {}) {
     : [];
   return {
     hasLocalDraft: !!context?.dirty,
-    hasSharedDraft: !!context?.has_shared_draft,
+    hasLegacySharedDraft: !!context?.has_shared_draft,
     saveOnlyChanges,
   };
-}
-
-function readSnapshotCategories(snapshot = {}) {
-  const cats = Array.isArray(snapshot?.cats) ? snapshot.cats : [];
-  return cats
-    .map((category, categoryIndex) => ({
-      key: String(category?.key || '').trim(),
-      label: String(category?.label || '').trim(),
-      icon: String(category?.icon || ''),
-      displayOrder: Number.isFinite(Number(category?.display_order))
-        ? Number(category.display_order)
-        : categoryIndex,
-      items: Array.isArray(category?.items) ? category.items : [],
-    }))
-    .filter(category => category.key && category.key !== '__uncategorized__');
-}
-
-function isVisibleItem(item = {}) {
-  const onMenu = item?.on_menu !== false && item?.onMenu !== false;
-  const visibility = String(item?.visibility || 'public');
-  return onMenu && visibility !== 'off_menu';
-}
-
-function isEightySixed(item = {}) {
-  return !!(item?.is_eighty_sixed ?? item?.eightySixed);
-}
-
-function buildCategoryDiff(category, lastSentItems = []) {
-  const lastByName = new Map();
-  const currentNames = [];
-  const lastNames = [];
-  const currentSet = new Set();
-  const lastSet = new Set();
-  const eightySixed = [];
-  const restored = [];
-  const eightySixedNames = new Set();
-  const restoredNames = new Set();
-
-  (Array.isArray(lastSentItems) ? lastSentItems : []).forEach(item => {
-    const name = normalizeName(item?.name);
-    if (!name) return;
-    const key = name.toLowerCase();
-    lastByName.set(key, item);
-    if (isVisibleItem(item) && !isEightySixed(item)) {
-      lastNames.push(name);
-      lastSet.add(key);
-    }
-  });
-
-  category.items.forEach(item => {
-    const name = normalizeName(item?.name);
-    if (!name) return;
-    const key = name.toLowerCase();
-    const isVisible = isVisibleItem(item);
-    const previous = lastByName.get(key);
-
-    if (isVisible && previous && isVisibleItem(previous)) {
-      if (!isEightySixed(previous) && isEightySixed(item)) {
-        eightySixed.push(name);
-        eightySixedNames.add(key);
-      }
-      if (isEightySixed(previous) && !isEightySixed(item)) {
-        restored.push(name);
-        restoredNames.add(key);
-      }
-    }
-
-    if (isVisible && !isEightySixed(item)) {
-      currentNames.push(name);
-      currentSet.add(key);
-    }
-  });
-
-  const added = currentNames.filter(name => !lastSet.has(name.toLowerCase()) && !restoredNames.has(name.toLowerCase()));
-  const removed = lastNames.filter(name => !currentSet.has(name.toLowerCase()) && !eightySixedNames.has(name.toLowerCase()));
-  if (!added.length && !removed.length && !eightySixed.length && !restored.length) return null;
-  return {
-    id: category.key,
-    icon: category.icon || '',
-    label: category.label || category.key,
-    added,
-    removed,
-    eightySixed,
-    restored,
-    displayOrder: category.displayOrder,
-  };
-}
-
-function buildNotificationSections(diff = []) {
-  return diff
-    .map(section => {
-      const changes = [];
-      (section.added || []).forEach(name => {
-        changes.push({
-          id: createPreviewChangeId(section.id, 'added', name),
-          kind: 'added',
-          text: `+ ${name}`,
-          name,
-          sectionId: section.id,
-          sectionLabel: section.label,
-          icon: section.icon,
-        });
-      });
-      (section.removed || []).forEach(name => {
-        changes.push({
-          id: createPreviewChangeId(section.id, 'removed', name),
-          kind: 'removed',
-          text: `- ${name}`,
-          name,
-          sectionId: section.id,
-          sectionLabel: section.label,
-          icon: section.icon,
-        });
-      });
-      (section.eightySixed || []).forEach(name => {
-        changes.push({
-          id: createPreviewChangeId(section.id, 'eightySixed', name),
-          kind: 'eightySixed',
-          text: `86'd: ${name}`,
-          name,
-          sectionId: section.id,
-          sectionLabel: section.label,
-          icon: section.icon,
-        });
-      });
-      (section.restored || []).forEach(name => {
-        changes.push({
-          id: createPreviewChangeId(section.id, 'restored', name),
-          kind: 'restored',
-          text: `${readRestoreLabel(section)}: ${name}`,
-          name,
-          sectionId: section.id,
-          sectionLabel: section.label,
-          icon: section.icon,
-        });
-      });
-      return { ...section, changes };
-    })
-    .filter(section => section.changes.length > 0);
 }
 
 function groupNotificationChangesBySection(changes = []) {
   const sections = new Map();
   (changes || []).forEach(change => {
-    if (!sections.has(change.sectionId)) {
-      sections.set(change.sectionId, {
-        id: change.sectionId,
-        icon: change.icon,
-        label: change.sectionLabel,
+    const sectionId = String(change?.sectionId || '').trim();
+    if (!sectionId) return;
+    if (!sections.has(sectionId)) {
+      sections.set(sectionId, {
+        id: sectionId,
+        icon: change.icon || '',
+        label: change.sectionLabel || sectionId,
         changes: [],
       });
     }
-    sections.get(change.sectionId).changes.push(change);
+    sections.get(sectionId).changes.push(change);
   });
   return Array.from(sections.values());
 }
@@ -310,6 +139,23 @@ function serializeNotificationSectionsForLog(sections = []) {
   }));
 }
 
+function serializeSaveOnlyChangesForLog(saveOnlyChanges = []) {
+  const names = (Array.isArray(saveOnlyChanges) ? saveOnlyChanges : [])
+    .map(change => change?.label || change?.message || '')
+    .map(label => String(label || '').trim())
+    .filter(Boolean);
+  if (!names.length) return [];
+  return [{
+    id: '__save_only__',
+    icon: '💾',
+    label: 'Will Save Only',
+    added: names,
+    removed: [],
+    eightySixed: [],
+    restored: [],
+  }];
+}
+
 function buildPatchMessage(sections = [], { menuName = '', menuLink = '', now = new Date() } = {}) {
   const dateStr = now.toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
   const timeStr = now.toLocaleTimeString('en-US', { hour: 'numeric', minute: '2-digit' });
@@ -319,11 +165,10 @@ function buildPatchMessage(sections = [], { menuName = '', menuLink = '', now = 
   (sections || []).forEach(section => {
     lines.push(`${section.icon} ${String(section.label || '').toUpperCase()}`);
     (section.changes || []).forEach(change => {
-      const cleanName = normalizeName(change.name);
-      if (change.kind === 'added') lines.push(`  ✅ + ${cleanName}`);
-      if (change.kind === 'removed') lines.push(`  ❌ - ${cleanName}`);
-      if (change.kind === 'eightySixed') lines.push(`  🚫 86'd: ${cleanName}`);
-      if (change.kind === 'restored') lines.push(`  ✅ ${readRestoreLabel(section)}: ${cleanName}`);
+      if (change.kind === 'added') lines.push(`  ✅ Added ${normalizeName(change.name)}`);
+      if (change.kind === 'removed') lines.push(`  ❌ Removed ${normalizeName(change.name)}`);
+      if (change.kind === 'eightySixed') lines.push(`  🚫 86'd ${normalizeName(change.name)}`);
+      if (change.kind === 'restored') lines.push(`  ✅ ${String(change.text || '').trim()}`);
     });
     lines.push('');
   });
@@ -346,9 +191,36 @@ async function readItemNamesByIds(itemIds = []) {
   return new Map((Array.isArray(rows) ? rows : []).map(row => [row.id, normalizeName(row?.name)]));
 }
 
-async function computeFeaturedDiffForMenu(knownMenu, meta = {}) {
+function createFeaturedChangeLine(groupId, section, kind, itemId, name) {
+  const normalizedName = normalizeName(name);
+  const text = kind === 'added'
+    ? `Added ${normalizedName}`
+    : `Removed ${normalizedName}`;
+  return {
+    id: `${groupId}::${kind}::${encodeURIComponent(normalizedName.toLowerCase())}`,
+    groupId,
+    kind,
+    text,
+    name: normalizedName,
+    itemId: String(itemId || ''),
+    sectionId: section.id,
+    sectionLabel: section.label,
+    icon: section.icon,
+  };
+}
+
+async function buildFeaturedQueueState(knownMenu = null, meta = {}) {
   const restaurantId = knownMenu?.restaurantId || '';
-  if (!restaurantId) return { diff: null, currentFeaturedIds: [] };
+  if (!restaurantId) {
+    return {
+      currentFeaturedIds: [],
+      groups: [],
+      sections: [],
+      notificationChanges: [],
+      diff: [],
+      unsentItemIds: [],
+    };
+  }
 
   const currentFeaturedIds = await readCurrentFeaturedIdsForRestaurant(restaurantId);
   const lastSentFeaturedIds = Array.isArray(meta?.last_sent_featured)
@@ -359,29 +231,91 @@ async function computeFeaturedDiffForMenu(knownMenu, meta = {}) {
   const addedIds = currentFeaturedIds.filter(id => !lastSet.has(id));
   const removedIds = lastSentFeaturedIds.filter(id => !currentSet.has(id));
   if (!addedIds.length && !removedIds.length) {
-    return { diff: null, currentFeaturedIds };
+    return {
+      currentFeaturedIds,
+      groups: [],
+      sections: [],
+      notificationChanges: [],
+      diff: [],
+      unsentItemIds: [],
+    };
   }
 
-  const namesById = await readItemNamesByIds([...addedIds, ...removedIds]);
   const config = getRestaurantSpecialConfig(restaurantId);
-  const label = String(config?.name || 'Featured');
+  const namesById = await readItemNamesByIds([...addedIds, ...removedIds]);
+  const section = {
+    id: '__featured__',
+    icon: '⭐',
+    label: String(config?.name || 'Featured'),
+  };
+  const groups = [];
+
+  addedIds.forEach(itemId => {
+    const groupId = `${section.id}::added::${encodeURIComponent(String(itemId || '').trim())}`;
+    groups.push({
+      id: groupId,
+      kind: 'added',
+      selectable: true,
+      sectionId: section.id,
+      sectionLabel: section.label,
+      icon: section.icon,
+      itemId: String(itemId || ''),
+      lines: [createFeaturedChangeLine(groupId, section, 'added', itemId, namesById.get(itemId) || '(featured item)')],
+    });
+  });
+  removedIds.forEach(itemId => {
+    const groupId = `${section.id}::removed::${encodeURIComponent(String(itemId || '').trim())}`;
+    groups.push({
+      id: groupId,
+      kind: 'removed',
+      selectable: true,
+      sectionId: section.id,
+      sectionLabel: section.label,
+      icon: section.icon,
+      itemId: String(itemId || ''),
+      lines: [createFeaturedChangeLine(groupId, section, 'removed', itemId, namesById.get(itemId) || '(removed featured item)')],
+    });
+  });
+
+  const notificationChanges = groups.flatMap(group => group.lines);
+  const sections = groupNotificationChangesBySection(notificationChanges);
+  const diff = serializeNotificationSectionsForLog(sections);
 
   return {
     currentFeaturedIds,
-    diff: {
-      id: '__featured__',
-      icon: '⭐',
-      label,
-      added: addedIds.map(itemId => namesById.get(itemId) || '(featured item)'),
-      removed: removedIds.map(itemId => namesById.get(itemId) || '(removed item)'),
-      eightySixed: [],
-      restored: [],
-      displayOrder: Number.MAX_SAFE_INTEGER,
-    },
+    groups,
+    sections,
+    notificationChanges,
+    diff,
+    unsentItemIds: [...addedIds],
   };
 }
 
-function mapLegacySelectionToIds(legacySections = [], notificationChanges = []) {
+function buildSectionsByOutcome({
+  preview = {},
+  selectedGroupIds = [],
+} = {}) {
+  const selectableGroups = Array.isArray(preview?.changeGroups)
+    ? preview.changeGroups.filter(group => group?.selectable)
+    : [];
+  const defaultIds = selectableGroups.map(group => group.id);
+  const selectedIds = selectedGroupIds.length ? selectedGroupIds : defaultIds;
+  const selectedSet = new Set(selectedIds.map(id => String(id || '').trim()).filter(Boolean));
+  const notificationChanges = Array.isArray(preview?.notificationChanges) ? preview.notificationChanges : [];
+  const selectedLines = notificationChanges.filter(change => selectedSet.has(String(change?.groupId || '').trim()));
+  const clearLines = notificationChanges.filter(change => (
+    !selectedSet.has(String(change?.groupId || '').trim()) &&
+    defaultIds.includes(String(change?.groupId || '').trim())
+  ));
+
+  return {
+    willSend: groupNotificationChangesBySection(selectedLines),
+    willClearWithoutSending: groupNotificationChangesBySection(clearLines),
+    willSaveOnly: Array.isArray(preview?.saveOnlyChanges) ? preview.saveOnlyChanges : [],
+  };
+}
+
+function mapLegacySelectionToLineIds(legacySections = [], notificationChanges = []) {
   const byKey = new Set();
   (Array.isArray(legacySections) ? legacySections : []).forEach(section => {
     const sectionId = String(section?.id || '').trim();
@@ -406,22 +340,90 @@ function mapLegacySelectionToIds(legacySections = [], notificationChanges = []) 
     .map(change => change.id);
 }
 
-function resolveSelectedChanges(preview, selectedChangeIds = null, legacySelectedSections = []) {
-  const notificationChanges = Array.isArray(preview?.notificationChanges) ? preview.notificationChanges : [];
-  if (!notificationChanges.length) return [];
+function resolveSelection(preview, selectedChangeIds = null, legacySelectedSections = []) {
+  const groups = Array.isArray(preview?.changeGroups) ? preview.changeGroups : [];
+  const selectableGroups = groups.filter(group => group?.selectable);
+  if (!selectableGroups.length) {
+    return {
+      selectedGroups: [],
+      selectedGroupIds: [],
+      selectedLines: [],
+      clearGroups: [],
+      clearLines: [],
+    };
+  }
 
+  const groupById = new Map(selectableGroups.map(group => [String(group.id), group]));
+  const lineToGroupId = new Map();
+  selectableGroups.forEach(group => {
+    (Array.isArray(group?.lines) ? group.lines : []).forEach(line => {
+      lineToGroupId.set(String(line?.id || ''), String(group.id));
+    });
+  });
+
+  let selectedSet = null;
   if (Array.isArray(selectedChangeIds)) {
-    const selectedSet = new Set(selectedChangeIds.map(changeId => String(changeId || '').trim()).filter(Boolean));
-    return notificationChanges.filter(change => selectedSet.has(change.id));
+    selectedSet = new Set();
+    selectedChangeIds
+      .map(value => String(value || '').trim())
+      .filter(Boolean)
+      .forEach(id => {
+        if (groupById.has(id)) {
+          selectedSet.add(id);
+          return;
+        }
+        const groupId = lineToGroupId.get(id);
+        if (groupId) selectedSet.add(groupId);
+      });
+  } else {
+    const legacyLineIds = mapLegacySelectionToLineIds(legacySelectedSections, preview?.notificationChanges || []);
+    if (legacyLineIds.length) {
+      selectedSet = new Set();
+      legacyLineIds.forEach(lineId => {
+        const groupId = lineToGroupId.get(String(lineId || '').trim());
+        if (groupId) selectedSet.add(groupId);
+      });
+    }
   }
 
-  const legacySelectedIds = mapLegacySelectionToIds(legacySelectedSections, notificationChanges);
-  if (legacySelectedIds.length) {
-    const selectedSet = new Set(legacySelectedIds);
-    return notificationChanges.filter(change => selectedSet.has(change.id));
+  if (!selectedSet) {
+    selectedSet = new Set(selectableGroups.map(group => String(group.id)));
   }
 
-  return notificationChanges.slice();
+  const selectedGroups = selectableGroups.filter(group => selectedSet.has(String(group.id)));
+  const clearGroups = selectableGroups.filter(group => !selectedSet.has(String(group.id)));
+  const selectedLines = selectedGroups.flatMap(group => group.lines || []);
+  const clearLines = clearGroups.flatMap(group => group.lines || []);
+
+  return {
+    selectedGroups,
+    selectedGroupIds: selectedGroups.map(group => group.id),
+    selectedLines,
+    clearGroups,
+    clearLines,
+  };
+}
+
+function mergeQueueStates(categoryState = {}, featuredState = {}) {
+  const changeGroups = [
+    ...(Array.isArray(categoryState?.groups) ? categoryState.groups : []),
+    ...(Array.isArray(featuredState?.groups) ? featuredState.groups : []),
+  ];
+  const notificationChanges = changeGroups.flatMap(group => group.lines || []);
+  const sections = groupNotificationChangesBySection(notificationChanges);
+  const diff = serializeNotificationSectionsForLog(sections);
+  const unsentItemIds = Array.from(new Set([
+    ...(Array.isArray(categoryState?.unsentItemIds) ? categoryState.unsentItemIds : []),
+    ...(Array.isArray(featuredState?.unsentItemIds) ? featuredState.unsentItemIds : []),
+  ]));
+
+  return {
+    changeGroups,
+    notificationChanges,
+    sections,
+    diff,
+    unsentItemIds,
+  };
 }
 
 async function buildCanonicalPreviewForMenu({
@@ -429,56 +431,56 @@ async function buildCanonicalPreviewForMenu({
   meta = {},
   knownMenu = null,
 }) {
-  const snapshotCategories = readSnapshotCategories(snapshot);
   const lastSentState = meta?.last_sent_state && typeof meta.last_sent_state === 'object'
     ? meta.last_sent_state
     : {};
-  const diff = [];
-
-  snapshotCategories.forEach(category => {
-    const sectionDiff = buildCategoryDiff(category, lastSentState[category.key] || []);
-    if (sectionDiff) diff.push(sectionDiff);
+  const categoryState = buildCategoryQueueState({
+    snapshot,
+    lastSentState,
   });
-
-  const featuredResult = await computeFeaturedDiffForMenu(knownMenu, meta);
-  if (featuredResult.diff) diff.push(featuredResult.diff);
-  diff.sort((a, b) => (a.displayOrder || 0) - (b.displayOrder || 0));
-
-  const sections = buildNotificationSections(diff);
-  const notificationChanges = sections.flatMap(section => section.changes);
+  const featuredState = await buildFeaturedQueueState(knownMenu, meta);
+  const queueState = mergeQueueStates(categoryState, featuredState);
   const previewContext = readSnapshotPreviewContext(snapshot);
-  const hasNotificationChanges = notificationChanges.length > 0;
+  const hasNotificationChanges = queueState.changeGroups.length > 0;
   const hasSaveOnlyChanges = previewContext.saveOnlyChanges.length > 0;
-  const mode = (previewContext.hasLocalDraft || previewContext.hasSharedDraft)
-    ? 'save'
-    : (hasNotificationChanges ? 'update-only' : 'save');
+  const mode = previewContext.hasLocalDraft
+    ? (hasNotificationChanges ? 'save-and-send' : 'save')
+    : (hasNotificationChanges ? 'send' : 'save');
   const patchMessage = hasNotificationChanges
-    ? buildPatchMessage(groupNotificationChangesBySection(notificationChanges), {
+    ? buildPatchMessage(queueState.sections, {
       menuName: knownMenu?.name || '',
       menuLink: String(meta?.notifications?.menu_url || '').trim(),
     })
     : '';
+  const selectionDefaults = queueState.changeGroups
+    .filter(group => group?.selectable)
+    .map(group => group.id);
 
-  return {
+  const preview = {
     mode,
     hasChanges: hasNotificationChanges || hasSaveOnlyChanges,
     hasLocalDraft: previewContext.hasLocalDraft,
-    hasSharedDraft: previewContext.hasSharedDraft,
+    hasLegacySharedDraft: previewContext.hasLegacySharedDraft,
     hasNotificationChanges,
     hasSaveOnlyChanges,
-    diff,
-    sections,
-    notificationChanges,
+    diff: queueState.diff,
+    sections: queueState.sections,
+    notificationChanges: queueState.notificationChanges,
+    changeGroups: queueState.changeGroups,
     saveOnlyChanges: previewContext.saveOnlyChanges,
     patchMessage,
     truncated: patchMessage.length > MAX_NOTIFICATION_TEXT_LENGTH,
-    selectionDefaults: notificationChanges.map(change => change.id),
+    selectionDefaults,
+    legacySelectionDefaults: queueState.notificationChanges.map(change => change.id),
     metadata: {
       serverOwned: true,
       contract: PREVIEW_CONTRACT,
-      currentFeaturedIds: featuredResult.currentFeaturedIds,
+      currentFeaturedIds: featuredState.currentFeaturedIds,
+      unsentItemIds: queueState.unsentItemIds,
     },
   };
+  preview.sectionsByOutcome = buildSectionsByOutcome({ preview, selectedGroupIds: selectionDefaults });
+  return preview;
 }
 
 function assertPublishRevisions({
@@ -490,15 +492,57 @@ function assertPublishRevisions({
   const currentRevisions = readRevisionState(meta);
   assertExpectedRevision(expectedLiveRevision, meta?.last_updated_ts || null, 'live_revision', {
     menuId,
-    command: 'menu-publish.v1',
+    command: 'menu-publish.v2',
     currentRevisions,
   });
   assertExpectedRevision(expectedDraftRevision, meta?.draft_saved_ts || null, 'draft_revision', {
     menuId,
-    command: 'menu-publish.v1',
+    command: 'menu-publish.v2',
     currentRevisions,
   });
   return currentRevisions;
+}
+
+function normalizePublishMode(mode = '', previewMode = 'save') {
+  const normalized = String(mode || '').trim().toLowerCase();
+  if (normalized === 'save') return 'save';
+  if (normalized === 'save-only') return 'save';
+  if (normalized === 'save-and-send') return 'save-and-send';
+  if (normalized === 'save-and-update') return 'save-and-send';
+  if (normalized === 'send') return 'send';
+  if (normalized === 'update-only') return 'send';
+  return normalizePublishMode(previewMode || 'save', 'save');
+}
+
+function mergeDowngradedFields(...compatResults) {
+  const merged = [];
+  compatResults.forEach(result => {
+    (Array.isArray(result?.downgradedFields) ? result.downgradedFields : []).forEach(field => {
+      if (!merged.includes(field)) merged.push(field);
+    });
+  });
+  return merged;
+}
+
+async function appendHistoryEvent({
+  menuId,
+  actor,
+  source,
+  operationId,
+  eventType,
+  sections = [],
+  message = '',
+}) {
+  if (!message) return { downgradedFields: [] };
+  return insertUpdateLog({
+    menuId,
+    actor,
+    diff: serializeNotificationSectionsForLog(sections),
+    message,
+    source,
+    operationId,
+    eventType,
+  });
 }
 
 export async function previewMenuUpdateForMenu({
@@ -570,20 +614,26 @@ export async function publishMenuUpdateForMenu({
     meta,
     knownMenu,
   });
-  const selectedChanges = resolveSelectedChanges(preview, selectedChangeIds, legacySelectedSections);
-  const selectedSections = groupNotificationChangesBySection(selectedChanges);
-  const patchMessage = selectedSections.length
+  const selection = resolveSelection(preview, selectedChangeIds, legacySelectedSections);
+  const selectedSections = groupNotificationChangesBySection(selection.selectedLines);
+  const clearSections = groupNotificationChangesBySection(selection.clearLines);
+  const selectedPatchMessage = selectedSections.length
     ? buildPatchMessage(selectedSections, {
       menuName: knownMenu?.name || '',
       menuLink: String(meta?.notifications?.menu_url || '').trim(),
     })
     : '';
-
-  const publishMode = ['save', 'save-and-update', 'update-only'].includes(mode) ? mode : preview.mode;
-  const shouldPersistLive = publishMode !== 'update-only';
-  const shouldNotify = (publishMode === 'save-and-update' || publishMode === 'update-only') && selectedSections.length > 0;
-  const liveTs = Date.now();
+  const publishMode = normalizePublishMode(mode, preview.mode);
+  const shouldPersistLive = publishMode !== 'send';
+  const shouldNotify = (publishMode === 'save-and-send' || publishMode === 'send') && selectedSections.length > 0;
+  const shouldAdvanceQueueBaseline = (publishMode === 'save-and-send' || publishMode === 'send') && (
+    selectedSections.length > 0 || clearSections.length > 0
+  );
+  const ts = Date.now();
   const normalizedSource = inferAuditSource(actor, source);
+  const operationId = randomUUID();
+  const warnings = [];
+  const historyCompat = [];
 
   if (shouldPersistLive) {
     await saveLiveMenuForMenu({
@@ -595,51 +645,73 @@ export async function publishMenuUpdateForMenu({
   }
 
   const notificationStatus = shouldNotify
-    ? createNotificationStatus(await deliverMenuNotification(menuId, truncateNotificationText(patchMessage)), true)
+    ? createNotificationStatus(await deliverMenuNotification(menuId, truncateNotificationText(selectedPatchMessage)), true)
     : createNotificationStatus(null, false);
 
-  const warnings = [];
-  if (notificationStatus.partial) {
-    warnings.push(...collectNotificationWarnings(notificationStatus.summary));
-    warnings.push('Some channels did not receive the update. The lines remain ready to send again.');
-    return {
-      ok: true,
-      ts: liveTs,
-      preview,
-      current_revisions: currentRevisions,
-      notificationStatus,
-      warnings,
-      warningMessage: warnings[0] || '',
-      successMessage: `✅ ${knownMenu.name || 'Menu'} saved live. Update still needs attention.`,
-      selected_change_ids: selectedChanges.map(change => change.id),
-      compatibility: {
-        contract: PREVIEW_CONTRACT,
-        serverOwned: true,
-      },
-    };
-  }
+  if (shouldNotify && (notificationStatus.partial || !notificationStatus.ok)) {
+    if (notificationStatus.partial) {
+      warnings.push(...collectNotificationWarnings(notificationStatus.summary));
+      warnings.push('Some channels did not receive the update. The queue was preserved so you can retry.');
+    } else {
+      warnings.push('Update could not be sent. The queue was preserved.');
+    }
 
-  if (shouldNotify && !notificationStatus.ok) {
-    warnings.push('Update could not be sent.');
+    const [metaCompatibility, failedSendCompatibility] = await Promise.all([
+      patchMenuMetaForMenuWithCompatibility(menuId, {
+        last_updated_ts: shouldPersistLive ? ts : (meta?.last_updated_ts || null),
+        draft_state: shouldPersistLive ? {} : (meta?.draft_state || {}),
+        draft_saved_ts: shouldPersistLive ? null : (meta?.draft_saved_ts || null),
+        draft_saved_by_user_id: shouldPersistLive ? null : (meta?.draft_saved_by_user_id ?? undefined),
+        draft_saved_by_name: shouldPersistLive ? '' : (meta?.draft_saved_by_name ?? undefined),
+        draft_saved_source: shouldPersistLive ? '' : (meta?.draft_saved_source ?? undefined),
+      }, {
+        optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
+      }),
+      appendHistoryEvent({
+        menuId,
+        actor,
+        source: normalizedSource,
+        operationId,
+        eventType: 'send_failed',
+        sections: selectedSections,
+        message: notificationStatus.partial
+          ? 'Notification delivery was partially successful. Queue preserved for retry.'
+          : 'Notification delivery failed. Queue preserved for retry.',
+      }),
+    ]);
+    historyCompat.push(failedSendCompatibility);
+
     return {
       ok: true,
-      ts: liveTs,
+      ts,
       preview,
-      current_revisions: currentRevisions,
+      sections_by_outcome: buildSectionsByOutcome({
+        preview,
+        selectedGroupIds: selection.selectedGroupIds,
+      }),
+      current_revisions: {
+        ...currentRevisions,
+        live_revision: shouldPersistLive ? ts : currentRevisions.live_revision,
+      },
       notificationStatus,
       warnings,
       warningMessage: warnings[0] || '',
-      successMessage: `✅ ${knownMenu.name || 'Menu'} saved live. Update still needs to be sent.`,
-      selected_change_ids: selectedChanges.map(change => change.id),
+      successMessage: `✅ ${knownMenu.name || 'Menu'} saved live. Send attempt failed and the queue was preserved.`,
+      selected_change_ids: selection.selectedGroupIds,
+      legacy_selected_change_ids: selection.selectedLines.map(change => change.id),
+      operation_id: operationId,
       compatibility: {
         contract: PREVIEW_CONTRACT,
         serverOwned: true,
+        downgradedFields: mergeDowngradedFields(metaCompatibility, ...historyCompat),
+        sourceStamped: !mergeDowngradedFields(...historyCompat).includes('source'),
+        typedHistory: !mergeDowngradedFields(...historyCompat).includes('event_type'),
+        operationGrouping: !mergeDowngradedFields(...historyCompat).includes('operation_id'),
       },
     };
   }
 
   warnings.push(...collectNotificationWarnings(notificationStatus.summary));
-  const ts = liveTs;
   const currentFeaturedIds = Array.isArray(preview?.metadata?.currentFeaturedIds)
     ? preview.metadata.currentFeaturedIds
     : await readCurrentFeaturedIdsForRestaurant(knownMenu.restaurantId);
@@ -648,20 +720,39 @@ export async function publishMenuUpdateForMenu({
   const lastSentState = snapshotLastSentState(snapshot);
 
   if (publishMode === 'save') {
-    const metaCompatibility = await patchMenuMetaForMenuWithCompatibility(menuId, {
-      last_updated_ts: ts,
-      draft_state: {},
-      draft_saved_ts: null,
-      draft_saved_by_user_id: null,
-      draft_saved_by_name: '',
-      draft_saved_source: '',
-    }, {
-      optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
-    });
+    const [metaCompatibility, quietSaveCompatibility] = await Promise.all([
+      patchMenuMetaForMenuWithCompatibility(menuId, {
+        last_updated_ts: ts,
+        draft_state: {},
+        draft_saved_ts: null,
+        draft_saved_by_user_id: null,
+        draft_saved_by_name: '',
+        draft_saved_source: '',
+      }, {
+        optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
+      }),
+      insertUpdateLog({
+        menuId,
+        actor,
+        diff: serializeSaveOnlyChangesForLog(preview.saveOnlyChanges),
+        message: preview.hasNotificationChanges
+          ? 'Saved live quietly. Notification queue was preserved for later send.'
+          : 'Saved live quietly.',
+        source: normalizedSource,
+        operationId,
+        eventType: 'quiet_save',
+      }),
+    ]);
+    historyCompat.push(quietSaveCompatibility);
+
     return {
       ok: true,
       ts,
       preview,
+      sections_by_outcome: buildSectionsByOutcome({
+        preview,
+        selectedGroupIds: selection.selectedGroupIds,
+      }),
       current_revisions: {
         ...currentRevisions,
         live_revision: ts,
@@ -669,73 +760,112 @@ export async function publishMenuUpdateForMenu({
       notificationStatus: null,
       warnings,
       warningMessage: warnings[0] || '',
-      successMessage: `✅ ${knownMenu.name || 'Menu'} saved to the live menu.`,
-      selected_change_ids: selectedChanges.map(change => change.id),
+      successMessage: preview.hasNotificationChanges
+        ? `✅ ${knownMenu.name || 'Menu'} saved live. Queue is ready to send.`
+        : `✅ ${knownMenu.name || 'Menu'} saved to the live menu.`,
+      selected_change_ids: selection.selectedGroupIds,
+      legacy_selected_change_ids: selection.selectedLines.map(change => change.id),
+      operation_id: operationId,
       compatibility: {
         contract: PREVIEW_CONTRACT,
         serverOwned: true,
-        downgradedFields: metaCompatibility.downgradedFields,
-        sourceStamped: !metaCompatibility.downgradedFields.includes('draft_saved_source'),
+        downgradedFields: mergeDowngradedFields(metaCompatibility, ...historyCompat),
+        sourceStamped: !mergeDowngradedFields(...historyCompat).includes('source'),
+        typedHistory: !mergeDowngradedFields(...historyCompat).includes('event_type'),
+        operationGrouping: !mergeDowngradedFields(...historyCompat).includes('operation_id'),
       },
     };
   }
 
   const [metaCompatibility] = await Promise.all([
     patchMenuMetaForMenuWithCompatibility(menuId, {
-      last_updated_ts: ts,
-      last_sent_ts: ts,
-      last_sent_state: lastSentState,
-      last_sent_categories: Array.isArray(preview?.diff) ? preview.diff.map(section => section.id).filter(Boolean) : [],
-      last_sent_featured: currentFeaturedIds,
-      draft_state: shouldPersistLive ? {} : meta?.draft_state || {},
-      draft_saved_ts: shouldPersistLive ? null : meta?.draft_saved_ts || null,
+      last_updated_ts: shouldPersistLive ? ts : (meta?.last_updated_ts || currentRevisions.live_revision || null),
+      last_sent_ts: shouldAdvanceQueueBaseline ? ts : (meta?.last_sent_ts || null),
+      last_sent_state: shouldAdvanceQueueBaseline ? lastSentState : (meta?.last_sent_state || {}),
+      last_sent_categories: shouldAdvanceQueueBaseline
+        ? (Array.isArray(preview?.diff) ? preview.diff.map(section => section.id).filter(Boolean) : [])
+        : (Array.isArray(meta?.last_sent_categories) ? meta.last_sent_categories : []),
+      last_sent_featured: shouldAdvanceQueueBaseline
+        ? currentFeaturedIds
+        : (Array.isArray(meta?.last_sent_featured) ? meta.last_sent_featured : []),
+      draft_state: shouldPersistLive ? {} : (meta?.draft_state || {}),
+      draft_saved_ts: shouldPersistLive ? null : (meta?.draft_saved_ts || null),
       draft_saved_by_user_id: shouldPersistLive ? null : (meta?.draft_saved_by_user_id ?? undefined),
       draft_saved_by_name: shouldPersistLive ? '' : (meta?.draft_saved_by_name ?? undefined),
       draft_saved_source: shouldPersistLive ? '' : (meta?.draft_saved_source ?? undefined),
     }, {
       optionalFields: ['last_sent_featured', 'draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
     }),
-    ...siblingMenuIds.map(candidateId => patchMenuMetaForMenu(candidateId, {
-      last_sent_featured: currentFeaturedIds,
-    })),
+    ...(shouldAdvanceQueueBaseline
+      ? siblingMenuIds.map(candidateId => patchMenuMetaForMenu(candidateId, {
+          last_sent_featured: currentFeaturedIds,
+        }))
+      : []),
   ]);
 
-  let logCompatibility = { downgradedFields: [] };
-  if (patchMessage) {
-    logCompatibility = await insertUpdateLog({
+  if (selectedSections.length > 0 && shouldNotify) {
+    const sendCompatibility = await appendHistoryEvent({
       menuId,
       actor,
-      diff: serializeNotificationSectionsForLog(selectedSections),
-      message: patchMessage,
       source: normalizedSource,
+      operationId,
+      eventType: 'send_notification',
+      sections: selectedSections,
+      message: selectedPatchMessage || 'Sent menu update notification.',
     });
+    historyCompat.push(sendCompatibility);
   }
+
+  if (clearSections.length > 0) {
+    const clearCompatibility = await appendHistoryEvent({
+      menuId,
+      actor,
+      source: normalizedSource,
+      operationId,
+      eventType: 'clear_without_send',
+      sections: clearSections,
+      message: `Cleared ${clearSections.reduce((count, section) => count + (section.changes || []).length, 0)} queued line(s) without sending.`,
+    });
+    historyCompat.push(clearCompatibility);
+  }
+
+  const queueWasClearedWithoutSend = clearSections.length > 0 && !shouldNotify;
+  const successMessage = shouldNotify
+    ? (clearSections.length > 0
+        ? `✅ ${knownMenu.name || 'Menu'} sent selected updates and cleared unchecked lines.`
+        : `✅ ${knownMenu.name || 'Menu'} updates sent.`)
+    : (queueWasClearedWithoutSend
+        ? `✅ ${knownMenu.name || 'Menu'} update list cleared without notifying channels.`
+        : `✅ ${knownMenu.name || 'Menu'} save completed.`);
 
   return {
     ok: true,
     ts,
     preview,
+    sections_by_outcome: buildSectionsByOutcome({
+      preview,
+      selectedGroupIds: selection.selectedGroupIds,
+    }),
     current_revisions: {
       ...currentRevisions,
-      live_revision: ts,
-      last_sent_revision: ts,
+      live_revision: shouldPersistLive ? ts : currentRevisions.live_revision,
+      last_sent_revision: shouldAdvanceQueueBaseline ? ts : currentRevisions.last_sent_revision,
       draft_revision: shouldPersistLive ? null : currentRevisions.draft_revision,
     },
     notificationStatus: shouldNotify ? notificationStatus : null,
     warnings,
     warningMessage: warnings[0] || '',
-    successMessage: shouldNotify
-      ? `✅ ${knownMenu.name || 'Menu'} saved and sent!`
-      : `✅ ${knownMenu.name || 'Menu'} update list cleared without notifying channels.`,
-    selected_change_ids: selectedChanges.map(change => change.id),
+    successMessage,
+    selected_change_ids: selection.selectedGroupIds,
+    legacy_selected_change_ids: selection.selectedLines.map(change => change.id),
+    operation_id: operationId,
     compatibility: {
       contract: PREVIEW_CONTRACT,
       serverOwned: true,
-      downgradedFields: [
-        ...(Array.isArray(metaCompatibility?.downgradedFields) ? metaCompatibility.downgradedFields : []),
-        ...(Array.isArray(logCompatibility?.downgradedFields) ? logCompatibility.downgradedFields : []),
-      ],
-      sourceStamped: !Array.isArray(logCompatibility?.downgradedFields) || !logCompatibility.downgradedFields.includes('source'),
+      downgradedFields: mergeDowngradedFields(metaCompatibility, ...historyCompat),
+      sourceStamped: !mergeDowngradedFields(...historyCompat).includes('source'),
+      typedHistory: !mergeDowngradedFields(...historyCompat).includes('event_type'),
+      operationGrouping: !mergeDowngradedFields(...historyCompat).includes('operation_id'),
     },
   };
 }

--- a/server/_menu-queue.js
+++ b/server/_menu-queue.js
@@ -1,0 +1,359 @@
+const UNCATEGORIZED_KEY = '__uncategorized__';
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+export function normalizeName(value) {
+  return String(value || '').replace(/[\r\n]+/g, ' ').trim();
+}
+
+export function isVisibleItem(item = {}) {
+  const onMenu = item?.on_menu !== false && item?.onMenu !== false;
+  const visibility = String(item?.visibility || 'public').trim().toLowerCase();
+  return onMenu && visibility !== 'off_menu';
+}
+
+export function isEightySixed(item = {}) {
+  return !!(item?.is_eighty_sixed ?? item?.eightySixed);
+}
+
+function classifyItem(item = null) {
+  if (!item || !item.visible) return 'hidden';
+  return item.eightySixed ? 'eighty' : 'active';
+}
+
+function toNormalizedQueueItem(item = {}, {
+  categoryKey = '',
+  index = 0,
+  fallbackPrefix = 'item',
+} = {}) {
+  const name = normalizeName(item?.name);
+  if (!name) return null;
+
+  const rawId = String(item?.id || '').trim();
+  const fallbackId = `${fallbackPrefix}:${categoryKey}:${index}:${name.toLowerCase()}`;
+  return {
+    id: rawId || fallbackId,
+    name,
+    nameKey: name.toLowerCase(),
+    visible: isVisibleItem(item),
+    eightySixed: isEightySixed(item),
+  };
+}
+
+function readCategoryDisplayOrder(category = {}, fallback) {
+  const numeric = Number(category?.display_order);
+  if (Number.isFinite(numeric)) return numeric;
+  return fallback;
+}
+
+function readCategoryItems(category = {}) {
+  return asArray(category?.items);
+}
+
+export function readSnapshotCategories(snapshot = {}) {
+  const cats = Array.isArray(snapshot) ? snapshot : asArray(snapshot?.cats);
+  return cats
+    .map((category, categoryIndex) => ({
+      key: String(category?.key || '').trim(),
+      label: String(category?.label || '').trim(),
+      icon: String(category?.icon || ''),
+      displayOrder: readCategoryDisplayOrder(category, categoryIndex),
+      items: readCategoryItems(category),
+    }))
+    .filter(category => category.key && category.key !== UNCATEGORIZED_KEY);
+}
+
+function createSectionState(category = {}, fallbackOrder = Number.MAX_SAFE_INTEGER) {
+  return {
+    id: category.key,
+    icon: category.icon || '',
+    label: category.label || category.key,
+    displayOrder: Number.isFinite(Number(category.displayOrder))
+      ? Number(category.displayOrder)
+      : fallbackOrder,
+  };
+}
+
+function createGroupId(sectionId, kind, itemId) {
+  return `${sectionId}::${kind}::${encodeURIComponent(String(itemId || '').trim())}`;
+}
+
+function createChangeLine(groupId, section, {
+  kind,
+  name,
+  itemId,
+}) {
+  const normalizedName = normalizeName(name);
+  let text = '';
+  if (kind === 'added') text = `Added ${normalizedName}`;
+  if (kind === 'removed') text = `Removed ${normalizedName}`;
+  if (kind === 'eightySixed') text = `86'd ${normalizedName}`;
+  if (kind === 'restored') {
+    const restoreLabel = String(section?.label || '').toLowerCase().includes('tap')
+      ? 'Back on Tap'
+      : 'Back in Stock';
+    text = `${restoreLabel}: ${normalizedName}`;
+  }
+  return {
+    id: `${groupId}::${kind}::${encodeURIComponent(normalizedName.toLowerCase())}`,
+    groupId,
+    kind,
+    text,
+    name: normalizedName,
+    itemId: String(itemId || ''),
+    sectionId: section.id,
+    sectionLabel: section.label,
+    icon: section.icon,
+  };
+}
+
+function toSectionsFromGroups(groups = []) {
+  const sections = new Map();
+  groups.forEach(group => {
+    const sectionId = String(group?.sectionId || '');
+    if (!sectionId) return;
+    if (!sections.has(sectionId)) {
+      sections.set(sectionId, {
+        id: sectionId,
+        icon: String(group?.icon || ''),
+        label: String(group?.sectionLabel || ''),
+        displayOrder: Number.isFinite(Number(group?.displayOrder))
+          ? Number(group.displayOrder)
+          : Number.MAX_SAFE_INTEGER,
+        changes: [],
+      });
+    }
+    const section = sections.get(sectionId);
+    section.changes.push(...asArray(group.lines));
+  });
+  return Array.from(sections.values())
+    .sort((a, b) => a.displayOrder - b.displayOrder)
+    .map(section => ({
+      id: section.id,
+      icon: section.icon,
+      label: section.label,
+      changes: section.changes,
+    }));
+}
+
+function toLegacyDiff(sections = []) {
+  return sections.map(section => ({
+    id: section.id,
+    icon: section.icon,
+    label: section.label,
+    added: section.changes.filter(change => change.kind === 'added').map(change => change.name),
+    removed: section.changes.filter(change => change.kind === 'removed').map(change => change.name),
+    eightySixed: section.changes.filter(change => change.kind === 'eightySixed').map(change => change.name),
+    restored: section.changes.filter(change => change.kind === 'restored').map(change => change.name),
+  })).filter(section => (
+    section.added.length ||
+    section.removed.length ||
+    section.eightySixed.length ||
+    section.restored.length
+  ));
+}
+
+function normalizeBaselineCategoryItems(lastSentState = {}, categoryKey = '') {
+  const items = asArray(lastSentState?.[categoryKey]);
+  return items
+    .map((item, itemIndex) => toNormalizedQueueItem(item, {
+      categoryKey,
+      index: itemIndex,
+      fallbackPrefix: 'baseline',
+    }))
+    .filter(Boolean);
+}
+
+function normalizeCurrentCategoryItems(category = {}) {
+  return asArray(category?.items)
+    .map((item, itemIndex) => toNormalizedQueueItem(item, {
+      categoryKey: category.key,
+      index: itemIndex,
+      fallbackPrefix: 'live',
+    }))
+    .filter(Boolean);
+}
+
+function buildCategoryGroupChanges(section, currentItems = [], previousItems = []) {
+  const currentById = new Map(currentItems.map(item => [item.id, item]));
+  const previousById = new Map(previousItems.map(item => [item.id, item]));
+  const orderedIds = [];
+
+  currentItems.forEach(item => {
+    if (!orderedIds.includes(item.id)) orderedIds.push(item.id);
+  });
+  previousItems.forEach(item => {
+    if (!orderedIds.includes(item.id)) orderedIds.push(item.id);
+  });
+
+  const groups = [];
+  const unsentCurrentItemIds = new Set();
+
+  orderedIds.forEach(itemId => {
+    const current = currentById.get(itemId) || null;
+    const previous = previousById.get(itemId) || null;
+    const currentState = classifyItem(current);
+    const previousState = classifyItem(previous);
+
+    if (previousState === 'active' && currentState === 'active' && previous?.nameKey !== current?.nameKey) {
+      const groupId = createGroupId(section.id, 'rename', itemId);
+      groups.push({
+        id: groupId,
+        kind: 'rename',
+        selectable: true,
+        sectionId: section.id,
+        sectionLabel: section.label,
+        icon: section.icon,
+        displayOrder: section.displayOrder,
+        itemId: String(itemId || ''),
+        lines: [
+          createChangeLine(groupId, section, { kind: 'removed', name: previous?.name, itemId }),
+          createChangeLine(groupId, section, { kind: 'added', name: current?.name, itemId }),
+        ],
+      });
+      unsentCurrentItemIds.add(itemId);
+      return;
+    }
+
+    if (previousState === 'active' && currentState === 'eighty') {
+      const groupId = createGroupId(section.id, 'eightySixed', itemId);
+      groups.push({
+        id: groupId,
+        kind: 'eightySixed',
+        selectable: true,
+        sectionId: section.id,
+        sectionLabel: section.label,
+        icon: section.icon,
+        displayOrder: section.displayOrder,
+        itemId: String(itemId || ''),
+        lines: [createChangeLine(groupId, section, { kind: 'eightySixed', name: current?.name, itemId })],
+      });
+      unsentCurrentItemIds.add(itemId);
+      return;
+    }
+
+    if (previousState === 'eighty' && currentState === 'active') {
+      const groupId = createGroupId(section.id, 'restored', itemId);
+      groups.push({
+        id: groupId,
+        kind: 'restored',
+        selectable: true,
+        sectionId: section.id,
+        sectionLabel: section.label,
+        icon: section.icon,
+        displayOrder: section.displayOrder,
+        itemId: String(itemId || ''),
+        lines: [createChangeLine(groupId, section, { kind: 'restored', name: current?.name, itemId })],
+      });
+      unsentCurrentItemIds.add(itemId);
+      return;
+    }
+
+    if (previousState === 'active' && currentState === 'hidden') {
+      const groupId = createGroupId(section.id, 'removed', itemId);
+      groups.push({
+        id: groupId,
+        kind: 'removed',
+        selectable: true,
+        sectionId: section.id,
+        sectionLabel: section.label,
+        icon: section.icon,
+        displayOrder: section.displayOrder,
+        itemId: String(itemId || ''),
+        lines: [createChangeLine(groupId, section, { kind: 'removed', name: previous?.name, itemId })],
+      });
+      return;
+    }
+
+    if (previousState === 'eighty' && currentState === 'hidden') {
+      const groupId = createGroupId(section.id, 'removed', itemId);
+      groups.push({
+        id: groupId,
+        kind: 'removed',
+        selectable: true,
+        sectionId: section.id,
+        sectionLabel: section.label,
+        icon: section.icon,
+        displayOrder: section.displayOrder,
+        itemId: String(itemId || ''),
+        lines: [createChangeLine(groupId, section, { kind: 'removed', name: previous?.name, itemId })],
+      });
+      return;
+    }
+
+    if (previousState === 'hidden' && currentState === 'active') {
+      const groupId = createGroupId(section.id, 'added', itemId);
+      groups.push({
+        id: groupId,
+        kind: 'added',
+        selectable: true,
+        sectionId: section.id,
+        sectionLabel: section.label,
+        icon: section.icon,
+        displayOrder: section.displayOrder,
+        itemId: String(itemId || ''),
+        lines: [createChangeLine(groupId, section, { kind: 'added', name: current?.name, itemId })],
+      });
+      unsentCurrentItemIds.add(itemId);
+    }
+  });
+
+  return {
+    groups,
+    unsentCurrentItemIds: Array.from(unsentCurrentItemIds),
+  };
+}
+
+export function buildCategoryQueueState({
+  snapshot = {},
+  lastSentState = {},
+} = {}) {
+  const categories = readSnapshotCategories(snapshot);
+  const categoriesByKey = new Map(categories.map(category => [category.key, category]));
+  const sectionKeys = Array.from(new Set([
+    ...categories.map(category => category.key),
+    ...Object.keys(lastSentState || {}).filter(Boolean),
+  ]))
+    .filter(categoryKey => categoryKey !== UNCATEGORIZED_KEY);
+
+  const groups = [];
+  const unsentItemIds = new Set();
+
+  sectionKeys.forEach((sectionKey, sectionIndex) => {
+    const category = categoriesByKey.get(sectionKey) || {
+      key: sectionKey,
+      label: sectionKey,
+      icon: '',
+      displayOrder: Number.MAX_SAFE_INTEGER - 1000 + sectionIndex,
+      items: [],
+    };
+    const section = createSectionState(category, Number.MAX_SAFE_INTEGER - 1000 + sectionIndex);
+    const currentItems = normalizeCurrentCategoryItems(category);
+    const previousItems = normalizeBaselineCategoryItems(lastSentState, sectionKey);
+    const result = buildCategoryGroupChanges(section, currentItems, previousItems);
+    result.groups.forEach(group => groups.push(group));
+    result.unsentCurrentItemIds.forEach(itemId => {
+      if (itemId) unsentItemIds.add(String(itemId));
+    });
+  });
+
+  const orderedGroups = groups.slice().sort((a, b) => {
+    const sectionOrder = Number(a.displayOrder || 0) - Number(b.displayOrder || 0);
+    if (sectionOrder !== 0) return sectionOrder;
+    return String(a.id || '').localeCompare(String(b.id || ''));
+  });
+  const sections = toSectionsFromGroups(orderedGroups);
+  const notificationChanges = sections.flatMap(section => section.changes);
+  const diff = toLegacyDiff(sections);
+
+  return {
+    groups: orderedGroups,
+    sections,
+    notificationChanges,
+    diff,
+    unsentItemIds: Array.from(unsentItemIds),
+    hasNotificationChanges: orderedGroups.length > 0,
+  };
+}

--- a/server/_menu-read.js
+++ b/server/_menu-read.js
@@ -10,6 +10,7 @@ import {
   readJsonSafe,
   serviceHeaders,
 } from './_supabase.js';
+import { buildCategoryQueueState } from './_menu-queue.js';
 
 const domainConstants = (globalThis.__HF_DOMAIN_CONSTANTS__ && typeof globalThis.__HF_DOMAIN_CONSTANTS__ === 'object')
   ? globalThis.__HF_DOMAIN_CONSTANTS__
@@ -77,6 +78,29 @@ async function fetchJsonOrThrow(url, fallbackMessage) {
   throw new Error(getApiErrorMessage(payload, fallbackMessage));
 }
 
+export async function readCurrentFeaturedIdsForRestaurant(restaurantId = '') {
+  const config = getRestaurantSpecialConfig(restaurantId);
+  if (!config?.canonicalId) return [];
+
+  const { sbUrl } = getSupabaseServerConfig();
+  const groupResponse = await fetch(
+    `${sbUrl}/rest/v1/featured_groups?canonical_id=eq.${encodeURIComponent(config.canonicalId)}&select=id&limit=1`,
+    { headers: serviceHeaders() }
+  );
+  if (!groupResponse.ok) return [];
+  const groups = await groupResponse.json();
+  const groupId = groups?.[0]?.id;
+  if (!groupId) return [];
+
+  const slotsResponse = await fetch(
+    `${sbUrl}/rest/v1/featured_slots?featured_group_id=eq.${groupId}&select=item_id`,
+    { headers: serviceHeaders() }
+  );
+  if (!slotsResponse.ok) return [];
+  const slots = await slotsResponse.json();
+  return Array.from(new Set((Array.isArray(slots) ? slots : []).map(slot => slot?.item_id).filter(Boolean)));
+}
+
 export async function readMenuStateBundle(menuId) {
   if (!isSupportedMenuId(menuId)) {
     throw { status: 400, message: 'Unsupported menu_id' };
@@ -107,6 +131,7 @@ export async function readMenuStateBundle(menuId) {
     `${sbUrl}/rest/v1/restaurants?id=eq.${menuRow.restaurant_id}&select=id,name,slug,design,use_custom_design&limit=1`,
     'Failed to load restaurant'
   );
+  const featuredCurrentIds = await readCurrentFeaturedIdsForRestaurant(menuRow.restaurant_id || '');
 
   return {
     menu: {
@@ -119,6 +144,7 @@ export async function readMenuStateBundle(menuId) {
     cats: Array.isArray(cats) ? cats : [],
     meta: metaRows?.[0] || {},
     restaurant: restaurantRows?.[0] || null,
+    featuredCurrentIds,
   };
 }
 
@@ -253,9 +279,35 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
       : null,
     source: String(draftMeta?.draft_saved_source || '').trim(),
   };
+  const lastSentState = draftMeta?.last_sent_state && typeof draftMeta.last_sent_state === 'object'
+    ? draftMeta.last_sent_state
+    : {};
+  const queueState = buildCategoryQueueState({
+    snapshot: { cats: bundle?.cats || [] },
+    lastSentState,
+  });
+  const currentFeaturedIds = Array.isArray(bundle?.featuredCurrentIds)
+    ? bundle.featuredCurrentIds.filter(Boolean)
+    : [];
+  const baselineFeaturedIds = Array.isArray(draftMeta?.last_sent_featured)
+    ? draftMeta.last_sent_featured.filter(Boolean)
+    : [];
+  const currentFeaturedSet = new Set(currentFeaturedIds);
+  const baselineFeaturedSet = new Set(baselineFeaturedIds);
+  const unsentFeaturedIds = Array.from(new Set([
+    ...currentFeaturedIds.filter(itemId => !baselineFeaturedSet.has(itemId)),
+    ...baselineFeaturedIds.filter(itemId => !currentFeaturedSet.has(itemId)),
+  ]));
+  const unsentItemIds = Array.from(new Set([
+    ...queueState.unsentItemIds,
+    ...unsentFeaturedIds,
+  ]));
+  const hasUnsentChanges = queueState.hasNotificationChanges || unsentFeaturedIds.length > 0;
+  const publishStatus = hasUnsentChanges ? 'live_unsent' : 'live';
   const workspaceCapabilities = {
     canSaveDraft: canManage,
     canSaveLiveMenu: canManage,
+    canSaveQuietly: canManage,
     canPublishUpdates: canManage,
     canManageRestaurantSpecials: canEditRestaurantSpecials,
     canReadRestaurantTools: canEditRestaurantSpecials,
@@ -278,6 +330,22 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
       accessibleMenuIds,
       hasSharedDraft,
       sharedDraft,
+      publishState: {
+        status: publishStatus,
+        statusLabel: hasUnsentChanges ? 'Live | Unsent' : 'Live',
+        hasUnsentChanges,
+        revisions: {
+          liveRevision: bundle?.meta?.last_updated_ts || null,
+          notificationRevision: bundle?.meta?.last_sent_ts || null,
+        },
+        queue: {
+          contract: 'menu-queue.v1',
+          unsentItemIds,
+          unsentFeaturedIds,
+          sections: queueState.diff,
+          selectableGroupIds: queueState.groups.map(group => group.id),
+        },
+      },
       permissions: {
         canManage,
         canAdmin: normalizedActor?.role === 'admin',
@@ -292,10 +360,12 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
     },
     capabilities: workspaceCapabilities,
     compatibility: {
-      contract: 'menu-workspace.v3',
+      contract: 'menu-workspace.v4',
       actorStamped: !!normalizedActor?.id,
       permissionShape: 'workspace.permissions.v1',
       capabilityShape: 'workspace.capabilities.v1',
+      publishStateShape: 'workspace.publish-state.v1',
+      sharedDraftDeprecated: true,
     },
   };
 }

--- a/server/_menu-write.js
+++ b/server/_menu-write.js
@@ -464,9 +464,18 @@ export async function patchMenuMetaForMenuWithCompatibility(menuId, update = {},
   }
 }
 
-export async function insertUpdateLog({ menuId, actor = null, diff = [], message = '', source = '' }) {
+export async function insertUpdateLog({
+  menuId,
+  actor = null,
+  diff = [],
+  message = '',
+  source = '',
+  operationId = '',
+  eventType = '',
+} = {}) {
   if (!message) return true;
   const { sbUrl } = getSupabaseServerConfig();
+  const normalizedEventType = String(eventType || '').trim().toLowerCase();
   const requestBody = {
     menu_id: menuId,
     user_id: actor?.id || null,
@@ -474,36 +483,39 @@ export async function insertUpdateLog({ menuId, actor = null, diff = [], message
     diff: Array.isArray(diff) ? diff : [],
     message: String(message || ''),
     source: normalizeAuditSource(source, { fallback: inferAuditSource(actor) }),
+    operation_id: operationId || undefined,
+    event_type: normalizedEventType || undefined,
   };
   const baseHeaders = serviceHeaders({
     'Content-Type': 'application/json',
     Prefer: 'return=minimal',
   });
-  let response = await fetch(`${sbUrl}/rest/v1/update_log`, {
-    method: 'POST',
-    headers: baseHeaders,
-    body: JSON.stringify(requestBody),
-  });
-  if (!response.ok) {
+
+  const downgradedFields = [];
+  const removableFields = ['source', 'operation_id', 'event_type'];
+  const requestPayload = { ...requestBody };
+
+  while (true) {
+    const response = await fetch(`${sbUrl}/rest/v1/update_log`, {
+      method: 'POST',
+      headers: baseHeaders,
+      body: JSON.stringify(requestPayload),
+    });
+    if (response.ok) break;
+
     const payload = await readJsonSafe(response);
-    if (isMissingColumnIssue(payload, 'source')) {
-      const { source: _ignored, ...fallbackBody } = requestBody;
-      response = await fetch(`${sbUrl}/rest/v1/update_log`, {
-        method: 'POST',
-        headers: baseHeaders,
-        body: JSON.stringify(fallbackBody),
-      });
-      if (response.ok) {
-        return {
-          downgradedFields: ['source'],
-        };
-      }
-      const fallbackPayload = await readJsonSafe(response);
-      throw new Error(getApiErrorMessage(fallbackPayload, 'Failed to write update log'));
+    const missingField = removableFields.find(fieldName => (
+      Object.prototype.hasOwnProperty.call(requestPayload, fieldName) &&
+      isMissingColumnIssue(payload, fieldName)
+    ));
+    if (!missingField) {
+      throw new Error(getApiErrorMessage(payload, 'Failed to write update log'));
     }
-    throw new Error(getApiErrorMessage(payload, 'Failed to write update log'));
+    delete requestPayload[missingField];
+    if (!downgradedFields.includes(missingField)) downgradedFields.push(missingField);
   }
+
   return {
-    downgradedFields: [],
+    downgradedFields,
   };
 }

--- a/style.css
+++ b/style.css
@@ -712,6 +712,7 @@
   .modal-bg.open .modal { transform: translateY(0); }
   .modal h2 { font-family: var(--font-heading); font-size: 22px; letter-spacing: 1px; margin-bottom: 4px; color: var(--text); }
   .modal-sub { font-size: 12px; color: var(--muted); margin-bottom: 18px; }
+  .preview-group-title { font-family: var(--font-body); font-size: 11px; font-weight: 700; letter-spacing: 0.08em; text-transform: uppercase; color: var(--muted); margin: 0 0 8px; }
   .preview-block { margin-bottom: 16px; }
   .preview-cat { font-family: var(--font-heading); font-size: 13px; letter-spacing: 1px; color: var(--ember); margin-bottom: 7px; }
   .preview-line { display: flex; align-items: center; gap: 7px; font-size: 13px; padding: 3px 0; }

--- a/supabase/migrations/20260416000000_v0.8.12_publish_queue_history.sql
+++ b/supabase/migrations/20260416000000_v0.8.12_publish_queue_history.sql
@@ -1,0 +1,21 @@
+-- v0.8.12: Typed publish history support with operation grouping.
+--
+-- Adds operation-level grouping and explicit event typing to update_log so
+-- quiet saves, sends, clears, and send failures can share one server model.
+
+ALTER TABLE public.update_log
+  ADD COLUMN IF NOT EXISTS operation_id uuid,
+  ADD COLUMN IF NOT EXISTS event_type text NOT NULL DEFAULT 'send_notification';
+
+ALTER TABLE public.update_log
+  ALTER COLUMN operation_id SET DEFAULT gen_random_uuid();
+
+UPDATE public.update_log
+SET operation_id = COALESCE(operation_id, gen_random_uuid())
+WHERE operation_id IS NULL;
+
+ALTER TABLE public.update_log
+  ALTER COLUMN operation_id SET NOT NULL;
+
+CREATE INDEX IF NOT EXISTS update_log_operation_id_idx ON public.update_log(operation_id);
+CREATE INDEX IF NOT EXISTS update_log_event_type_idx ON public.update_log(event_type);

--- a/tests/architecture-boundaries.test.cjs
+++ b/tests/architecture-boundaries.test.cjs
@@ -543,6 +543,102 @@ test('manager action bar stays visible and reflects idle and active draft states
   assert.equal(sendBtn.textContent, 'Send');
 });
 
+test('manager action bar reconciles stale dirty flags against the actual local draft state', () => {
+  const sandbox = loadAppSandbox();
+  const bar = sandbox.document._registerElement('manager-action-bar', createElement('div', 'manager-action-bar'));
+  sandbox.document._registerElement('manager-primary-action-group', createElement('div', 'manager-primary-action-group'));
+  const summary = sandbox.document._registerElement('manager-action-bar-summary', createElement('div', 'manager-action-bar-summary'));
+  sandbox.document._registerElement('sync-status', createElement('div', 'sync-status'));
+  const saveBtn = sandbox.document._registerElement('save-btn', createElement('button', 'save-btn'));
+  const sendBtn = sandbox.document._registerElement('send-btn', createElement('button', 'send-btn'));
+
+  sandbox.setLocalDraftBaseSnapshot(sandbox.buildPersistedDraftStateSnapshot());
+  setState(sandbox, {
+    _dirty: true,
+    _diffDirty: false,
+    _diffCache: [],
+  });
+
+  sandbox.updateManagerActionBar();
+
+  assert.equal(summary.textContent, 'No pending changes');
+  assert.equal(saveBtn.disabled, true);
+  assert.equal(saveBtn.textContent, 'Save');
+  assert.equal(sendBtn.disabled, true);
+  assert.equal(sendBtn.textContent, 'Send');
+  assert.equal(bar.classList.contains('is-idle'), true);
+  assert.equal(getState(sandbox, '_dirty'), false);
+});
+
+test('save actions blur the focused editor before publishing workspace changes', async () => {
+  const sandbox = loadAppSandbox();
+  let blurred = false;
+  const requests = [];
+
+  sandbox.document.activeElement = {
+    tagName: 'INPUT',
+    blur() {
+      blurred = true;
+    },
+  };
+  setState(sandbox, {
+    MENU_ID: 'menu-main',
+    _activeMenuName: 'Main Menu',
+    _dirty: true,
+    _diffDirty: false,
+    _diffCache: [
+      {
+        id: 'beer',
+        icon: '🍺',
+        label: 'Beers on Tap',
+        added: ['Draft Lager'],
+        removed: [],
+        eightySixed: [],
+        restored: [],
+      },
+    ],
+    currentUser: { accessToken: 'token-1', uid: 'user-1' },
+  });
+
+  sandbox.fetch = async (url, options = {}) => {
+    const body = JSON.parse(options.body || '{}');
+    requests.push(body.action);
+    if (body.action === 'preview_publish') {
+      return {
+        ok: true,
+        status: 200,
+        text: async () => JSON.stringify({
+          ok: true,
+          preview: {
+            hasChanges: true,
+            hasLocalDraft: true,
+            hasSharedDraft: false,
+            hasNotificationChanges: true,
+            hasSaveOnlyChanges: false,
+            diff: [{ id: 'beer', icon: '🍺', label: 'Beers on Tap', added: ['Draft Lager'], removed: [], eightySixed: [], restored: [] }],
+            sections: [{ id: 'beer', icon: '🍺', label: 'Beers on Tap', changes: [{ id: 'beer:add:Draft Lager', kind: 'added', text: '+ Draft Lager', name: 'Draft Lager' }] }],
+            notificationChanges: [{ id: 'beer:add:Draft Lager', kind: 'added', text: '+ Draft Lager', name: 'Draft Lager', sectionId: 'beer', itemId: '' }],
+            saveOnlyChanges: [],
+            patchMessage: '',
+            truncated: false,
+            mode: 'save-and-send',
+          },
+        }),
+      };
+    }
+    return {
+      ok: true,
+      status: 200,
+      text: async () => JSON.stringify({ ok: true, ts: 1712705100000, successMessage: 'Saved.' }),
+    };
+  };
+
+  await sandbox.saveMenu();
+
+  assert.equal(blurred, true);
+  assert.deepEqual(requests.slice(0, 2), ['preview_publish', 'publish']);
+});
+
 test('save-only menu edits stay in the draft session until save', async () => {
   const sandbox = loadAppSandbox();
   const persistCalls = [];

--- a/tests/architecture-boundaries.test.cjs
+++ b/tests/architecture-boundaries.test.cjs
@@ -255,41 +255,46 @@ test('menu session lifecycle routes poll and manual refreshes through one bounda
   ]);
 });
 
-test('menu session lifecycle saveDraft persists and patches last-updated metadata', async () => {
+test('menu session lifecycle saveDraft routes quiet saves through the publish boundary', async () => {
   const sandbox = loadAppSandbox();
-  const patchDraftCalls = [];
-  const commitCalls = [];
+  const publishCalls = [];
 
   const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts({
     buildSnapshot: (source, request) => ({ source, request, dirty: true }),
-    patchMenuDraftState: async (snapshot, ts) => {
-      patchDraftCalls.push([snapshot, ts]);
-      return { downgradedFields: [] };
-    },
-    commitDraft: ts => {
-      commitCalls.push(ts);
+    publishMenuUpdate: async options => {
+      publishCalls.push(options);
+      return {
+        ok: true,
+        successMessage: 'quiet save',
+        snapshot: { source: 'saved-live' },
+      };
     },
   }));
 
   const result = await lifecycle.saveDraft();
 
   assert.equal(result.ok, true);
-  assert.equal(result.snapshot.source, 'draft-saved');
-  assert.equal(patchDraftCalls.length, 1);
-  assert.ok(Array.isArray(patchDraftCalls[0][0].cats));
-  assert.equal(patchDraftCalls[0][1], 1712705100000);
-  assert.deepEqual(commitCalls, [1712705100000]);
+  assert.equal(result.snapshot.source, 'saved-live');
+  assert.equal(publishCalls.length, 1);
+  assert.equal(publishCalls[0].mode, 'save');
+  assert.equal(publishCalls[0].notify, false);
+  assert.equal(publishCalls[0].preview.mode, 'update-only');
 });
 
-test('menu publish service exposes draft-save and publish boundaries directly', async () => {
+test('menu publish service exposes quiet-save and publish boundaries directly', async () => {
   const sandbox = loadAppSandbox();
-  const patchDraftCalls = [];
+  const quietSaveCalls = [];
 
   const ports = createMenuSessionPorts({
     buildSnapshot: source => ({ source, dirty: true }),
-    patchMenuDraftState: async (_snapshot, ts) => {
-      patchDraftCalls.push(ts);
-      return { downgradedFields: [] };
+    publishMenuUpdate: async options => {
+      quietSaveCalls.push(options);
+      return {
+        ok: true,
+        snapshot: { source: 'saved-live' },
+        notificationStatus: null,
+        warnings: [],
+      };
     },
     syncLocalCache: () => true,
     logUpdate: async () => true,
@@ -304,8 +309,10 @@ test('menu publish service exposes draft-save and publish boundaries directly', 
 
   const draftResult = await service.saveDraft();
   assert.equal(draftResult.ok, true);
-  assert.equal(draftResult.snapshot.source, 'draft-saved');
-  assert.deepEqual(patchDraftCalls, [1712705100000]);
+  assert.equal(draftResult.snapshot.source, 'saved-live');
+  assert.equal(quietSaveCalls.length, 1);
+  assert.equal(quietSaveCalls[0].mode, 'save');
+  assert.equal(quietSaveCalls[0].notify, false);
 
   const publishResult = await service.publishUpdate({ notify: false });
   assert.equal(publishResult.ok, true);
@@ -410,7 +417,7 @@ test('draft ledger service provides action-bar and item badge state through one 
     isDirty: () => true,
     hasSharedDraft: () => false,
     getDraftChangeCount: () => 2,
-    getDiffLinesCount: () => 0,
+    getDiffLinesCount: () => 1,
     getDiffSections: () => [{
       id: 'beer',
       added: ['Lager'],
@@ -423,8 +430,9 @@ test('draft ledger service provides action-bar and item badge state through one 
   const actionBarState = service.getActionBarState({ isCompactViewport: false });
   assert.equal(actionBarState.hasDraftChanges, true);
   assert.equal(actionBarState.hasPendingUpdate, false);
-  assert.equal(actionBarState.publishLabel, 'Save');
-  assert.equal(actionBarState.summaryText, '2 pending changes. Save Draft updates the shared draft. Save opens Patch Notes Preview to publish live.');
+  assert.equal(actionBarState.saveLabel, 'Save Quietly');
+  assert.equal(actionBarState.publishLabel, 'Save & Send');
+  assert.equal(actionBarState.summaryText, '2 pending changes. Save Quietly writes live without sending. Save & Send reviews the queue before notifying.');
 
   const draftBadge = service.getItemBadge({
     item: { id: 'item-1', name: 'Lager', eightySixed: false },
@@ -478,10 +486,11 @@ test('manager action bar stays visible and reflects idle and active draft states
 
   assert.equal(bar.hidden, false);
   assert.equal(primaryGroup.hidden, false);
-  assert.equal(summary.textContent, 'No Pending Changes');
+  assert.equal(summary.textContent, 'No pending changes');
   assert.equal(saveBtn.disabled, true);
-  assert.equal(saveBtn.textContent, 'Save Draft');
+  assert.equal(saveBtn.textContent, 'Save');
   assert.equal(sendBtn.disabled, true);
+  assert.equal(sendBtn.textContent, 'Send');
   assert.equal(bar.classList.contains('is-idle'), true);
 
   setState(sandbox, {
@@ -502,15 +511,15 @@ test('manager action bar stays visible and reflects idle and active draft states
 
   sandbox.updateManagerActionBar();
 
-  assert.equal(summary.textContent, '2 pending changes. Save Draft updates the shared draft. Save opens Patch Notes Preview to publish live.');
+  assert.equal(summary.textContent, '2 pending changes. Save Quietly writes live without sending. Save & Send reviews the queue before notifying.');
   assert.equal(saveBtn.disabled, false);
-  assert.equal(saveBtn.textContent, 'Save Draft');
+  assert.equal(saveBtn.textContent, 'Save Quietly');
   assert.equal(sendBtn.disabled, false);
+  assert.equal(sendBtn.textContent, 'Save & Send');
   assert.equal(bar.classList.contains('is-idle'), false);
 
   setState(sandbox, {
     _dirty: false,
-    _hasSharedDraft: true,
     _diffDirty: false,
     _diffCache: [
       {
@@ -527,26 +536,11 @@ test('manager action bar stays visible and reflects idle and active draft states
 
   sandbox.updateManagerActionBar();
 
-  assert.equal(summary.textContent, '1 saved draft change is ready to publish.');
+  assert.equal(summary.textContent, '1 update line is live and ready to send.');
   assert.equal(saveBtn.disabled, true);
-  assert.equal(saveBtn.textContent, 'Save Draft');
+  assert.equal(saveBtn.hidden, true);
   assert.equal(sendBtn.disabled, false);
-  assert.equal(sendBtn.textContent, 'Save');
-
-  setState(sandbox, {
-    _dirty: false,
-    _hasSharedDraft: true,
-    _diffDirty: false,
-    _diffCache: [],
-  });
-
-  sandbox.updateManagerActionBar();
-
-  assert.equal(summary.textContent, 'Saved draft matches the live menu. Clear Draft removes it.');
-  assert.equal(saveBtn.disabled, false);
-  assert.equal(saveBtn.textContent, 'Clear Draft');
-  assert.equal(sendBtn.disabled, true);
-  assert.equal(sendBtn.textContent, 'Save');
+  assert.equal(sendBtn.textContent, 'Send');
 });
 
 test('save-only menu edits stay in the draft session until save', async () => {
@@ -582,7 +576,7 @@ test('save-only menu edits stay in the draft session until save', async () => {
   assert.equal(getState(sandbox, 'getDraftSaveOnlyChanges().length'), 1);
 });
 
-test('save draft persists a shared draft snapshot without publishing the live menu', async () => {
+test('save draft routes a quiet live save through the publish boundary and leaves the queue unsent', async () => {
   const sandbox = loadAppSandbox();
   const requests = [];
 
@@ -626,94 +620,22 @@ test('save draft persists a shared draft snapshot without publishing the live me
   assert.equal(result.ok, true);
   assert.equal(requests.length, 1);
   assert.equal(requests[0][0], '/api/manager');
-  assert.equal(requests[0][1].action, 'save_draft');
+  assert.equal(requests[0][1].action, 'publish');
+  assert.equal(requests[0][1].mode, 'save');
   assert.ok(Array.isArray(requests[0][1].snapshot.cats));
   assert.equal(getState(sandbox, '_dirty'), false);
-  assert.equal(getState(sandbox, 'hasSharedDraftState()'), true);
-  assert.equal(getState(sandbox, "buildMenuSessionSnapshot('test').status"), 'DRAFTED');
-});
-
-test('save draft clears a shared draft that already matches live', async () => {
-  const sandbox = loadAppSandbox();
-  const requests = [];
-
-  setState(sandbox, {
-    MENU_ID: 'menu-main',
-    currentUser: { accessToken: 'token-1', uid: 'user-1' },
-    _dirty: false,
-    _hasSharedDraft: true,
-    _diffDirty: false,
-    _diffCache: [],
-    menuState: {
-      beer: {
-        items: [
-          {
-            id: 'item-1',
-            name: 'Lager',
-            desc: '',
-            recipe: [],
-            price: '$8',
-            eightySixed: false,
-            onMenu: true,
-            visibility: 'public',
-            upcharges: [],
-            showDescription: true,
-            showRecipe: false,
-          },
-        ],
-        lastSent: [
-          {
-            id: 'item-1',
-            name: 'Lager',
-            desc: '',
-            recipe: [],
-            price: '$8',
-            eightySixed: false,
-            onMenu: true,
-            visibility: 'public',
-            upcharges: [],
-            showDescription: true,
-            showRecipe: false,
-          },
-        ],
-      },
-      _meta: {},
-    },
-  });
-  sandbox.fetch = async (url, options = {}) => {
-    requests.push([url, JSON.parse(options.body || '{}')]);
-    return {
-      ok: true,
-      status: 200,
-      text: async () => JSON.stringify({
-        ok: true,
-        status: 'draft_cleared',
-        sharedDraft: { exists: false, savedAt: null, savedBy: null, source: '' },
-      }),
-    };
-  };
-
-  const result = await sandbox.ensureCurrentMenuSession().saveDraft();
-
-  assert.equal(result.ok, true);
-  assert.equal(result.cleared, true);
-  assert.equal(requests.length, 1);
-  assert.equal(requests[0][0], '/api/manager');
-  assert.equal(requests[0][1].action, 'save_draft');
-  assert.deepEqual(requests[0][1].snapshot, {});
   assert.equal(getState(sandbox, 'hasSharedDraftState()'), false);
-  assert.equal(getState(sandbox, "buildMenuSessionSnapshot('test').status"), 'LIVE');
+  assert.equal(getState(sandbox, "buildMenuSessionSnapshot('test').status"), 'LIVE | UNSENT');
 });
 
-test('save menu publishes a shared draft to live and leaves unsent changes behind', async () => {
+test('save menu quietly writes a local draft to live and leaves unsent changes behind', async () => {
   const sandbox = loadAppSandbox();
   const requests = [];
 
   setState(sandbox, {
     MENU_ID: 'menu-main',
     _activeMenuName: 'Main Menu',
-    _dirty: false,
-    _hasSharedDraft: true,
+    _dirty: true,
     _diffDirty: false,
     _diffCache: [
       {

--- a/tests/boundaries/publish.boundary.test.cjs
+++ b/tests/boundaries/publish.boundary.test.cjs
@@ -37,7 +37,6 @@ function createMenuSessionPorts(overrides = {}) {
     persistState: async () => true,
     patchMenuMeta: async () => ({ downgradedFields: [] }),
     patchMenuMetaForMenu: async () => ({ downgradedFields: [] }),
-    patchMenuDraftState: async () => ({ downgradedFields: [] }),
     commitDraft() {},
     commitLiveSave() {},
     buildPreview: snapshot => ({
@@ -74,11 +73,32 @@ function createMenuSessionPorts(overrides = {}) {
 
 test('menu publish service boundary saves drafts and publishes updates', async () => {
   const sandbox = loadAppSandbox();
-  const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts());
+  const saveCalls = [];
+  const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts({
+    publishMenuUpdate: async options => {
+      saveCalls.push(options);
+      if (options?.mode === 'save') {
+        return {
+          ok: true,
+          successMessage: 'quiet save',
+          snapshot: { source: 'saved-live' },
+        };
+      }
+      return {
+        ok: true,
+        successMessage: '✅ Main Menu saved to the live menu.',
+        notificationStatus: null,
+      };
+    },
+  }));
 
   const draftResult = await lifecycle.saveDraft();
   assert.equal(draftResult.ok, true);
-  assert.equal(draftResult.snapshot.source, 'draft-saved');
+  assert.equal(draftResult.snapshot.source, 'saved-live');
+  assert.equal(saveCalls.length, 1);
+  assert.equal(saveCalls[0].mode, 'save');
+  assert.equal(saveCalls[0].notify, false);
+  assert.equal(saveCalls[0].preview.mode, 'update-only');
 
   const publishResult = await lifecycle.publishUpdate({ notify: false });
   assert.equal(publishResult.ok, true);

--- a/tests/boundaries/session.boundary.test.cjs
+++ b/tests/boundaries/session.boundary.test.cjs
@@ -33,7 +33,6 @@ function createMenuSessionPorts(overrides = {}) {
     persistState: async () => true,
     patchMenuMeta: async () => ({ downgradedFields: [] }),
     patchMenuMetaForMenu: async () => ({ downgradedFields: [] }),
-    patchMenuDraftState: async () => ({ downgradedFields: [] }),
     commitDraft() {},
     commitLiveSave() {},
     buildPreview: snapshot => ({
@@ -90,7 +89,7 @@ test('menu session lifecycle boundary handles redirect and fallback', async () =
   assert.equal(fallback.snapshot.source, 'cache');
 });
 
-test('menu state loader boundary forwards wave 1 api projections through one loader contract', async () => {
+test('menu state loader boundary reapplies the stored local draft envelope on top of live workspace data', async () => {
   const sandbox = loadAppSandbox();
   const apiProjection = {
     cats: [{ key: 'beer', items: [{ id: 'lager' }] }],
@@ -105,17 +104,22 @@ test('menu state loader boundary forwards wave 1 api projections through one loa
     },
   };
   let hydrated = null;
-  let draftState = null;
+  let appliedEnvelope = null;
   let cached = null;
   let clearCalls = 0;
+  const draftEnvelope = {
+    baseSnapshot: { cats: [{ key: 'beer', items: [{ id: 'lager' }] }] },
+    draftSnapshot: { cats: [{ key: 'beer', items: [{ id: 'lager', name: 'Draft Lager' }] }] },
+  };
 
   const service = sandbox.createMenuStateLoaderService({
     readState: async () => apiProjection,
     hydrateFromState: data => {
       hydrated = data;
     },
-    applyPersistedDraftState: draft => {
-      draftState = draft;
+    readStoredLocalDraftEnvelope: () => draftEnvelope,
+    applyLocalDraftEnvelope: envelope => {
+      appliedEnvelope = envelope;
       return true;
     },
     setDefaultState: () => {
@@ -138,7 +142,7 @@ test('menu state loader boundary forwards wave 1 api projections through one loa
 
   assert.equal(snapshot.source, 'network');
   assert.equal(hydrated, apiProjection);
-  assert.deepEqual(draftState, apiProjection.meta.draft_state);
+  assert.deepEqual(appliedEnvelope, draftEnvelope);
   assert.equal(cached, apiProjection);
   assert.equal(clearCalls, 0);
 });

--- a/tests/boundaries/session.boundary.test.cjs
+++ b/tests/boundaries/session.boundary.test.cjs
@@ -122,6 +122,7 @@ test('menu state loader boundary reapplies the stored local draft envelope on to
       appliedEnvelope = envelope;
       return true;
     },
+    syncLocalDraftDirtyState: () => true,
     setDefaultState: () => {
       throw new Error('should not fall back');
     },
@@ -145,4 +146,52 @@ test('menu state loader boundary reapplies the stored local draft envelope on to
   assert.deepEqual(appliedEnvelope, draftEnvelope);
   assert.equal(cached, apiProjection);
   assert.equal(clearCalls, 0);
+});
+
+test('menu state loader boundary clears no-op stored local drafts instead of entering drafting state', async () => {
+  const sandbox = loadAppSandbox();
+  const clearDraftOptions = [];
+  const dirtyStates = [];
+  let clearCalls = 0;
+
+  const service = sandbox.createMenuStateLoaderService({
+    readState: async () => ({
+      cats: [{ key: 'beer', items: [{ id: 'lager' }] }],
+      meta: {},
+      restaurant: { id: 'restaurant-main', name: 'Main Restaurant' },
+      workspace: {
+        actor: { id: 'user-1', role: 'manager' },
+        permissions: { canManage: true },
+      },
+    }),
+    hydrateFromState: () => {},
+    readStoredLocalDraftEnvelope: () => ({
+      baseSnapshot: { cats: [{ key: 'beer', items: [{ id: 'lager' }] }] },
+      draftSnapshot: { cats: [{ key: 'beer', items: [{ id: 'lager' }] }] },
+    }),
+    applyLocalDraftEnvelope: () => true,
+    syncLocalDraftDirtyState: () => false,
+    clearCurrentLocalDraft: options => {
+      clearDraftOptions.push(options);
+    },
+    setDirty: value => {
+      dirtyStates.push(value);
+    },
+    clearDraftChanges: () => {
+      clearCalls += 1;
+    },
+    writeMenuCache: () => {},
+    refreshFeatured: async () => {},
+    buildSnapshot: source => ({ source }),
+  });
+
+  const snapshot = await service.load({
+    request: { pageMode: 'manager' },
+    source: 'network',
+  });
+
+  assert.equal(snapshot.source, 'network');
+  assert.deepEqual(clearDraftOptions, [undefined]);
+  assert.deepEqual(dirtyStates, [false]);
+  assert.equal(clearCalls, 1);
 });

--- a/tests/phase10-conflict-hardening-boundaries.test.cjs
+++ b/tests/phase10-conflict-hardening-boundaries.test.cjs
@@ -103,7 +103,7 @@ test('wave 4 server modules harden actor authorization and check revisions befor
   assert.match(menuWrite, /reconnect:/);
 
   assert.match(menuPublish, /const currentRevisions = readRevisionState\(meta\)/);
-  assert.match(menuPublish, /command: 'menu-publish\.v1'/);
+  assert.match(menuPublish, /command: 'menu-publish\.v2'/);
   assert.match(menuPublish, /assertExpectedRevision\(expectedLiveRevision, meta\?\.last_updated_ts \|\| null, 'live_revision', \{/);
   assert.match(menuPublish, /assertExpectedRevision\(expectedDraftRevision, meta\?\.draft_saved_ts \|\| null, 'draft_revision', \{/);
   const liveRevisionCheckIndex = menuPublish.indexOf("assertExpectedRevision(expectedLiveRevision, meta?.last_updated_ts || null, 'live_revision', {");

--- a/tests/phase10-conflict-hardening-boundaries.test.cjs
+++ b/tests/phase10-conflict-hardening-boundaries.test.cjs
@@ -105,13 +105,14 @@ test('wave 4 server modules harden actor authorization and check revisions befor
   assert.match(menuPublish, /const currentRevisions = readRevisionState\(meta\)/);
   assert.match(menuPublish, /command: 'menu-publish\.v2'/);
   assert.match(menuPublish, /assertExpectedRevision\(expectedLiveRevision, meta\?\.last_updated_ts \|\| null, 'live_revision', \{/);
-  assert.match(menuPublish, /assertExpectedRevision\(expectedDraftRevision, meta\?\.draft_saved_ts \|\| null, 'draft_revision', \{/);
+  assert.match(menuPublish, /const notificationBaselineRevision = expectedNotificationRevision \?\? expectedDraftRevision \?\? null;/);
+  assert.match(menuPublish, /assertExpectedRevision\(notificationBaselineRevision, meta\?\.last_sent_ts \|\| null, 'notification_revision', \{/);
   const liveRevisionCheckIndex = menuPublish.indexOf("assertExpectedRevision(expectedLiveRevision, meta?.last_updated_ts || null, 'live_revision', {");
-  const draftRevisionCheckIndex = menuPublish.indexOf("assertExpectedRevision(expectedDraftRevision, meta?.draft_saved_ts || null, 'draft_revision', {");
+  const notificationRevisionCheckIndex = menuPublish.indexOf("assertExpectedRevision(notificationBaselineRevision, meta?.last_sent_ts || null, 'notification_revision', {");
   const saveLiveIndex = menuPublish.indexOf('await saveLiveMenuForMenu({');
   const notifyIndex = menuPublish.indexOf('await deliverMenuNotification(');
   assert.ok(liveRevisionCheckIndex > -1 && liveRevisionCheckIndex < saveLiveIndex);
-  assert.ok(draftRevisionCheckIndex > -1 && draftRevisionCheckIndex < notifyIndex);
+  assert.ok(notificationRevisionCheckIndex > -1 && notificationRevisionCheckIndex < notifyIndex);
 
   assert.match(adminSettings, /export async function authorizeAdminSettingsRequest\(req\)/);
   assert.match(adminSettings, /requireRole\(req, 'admin'\)/);
@@ -130,6 +131,7 @@ test('consolidated write routes preserve structured API error bodies and explici
   assert.match(manager, /if \(!menuId\) return res\.status\(400\)\.json\(\{ error: 'Missing menu_id' \}\)/);
   assert.match(manager, /expectedLiveRevision/);
   assert.match(manager, /expectedDraftRevision/);
+  assert.match(manager, /expectedNotificationRevision/);
   assert.match(adminSettings, /status: 'admin_unauthorized'/);
   assert.match(adminSettings, /Unsupported admin action/);
 });

--- a/tests/phase18-menu-history-boundaries.test.cjs
+++ b/tests/phase18-menu-history-boundaries.test.cjs
@@ -59,23 +59,33 @@ test('menu history payload preserves diff and message fields for manager consume
       diff: [{ id: 'beer', label: 'Beer', added: ['Lager'] }],
       message: 'Heads up: taps moved.',
       source: 'web_manager',
+      operation_id: 'operation-1',
+      event_type: 'send_notification',
       created_at: '2026-04-13T12:00:00.000Z',
     }],
     days: 7,
     limit: 25,
     includesSource: true,
+    includesOperationId: true,
+    includesEventType: true,
   });
 
   assert.equal(payload.context.kind, 'menu-history');
   assert.equal(payload.logs.length, 1);
   assert.equal(payload.logs[0].message, 'Heads up: taps moved.');
-   assert.equal(payload.logs[0].source, 'web_manager');
+  assert.equal(payload.logs[0].source, 'web_manager');
+  assert.equal(payload.logs[0].operation_id, 'operation-1');
+  assert.equal(payload.logs[0].event_type, 'send_notification');
   assert.deepEqual(payload.logs[0].diff, [{ id: 'beer', label: 'Beer', added: ['Lager'] }]);
+  assert.equal(payload.operations.length, 1);
+  assert.equal(payload.operations[0].operation_id, 'operation-1');
+  assert.equal(payload.operations[0].event_count, 1);
   assert.equal(payload.capabilities.canReadHistory, true);
   assert.equal(payload.capabilities.includesMessage, true);
   assert.equal(payload.capabilities.includesSource, true);
+  assert.equal(payload.capabilities.includesOperationGrouping, true);
   assert.equal(payload.history.scope, 'menu');
-  assert.equal(payload.compatibility.contract, 'menu-history.v2');
+  assert.equal(payload.compatibility.contract, 'menu-history.v3');
 });
 
 test('restaurant history payload adds menu metadata while preserving flat log rows', async () => {
@@ -102,6 +112,8 @@ test('restaurant history payload adds menu metadata while preserving flat log ro
       diff: [{ id: 'beer', label: 'Beer', added: ['Lager'] }],
       message: 'Heads up: taps moved.',
       source: 'web_manager',
+      operation_id: 'operation-1',
+      event_type: 'send_notification',
       created_at: '2026-04-13T12:00:00.000Z',
       menu: {
         id: '00000000-0000-0000-0000-000000000020',
@@ -115,6 +127,8 @@ test('restaurant history payload adds menu metadata while preserving flat log ro
     limit: 25,
     scope: 'restaurant',
     includesSource: true,
+    includesOperationId: true,
+    includesEventType: true,
   });
 
   assert.equal(payload.context.kind, 'restaurant-history');
@@ -122,6 +136,7 @@ test('restaurant history payload adds menu metadata while preserving flat log ro
   assert.equal(payload.history.scope, 'restaurant');
   assert.equal(payload.logs[0].menu.slug, 'leroys-lounge-drinks');
   assert.equal(payload.logs[0].source, 'web_manager');
+  assert.equal(payload.logs[0].event_type, 'send_notification');
 });
 
 test('app runtime routes recent changes through the consolidated manager endpoint', () => {

--- a/tests/phase19-menu-preview-boundaries.test.cjs
+++ b/tests/phase19-menu-preview-boundaries.test.cjs
@@ -20,8 +20,10 @@ test('manager route supports server-owned preview and publish actions on one bou
 
   assert.match(publishRoute, /previewMenuUpdateForMenu/);
   assert.match(publishRoute, /publishMenuUpdateForMenu/);
+  assert.match(publishRoute, /save_quietly/);
   assert.match(publishRoute, /parsePublishBody/);
   assert.match(publishRoute, /selected_change_ids/);
+  assert.match(publishRoute, /selected_group_ids/);
 });
 
 test('wave 4 publish command module exports canonical preview and selected-change publish contract', async () => {
@@ -30,9 +32,15 @@ test('wave 4 publish command module exports canonical preview and selected-chang
 
   assert.equal(typeof publishModule.previewMenuUpdateForMenu, 'function');
   assert.equal(typeof publishModule.publishMenuUpdateForMenu, 'function');
-  assert.match(publishModuleSource, /menu-publish-preview\.v1/);
+  assert.match(publishModuleSource, /menu-publish-preview\.v2/);
   assert.match(publishModuleSource, /serverOwned: true/);
+  assert.match(publishModuleSource, /Will Save Only/);
+  assert.match(publishModuleSource, /operation_id/);
+  assert.match(publishModuleSource, /eventType: 'send_failed'/);
+  assert.match(publishModuleSource, /__featured__/);
   assert.match(publishModuleSource, /selected_change_ids/);
+  assert.match(publishModuleSource, /legacy_selected_change_ids/);
+  assert.match(publishModuleSource, /sections_by_outcome/);
   assert.doesNotMatch(publishModuleSource, /previewDiff/);
 });
 

--- a/tests/phase19-menu-preview-boundaries.test.cjs
+++ b/tests/phase19-menu-preview-boundaries.test.cjs
@@ -56,6 +56,8 @@ test('app runtime requests canonical preview and no longer posts legacy preview 
   assert.match(publishApiSource, /action:\s*'preview_publish'/);
   assert.match(publishApiSource, /action:\s*'publish'/);
   assert.match(publishApiSource, /selected_change_ids/);
+  assert.match(publishApiSource, /expected_notification_revision/);
+  assert.doesNotMatch(publishApiSource, /expected_draft_revision:\s*draftEnvelope\?\.baseLastSentRevision/);
   assert.doesNotMatch(publishApiSource, /preview_diff/);
   assert.doesNotMatch(publishApiSource, /selected_sections/);
   assert.doesNotMatch(publishApiSource, /patch_message/);

--- a/tests/phase20-metadata-read-model-boundaries.test.cjs
+++ b/tests/phase20-metadata-read-model-boundaries.test.cjs
@@ -34,6 +34,8 @@ test('server write helpers degrade optional draft and source metadata cleanly', 
   assert.equal(helper.normalizeAuditSource('WEB_ADMIN'), 'web_admin');
   assert.equal(helper.inferAuditSource({ role: 'manager' }, ''), 'web_manager');
   assert.match(helperSource, /\/rest\/v1\/categories\?on_conflict=menu_id,key/);
+  assert.match(helperSource, /operation_id/);
+  assert.match(helperSource, /event_type/);
 });
 
 test('auth bootstrap route exposes compatibility config and readiness on the unified boundary', () => {

--- a/tests/phase21-menu-queue-diff-boundaries.test.cjs
+++ b/tests/phase21-menu-queue-diff-boundaries.test.cjs
@@ -1,0 +1,118 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+const ROOT = path.join(__dirname, '..');
+
+async function importApiModule(relativePath) {
+  const fileUrl = pathToFileURL(path.join(ROOT, relativePath)).href;
+  return import(`${fileUrl}?phase21=${Date.now()}-${Math.random()}`);
+}
+
+test('queue diff derives rename as one grouped change on stable item id', async () => {
+  const queue = await importApiModule('server/_menu-queue.js');
+  const state = queue.buildCategoryQueueState({
+    snapshot: {
+      cats: [{
+        key: 'beer',
+        label: 'Beer',
+        icon: '🍺',
+        items: [{
+          id: 'item-1',
+          name: 'After Name',
+          price: '$11',
+          desc: 'quiet field change',
+          on_menu: true,
+          visibility: 'public',
+          is_eighty_sixed: false,
+        }],
+      }],
+    },
+    lastSentState: {
+      beer: [{
+        id: 'item-1',
+        name: 'Before Name',
+        onMenu: true,
+        visibility: 'public',
+        eightySixed: false,
+      }],
+    },
+  });
+
+  assert.equal(state.groups.length, 1);
+  assert.equal(state.groups[0].kind, 'rename');
+  assert.equal(state.groups[0].lines.length, 2);
+  assert.deepEqual(
+    state.groups[0].lines.map(line => line.text),
+    ['Removed Before Name', 'Added After Name']
+  );
+  assert.deepEqual(state.unsentItemIds, ['item-1']);
+});
+
+test('queue diff excludes quiet-only field changes from notification lines', async () => {
+  const queue = await importApiModule('server/_menu-queue.js');
+  const state = queue.buildCategoryQueueState({
+    snapshot: {
+      cats: [{
+        key: 'beer',
+        label: 'Beer',
+        icon: '🍺',
+        items: [{
+          id: 'item-1',
+          name: 'Quiet Lager',
+          price: '$11',
+          desc: 'new details',
+          recipe: ['quiet'],
+          on_menu: true,
+          visibility: 'public',
+          is_eighty_sixed: false,
+        }],
+      }],
+    },
+    lastSentState: {
+      beer: [{
+        id: 'item-1',
+        name: 'Quiet Lager',
+        price: '$9',
+        desc: 'old details',
+        recipe: [],
+        onMenu: true,
+        visibility: 'public',
+        eightySixed: false,
+      }],
+    },
+  });
+
+  assert.equal(state.hasNotificationChanges, false);
+  assert.equal(state.groups.length, 0);
+  assert.deepEqual(state.diff, []);
+});
+
+test('queue diff preserves net final state for 86/restore and add/remove transitions', async () => {
+  const queue = await importApiModule('server/_menu-queue.js');
+  const state = queue.buildCategoryQueueState({
+    snapshot: {
+      cats: [{
+        key: 'beer',
+        label: 'Beer',
+        icon: '🍺',
+        items: [
+          { id: 'item-stable', name: 'Stable Lager', on_menu: true, visibility: 'public', is_eighty_sixed: false },
+          { id: 'item-added', name: 'Fresh Add', on_menu: true, visibility: 'public', is_eighty_sixed: false },
+        ],
+      }],
+    },
+    lastSentState: {
+      beer: [
+        { id: 'item-stable', name: 'Stable Lager', onMenu: true, visibility: 'public', eightySixed: false },
+        { id: 'item-removed', name: 'Old Remove', onMenu: true, visibility: 'public', eightySixed: false },
+      ],
+    },
+  });
+
+  assert.equal(state.groups.length, 2);
+  const kinds = state.groups.map(group => group.kind).sort();
+  assert.deepEqual(kinds, ['added', 'removed']);
+  assert.deepEqual(state.unsentItemIds, ['item-added']);
+});

--- a/tests/phase7-server-read-boundaries.test.cjs
+++ b/tests/phase7-server-read-boundaries.test.cjs
@@ -68,9 +68,14 @@ test('workspace payload preserves the live menu snapshot shape and adds staff co
       type: 'drinks',
       name: "Leroy's Lounge Drinks",
     },
-    cats: [{ key: 'beer', items: [{ id: 'draft-lager', on_menu: true, visibility: 'public' }] }],
+    cats: [{ key: 'beer', items: [{ id: 'draft-lager', name: 'Draft Lager', on_menu: true, visibility: 'public' }] }],
     meta: {
       last_updated_ts: 1712705100000,
+      last_sent_ts: 1712705100000,
+      last_sent_state: {
+        beer: [{ id: 'draft-lager', name: 'Draft Lager', onMenu: true, visibility: 'public', eightySixed: false }],
+      },
+      last_sent_featured: [],
       draft_state: { cats: [{ key: 'beer', items: [] }] },
       draft_saved_ts: 1712705200000,
       draft_saved_by_user_id: 'user-1',
@@ -114,10 +119,48 @@ test('workspace payload preserves the live menu snapshot shape and adds staff co
   assert.equal(payload.workspace.sharedDraft.savedAt, 1712705200000);
   assert.deepEqual(payload.workspace.sharedDraft.savedBy, { id: 'user-1', name: 'Alex' });
   assert.equal(payload.workspace.sharedDraft.source, 'web_manager');
+  assert.equal(payload.workspace.publishState.status, 'live');
+  assert.equal(payload.workspace.publishState.statusLabel, 'Live');
+  assert.equal(payload.workspace.publishState.hasUnsentChanges, false);
+  assert.deepEqual(payload.workspace.publishState.queue.unsentItemIds, []);
   assert.equal(payload.workspace.capabilities.includesDraftAuthorship, true);
   assert.equal(payload.workspace.capabilities.includesRestaurantTools, true);
+  assert.equal(payload.workspace.capabilities.canSaveQuietly, true);
   assert.equal(payload.restaurantTools.restaurantId, '00000000-0000-0000-0000-000000000010');
   assert.equal(payload.context.kind, 'menu-workspace');
+  assert.equal(payload.compatibility.contract, 'menu-workspace.v4');
+});
+
+test('workspace payload projects server-owned Live | Unsent queue state from stable item IDs', async () => {
+  const helper = await importApiModule('server/_menu-read.js');
+  const payload = helper.createMenuWorkspacePayload({
+    menu: {
+      id: '00000000-0000-0000-0000-000000000020',
+      restaurantId: '00000000-0000-0000-0000-000000000010',
+      slug: 'leroys-lounge-drinks',
+      type: 'drinks',
+      name: "Leroy's Lounge Drinks",
+    },
+    cats: [{ key: 'beer', label: 'Beer', icon: '🍺', items: [{ id: 'item-1', name: 'New Lager', on_menu: true, visibility: 'public' }] }],
+    meta: {
+      last_updated_ts: 1712705300000,
+      last_sent_ts: 1712705100000,
+      last_sent_state: {
+        beer: [{ id: 'item-1', name: 'Old Lager', onMenu: true, visibility: 'public', eightySixed: false }],
+      },
+      last_sent_featured: [],
+    },
+    featuredCurrentIds: [],
+    restaurant: null,
+  }, {
+    actor: { id: 'user-1', name: 'Alex', role: 'manager', accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'] },
+  });
+
+  assert.equal(payload.workspace.publishState.status, 'live_unsent');
+  assert.equal(payload.workspace.publishState.statusLabel, 'Live | Unsent');
+  assert.equal(payload.workspace.publishState.hasUnsentChanges, true);
+  assert.deepEqual(payload.workspace.publishState.queue.unsentItemIds, ['item-1']);
+  assert.ok(payload.workspace.publishState.queue.selectableGroupIds.some(groupId => groupId.includes('rename')));
 });
 
 test('public payload strips staff-only menu metadata and filters non-public items', async () => {

--- a/tests/phase8-server-write-boundaries.test.cjs
+++ b/tests/phase8-server-write-boundaries.test.cjs
@@ -111,5 +111,7 @@ test('category deletion no longer performs direct Supabase writes before the ser
 
   assert.doesNotMatch(deleteCategorySource, /await sbDeleteCategory/);
   assert.doesNotMatch(deleteCategorySource, /rest\/v1\/items/);
-  assert.match(deleteCategorySource, /await persistState\(\)/);
+  assert.doesNotMatch(deleteCategorySource, /await persistState\(\)/);
+  assert.match(deleteCategorySource, /invalidateDiff\(\)/);
+  assert.match(deleteCategorySource, /updateDraftIndicator\(\)/);
 });

--- a/tests/phase9-publish-specials-boundaries.test.cjs
+++ b/tests/phase9-publish-specials-boundaries.test.cjs
@@ -40,9 +40,9 @@ test('wave 3 publish command module owns notification delivery and persistence c
   assert.match(publishModuleSource, /saveLiveMenuForMenu/);
   assert.match(publishModuleSource, /patchMenuMetaForMenu/);
   assert.match(publishModuleSource, /insertUpdateLog/);
-  assert.match(publishModuleSource, /menu-publish-preview\.v1/);
+  assert.match(publishModuleSource, /menu-publish-preview\.v2/);
   assert.match(publishModuleSource, /buildCanonicalPreviewForMenu/);
-  assert.match(publishModuleSource, /resolveSelectedChanges/);
+  assert.match(publishModuleSource, /resolveSelection/);
 });
 
 test('app runtime prefers consolidated publish and specials server boundaries', () => {


### PR DESCRIPTION
## What changed

Fixes the web manager save flow so the workspace status and action bar stop sticking in `Drafting` after a successful save.

- reconciles manager draft status from the actual synced local-draft state instead of trusting a stale `_dirty` flag
- flushes the focused editor before `Save`, `Save Quietly`, or preview actions so blur-driven field writes land before publish/save runs
- refreshes the client live snapshot baseline after save and send transitions
- adds regression coverage for stale dirty flags and focused-editor save behavior

## Why it changed

`Send` was clearing the status correctly, but the save paths could leave the web manager showing `Drafting` even after the live save completed.

## Root cause

Two issues were interacting:

1. Parts of the shared manager workspace UI still derived status from the raw `_dirty` flag rather than the normalized local-draft state.
2. If an edited field still had focus when save started, its blur handler could fire around the save and re-dirty the client session after the successful response.

## Impact

- `Save Quietly` now settles to `Live | Unsent` when notification changes remain queued.
- `Save` now settles to `Live` when only quiet changes were saved.
- The manager action bar and overview status stay aligned with the actual post-save state.

## Validation

- `node --test tests/architecture-boundaries.test.cjs tests/boundaries/*.test.cjs tests/phase*.test.cjs`
- `node --check app.js`
- `git diff --check`
