### PR TITLE
[codex] Fix nilIfBlank extension visibility

### DIFF
--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -1255,10 +1255,3 @@ private extension EditableMenuDocument {
     }
   }
 }
-
-private extension String {
-  var nilIfBlank: String? {
-    let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmed.isEmpty ? nil : trimmed
-  }
-}

--- a/ios/ElRoysManagerApp/Features/Home/HomeViews.swift
+++ b/ios/ElRoysManagerApp/Features/Home/HomeViews.swift
@@ -1448,13 +1448,6 @@ private extension JSONValue {
   }
 }
 
-private extension String {
-  var nilIfBlank: String? {
-    let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
-    return trimmed.isEmpty ? nil : trimmed
-  }
-}
-
 private extension ISO8601DateFormatter {
   static let withFractional: ISO8601DateFormatter = {
     let formatter = ISO8601DateFormatter()

--- a/ios/ElRoysManagerApp/Models/AppModels.swift
+++ b/ios/ElRoysManagerApp/Models/AppModels.swift
@@ -1798,7 +1798,7 @@ struct EditableMenuDocument: Codable, Equatable {
   }
 }
 
-private extension String {
+extension String {
   var nilIfBlank: String? {
     let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
     return trimmed.isEmpty ? nil : trimmed


### PR DESCRIPTION
## Summary
- move `String.nilIfBlank` to a shared module-level extension in `AppModels.swift`
- remove the duplicate file-scoped `nilIfBlank` helpers from `AppModel.swift` and `HomeViews.swift`
- keep the menu preview UI call site unchanged now that the helper is visible across the iOS target

## Why
`MenuViews.swift` started using `change.label.nilIfBlank`, but the only available implementations were declared inside other files as private extensions. That made the helper inaccessible outside those files and broke the iOS build.

## Impact
This restores access to the shared blank-string normalization helper across the app and avoids maintaining multiple duplicate implementations.

## Root Cause
The helper lived in file-scoped private extensions, so code in `Features/Menu/MenuViews.swift` could not see it.

## Validation
- `git diff --check`
- `rg -n "var nilIfBlank" ios/ElRoysManagerApp`
- manual diff review of the three touched iOS files
- full `xcodebuild` validation could not run in this shell because `xcode-select` is currently pointed at `/Library/Developer/CommandLineTools` instead of a full Xcode installation