### PR TITLE
[codex] Normalize workspace baselines across server web and iOS

### DIFF
--- a/app.js
+++ b/app.js
@@ -1163,6 +1163,43 @@ function setServerLiveSnapshot(snapshot = null) {
 function getServerLiveSnapshot() {
   return cloneJsonCompatible(_serverLiveSnapshot, null);
 }
+function syncServerLiveSnapshot() {
+  setServerLiveSnapshot(buildMenuCacheSnapshot());
+}
+function alignDraftDocumentSnapshotWithLiveSnapshot(snapshot = null, liveSnapshot = getServerLiveSnapshot()) {
+  const nextSnapshot = snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot)
+    ? cloneJsonCompatible(snapshot, null)
+    : null;
+  if (!nextSnapshot) return null;
+
+  const normalizedLiveSnapshot = normalizeDraftDocumentSnapshot(liveSnapshot);
+  const liveFeaturedGroups = Array.isArray(normalizedLiveSnapshot.featured_groups)
+    ? cloneJsonCompatible(normalizedLiveSnapshot.featured_groups, [])
+    : [];
+  const liveSaveOnlyChanges = Array.isArray(normalizedLiveSnapshot.save_only_changes)
+    ? cloneJsonCompatible(normalizedLiveSnapshot.save_only_changes, [])
+    : [];
+  const hasFeaturedGroups = Array.isArray(nextSnapshot.featured_groups);
+  const hasSaveOnlyChanges = Array.isArray(nextSnapshot.save_only_changes) || Array.isArray(nextSnapshot.saveOnlyChanges);
+
+  if (!hasFeaturedGroups || (!nextSnapshot.featured_groups.length && liveFeaturedGroups.length)) {
+    nextSnapshot.featured_groups = liveFeaturedGroups;
+  }
+  if (!hasSaveOnlyChanges) {
+    nextSnapshot.save_only_changes = liveSaveOnlyChanges;
+  }
+
+  return nextSnapshot;
+}
+function alignLocalDraftEnvelopeWithLiveSnapshot(envelope = null, liveSnapshot = getServerLiveSnapshot()) {
+  const normalizedEnvelope = normalizeLocalDraftEnvelope(envelope);
+  if (!normalizedEnvelope) return null;
+  return {
+    ...normalizedEnvelope,
+    baseSnapshot: alignDraftDocumentSnapshotWithLiveSnapshot(normalizedEnvelope.baseSnapshot, liveSnapshot),
+    draftSnapshot: alignDraftDocumentSnapshotWithLiveSnapshot(normalizedEnvelope.draftSnapshot, liveSnapshot),
+  };
+}
 function setLocalDraftBaseSnapshot(snapshot = null) {
   _localDraftBaseSnapshot = snapshot && typeof snapshot === 'object'
     ? cloneJsonCompatible(snapshot, null)
@@ -5839,6 +5876,9 @@ function withMenuStateLoaderDefaults(deps = {}) {
     readStoredLocalDraftEnvelope: typeof deps.readStoredLocalDraftEnvelope === 'function'
       ? deps.readStoredLocalDraftEnvelope
       : (() => readStoredLocalDraftEnvelope()),
+    alignLocalDraftEnvelope: typeof deps.alignLocalDraftEnvelope === 'function'
+      ? deps.alignLocalDraftEnvelope
+      : ((envelope, liveSnapshot = getServerLiveSnapshot()) => alignLocalDraftEnvelopeWithLiveSnapshot(envelope, liveSnapshot)),
     buildCurrentLocalDraftEnvelope: typeof deps.buildCurrentLocalDraftEnvelope === 'function'
       ? deps.buildCurrentLocalDraftEnvelope
       : (() => buildCurrentLocalDraftEnvelope()),
@@ -5848,6 +5888,12 @@ function withMenuStateLoaderDefaults(deps = {}) {
     clearCurrentLocalDraft: typeof deps.clearCurrentLocalDraft === 'function'
       ? deps.clearCurrentLocalDraft
       : ((options = {}) => clearCurrentLocalDraft(options)),
+    applyWorkspaceRestaurantTools: typeof deps.applyWorkspaceRestaurantTools === 'function'
+      ? deps.applyWorkspaceRestaurantTools
+      : (data => applyWorkspaceRestaurantTools(data)),
+    syncServerLiveSnapshot: typeof deps.syncServerLiveSnapshot === 'function'
+      ? deps.syncServerLiveSnapshot
+      : (() => syncServerLiveSnapshot()),
   };
 }
 
@@ -5882,9 +5928,12 @@ function createMenuStateLoaderService(deps = {}) {
   const getFeaturedSnapshotValue = resolvedDeps.getFeaturedSnapshot;
   const syncDraftDirtyState = resolvedDeps.syncLocalDraftDirtyState;
   const readStoredLocalDraft = resolvedDeps.readStoredLocalDraftEnvelope;
+  const alignLocalDraftEnvelope = resolvedDeps.alignLocalDraftEnvelope;
   const buildCurrentDraftEnvelope = resolvedDeps.buildCurrentLocalDraftEnvelope;
   const applyLocalDraft = resolvedDeps.applyLocalDraftEnvelope;
   const clearCurrentDraft = resolvedDeps.clearCurrentLocalDraft;
+  const applyWorkspaceRestaurantTools = resolvedDeps.applyWorkspaceRestaurantTools;
+  const syncServerLiveSnapshot = resolvedDeps.syncServerLiveSnapshot;
   const isDraftDirty = resolvedDeps.isDirty;
 
   return {
@@ -5901,7 +5950,11 @@ function createMenuStateLoaderService(deps = {}) {
         if (data) {
           hydrateFromState(data);
           const usedWorkspaceRestaurantTools = applyWorkspaceRestaurantTools(data);
-          const localDraftEnvelope = includePersistedDraft ? readStoredLocalDraft() : null;
+          syncServerLiveSnapshot();
+          const localDraftEnvelope = includePersistedDraft
+            ? alignLocalDraftEnvelope(readStoredLocalDraft(), getServerLiveSnapshot())
+            : null;
+          let hasActiveLocalDraft = false;
           const loadedDraft = includePersistedDraft
             ? (localDraftEnvelope
                 ? !!applyLocalDraft(localDraftEnvelope, { markDirty: false })
@@ -5911,24 +5964,34 @@ function createMenuStateLoaderService(deps = {}) {
             setLocalDraftBaseSnapshot(localDraftEnvelope?.baseSnapshot || getServerLiveSnapshot());
             if (syncDraftDirtyState()) {
               setDirty(true);
+              hasActiveLocalDraft = true;
             } else {
               clearCurrentDraft();
               setDirty(false);
               clearDraftChanges();
+              syncServerLiveSnapshot();
             }
           } else {
             clearCurrentDraft(localDraftEnvelope ? {} : { clearStorage: false });
             setDirty(false);
             clearDraftChanges();
+            syncServerLiveSnapshot();
           }
           if (persistCache) writeMenuCache(data);
-          if (includeFeatured && !usedWorkspaceRestaurantTools) await refreshFeatured();
+          if (includeFeatured && !usedWorkspaceRestaurantTools) {
+            await refreshFeatured();
+            if (!hasActiveLocalDraft) syncServerLiveSnapshot();
+          }
         } else if (fallbackToDefault) {
           setDefaultState();
           setDirty(false);
           clearDraftChanges();
           _workspaceRestaurantToolsReadable = false;
-          if (includeFeatured) await refreshFeatured();
+          syncServerLiveSnapshot();
+          if (includeFeatured) {
+            await refreshFeatured();
+            syncServerLiveSnapshot();
+          }
         }
       } catch (error) {
         if (fallbackToDefault) {
@@ -5936,7 +5999,11 @@ function createMenuStateLoaderService(deps = {}) {
           setDirty(false);
           clearDraftChanges();
           _workspaceRestaurantToolsReadable = false;
-          if (includeFeatured) await refreshFeatured();
+          syncServerLiveSnapshot();
+          if (includeFeatured) {
+            await refreshFeatured();
+            syncServerLiveSnapshot();
+          }
         } else {
           throw error;
         }
@@ -5963,23 +6030,34 @@ function createMenuStateLoaderService(deps = {}) {
       const activeDraftEnvelope = isDraftDirty() ? buildCurrentDraftEnvelope() : readStoredLocalDraft();
       hydrateFromState(data);
       const usedWorkspaceRestaurantTools = applyWorkspaceRestaurantTools(data);
-      if (activeDraftEnvelope?.draftSnapshot) {
-        const reappliedDraft = applyLocalDraft(activeDraftEnvelope, { markDirty: false });
+      syncServerLiveSnapshot();
+      let hasActiveLocalDraft = false;
+      const alignedDraftEnvelope = activeDraftEnvelope?.draftSnapshot
+        ? alignLocalDraftEnvelope(activeDraftEnvelope, getServerLiveSnapshot())
+        : activeDraftEnvelope;
+      if (alignedDraftEnvelope?.draftSnapshot) {
+        const reappliedDraft = applyLocalDraft(alignedDraftEnvelope, { markDirty: false });
         if (reappliedDraft && syncDraftDirtyState()) {
           setDirty(true);
+          hasActiveLocalDraft = true;
         } else {
           clearCurrentDraft();
           setDirty(false);
           clearDraftChanges();
+          syncServerLiveSnapshot();
         }
       } else {
         clearCurrentDraft({ clearStorage: false });
         setDirty(false);
         clearDraftChanges();
+        syncServerLiveSnapshot();
       }
       writeMenuCache(data);
       const newTs = getLastUpdatedTs();
-      if (newTs !== oldTs && !usedWorkspaceRestaurantTools) await refreshFeatured();
+      if (newTs !== oldTs && !usedWorkspaceRestaurantTools) {
+        await refreshFeatured();
+        if (!hasActiveLocalDraft) syncServerLiveSnapshot();
+      }
 
       const afterCats = getCategorySnapshot();
       const newDesign = getDesignSnapshotValue();

--- a/core/data/menu-state-loader.js
+++ b/core/data/menu-state-loader.js
@@ -24,6 +24,9 @@
     const readStoredLocalDraftEnvelope = typeof deps.readStoredLocalDraftEnvelope === 'function'
       ? deps.readStoredLocalDraftEnvelope
       : (() => globalScope.readStoredLocalDraftEnvelope?.());
+    const alignLocalDraftEnvelope = typeof deps.alignLocalDraftEnvelope === 'function'
+      ? deps.alignLocalDraftEnvelope
+      : ((envelope, liveSnapshot) => globalScope.alignLocalDraftEnvelopeWithLiveSnapshot?.(envelope, liveSnapshot));
     const buildCurrentLocalDraftEnvelope = typeof deps.buildCurrentLocalDraftEnvelope === 'function'
       ? deps.buildCurrentLocalDraftEnvelope
       : (() => globalScope.buildCurrentLocalDraftEnvelope?.());
@@ -33,6 +36,16 @@
     const clearCurrentLocalDraft = typeof deps.clearCurrentLocalDraft === 'function'
       ? deps.clearCurrentLocalDraft
       : ((options = {}) => globalScope.clearCurrentLocalDraft?.(options));
+    const applyWorkspaceRestaurantTools = typeof deps.applyWorkspaceRestaurantTools === 'function'
+      ? deps.applyWorkspaceRestaurantTools
+      : (data => globalScope.applyWorkspaceRestaurantTools?.(data) || false);
+    const syncServerLiveSnapshot = typeof deps.syncServerLiveSnapshot === 'function'
+      ? deps.syncServerLiveSnapshot
+      : (() => {
+          if (typeof globalScope.setServerLiveSnapshot === 'function' && typeof globalScope.buildMenuCacheSnapshot === 'function') {
+            globalScope.setServerLiveSnapshot(globalScope.buildMenuCacheSnapshot());
+          }
+        });
     const writeMenuCache = typeof deps.writeMenuCache === 'function'
       ? deps.writeMenuCache
       : (() => {});
@@ -71,8 +84,13 @@
           const data = await readState({ request, source: options.source || 'network', options });
           if (data) {
             hydrateFromState(data);
-            const persistedDraftEnvelope = includePersistedDraft ? readStoredLocalDraftEnvelope() : null;
+            const usedWorkspaceRestaurantTools = applyWorkspaceRestaurantTools(data);
+            syncServerLiveSnapshot();
+            const persistedDraftEnvelope = includePersistedDraft
+              ? alignLocalDraftEnvelope(readStoredLocalDraftEnvelope(), globalScope.getServerLiveSnapshot?.())
+              : null;
             let loadedDraft = false;
+            let hasActiveLocalDraft = false;
             if (includePersistedDraft) {
               if (persistedDraftEnvelope) {
                 loadedDraft = !!applyLocalDraftEnvelope(persistedDraftEnvelope, { markDirty: false });
@@ -81,10 +99,12 @@
                 const hasLocalDraft = !!syncLocalDraftDirtyState();
                 if (hasLocalDraft) {
                   setDirty(true);
+                  hasActiveLocalDraft = true;
                 } else {
                   clearCurrentLocalDraft();
                   setDirty(false);
                   clearDraftChanges();
+                  syncServerLiveSnapshot();
                 }
               }
             }
@@ -92,23 +112,37 @@
               clearCurrentLocalDraft(persistedDraftEnvelope ? {} : { clearStorage: false });
               setDirty(false);
               clearDraftChanges();
+              syncServerLiveSnapshot();
             }
             if (persistCache) writeMenuCache(data);
+            if (includeFeatured && !usedWorkspaceRestaurantTools) {
+              await refreshFeatured();
+              if (!hasActiveLocalDraft) syncServerLiveSnapshot();
+            }
           } else if (fallbackToDefault) {
             setDefaultState();
             setDirty(false);
             clearDraftChanges();
+            syncServerLiveSnapshot();
+            if (includeFeatured) {
+              await refreshFeatured();
+              syncServerLiveSnapshot();
+            }
           }
         } catch (error) {
           if (fallbackToDefault) {
             setDefaultState();
             setDirty(false);
             clearDraftChanges();
+            syncServerLiveSnapshot();
+            if (includeFeatured) {
+              await refreshFeatured();
+              syncServerLiveSnapshot();
+            }
           } else {
             throw error;
           }
         }
-        if (includeFeatured) await refreshFeatured();
         return buildSnapshot(options.source || 'network');
       },
 
@@ -132,23 +166,35 @@
           ? buildCurrentLocalDraftEnvelope()
           : readStoredLocalDraftEnvelope();
         hydrateFromState(data);
-        if (activeDraftEnvelope) {
-          const reappliedDraft = applyLocalDraftEnvelope(activeDraftEnvelope, { markDirty: false });
+        const usedWorkspaceRestaurantTools = applyWorkspaceRestaurantTools(data);
+        syncServerLiveSnapshot();
+        let hasActiveLocalDraft = false;
+        const alignedDraftEnvelope = activeDraftEnvelope
+          ? alignLocalDraftEnvelope(activeDraftEnvelope, globalScope.getServerLiveSnapshot?.())
+          : null;
+        if (alignedDraftEnvelope) {
+          const reappliedDraft = applyLocalDraftEnvelope(alignedDraftEnvelope, { markDirty: false });
           if (reappliedDraft && syncLocalDraftDirtyState()) {
             setDirty(true);
+            hasActiveLocalDraft = true;
           } else {
             clearCurrentLocalDraft(reappliedDraft ? {} : { clearStorage: false });
             setDirty(false);
             clearDraftChanges();
+            syncServerLiveSnapshot();
           }
         } else {
           clearCurrentLocalDraft({ clearStorage: false });
           setDirty(false);
           clearDraftChanges();
+          syncServerLiveSnapshot();
         }
         writeMenuCache(data);
         const newTs = getLastUpdatedTs();
-        if (newTs !== oldTs) await refreshFeatured();
+        if (newTs !== oldTs && !usedWorkspaceRestaurantTools) {
+          await refreshFeatured();
+          if (!hasActiveLocalDraft) syncServerLiveSnapshot();
+        }
 
         const afterCats = getCategorySnapshot();
         const newDesign = getDesignSnapshotValue();

--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -341,7 +341,8 @@ final class AppModel {
     }
 
     do {
-      let workspace = try await services.workspace.fetch(menuId: menuId, accessToken: accessToken)
+      let fetchedWorkspace = try await services.workspace.fetch(menuId: menuId, accessToken: accessToken)
+      let workspace = normalizedEditorWorkspace(fetchedWorkspace)
       guard let currentWorkspace = currentEditorWorkspace else { return }
       guard workspace.workspace.revisions != currentWorkspace.workspace.revisions else { return }
       let history: HistoryPayload?
@@ -855,12 +856,7 @@ final class AppModel {
     history: HistoryPayload?,
     document: EditableMenuDocument? = nil
   ) throws {
-    var normalizedWorkspace = workspace
-    if normalizedWorkspace.workspace.revisions.notificationBaselineRevision == nil {
-      normalizedWorkspace.workspace.revisions.notificationBaselineRevision = normalizedWorkspace.meta.lastSentTs
-        ?? normalizedWorkspace.workspace.revisions.lastSentRevision
-        ?? normalizedWorkspace.workspace.revisions.draftRevision
-    }
+    let normalizedWorkspace = normalizedEditorWorkspace(workspace)
     let liveDocument = EditableMenuDocument(workspace: normalizedWorkspace)
     let serverDocument = serverWorkspaceDocument(from: normalizedWorkspace, liveDocument: liveDocument)
     currentEditorWorkspace = normalizedWorkspace
@@ -883,7 +879,11 @@ final class AppModel {
     guard let currentEditorDocument else { return }
     try? setEditorBaselines(liveDocument: liveDocument, serverDocument: serverDocument)
     if let revisions {
-      currentEditorWorkspace?.workspace.revisions = revisions
+      if let meta = currentEditorWorkspace?.meta {
+        currentEditorWorkspace?.workspace.revisions = normalizedWorkspaceRevisions(revisions, meta: meta)
+      } else {
+        currentEditorWorkspace?.workspace.revisions = revisions
+      }
     }
     editorHasServerUnsentChanges = serverHasUnsentChanges(in: currentEditorWorkspace)
     editorRefreshRequirement = nil
@@ -996,6 +996,25 @@ final class AppModel {
     let decoder = JSONDecoder()
     decoder.keyDecodingStrategy = .convertFromSnakeCase
     return try? decoder.decode(EditableMenuDocument.self, from: data)
+  }
+
+  private func normalizedEditorWorkspace(_ workspace: MenuWorkspacePayload) -> MenuWorkspacePayload {
+    var normalizedWorkspace = workspace
+    normalizedWorkspace.workspace.revisions = normalizedWorkspaceRevisions(workspace.workspace.revisions, meta: workspace.meta)
+    return normalizedWorkspace
+  }
+
+  private func normalizedWorkspaceRevisions(_ revisions: WorkspaceRevisions, meta: MenuMetaPayload) -> WorkspaceRevisions {
+    var normalizedRevisions = revisions
+    if normalizedRevisions.lastSentRevision == nil {
+      normalizedRevisions.lastSentRevision = meta.lastSentTs
+    }
+    if normalizedRevisions.notificationBaselineRevision == nil {
+      normalizedRevisions.notificationBaselineRevision = meta.lastSentTs
+        ?? normalizedRevisions.lastSentRevision
+        ?? normalizedRevisions.draftRevision
+    }
+    return normalizedRevisions
   }
 
   private func expectedNotificationBaselineRevision(for workspace: MenuWorkspacePayload) -> Int? {

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -935,6 +935,195 @@ final class MenuDocumentTests: XCTestCase {
   }
 
   @MainActor
+  func testInitialRemoteCheckIgnoresNormalizedQueueBaselineOnlyDifferences() async throws {
+    let meta = MenuMetaPayload(lastUpdatedTs: 30, lastSentTs: 20)
+    let initialWorkspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      meta: meta,
+      revisions: WorkspaceRevisions(liveRevision: 30, draftRevision: nil, lastSentRevision: nil, notificationBaselineRevision: nil)
+    )
+    let repeatedWorkspace = makeWorkspace(
+      categories: initialWorkspace.cats,
+      meta: meta,
+      revisions: WorkspaceRevisions(liveRevision: 30, draftRevision: nil, lastSentRevision: nil, notificationBaselineRevision: nil)
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [initialWorkspace, repeatedWorkspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload())
+      ),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+    await model.checkForRemoteMenuUpdate(menuId: "menu", force: true)
+
+    XCTAssertNil(model.editorRefreshRequirement)
+  }
+
+  @MainActor
+  func testRemoteQueueOnlyUpdateClassifiesAsQueueState() async throws {
+    let initialWorkspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      meta: MenuMetaPayload(lastUpdatedTs: 30, lastSentTs: 20),
+      revisions: WorkspaceRevisions(liveRevision: 30, draftRevision: nil, lastSentRevision: nil, notificationBaselineRevision: nil)
+    )
+    let updatedWorkspace = makeWorkspace(
+      categories: initialWorkspace.cats,
+      meta: MenuMetaPayload(lastUpdatedTs: 30, lastSentTs: 25),
+      revisions: WorkspaceRevisions(liveRevision: 30, draftRevision: nil, lastSentRevision: nil, notificationBaselineRevision: nil)
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [initialWorkspace, updatedWorkspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload())
+      ),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+    await model.checkForRemoteMenuUpdate(menuId: "menu", force: true)
+
+    XCTAssertEqual(model.editorRefreshRequirement?.kind, .queueState)
+  }
+
+  @MainActor
+  func testRemoteLiveOnlyUpdateClassifiesAsLiveMenu() async throws {
+    let initialWorkspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      meta: MenuMetaPayload(lastUpdatedTs: 30, lastSentTs: 20),
+      revisions: WorkspaceRevisions(liveRevision: 30, draftRevision: nil, lastSentRevision: nil, notificationBaselineRevision: nil)
+    )
+    let updatedWorkspace = makeWorkspace(
+      categories: initialWorkspace.cats,
+      meta: MenuMetaPayload(lastUpdatedTs: 40, lastSentTs: 20),
+      revisions: WorkspaceRevisions(liveRevision: 40, draftRevision: nil, lastSentRevision: nil, notificationBaselineRevision: nil)
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [initialWorkspace, updatedWorkspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload())
+      ),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+    await model.checkForRemoteMenuUpdate(menuId: "menu", force: true)
+
+    XCTAssertEqual(model.editorRefreshRequirement?.kind, .liveMenu)
+  }
+
+  @MainActor
+  func testRemoteLiveAndQueueUpdateClassifiesAsLiveAndQueue() async throws {
+    let initialWorkspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      meta: MenuMetaPayload(lastUpdatedTs: 30, lastSentTs: 20),
+      revisions: WorkspaceRevisions(liveRevision: 30, draftRevision: nil, lastSentRevision: nil, notificationBaselineRevision: nil)
+    )
+    let updatedWorkspace = makeWorkspace(
+      categories: initialWorkspace.cats,
+      meta: MenuMetaPayload(lastUpdatedTs: 40, lastSentTs: 25),
+      revisions: WorkspaceRevisions(liveRevision: 40, draftRevision: nil, lastSentRevision: nil, notificationBaselineRevision: nil)
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [initialWorkspace, updatedWorkspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload())
+      ),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+    await model.checkForRemoteMenuUpdate(menuId: "menu", force: true)
+
+    XCTAssertEqual(model.editorRefreshRequirement?.kind, .liveAndQueue)
+  }
+
+  @MainActor
   func testRefreshAndUpdateDraftsDropsOnlyOverlappingChanges() async throws {
     let offlineStore = TestOfflineDraftStore()
     let sessionStore = TestSessionStore()

--- a/server/_menu-read.js
+++ b/server/_menu-read.js
@@ -304,6 +304,9 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
   ]));
   const hasUnsentChanges = queueState.hasNotificationChanges || unsentFeaturedIds.length > 0;
   const publishStatus = hasUnsentChanges ? 'live_unsent' : 'live';
+  const liveRevision = bundle?.meta?.last_updated_ts || null;
+  const draftRevision = bundle?.meta?.draft_saved_ts || null;
+  const lastSentRevision = bundle?.meta?.last_sent_ts || null;
   const workspaceCapabilities = {
     canSaveDraft: canManage,
     canSaveLiveMenu: canManage,
@@ -335,8 +338,8 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
         statusLabel: hasUnsentChanges ? 'Live | Unsent' : 'Live',
         hasUnsentChanges,
         revisions: {
-          liveRevision: bundle?.meta?.last_updated_ts || null,
-          notificationRevision: bundle?.meta?.last_sent_ts || null,
+          liveRevision,
+          notificationRevision: lastSentRevision,
         },
         queue: {
           contract: 'menu-queue.v1',
@@ -354,8 +357,10 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
       },
       capabilities: workspaceCapabilities,
       revisions: {
-        liveRevision: bundle?.meta?.last_updated_ts || null,
-        draftRevision: bundle?.meta?.draft_saved_ts || null,
+        liveRevision,
+        draftRevision,
+        lastSentRevision,
+        notificationBaselineRevision: lastSentRevision,
       },
     },
     capabilities: workspaceCapabilities,

--- a/tests/boundaries/session.boundary.test.cjs
+++ b/tests/boundaries/session.boundary.test.cjs
@@ -118,6 +118,7 @@ test('menu state loader boundary reapplies the stored local draft envelope on to
       hydrated = data;
     },
     readStoredLocalDraftEnvelope: () => draftEnvelope,
+    alignLocalDraftEnvelope: envelope => envelope,
     applyLocalDraftEnvelope: envelope => {
       appliedEnvelope = envelope;
       return true;
@@ -169,6 +170,7 @@ test('menu state loader boundary clears no-op stored local drafts instead of ent
       baseSnapshot: { cats: [{ key: 'beer', items: [{ id: 'lager' }] }] },
       draftSnapshot: { cats: [{ key: 'beer', items: [{ id: 'lager' }] }] },
     }),
+    alignLocalDraftEnvelope: envelope => envelope,
     applyLocalDraftEnvelope: () => true,
     syncLocalDraftDirtyState: () => false,
     clearCurrentLocalDraft: options => {
@@ -194,4 +196,91 @@ test('menu state loader boundary clears no-op stored local drafts instead of ent
   assert.deepEqual(clearDraftOptions, [undefined]);
   assert.deepEqual(dirtyStates, [false]);
   assert.equal(clearCalls, 1);
+});
+
+test('menu state loader boundary aligns stored drafts after workspace restaurant tools hydrate', async () => {
+  const sandbox = loadAppSandbox();
+  const callOrder = [];
+  const clearDraftOptions = [];
+  const dirtyStates = [];
+  let clearCalls = 0;
+  let refreshCalls = 0;
+  const rawEnvelope = {
+    baseSnapshot: { cats: [{ key: 'beer', items: [{ id: 'lager' }] }], featured_groups: [] },
+    draftSnapshot: { cats: [{ key: 'beer', items: [{ id: 'lager' }] }], featured_groups: [] },
+  };
+  const alignedEnvelope = {
+    baseSnapshot: { cats: [{ key: 'beer', items: [{ id: 'lager' }] }], featured_groups: [{ id: 'group-1' }] },
+    draftSnapshot: { cats: [{ key: 'beer', items: [{ id: 'lager' }] }], featured_groups: [{ id: 'group-1' }] },
+  };
+
+  const service = sandbox.createMenuStateLoaderService({
+    readState: async () => ({
+      cats: [{ key: 'beer', items: [{ id: 'lager' }] }],
+      meta: {},
+      restaurant: { id: 'restaurant-main', name: 'Main Restaurant' },
+      restaurantTools: {
+        featuredGroups: [{ id: 'group-1', name: 'Featured', slots: [] }],
+      },
+      workspace: {
+        actor: { id: 'user-1', role: 'manager' },
+        permissions: { canManage: true },
+      },
+    }),
+    hydrateFromState: () => {
+      callOrder.push('hydrate');
+    },
+    applyWorkspaceRestaurantTools: () => {
+      callOrder.push('tools');
+      return true;
+    },
+    syncServerLiveSnapshot: () => {
+      callOrder.push('snapshot');
+    },
+    readStoredLocalDraftEnvelope: () => rawEnvelope,
+    alignLocalDraftEnvelope: envelope => {
+      callOrder.push('align');
+      assert.equal(envelope, rawEnvelope);
+      return alignedEnvelope;
+    },
+    applyLocalDraftEnvelope: envelope => {
+      callOrder.push('apply');
+      assert.equal(envelope, alignedEnvelope);
+      return true;
+    },
+    syncLocalDraftDirtyState: () => {
+      callOrder.push('dirty');
+      return false;
+    },
+    clearCurrentLocalDraft: options => {
+      clearDraftOptions.push(options);
+    },
+    setDirty: value => {
+      dirtyStates.push(value);
+    },
+    clearDraftChanges: () => {
+      clearCalls += 1;
+    },
+    writeMenuCache: () => {},
+    refreshFeatured: async () => {
+      refreshCalls += 1;
+    },
+    buildSnapshot: source => ({ source }),
+  });
+
+  const snapshot = await service.load({
+    request: { pageMode: 'manager' },
+    source: 'network',
+  });
+
+  assert.equal(snapshot.source, 'network');
+  assert.ok(callOrder.indexOf('tools') !== -1);
+  assert.ok(callOrder.indexOf('snapshot') !== -1);
+  assert.ok(callOrder.indexOf('tools') < callOrder.indexOf('align'));
+  assert.ok(callOrder.indexOf('snapshot') < callOrder.indexOf('align'));
+  assert.ok(callOrder.indexOf('align') < callOrder.indexOf('apply'));
+  assert.deepEqual(clearDraftOptions, [undefined]);
+  assert.deepEqual(dirtyStates, [false]);
+  assert.equal(clearCalls, 1);
+  assert.equal(refreshCalls, 0);
 });

--- a/tests/phase7-server-read-boundaries.test.cjs
+++ b/tests/phase7-server-read-boundaries.test.cjs
@@ -122,7 +122,13 @@ test('workspace payload preserves the live menu snapshot shape and adds staff co
   assert.equal(payload.workspace.publishState.status, 'live');
   assert.equal(payload.workspace.publishState.statusLabel, 'Live');
   assert.equal(payload.workspace.publishState.hasUnsentChanges, false);
+  assert.equal(payload.workspace.publishState.revisions.liveRevision, 1712705100000);
+  assert.equal(payload.workspace.publishState.revisions.notificationRevision, 1712705100000);
   assert.deepEqual(payload.workspace.publishState.queue.unsentItemIds, []);
+  assert.equal(payload.workspace.revisions.liveRevision, 1712705100000);
+  assert.equal(payload.workspace.revisions.draftRevision, 1712705200000);
+  assert.equal(payload.workspace.revisions.lastSentRevision, 1712705100000);
+  assert.equal(payload.workspace.revisions.notificationBaselineRevision, 1712705100000);
   assert.equal(payload.workspace.capabilities.includesDraftAuthorship, true);
   assert.equal(payload.workspace.capabilities.includesRestaurantTools, true);
   assert.equal(payload.workspace.capabilities.canSaveQuietly, true);
@@ -159,7 +165,12 @@ test('workspace payload projects server-owned Live | Unsent queue state from sta
   assert.equal(payload.workspace.publishState.status, 'live_unsent');
   assert.equal(payload.workspace.publishState.statusLabel, 'Live | Unsent');
   assert.equal(payload.workspace.publishState.hasUnsentChanges, true);
+  assert.equal(payload.workspace.publishState.revisions.notificationRevision, 1712705100000);
   assert.deepEqual(payload.workspace.publishState.queue.unsentItemIds, ['item-1']);
+  assert.equal(payload.workspace.revisions.liveRevision, 1712705300000);
+  assert.equal(payload.workspace.revisions.draftRevision, null);
+  assert.equal(payload.workspace.revisions.lastSentRevision, 1712705100000);
+  assert.equal(payload.workspace.revisions.notificationBaselineRevision, 1712705100000);
   assert.ok(payload.workspace.publishState.queue.selectableGroupIds.some(groupId => groupId.includes('rename')));
 });
 


### PR DESCRIPTION
## What changed
- added `lastSentRevision` and `notificationBaselineRevision` to the server workspace payload without removing the existing publish-state fields
- normalized freshly fetched iOS workspace revisions before remote-update comparison and rebaseline paths
- updated the shared web menu-state loader to finalize the live snapshot after restaurant tools hydrate and to align stored local draft envelopes against that snapshot
- added regression coverage for the server payload shape, web session loader behavior, and iOS remote-update classification

## Why
The web manager and iOS editor were both comparing against mismatched baselines. On web, the manager could capture its server-live snapshot before featured/restaurant-tool state settled and then incorrectly open in `Drafting`. On iOS, the app could compare raw fetched revisions against an already-normalized local workspace and show a false `Unsent Queue Updated` refresh requirement.

## Impact
- clean manager/admin loads stay `Live` when there are no local edits
- unchanged iOS editor loads stop raising false queue-refresh prompts
- the server contract remains backward-compatible while giving clients an explicit queue baseline to compare

## Checks
- `node --test tests/phase7-server-read-boundaries.test.cjs tests/boundaries/session.boundary.test.cjs`
- `node --check app.js`
- `node --check core/data/menu-state-loader.js`
- focused `xcodebuild test` for the new `MenuDocumentTests` cases compiled the app and test targets cleanly, but the local XCTest runner did not return a final result on this machine before timing out the check window