### PR TITLE
[codex] fix ios save-send contract

### DIFF
--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -419,12 +419,14 @@ final class AppModel {
 
     let operationLabel = hasLiveMenuChanges ? "Building Save & Send Preview" : "Building Send Preview"
     await run(operationLabel) { model in
-      let expectedBaselineRevision = model.expectedNotificationBaselineRevision(for: workspace)
+      let expectedDraftRevision = model.expectedDraftRevision(for: workspace)
+      let expectedNotificationRevision = model.expectedNotificationBaselineRevision(for: workspace)
       let response = try await model.services.publish.preview(
         menuId: menuId,
         snapshot: snapshot,
         expectedLiveRevision: workspace.workspace.revisions.liveRevision,
-        expectedDraftRevision: expectedBaselineRevision,
+        expectedDraftRevision: expectedDraftRevision,
+        expectedNotificationRevision: expectedNotificationRevision,
         accessToken: accessToken,
         source: "ios_app"
       )
@@ -443,7 +445,8 @@ final class AppModel {
 
     let operationLabel = hasLiveMenuChanges ? "Saving And Sending" : "Sending Updates"
     await run(operationLabel) { model in
-      let expectedBaselineRevision = model.expectedNotificationBaselineRevision(for: workspace)
+      let expectedDraftRevision = model.expectedDraftRevision(for: workspace)
+      let expectedNotificationRevision = model.expectedNotificationBaselineRevision(for: workspace)
       let preview: MenuPreviewPayload?
       if let existing = model.currentEditorPreview {
         preview = existing
@@ -452,7 +455,8 @@ final class AppModel {
           menuId: menuId,
           snapshot: snapshot,
           expectedLiveRevision: workspace.workspace.revisions.liveRevision,
-          expectedDraftRevision: expectedBaselineRevision,
+          expectedDraftRevision: expectedDraftRevision,
+          expectedNotificationRevision: expectedNotificationRevision,
           accessToken: accessToken,
           source: "ios_app"
         ).preview
@@ -468,7 +472,8 @@ final class AppModel {
         snapshot: snapshot,
         selectedChangeIds: selection,
         expectedLiveRevision: workspace.workspace.revisions.liveRevision,
-        expectedDraftRevision: expectedBaselineRevision,
+        expectedDraftRevision: expectedDraftRevision,
+        expectedNotificationRevision: expectedNotificationRevision,
         accessToken: accessToken,
         source: "ios_app"
       )
@@ -520,12 +525,12 @@ final class AppModel {
 
     await run("Saving Quietly") { model in
       var currentDocument = try model.requireCurrentEditorDocument()
-      let expectedBaselineRevision = model.expectedNotificationBaselineRevision(for: workspace)
+      let expectedDraftRevision = model.expectedDraftRevision(for: workspace)
       let response = try await model.services.liveSave.save(
         menuId: menuId,
         snapshot: snapshot,
         expectedLiveRevision: workspace.workspace.revisions.liveRevision,
-        expectedDraftRevision: expectedBaselineRevision,
+        expectedDraftRevision: expectedDraftRevision,
         accessToken: accessToken
       )
       if let currentRevisions = response.currentRevisions {
@@ -1022,6 +1027,11 @@ final class AppModel {
       ?? workspace.workspace.revisions.lastSentRevision
       ?? workspace.meta.lastSentTs
       ?? workspace.workspace.revisions.draftRevision
+  }
+
+  private func expectedDraftRevision(for workspace: MenuWorkspacePayload) -> Int? {
+    workspace.workspace.revisions.draftRevision
+      ?? workspace.meta.draftSavedTs
   }
 
   private func serverHasUnsentChanges(in workspace: MenuWorkspacePayload?) -> Bool {

--- a/ios/ElRoysManagerApp/Clients/BackendClients.swift
+++ b/ios/ElRoysManagerApp/Clients/BackendClients.swift
@@ -61,8 +61,8 @@ protocol LiveSaveClienting {
 }
 
 protocol PublishClienting {
-  func preview(menuId: String, snapshot: MenuSnapshotPayload, expectedLiveRevision: Int?, expectedDraftRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse
-  func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse
+  func preview(menuId: String, snapshot: MenuSnapshotPayload, expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse
+  func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse
 }
 
 protocol HistoryClienting {
@@ -163,7 +163,6 @@ private struct LiveSaveRequest: Encodable {
   var snapshot: MenuSnapshotPayload
   var expectedLiveRevision: Int?
   var expectedDraftRevision: Int?
-  var expectedNotificationBaselineRevision: Int?
 }
 
 private struct PublishRequest: Encodable {
@@ -174,7 +173,7 @@ private struct PublishRequest: Encodable {
   var selectedChangeIds: [String]?
   var expectedLiveRevision: Int?
   var expectedDraftRevision: Int?
-  var expectedNotificationBaselineRevision: Int?
+  var expectedNotificationRevision: Int?
 }
 
 private struct SpecialsRequest: Encodable {
@@ -515,8 +514,7 @@ final class LiveSaveClient: LiveSaveClienting {
         menuId: menuId,
         snapshot: snapshot,
         expectedLiveRevision: expectedLiveRevision,
-        expectedDraftRevision: expectedDraftRevision,
-        expectedNotificationBaselineRevision: expectedDraftRevision
+        expectedDraftRevision: expectedDraftRevision
       )
     )
   }
@@ -529,7 +527,7 @@ final class PublishClient: PublishClienting {
     http = HTTPService(environment: environment, session: session)
   }
 
-  func preview(menuId: String, snapshot: MenuSnapshotPayload, expectedLiveRevision: Int?, expectedDraftRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
+  func preview(menuId: String, snapshot: MenuSnapshotPayload, expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
     try await http.request(
       path: "api/manager",
       method: .post,
@@ -542,12 +540,12 @@ final class PublishClient: PublishClienting {
         selectedChangeIds: nil,
         expectedLiveRevision: expectedLiveRevision,
         expectedDraftRevision: expectedDraftRevision,
-        expectedNotificationBaselineRevision: expectedDraftRevision
+        expectedNotificationRevision: expectedNotificationRevision
       )
     )
   }
 
-  func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
+  func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
     try await http.request(
       path: "api/manager",
       method: .post,
@@ -560,7 +558,7 @@ final class PublishClient: PublishClienting {
         selectedChangeIds: selectedChangeIds,
         expectedLiveRevision: expectedLiveRevision,
         expectedDraftRevision: expectedDraftRevision,
-        expectedNotificationBaselineRevision: expectedDraftRevision
+        expectedNotificationRevision: expectedNotificationRevision
       )
     )
   }

--- a/ios/ElRoysManagerApp/Models/AppModels.swift
+++ b/ios/ElRoysManagerApp/Models/AppModels.swift
@@ -1159,6 +1159,41 @@ struct PreviewDiffSection: Codable, Equatable, Hashable, Identifiable {
   var eightySixed: [String]
   var restored: [String]
   var displayOrder: Int
+
+  enum CodingKeys: String, CodingKey {
+    case id
+    case icon
+    case label
+    case added
+    case removed
+    case eightySixed
+    case restored
+    case displayOrder
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.id = try container.decodeString(forKey: .id)
+    self.icon = try container.decodeString(forKey: .icon)
+    self.label = try container.decodeString(forKey: .label)
+    self.added = try container.decodeArray([String].self, forKey: .added)
+    self.removed = try container.decodeArray([String].self, forKey: .removed)
+    self.eightySixed = try container.decodeArray([String].self, forKey: .eightySixed)
+    self.restored = try container.decodeArray([String].self, forKey: .restored)
+    self.displayOrder = try container.decodeInt(forKey: .displayOrder, default: 0)
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .id)
+    try container.encode(icon, forKey: .icon)
+    try container.encode(label, forKey: .label)
+    try container.encode(added, forKey: .added)
+    try container.encode(removed, forKey: .removed)
+    try container.encode(eightySixed, forKey: .eightySixed)
+    try container.encode(restored, forKey: .restored)
+    try container.encode(displayOrder, forKey: .displayOrder)
+  }
 }
 
 struct PreviewChange: Codable, Equatable, Hashable, Identifiable {

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -508,7 +508,15 @@ final class MenuDocumentTests: XCTestCase {
         "has_shared_draft": true,
         "has_notification_changes": true,
         "has_save_only_changes": false,
-        "diff": [],
+        "diff": [{
+          "id": "beer",
+          "icon": "🍺",
+          "label": "Beer",
+          "added": ["IPA"],
+          "removed": [],
+          "eighty_sixed": [],
+          "restored": []
+        }],
         "sections": [],
         "notification_changes": [],
         "save_only_changes": [],
@@ -533,6 +541,7 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(payload.preview?.metadata.currentFeaturedIds, ["item-1"])
     XCTAssertEqual(payload.preview?.menuStatus, "Live | Unsent")
     XCTAssertEqual(payload.preview?.hasUnsentChanges, true)
+    XCTAssertEqual(payload.preview?.diff.first?.displayOrder, 0)
   }
 
   @MainActor
@@ -689,10 +698,10 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(model.currentEditorDocument?.itemRecord(for: "item-1")?.item.name, "House Pilsner")
     XCTAssertFalse(model.editorDirty)
     XCTAssertTrue(model.editorHasLiveChanges)
-    XCTAssertTrue(model.hasServerUnsentChanges)
+    XCTAssertFalse(model.hasServerUnsentChanges)
     XCTAssertTrue(model.canSaveLiveRemotely)
     XCTAssertTrue(model.canLoadPublishPreview)
-    XCTAssertEqual(model.menuStatusLabel, "Live | Unsent")
+    XCTAssertEqual(model.menuStatusLabel, "Live")
   }
 
   @MainActor
@@ -769,7 +778,7 @@ final class MenuDocumentTests: XCTestCase {
 
     await model.loadEditor(menuId: "menu")
 
-    XCTAssertTrue(model.hasServerUnsentChanges)
+    XCTAssertFalse(model.hasServerUnsentChanges)
     XCTAssertTrue(model.editorHasLiveChanges)
 
     await model.saveLiveMenu()
@@ -779,9 +788,95 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertTrue(model.hasServerUnsentChanges)
     XCTAssertFalse(model.canSaveLiveRemotely)
     XCTAssertEqual(liveSaveClient.saveCallCount, 1)
+    XCTAssertEqual(liveSaveClient.lastExpectedLiveRevision, 10)
+    XCTAssertEqual(liveSaveClient.lastExpectedDraftRevision, 22)
     XCTAssertEqual(model.currentEditorWorkspace?.workspace.revisions.liveRevision, 44)
     XCTAssertNil(offlineStore.draft)
     XCTAssertEqual(model.notice?.title, "Saved Quietly")
+  }
+
+  @MainActor
+  func testLoadPublishPreviewUsesDraftAndNotificationRevisionsIndependently() async throws {
+    let baseWorkspace = makeWorkspace(categories: [
+      MenuCategoryPayload(
+        id: "beer",
+        menuId: "menu",
+        key: "beer",
+        label: "Beer",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 0,
+        items: [makeItem(id: "item-1", name: "Pilsner")]
+      )
+    ])
+    var sharedDraftDocument = EditableMenuDocument(workspace: baseWorkspace)
+    guard var sharedBeer = sharedDraftDocument.itemRecord(for: "item-1")?.item else {
+      XCTFail("Expected seeded beer item")
+      return
+    }
+    sharedBeer.name = "House Pilsner"
+    sharedDraftDocument.upsertItem(sharedBeer, categoryKey: "beer", originalCategoryKey: "beer")
+
+    let workspace = makeWorkspace(
+      categories: baseWorkspace.cats,
+      meta: MenuMetaPayload(
+        lastSentTs: 10,
+        draftState: makeJSONValue(from: sharedDraftDocument),
+        draftSavedTs: 22
+      ),
+      hasSharedDraft: true,
+      sharedDraft: SharedDraftInfo(
+        exists: true,
+        savedAt: 22,
+        savedBy: SharedDraftSavedBy(id: "staff-1", name: "Alex"),
+        source: "ios_app"
+      ),
+      revisions: WorkspaceRevisions(liveRevision: 10, draftRevision: 22, lastSentRevision: 10, notificationBaselineRevision: 10)
+    )
+    let publishClient = StubPublishClient(
+      previewResponse: PublishResponse(
+        ok: true,
+        action: "preview",
+        ts: nil,
+        preview: try makePreviewPayload(
+          mode: "save-and-send",
+          selectionDefaults: ["beer::added::ipa"]
+        ),
+        currentRevisions: WorkspaceRevisions(liveRevision: 10, draftRevision: 22, lastSentRevision: 10, notificationBaselineRevision: 10),
+        notificationStatus: nil,
+        warnings: nil,
+        warningMessage: nil,
+        successMessage: nil,
+        selectedChangeIds: nil
+      )
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [workspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload()),
+        publishClient: publishClient
+      ),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+    await model.loadPublishPreview()
+
+    XCTAssertEqual(publishClient.previewCallCount, 1)
+    XCTAssertEqual(publishClient.lastPreviewExpectedLiveRevision, 10)
+    XCTAssertEqual(publishClient.lastPreviewExpectedDraftRevision, 22)
+    XCTAssertEqual(publishClient.lastPreviewExpectedNotificationRevision, 10)
+    XCTAssertEqual(model.currentEditorPreview?.selectionDefaults, ["beer::added::ipa"])
   }
 
   @MainActor
@@ -1535,6 +1630,36 @@ final class MenuDocumentTests: XCTestCase {
       showRecipe: false
     )
   }
+
+  private func makePreviewPayload(
+    mode: String,
+    selectionDefaults: [String]
+  ) throws -> MenuPreviewPayload {
+    let selectionJSON = selectionDefaults.map { "\"\($0)\"" }.joined(separator: ", ")
+    let data = Data("""
+    {
+      "mode": "\(mode)",
+      "has_changes": true,
+      "has_local_draft": true,
+      "has_shared_draft": true,
+      "has_notification_changes": true,
+      "has_save_only_changes": false,
+      "diff": [],
+      "sections": [],
+      "notification_changes": [],
+      "save_only_changes": [],
+      "patch_message": "patch text",
+      "truncated": false,
+      "selection_defaults": [\(selectionJSON)],
+      "metadata": {
+        "server_owned": true,
+        "contract": "menu-publish-preview.v2",
+        "current_featured_ids": []
+      }
+    }
+    """.utf8)
+    return try JSONDecoder.backend.decode(MenuPreviewPayload.self, from: data)
+  }
 }
 
 private enum TestError: LocalizedError {
@@ -1704,6 +1829,8 @@ private final class StubDraftClient: DraftClienting {
 private final class StubLiveSaveClient: LiveSaveClienting {
   var response: PublishResponse?
   private(set) var saveCallCount = 0
+  private(set) var lastExpectedLiveRevision: Int?
+  private(set) var lastExpectedDraftRevision: Int?
 
   init(response: PublishResponse? = nil) {
     self.response = response
@@ -1711,6 +1838,8 @@ private final class StubLiveSaveClient: LiveSaveClienting {
 
   func save(menuId: String, snapshot: MenuSnapshotPayload, expectedLiveRevision: Int?, expectedDraftRevision: Int?, accessToken: String) async throws -> PublishResponse {
     saveCallCount += 1
+    lastExpectedLiveRevision = expectedLiveRevision
+    lastExpectedDraftRevision = expectedDraftRevision
     guard let response else {
       throw TestError.message("Unused in this test")
     }
@@ -1719,12 +1848,42 @@ private final class StubLiveSaveClient: LiveSaveClienting {
 }
 
 private final class StubPublishClient: PublishClienting {
-  func preview(menuId: String, snapshot: MenuSnapshotPayload, expectedLiveRevision: Int?, expectedDraftRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
-    throw TestError.message("Unused in this test")
+  var previewResponse: PublishResponse?
+  var publishResponse: PublishResponse?
+  private(set) var previewCallCount = 0
+  private(set) var publishCallCount = 0
+  private(set) var lastPreviewExpectedLiveRevision: Int?
+  private(set) var lastPreviewExpectedDraftRevision: Int?
+  private(set) var lastPreviewExpectedNotificationRevision: Int?
+  private(set) var lastPublishExpectedLiveRevision: Int?
+  private(set) var lastPublishExpectedDraftRevision: Int?
+  private(set) var lastPublishExpectedNotificationRevision: Int?
+
+  init(previewResponse: PublishResponse? = nil, publishResponse: PublishResponse? = nil) {
+    self.previewResponse = previewResponse
+    self.publishResponse = publishResponse
   }
 
-  func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
-    throw TestError.message("Unused in this test")
+  func preview(menuId: String, snapshot: MenuSnapshotPayload, expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
+    previewCallCount += 1
+    lastPreviewExpectedLiveRevision = expectedLiveRevision
+    lastPreviewExpectedDraftRevision = expectedDraftRevision
+    lastPreviewExpectedNotificationRevision = expectedNotificationRevision
+    guard let previewResponse else {
+      throw TestError.message("Unused in this test")
+    }
+    return previewResponse
+  }
+
+  func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
+    publishCallCount += 1
+    lastPublishExpectedLiveRevision = expectedLiveRevision
+    lastPublishExpectedDraftRevision = expectedDraftRevision
+    lastPublishExpectedNotificationRevision = expectedNotificationRevision
+    guard let publishResponse else {
+      throw TestError.message("Unused in this test")
+    }
+    return publishResponse
   }
 }
 

--- a/server/_menu-publish.js
+++ b/server/_menu-publish.js
@@ -119,12 +119,20 @@ function groupNotificationChangesBySection(changes = []) {
         id: sectionId,
         icon: change.icon || '',
         label: change.sectionLabel || sectionId,
+        displayOrder: Number.isFinite(Number(change?.displayOrder))
+          ? Number(change.displayOrder)
+          : Number.MAX_SAFE_INTEGER,
         changes: [],
       });
     }
-    sections.get(sectionId).changes.push(change);
+    const section = sections.get(sectionId);
+    if (Number.isFinite(Number(change?.displayOrder))) {
+      section.displayOrder = Math.min(section.displayOrder, Number(change.displayOrder));
+    }
+    section.changes.push(change);
   });
-  return Array.from(sections.values());
+  return Array.from(sections.values())
+    .sort((a, b) => a.displayOrder - b.displayOrder || String(a.id || '').localeCompare(String(b.id || '')));
 }
 
 function serializeNotificationSectionsForLog(sections = []) {
@@ -132,6 +140,7 @@ function serializeNotificationSectionsForLog(sections = []) {
     id: section.id,
     icon: section.icon,
     label: section.label,
+    displayOrder: Number.isFinite(Number(section.displayOrder)) ? Number(section.displayOrder) : 0,
     added: (section.changes || []).filter(change => change.kind === 'added').map(change => change.name),
     removed: (section.changes || []).filter(change => change.kind === 'removed').map(change => change.name),
     eightySixed: (section.changes || []).filter(change => change.kind === 'eightySixed').map(change => change.name),
@@ -206,6 +215,9 @@ function createFeaturedChangeLine(groupId, section, kind, itemId, name) {
     sectionId: section.id,
     sectionLabel: section.label,
     icon: section.icon,
+    displayOrder: Number.isFinite(Number(section?.displayOrder))
+      ? Number(section.displayOrder)
+      : Number.MAX_SAFE_INTEGER,
   };
 }
 
@@ -247,6 +259,7 @@ async function buildFeaturedQueueState(knownMenu = null, meta = {}) {
     id: '__featured__',
     icon: '⭐',
     label: String(config?.name || 'Featured'),
+    displayOrder: Number.MAX_SAFE_INTEGER - 500,
   };
   const groups = [];
 

--- a/server/_menu-queue.js
+++ b/server/_menu-queue.js
@@ -106,6 +106,7 @@ function createChangeLine(groupId, section, {
     sectionId: section.id,
     sectionLabel: section.label,
     icon: section.icon,
+    displayOrder: section.displayOrder,
   };
 }
 
@@ -134,6 +135,7 @@ function toSectionsFromGroups(groups = []) {
       id: section.id,
       icon: section.icon,
       label: section.label,
+      displayOrder: section.displayOrder,
       changes: section.changes,
     }));
 }
@@ -143,6 +145,7 @@ function toLegacyDiff(sections = []) {
     id: section.id,
     icon: section.icon,
     label: section.label,
+    displayOrder: Number.isFinite(Number(section.displayOrder)) ? Number(section.displayOrder) : 0,
     added: section.changes.filter(change => change.kind === 'added').map(change => change.name),
     removed: section.changes.filter(change => change.kind === 'removed').map(change => change.name),
     eightySixed: section.changes.filter(change => change.kind === 'eightySixed').map(change => change.name),

--- a/tests/phase19-menu-preview-boundaries.test.cjs
+++ b/tests/phase19-menu-preview-boundaries.test.cjs
@@ -44,6 +44,39 @@ test('wave 4 publish command module exports canonical preview and selected-chang
   assert.doesNotMatch(publishModuleSource, /previewDiff/);
 });
 
+test('queue and publish preview boundaries preserve section display order metadata', async () => {
+  const queueModule = await importApiModule('server/_menu-queue.js');
+  const publishModuleSource = read('server/_menu-publish.js');
+
+  const queueState = queueModule.buildCategoryQueueState({
+    snapshot: {
+      cats: [
+        {
+          key: 'wine',
+          label: 'Wine',
+          icon: '🍷',
+          display_order: 2,
+          items: [{ id: 'item-1', name: 'Rose', on_menu: true, visibility: 'public' }],
+        },
+        {
+          key: 'beer',
+          label: 'Beer',
+          icon: '🍺',
+          display_order: 0,
+          items: [{ id: 'item-2', name: 'IPA', on_menu: true, visibility: 'public' }],
+        },
+      ],
+    },
+    lastSentState: {},
+  });
+
+  assert.equal(queueState.diff[0].id, 'beer');
+  assert.equal(queueState.diff[0].displayOrder, 0);
+  assert.equal(queueState.diff[1].id, 'wine');
+  assert.equal(queueState.diff[1].displayOrder, 2);
+  assert.match(publishModuleSource, /displayOrder:\s*Number\.isFinite\(Number\(section\.displayOrder\)\) \? Number\(section\.displayOrder\) : 0/);
+});
+
 test('app runtime requests canonical preview and no longer posts legacy preview payload fields', () => {
   const source = read('app.js');
   const publishApiStart = source.indexOf('async function requestPublishPreviewThroughApi()');


### PR DESCRIPTION
## What changed
- separated the iOS save/send request baselines so quiet saves use the current draft revision while preview/publish send the notification baseline on the correct `expected_notification_revision` field
- made the native preview diff decoder tolerate missing `displayOrder` during rollout
- restored `displayOrder` metadata in the server queue and publish preview diff payloads
- added regression coverage in the focused iOS menu document tests and the JS preview boundary test

## Why this changed
`Save Quietly` was reusing the wrong baseline and triggering a false `draft_revision is stale` conflict. `Save & Send` was also decoding a preview payload that no longer guaranteed `preview.diff[].displayOrder`, which caused the native publish flow to fail before send completion.

## Impact
The iOS manager app can save drafts quietly again, and save/send now receives a stable preview contract from the server. The client-side decoder is also a little more resilient while mixed client/server versions are rolling out.

## Root cause
The iOS app conflated draft and notification revision expectations, and the server-side preview diff contract drifted from what the native decoder required.

## Validation
- `node --test tests/phase19-menu-preview-boundaries.test.cjs`
- `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -configuration Debug -destination 'platform=iOS Simulator,id=61CFA6DC-C165-415A-A0C1-A475FB3BECE1' -only-testing:ElRoysManagerAppTests/MenuDocumentTests CODE_SIGNING_ALLOWED=NO test`
