### PR TITLE
[codex] Fix manager item reorder save state

### DIFF
--- a/app.js
+++ b/app.js
@@ -10728,6 +10728,18 @@ function handleManagerItemDrop(event, catId, targetItemId) {
       ...items.filter(item => item.onMenu === false),
     ];
 
+  const category = catId === UNCATEGORIZED_ID
+    ? getUncategorizedCategoryDef()
+    : CATEGORY_DEFS.find(cat => cat.id === catId);
+  const categoryLabel = category?.title || category?.label || 'items';
+  markSaveOnlyDraftChange({
+    key: `item-order:${catId}`,
+    label: `Reordered ${categoryLabel}`,
+    message: `Reordered ${categoryLabel}`,
+    sectionId: catId,
+    itemId: movedItem?.id || '',
+    kind: 'item-order',
+  });
   invalidateDiff();
   renderManagerItems(catId);
   markSectionsStale(_activeManagerSection);

--- a/tests/manager-item-reorder-draft-state.test.cjs
+++ b/tests/manager-item-reorder-draft-state.test.cjs
@@ -1,0 +1,74 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const {
+  getState,
+  loadAppSandbox,
+  setState,
+} = require('./helpers/runtime.cjs');
+
+function createMenuItem(id, name) {
+  return {
+    id,
+    name,
+    desc: '',
+    recipe: [],
+    price: '',
+    eightySixed: false,
+    onMenu: true,
+    visibility: 'public',
+    upcharges: [],
+    showDescription: true,
+    showRecipe: false,
+  };
+}
+
+test('reordering manager items creates a saveable quiet draft change', () => {
+  const sandbox = loadAppSandbox();
+  const alpha = createMenuItem('alpha', 'Alpha');
+  const bravo = createMenuItem('bravo', 'Bravo');
+
+  setState(sandbox, {
+    CATEGORY_DEFS: [{
+      id: 'beer',
+      title: 'Beer',
+      icon: '',
+      color: '',
+      sub: '',
+      placeholder: '',
+      _uuid: 'cat-beer',
+    }],
+    menuState: {
+      beer: {
+        items: [alpha, bravo],
+        lastSent: [{ ...alpha }, { ...bravo }],
+      },
+      _meta: {
+        lastUpdatedTs: '1',
+        lastSentTs: '1',
+        lastSentCategories: [],
+      },
+    },
+    currentUser: { uid: 'manager-1' },
+    MENU_ID: 'menu-1',
+    renderManagerItems: () => {},
+    markSectionsStale: () => {},
+    updateDraftIndicator: () => {},
+    renderManagerOverviewStats: () => {},
+    showToast: () => {},
+    _activeManagerSection: 'manager-edit-section',
+    _managerDraggedCatId: 'beer',
+    _managerDraggedItemId: 'alpha',
+  });
+
+  getState(sandbox, 'setLocalDraftBaseSnapshot(buildPersistedDraftStateSnapshot(1000));');
+  getState(sandbox, 'handleManagerItemDrop({ preventDefault() {} }, "beer", "bravo");');
+
+  assert.deepEqual(
+    getState(sandbox, 'JSON.parse(JSON.stringify(menuState.beer.items.map(item => item.id)))'),
+    ['bravo', 'alpha'],
+  );
+  assert.equal(getState(sandbox, 'getDraftSaveOnlyChanges().length'), 1);
+  assert.equal(getState(sandbox, 'getDraftChangeCount()'), 1);
+  assert.equal(getState(sandbox, 'getMenuActionState().saveDisabled'), false);
+});


### PR DESCRIPTION
## What changed
- record manager item drag-and-drop reorders as a quiet draft change so the web manager treats them as saveable work
- add a runtime regression test that performs a real manager reorder and verifies the draft change is tracked and `Save` becomes enabled

## Why it changed
Item reordering changed in-memory item order and marked the draft dirty, but it did not create either a notification diff or a save-only change. The manager action state only enables quiet saves when one of those tracked change buckets exists, so reorder-only edits were left unsaveable.

## Impact
Managers can now reorder items on the web manager screen and save those order changes without needing any unrelated edit to unlock the save action.

## Validation
- `node --test tests/manager-item-reorder-draft-state.test.cjs tests/boundaries/publish.boundary.test.cjs`