### PR TITLE
[codex] Fix menu save and send flow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ design-loop/**/*.jpg
 # Bug loop artifacts (issues file is committed)
 bug-loop/log.md
 bug-loop/artifacts/
+*.xcworkspacedata

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -184,3 +184,64 @@ When building a future client:
    workflows.
 4. Treat the `Platform-specific` section as implementation guidance, not as the
    core parity contract.
+
+## Agreed Next Work (Not Yet Shipped)
+
+These notes capture design decisions that are agreed for upcoming work, but are
+not yet reflected in the status tables above.
+
+### Untappd-Assisted Add Item Import
+
+- Scope: web manager only in v1; iOS remains out of scope for the first pass.
+- Availability: drinks menus only, and only for categories explicitly marked as
+  Untappd-enabled.
+- Category control: Untappd-enabled is a saved per-category flag; any drinks
+  category may use it.
+- Permissions: only admins can change a category's Untappd status.
+- Add-item flow:
+  - Untappd lookup appears only in the add-item modal.
+  - The selected category must be Untappd-enabled.
+  - Lookup runs only on explicit button press.
+  - The name-field placeholder becomes `Brewery + Beer` for Untappd-enabled
+    categories.
+  - Search uses the typed name with light server-side normalization for
+    packaging/size hints.
+  - Search returns up to five matches.
+  - One match still goes through a lightweight confirmation step before apply.
+  - Multiple matches open an in-modal chooser, not a route change.
+  - Cancel/no-match preserves the manager's current typed values.
+- Import behavior:
+  - Applying a result overwrites only `Name` and `Description`.
+  - `Price`, category, recipe, upcharges, and other item state stay untouched.
+  - Imported description should be short and primarily generated from style plus
+    ABV.
+  - A per-import `Include brewery in imported name` toggle exists only during
+    the Untappd confirmation/apply flow and defaults to off for each attempt.
+  - Imported fields remain normal editable menu text after apply; items do not
+    stay linked to Untappd afterward.
+- Service model:
+  - All Untappd traffic goes through the app server; no client talks directly to
+    Untappd.
+  - v1 should use live lookups without a server cache.
+  - Untappd attribution should appear anywhere the Untappd lookup UI appears.
+- Failure model: Untappd is assistive only. Lookup failures, empty results, or
+  rate limits never block manual item creation.
+
+### Category Governance Hardening
+
+- Category structure is intended to become admin-only:
+  - add category
+  - rename category
+  - reorder categories
+  - delete category
+  - change Untappd-related category settings
+- Web manager behavior:
+  - admins keep full category editing
+  - managers keep the `Categories` section visible, but read-only
+- iOS behavior:
+  - categories become read-only for everyone
+  - admin category governance remains web-only
+- Server enforcement:
+  - category mutations must be enforced server-side, not only in UI
+  - if a manager submits forbidden category mutations, the whole save/publish
+    request should be rejected with a clear error rather than partially applied

--- a/docs/ios/2026-04-17-auth-gate-bug-findings.md
+++ b/docs/ios/2026-04-17-auth-gate-bug-findings.md
@@ -1,0 +1,68 @@
+# 2026-04-17 Auth Gate Bug Findings
+
+Manual iOS bug pass for the native SwiftUI manager app.
+
+## Test Scope
+
+- Date: `2026-04-17`
+- Build: Preview environment
+- Device: `iPhone 17` simulator
+- Coverage: unauthenticated auth-gate flows only
+- Tooling note: Computer Use access remained blocked, so testing used the simulator tooling from the iOS build plugin instead
+
+## Confirmed Bugs
+
+### 1. Validation banners are persistent instead of transient
+
+#### Repro
+
+1. Launch the app to the auth gate.
+2. Leave all fields empty.
+3. Tap `Sign In`.
+4. Wait at least 6 seconds.
+
+#### Expected
+
+The validation notice should dismiss itself after a short interval, or at minimum stop occupying permanent space once the user continues interacting with the form.
+
+#### Actual
+
+The inline `Missing Fields` banner remains pinned in the layout after 6 seconds and keeps pushing the rest of the form down.
+
+### 2. Validation errors leak across auth mode switches
+
+#### Repro
+
+1. Launch the app to the auth gate.
+2. Leave all fields empty.
+3. Tap `Sign In` to trigger `Missing Fields`.
+4. Switch to `Reset Password`.
+5. Switch again to `Create Account`.
+
+#### Expected
+
+Changing auth modes should clear any stale notice that was produced by the previous mode, since the form requirements and primary action have changed.
+
+#### Actual
+
+The original sign-in error remains visible on both the reset-password and sign-up forms until another submit replaces it.
+
+### 3. Auth mode labels are truncated on the default simulator width
+
+#### Repro
+
+1. Launch the app on the `iPhone 17` simulator.
+2. View the segmented auth mode control.
+
+#### Expected
+
+Each mode label should remain readable without truncation.
+
+#### Actual
+
+`Create Account` and `Reset Password` are truncated to `Create Acc...` and `Reset Pass...`, which makes the auth mode switcher feel cramped.
+
+## Notes
+
+- The validation copy itself appears correct for the mode that generated it.
+- I did not cover authenticated editor flows, save/send behavior, or menu management because this pass did not use a test staff account.

--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -432,7 +432,7 @@ final class AppModel {
       )
       let preview = response.preview
       model.currentEditorPreview = preview
-      model.selectedPreviewChangeIDs = Set(preview?.selectionDefaults ?? [])
+      model.selectedPreviewChangeIDs = model.defaultPreviewSelection(for: preview)
     }
   }
 
@@ -462,7 +462,7 @@ final class AppModel {
         ).preview
         model.currentEditorPreview = preview
         if model.selectedPreviewChangeIDs.isEmpty {
-          model.selectedPreviewChangeIDs = Set(preview?.selectionDefaults ?? [])
+          model.selectedPreviewChangeIDs = model.defaultPreviewSelection(for: preview)
         }
       }
 
@@ -492,8 +492,14 @@ final class AppModel {
       if let successMessage = response.successMessage?.nilIfBlank {
         message = successMessage
       }
+      let currentDocument = try model.requireCurrentEditorDocument()
+      model.applyPublishResponseLocally(
+        response,
+        preview: preview,
+        previousWorkspace: workspace,
+        currentDocument: currentDocument
+      )
       model.notice = AppNotice(tone: .success, title: title, message: message)
-      await model.loadEditor(menuId: menuId)
     }
   }
 
@@ -539,7 +545,9 @@ final class AppModel {
       if let ts = response.ts {
         currentDocument.meta.lastUpdatedTs = ts
         model.currentEditorWorkspace?.meta.lastUpdatedTs = ts
-        if model.currentEditorWorkspace?.workspace.revisions.liveRevision == nil {
+        if response.currentRevisions == nil {
+          model.currentEditorWorkspace?.workspace.revisions.liveRevision = ts
+        } else if model.currentEditorWorkspace?.workspace.revisions.liveRevision == nil {
           model.currentEditorWorkspace?.workspace.revisions.liveRevision = ts
         }
       }
@@ -905,6 +913,76 @@ final class AppModel {
     persistOfflineDraftIfNeeded()
   }
 
+  private func applyPublishResponseLocally(
+    _ response: PublishResponse,
+    preview: MenuPreviewPayload?,
+    previousWorkspace: MenuWorkspacePayload,
+    currentDocument: EditableMenuDocument
+  ) {
+    guard var workspace = currentEditorWorkspace else { return }
+
+    let previousNotificationBaseline = expectedNotificationBaselineRevision(for: previousWorkspace)
+    let previousLiveRevision = previousWorkspace.workspace.revisions.liveRevision
+    let publishMode = preview?.mode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
+    let didPersistLive = publishMode.isEmpty ? hasLiveMenuChanges : publishMode != "send"
+
+    var nextDocument = currentDocument
+    var nextRevisions = normalizedWorkspaceRevisions(
+      response.currentRevisions ?? workspace.workspace.revisions,
+      meta: workspace.meta
+    )
+
+    if didPersistLive,
+       let liveRevision = nextRevisions.liveRevision ?? response.ts {
+      nextRevisions.liveRevision = liveRevision
+      workspace.meta.lastUpdatedTs = liveRevision
+      nextDocument.meta.lastUpdatedTs = liveRevision
+    }
+
+    if let lastSentRevision = nextRevisions.lastSentRevision {
+      workspace.meta.lastSentTs = lastSentRevision
+      nextDocument.meta.lastSentTs = lastSentRevision
+    }
+
+    workspace.workspace.revisions = nextRevisions
+    workspace.workspace.hasSharedDraft = false
+    workspace.workspace.sharedDraft = SharedDraftInfo(exists: false, savedAt: nil, savedBy: nil, source: "")
+    workspace.workspace.revisions.draftRevision = nil
+    workspace.meta.draftState = nil
+    workspace.meta.draftSavedTs = nil
+    workspace.meta.draftSavedByUserId = nil
+    workspace.meta.draftSavedByName = nil
+    workspace.meta.draftSavedSource = nil
+    nextDocument.meta.draftState = nil
+    nextDocument.meta.draftSavedTs = nil
+    nextDocument.meta.draftSavedByUserId = nil
+    nextDocument.meta.draftSavedByName = nil
+    nextDocument.meta.draftSavedSource = nil
+
+    let nextNotificationBaseline = expectedNotificationBaselineRevision(for: workspace)
+    let queueBaselineAdvanced = nextNotificationBaseline != previousNotificationBaseline
+    let nextHasUnsentChanges: Bool
+    if queueBaselineAdvanced {
+      nextHasUnsentChanges = false
+    } else if preview?.hasNotificationChanges == true {
+      nextHasUnsentChanges = true
+    } else if didPersistLive, nextRevisions.liveRevision != previousLiveRevision {
+      nextHasUnsentChanges = false
+    } else {
+      nextHasUnsentChanges = serverHasUnsentChanges(in: previousWorkspace)
+    }
+    workspace.workspace.hasUnsentChanges = nextHasUnsentChanges
+    workspace.workspace.menuStatus = nextHasUnsentChanges ? "Live | Unsent" : "Live"
+
+    currentEditorWorkspace = workspace
+    currentEditorDocument = nextDocument
+    rebaselineCurrentEditorToServer(
+      liveDocument: nextDocument,
+      serverDocument: nextDocument,
+      revisions: nextRevisions
+    )
+  }
+
   private func makeRefreshRequirement(
     currentWorkspace: MenuWorkspacePayload,
     freshWorkspace: MenuWorkspacePayload,
@@ -1042,6 +1120,19 @@ final class AppModel {
     return workspace.workspace.revisions.draftRevision
       ?? workspace.workspace.sharedDraft.savedAt
       ?? workspace.meta.draftSavedTs
+  }
+
+  private func defaultPreviewSelection(for preview: MenuPreviewPayload?) -> Set<String> {
+    guard let preview else { return [] }
+    let notificationChangeIDs = preview.notificationChanges.map(\.id)
+    if !notificationChangeIDs.isEmpty {
+      return Set(notificationChangeIDs)
+    }
+    let sectionChangeIDs = preview.sections.flatMap(\.changes).map(\.id)
+    if !sectionChangeIDs.isEmpty {
+      return Set(sectionChangeIDs)
+    }
+    return Set(preview.selectionDefaults)
   }
 
   private func serverHasUnsentChanges(in workspace: MenuWorkspacePayload?) -> Bool {

--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -589,6 +589,13 @@ final class AppModel {
     mutateEditorDocument { $0.upsertItem(item, categoryKey: categoryKey, originalCategoryKey: originalCategoryKey) }
   }
 
+  func setItemEightySixed(itemID: String, categoryKey: String, isEightySixed: Bool) {
+    guard var item = currentEditorDocument?.itemRecord(for: itemID)?.item else { return }
+    guard item.isEightySixed != isEightySixed else { return }
+    item.isEightySixed = isEightySixed
+    upsertItem(item, categoryKey: categoryKey, originalCategoryKey: categoryKey)
+  }
+
   func canUseItemName(_ name: String, in categoryKey: String, excluding itemID: String? = nil) -> Bool {
     !(currentEditorDocument?.hasDuplicate(named: name, in: categoryKey, excluding: itemID) ?? false)
   }
@@ -1030,7 +1037,10 @@ final class AppModel {
   }
 
   private func expectedDraftRevision(for workspace: MenuWorkspacePayload) -> Int? {
-    workspace.workspace.revisions.draftRevision
+    let hasSharedDraft = workspace.workspace.hasSharedDraft || workspace.workspace.sharedDraft.exists
+    guard hasSharedDraft else { return nil }
+    return workspace.workspace.revisions.draftRevision
+      ?? workspace.workspace.sharedDraft.savedAt
       ?? workspace.meta.draftSavedTs
   }
 

--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -531,6 +531,7 @@ final class AppModel {
 
     await run("Saving Quietly") { model in
       var currentDocument = try model.requireCurrentEditorDocument()
+      currentDocument.normalizePersistentItemIdentifiersForRuntime()
       let expectedDraftRevision = model.expectedDraftRevision(for: workspace)
       let response = try await model.services.liveSave.save(
         menuId: menuId,
@@ -927,6 +928,7 @@ final class AppModel {
     let didPersistLive = publishMode.isEmpty ? hasLiveMenuChanges : publishMode != "send"
 
     var nextDocument = currentDocument
+    nextDocument.normalizePersistentItemIdentifiersForRuntime()
     var nextRevisions = normalizedWorkspaceRevisions(
       response.currentRevisions ?? workspace.workspace.revisions,
       meta: workspace.meta

--- a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
@@ -1,5 +1,12 @@
 import SwiftUI
 
+private enum MenuEditorSheet: String, Identifiable {
+  case itemEditor
+  case publishPreview
+
+  var id: String { rawValue }
+}
+
 struct MenuEditorScreen: View {
   @Environment(\.scenePhase) private var scenePhase
   @Bindable var model: AppModel
@@ -7,7 +14,7 @@ struct MenuEditorScreen: View {
   @State private var addCategoryName = ""
   @State private var showingAddCategory = false
   @State private var editingDraft = EditableItemDraft()
-  @State private var showingItemSheet = false
+  @State private var activeSheet: MenuEditorSheet?
   @State private var renameTarget: MenuCategoryPayload?
   @State private var renameText = ""
   @State private var showingDiscardDraftConfirm = false
@@ -46,17 +53,17 @@ struct MenuEditorScreen: View {
             theme: theme,
             menuAccent: menuAccent,
             onAddItem: presentNewItem,
-            onAddCategory: { showingAddCategory = true },
             onSaveQuietly: saveQuietly,
             onSendUpdate: loadSendPreview,
             onDiscardDraft: { showingDiscardDraftConfirm = true }
           )
 
-          if let preview = model.currentEditorPreview {
-            PublishPreviewCard(model: model, preview: preview, theme: theme, menuAccent: menuAccent, onPublish: publishChanges)
-          }
-
           if let document = model.currentEditorDocument {
+            MenuEditorCategoriesHeader(
+              theme: theme,
+              menuAccent: menuAccent,
+              onAddCategory: { showingAddCategory = true }
+            )
             ForEach(Array(document.visibleCategories.enumerated()), id: \.offset) { _, category in
               MenuEditorCategoryCard(
                 menu: menu,
@@ -72,7 +79,14 @@ struct MenuEditorScreen: View {
                 },
                 onSelectItem: { item in
                   editingDraft = EditableItemDraft(item: item, categoryKey: category.key, isFoodMenu: menu.isFoodMenu)
-                  showingItemSheet = true
+                  activeSheet = .itemEditor
+                },
+                onToggleEightySix: { item in
+                  model.setItemEightySixed(
+                    itemID: item.id,
+                    categoryKey: category.key,
+                    isEightySixed: !item.isEightySixed
+                  )
                 },
                 onMoveOffMenu: { item in
                   model.moveItemToOffMenu(itemID: item.id, from: category.key)
@@ -116,11 +130,25 @@ struct MenuEditorScreen: View {
     }
     .navigationTitle(menu.displayTypeLabel)
     .navigationBarTitleDisplayMode(.inline)
+    .toolbar {
+      ToolbarItem(placement: .topBarTrailing) {
+        NavigationLink(value: AppDestination.routePreview(menu)) {
+          Image(systemName: "safari")
+        }
+        .accessibilityLabel("Exact Route Preview")
+      }
+    }
     .task(id: menu.id) {
       await model.loadEditor(menuId: menu.id)
     }
     .task(id: menu.id) {
       await model.monitorEditorRemoteChanges(for: menu.id)
+    }
+    .task(id: model.notice?.id) {
+      guard let notice = model.notice else { return }
+      try? await Task.sleep(for: .seconds(4))
+      guard model.notice?.id == notice.id else { return }
+      model.notice = nil
     }
     .onChange(of: scenePhase) { _, phase in
       guard phase == .active else { return }
@@ -128,15 +156,31 @@ struct MenuEditorScreen: View {
     }
     .onChange(of: model.editorRefreshRequirement != nil) { _, required in
       guard required else { return }
-      showingItemSheet = false
+      activeSheet = nil
       showingAddCategory = false
       renameTarget = nil
     }
-    .sheet(isPresented: Binding(
-      get: { showingItemSheet && model.editorRefreshRequirement == nil },
-      set: { showingItemSheet = $0 }
-    )) {
-      ItemEditorSheet(model: model, menu: menu, draft: $editingDraft)
+    .sheet(item: Binding(
+      get: { model.editorRefreshRequirement == nil ? activeSheet : nil },
+      set: { activeSheet = $0 }
+    )) { sheet in
+      switch sheet {
+      case .itemEditor:
+        ItemEditorSheet(model: model, menu: menu, draft: $editingDraft)
+      case .publishPreview:
+        if let preview = model.currentEditorPreview {
+          PublishPreviewSheet(
+            model: model,
+            preview: preview,
+            theme: theme,
+            menuAccent: menuAccent,
+            onPublish: publishChanges
+          )
+        } else {
+          ProgressView("Loading preview…")
+            .presentationDetents([.medium])
+        }
+      }
     }
     .alert("Add Category", isPresented: $showingAddCategory) {
       TextField("Category name", text: $addCategoryName)
@@ -173,7 +217,7 @@ struct MenuEditorScreen: View {
   private func presentNewItem() {
     if let firstCategoryKey = model.currentEditorDocument?.visibleCategories.first?.key {
       editingDraft = EditableItemDraft(categoryKey: firstCategoryKey, isFoodMenu: menu.isFoodMenu)
-      showingItemSheet = true
+      activeSheet = .itemEditor
     } else {
       model.notice = AppNotice(
         tone: .warning,
@@ -188,11 +232,17 @@ struct MenuEditorScreen: View {
   }
 
   private func loadSendPreview() {
-    Task { await model.loadPublishPreview() }
+    Task {
+      await model.loadPublishPreview()
+      activeSheet = model.currentEditorPreview == nil ? nil : .publishPreview
+    }
   }
 
   private func publishChanges() {
-    Task { await model.publishSelectedChanges() }
+    Task {
+      await model.publishSelectedChanges()
+      activeSheet = nil
+    }
   }
 }
 
@@ -255,96 +305,147 @@ private struct EditorItemRow: View {
   }
 }
 
-private struct PublishPreviewCard: View {
+struct PublishPreviewSummary: Equatable {
+  struct NotificationChange: Identifiable, Equatable {
+    let id: String
+    let sectionLabel: String
+    let text: String
+
+    var displayText: String {
+      "\(sectionLabel): \(text)"
+    }
+  }
+
+  var selectedNotificationChanges: [NotificationChange]
+  var clearedNotificationChanges: [NotificationChange]
+  var saveOnlyChanges: [SaveOnlyChange]
+
+  init(preview: MenuPreviewPayload, selectedChangeIDs: Set<String>) {
+    let notificationChanges = preview.sections
+      .flatMap(\.changes)
+      .map {
+        NotificationChange(
+          id: $0.id,
+          sectionLabel: $0.sectionLabel,
+          text: $0.text
+        )
+      }
+    self.selectedNotificationChanges = notificationChanges.filter { selectedChangeIDs.contains($0.id) }
+    self.clearedNotificationChanges = notificationChanges.filter { !selectedChangeIDs.contains($0.id) }
+    self.saveOnlyChanges = preview.saveOnlyChanges
+  }
+}
+
+private struct PublishPreviewSheet: View {
+  @Environment(\.dismiss) private var dismiss
   @Bindable var model: AppModel
   let preview: MenuPreviewPayload
   let theme: MenuEditorTheme
   let menuAccent: Color
   let onPublish: () -> Void
 
-  var body: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text(previewTitle)
-        .font(EditorTypography.display(20, weight: .bold))
-        .foregroundStyle(theme.titleText)
-      if !preview.patchMessage.isEmpty {
-        Text(preview.patchMessage)
-          .font(EditorTypography.body(14))
-          .foregroundStyle(theme.subtleText)
-      }
-
-      if preview.hasNotificationChanges {
-        VStack(alignment: .leading, spacing: 6) {
-          Text("Will Send")
-            .font(EditorTypography.body(14, weight: .bold))
-            .foregroundStyle(theme.titleText)
-          ForEach(Array(preview.sections.enumerated()), id: \.offset) { _, section in
-            VStack(alignment: .leading, spacing: 6) {
-              Text(section.label)
-                .font(EditorTypography.body(13, weight: .semibold))
-                .foregroundStyle(theme.subtleText)
-              ForEach(Array(section.changes.enumerated()), id: \.offset) { _, change in
-                Toggle(isOn: Binding(
-                  get: { model.selectedPreviewChangeIDs.contains(change.id) },
-                  set: { model.updatePreviewSelection(change.id, selected: $0) }
-                )) {
-                  Text(change.text)
-                    .font(EditorTypography.body(13))
-                    .foregroundStyle(theme.bodyText)
-                }
-                .tint(menuAccent)
-              }
-            }
-          }
-        }
-        .padding(12)
-        .background(theme.itemRowFill, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-
-        if !uncheckedChanges.isEmpty {
-          VStack(alignment: .leading, spacing: 6) {
-            Text("Will Clear Without Sending")
-              .font(EditorTypography.body(14, weight: .bold))
-              .foregroundStyle(theme.titleText)
-            ForEach(Array(uncheckedChanges.enumerated()), id: \.offset) { _, change in
-              Text("\(change.sectionLabel): \(change.text)")
-                .font(EditorTypography.body(13))
-                .foregroundStyle(theme.bodyText)
-            }
-          }
-          .padding(12)
-          .background(theme.itemRowFill, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-        }
-      }
-
-      if !preview.saveOnlyChanges.isEmpty {
-        VStack(alignment: .leading, spacing: 6) {
-          Text("Will Save Only")
-            .font(EditorTypography.body(14, weight: .bold))
-            .foregroundStyle(theme.titleText)
-          ForEach(Array(preview.saveOnlyChanges.enumerated()), id: \.offset) { _, change in
-            Text(change.label.nilIfBlank ?? change.message)
-              .font(EditorTypography.body(13))
-              .foregroundStyle(theme.bodyText)
-          }
-        }
-        .padding(12)
-        .background(theme.itemRowFill, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-      }
-
-      Button(actionButtonTitle) {
-        onPublish()
-      }
-      .buttonStyle(PrimaryGlassButtonStyle())
-      .disabled(!model.canPublishRemotely)
-    }
-    .menuEditorSurface(colors: [theme.previewTop, theme.previewBottom], border: theme.previewBorder)
+  private var summary: PublishPreviewSummary {
+    PublishPreviewSummary(
+      preview: preview,
+      selectedChangeIDs: model.selectedPreviewChangeIDs
+    )
   }
 
-  private var previewTitle: String {
-    if !preview.hasNotificationChanges {
-      return "Save Preview"
+  var body: some View {
+    NavigationStack {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 18) {
+          if !preview.patchMessage.isEmpty {
+            Text(preview.patchMessage)
+              .font(EditorTypography.body(14))
+              .foregroundStyle(theme.subtleText)
+              .padding(.horizontal, 2)
+          }
+
+          if preview.hasNotificationChanges {
+            VStack(alignment: .leading, spacing: 10) {
+              Text("Notification Toggles")
+                .font(EditorTypography.body(15, weight: .bold))
+                .foregroundStyle(theme.titleText)
+              ForEach(Array(preview.sections.enumerated()), id: \.offset) { _, section in
+                VStack(alignment: .leading, spacing: 8) {
+                  Text(section.label)
+                    .font(EditorTypography.body(13, weight: .semibold))
+                    .foregroundStyle(theme.subtleText)
+                  ForEach(Array(section.changes.enumerated()), id: \.offset) { _, change in
+                    Toggle(isOn: Binding(
+                      get: { model.selectedPreviewChangeIDs.contains(change.id) },
+                      set: { model.updatePreviewSelection(change.id, selected: $0) }
+                    )) {
+                      Text(change.text)
+                        .font(EditorTypography.body(13))
+                        .foregroundStyle(theme.bodyText)
+                    }
+                    .tint(menuAccent)
+                  }
+                }
+              }
+            }
+            .menuEditorSurface(colors: [theme.previewTop, theme.previewBottom], border: theme.previewBorder)
+          }
+
+          if !summary.selectedNotificationChanges.isEmpty {
+            PublishPreviewSummaryCard(
+              title: "Changes To Send In Notification",
+              items: summary.selectedNotificationChanges.map(\.displayText),
+              theme: theme
+            )
+          }
+
+          if !summary.clearedNotificationChanges.isEmpty {
+            PublishPreviewSummaryCard(
+              title: "Changes To Clear",
+              items: summary.clearedNotificationChanges.map(\.displayText),
+              theme: theme
+            )
+          }
+
+          if !summary.saveOnlyChanges.isEmpty {
+            PublishPreviewSummaryCard(
+              title: "Save Only Changes",
+              items: summary.saveOnlyChanges.map { $0.label.nilIfBlank ?? $0.message },
+              theme: theme
+            )
+          }
+        }
+        .padding(24)
+      }
+      .background {
+        MenuEditorBackground(theme: theme)
+          .ignoresSafeArea()
+      }
+      .safeAreaInset(edge: .bottom) {
+        Button(actionButtonTitle) {
+          onPublish()
+        }
+        .buttonStyle(PrimaryGlassButtonStyle())
+        .disabled(!model.canPublishRemotely)
+        .padding(.horizontal, 24)
+        .padding(.top, 12)
+        .padding(.bottom, 16)
+        .background(.ultraThinMaterial)
+      }
+      .navigationTitle(screenTitle)
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Close") {
+            dismiss()
+          }
+        }
+      }
     }
-    return model.hasLocalDraftChanges ? "Save & Send Preview" : "Send Preview"
+    .presentationDetents([.large])
+    .presentationDragIndicator(.visible)
+  }
+
+  private var screenTitle: String {
+    preview.hasNotificationChanges ? "Send Notification" : "Save Changes"
   }
 
   private var actionButtonTitle: String {
@@ -353,11 +454,25 @@ private struct PublishPreviewCard: View {
     }
     return model.hasLocalDraftChanges ? "Save & Send" : "Send"
   }
+}
 
-  private var uncheckedChanges: [PreviewChange] {
-    preview.sections
-      .flatMap(\.changes)
-      .filter { !model.selectedPreviewChangeIDs.contains($0.id) }
+private struct PublishPreviewSummaryCard: View {
+  let title: String
+  let items: [String]
+  let theme: MenuEditorTheme
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text(title)
+        .font(EditorTypography.body(15, weight: .bold))
+        .foregroundStyle(theme.titleText)
+      ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+        Text(item)
+          .font(EditorTypography.body(13))
+          .foregroundStyle(theme.bodyText)
+      }
+    }
+    .menuEditorSurface(colors: [theme.panelTop, theme.panelBottom], border: theme.panelBorder)
   }
 }
 
@@ -383,57 +498,46 @@ private struct MenuEditorHeaderCard: View {
             .font(EditorTypography.display(30, weight: .bold))
             .foregroundStyle(theme.titleText)
           Text(menu.isFoodMenu ? "Kitchen edit deck" : "Bar edit deck")
-            .font(EditorTypography.body(14, weight: .medium))
-            .foregroundStyle(theme.subtleText)
+          .font(EditorTypography.body(14, weight: .medium))
+          .foregroundStyle(theme.subtleText)
         }
         Spacer()
-        Text(menu.displayTypeLabel)
-          .font(EditorTypography.body(12, weight: .bold))
-          .padding(.vertical, 8)
-          .padding(.horizontal, 10)
-          .background(menuAccent.opacity(0.18), in: Capsule())
-          .foregroundStyle(menuAccent)
+        VStack(alignment: .trailing, spacing: 10) {
+          Text(menu.displayTypeLabel)
+            .font(EditorTypography.body(12, weight: .bold))
+            .padding(.vertical, 8)
+            .padding(.horizontal, 10)
+            .background(menuAccent.opacity(0.18), in: Capsule())
+            .foregroundStyle(menuAccent)
+          MenuEditorBadge(
+            label: menuStatusLabel.uppercased(),
+            fill: statusFill,
+            text: statusText
+          )
+        }
       }
-
-      HStack(alignment: .top, spacing: 10) {
-        MenuEditorBadge(
-          label: menuStatusLabel,
-          fill: hasServerUnsentChanges ? menuAccent.opacity(0.16) : theme.successAccent.opacity(0.18),
-          text: hasServerUnsentChanges ? menuAccent : theme.successAccent
-        )
-        MenuEditorBadge(
-          label: hasLocalDraftChanges ? "Drafting locally" : "No local drafts",
-          fill: hasLocalDraftChanges ? theme.warningAccent.opacity(0.18) : theme.neutralAccent.opacity(0.16),
-          text: hasLocalDraftChanges ? theme.warningAccent : theme.neutralAccent
-        )
-        MenuEditorBadge(
-          label: hasLiveMenuChanges ? "Live menu behind working copy" : "Live menu aligned",
-          fill: hasLiveMenuChanges ? menuAccent.opacity(0.16) : theme.successAccent.opacity(0.18),
-          text: hasLiveMenuChanges ? menuAccent : theme.successAccent
-        )
-      }
-
-      Text(workflowSummary)
-        .font(EditorTypography.body(13, weight: .medium))
-        .foregroundStyle(theme.bodyText)
     }
     .menuEditorSurface(colors: [theme.headerTop, theme.headerBottom], border: theme.headerBorder)
   }
 
-  private var workflowSummary: String {
-    if hasLocalDraftChanges && hasServerUnsentChanges {
-      return "This device has unsaved local edits, and the server queue still has unsent menu changes."
-    }
+  private var statusFill: Color {
     if hasLocalDraftChanges {
-      return "Your draft is local to this device until you Save Quietly or Save & Send."
+      return theme.warningAccent.opacity(0.18)
     }
-    if hasServerUnsentChanges {
-      return "The menu is live with unsent queue work. Use Send to notify channels or clear remaining queue groups."
+    if hasServerUnsentChanges || hasLiveMenuChanges {
+      return menuAccent.opacity(0.16)
     }
-    if hasLiveMenuChanges {
-      return "Your working copy differs from live. Save Quietly to stage it live without sending."
+    return theme.successAccent.opacity(0.18)
+  }
+
+  private var statusText: Color {
+    if hasLocalDraftChanges {
+      return theme.warningAccent
     }
-    return "Live state and notification baseline are aligned."
+    if hasServerUnsentChanges || hasLiveMenuChanges {
+      return menuAccent
+    }
+    return theme.successAccent
   }
 }
 
@@ -458,7 +562,6 @@ private struct MenuEditorActionPanel: View {
   let theme: MenuEditorTheme
   let menuAccent: Color
   let onAddItem: () -> Void
-  let onAddCategory: () -> Void
   let onSaveQuietly: () -> Void
   let onSendUpdate: () -> Void
   let onDiscardDraft: () -> Void
@@ -474,14 +577,6 @@ private struct MenuEditorActionPanel: View {
           MenuEditorActionLabel(title: "Add Item", subtitle: "Create a new menu item", icon: "plus.circle.fill", accent: menuAccent)
         }
         .buttonStyle(.plain)
-
-        Button(action: onAddCategory) {
-          MenuEditorActionLabel(title: "Add Category", subtitle: "Create a new section", icon: "square.split.1x2.fill", accent: menuAccent)
-        }
-        .buttonStyle(.plain)
-      }
-
-      HStack(spacing: 12) {
         Button(action: onSaveQuietly) {
           MenuEditorActionLabel(
             title: "Save Quietly",
@@ -492,7 +587,9 @@ private struct MenuEditorActionPanel: View {
         }
         .buttonStyle(.plain)
         .disabled(!model.canSaveQuietlyRemotely)
+      }
 
+      HStack(spacing: 12) {
         Button(action: onSendUpdate) {
           MenuEditorActionLabel(
             title: model.hasLocalDraftChanges ? "Save & Send" : "Send",
@@ -500,7 +597,7 @@ private struct MenuEditorActionPanel: View {
               ? (model.hasLocalDraftChanges
                   ? "Save live, then choose what to send or clear"
                   : "Choose which unsent queue groups to send or clear")
-              : "Preview loaded below",
+              : "Review the current send plan",
             icon: "paperplane.fill",
             accent: menuAccent
           )
@@ -520,14 +617,29 @@ private struct MenuEditorActionPanel: View {
         }
         .buttonStyle(.plain)
         .disabled(!model.canDiscardLocalDraft)
-
-        NavigationLink(value: AppDestination.routePreview(menu)) {
-          MenuEditorActionLabel(title: "Exact Route", subtitle: "See the true public route", icon: "safari.fill", accent: theme.neutralAccent)
-        }
-        .buttonStyle(.plain)
       }
     }
     .menuEditorSurface(colors: [theme.panelTop, theme.panelBottom], border: theme.panelBorder)
+  }
+}
+
+private struct MenuEditorCategoriesHeader: View {
+  let theme: MenuEditorTheme
+  let menuAccent: Color
+  let onAddCategory: () -> Void
+
+  var body: some View {
+    HStack(alignment: .center) {
+      Text("Categories")
+        .font(EditorTypography.display(20, weight: .bold))
+        .foregroundStyle(theme.titleText)
+      Spacer()
+      Button(action: onAddCategory) {
+        Label("Add Category", systemImage: "square.split.1x2.fill")
+      }
+      .buttonStyle(SecondaryGlassButtonStyle())
+      .tint(menuAccent)
+    }
   }
 }
 
@@ -568,6 +680,7 @@ private struct MenuEditorCategoryCard: View {
   let onRename: () -> Void
   let onDelete: () -> Void
   let onSelectItem: (MenuItemPayload) -> Void
+  let onToggleEightySix: (MenuItemPayload) -> Void
   let onMoveOffMenu: (MenuItemPayload) -> Void
 
   private var visibleItems: [MenuItemPayload] {
@@ -611,6 +724,14 @@ private struct MenuEditorCategoryCard: View {
           EditorItemRow(item: item, theme: theme)
         }
         .buttonStyle(.plain)
+        .swipeActions(edge: .leading, allowsFullSwipe: true) {
+          Button {
+            onToggleEightySix(item)
+          } label: {
+            Label(item.isEightySixed ? "Restore" : "86", systemImage: item.isEightySixed ? "arrow.uturn.backward.circle.fill" : "nosign.app.fill")
+          }
+          .tint(item.isEightySixed ? theme.successAccent : theme.warningAccent)
+        }
         .swipeActions(edge: .trailing) {
           Button(role: .destructive) {
             onMoveOffMenu(item)

--- a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
@@ -420,11 +420,15 @@ private struct PublishPreviewSheet: View {
           .ignoresSafeArea()
       }
       .safeAreaInset(edge: .bottom) {
-        Button(actionButtonTitle) {
-          onPublish()
-        }
-        .buttonStyle(PrimaryGlassButtonStyle())
-        .disabled(!model.canPublishRemotely)
+        PublishPreviewActionButton(
+          title: actionButtonTitle,
+          subtitle: actionButtonSubtitle,
+          icon: actionButtonIcon,
+          accent: menuAccent,
+          theme: theme,
+          enabled: model.canPublishRemotely,
+          action: onPublish
+        )
         .padding(.horizontal, 24)
         .padding(.top, 12)
         .padding(.bottom, 16)
@@ -454,6 +458,20 @@ private struct PublishPreviewSheet: View {
     }
     return model.hasLocalDraftChanges ? "Save & Send" : "Send"
   }
+
+  private var actionButtonSubtitle: String {
+    if !preview.hasNotificationChanges {
+      return "Save live without sending notifications."
+    }
+    if model.hasLocalDraftChanges {
+      return "Checked rows send now, unchecked rows clear quietly."
+    }
+    return "Send checked queue rows now."
+  }
+
+  private var actionButtonIcon: String {
+    preview.hasNotificationChanges ? "paperplane.fill" : "square.and.arrow.down.fill"
+  }
 }
 
 private struct PublishPreviewSummaryCard: View {
@@ -473,6 +491,73 @@ private struct PublishPreviewSummaryCard: View {
       }
     }
     .menuEditorSurface(colors: [theme.panelTop, theme.panelBottom], border: theme.panelBorder)
+  }
+}
+
+private struct PublishPreviewActionButton: View {
+  let title: String
+  let subtitle: String
+  let icon: String
+  let accent: Color
+  let theme: MenuEditorTheme
+  let enabled: Bool
+  let action: () -> Void
+
+  var body: some View {
+    Button(action: action) {
+      HStack(spacing: 14) {
+        VStack(alignment: .leading, spacing: 5) {
+          Text(title)
+            .font(EditorTypography.body(16, weight: .bold))
+            .foregroundStyle(theme.titleText)
+          Text(subtitle)
+            .font(EditorTypography.body(12, weight: .medium))
+            .foregroundStyle(theme.subtleText)
+        }
+
+        Spacer()
+
+        Image(systemName: icon)
+          .font(.system(size: 18, weight: .bold))
+          .foregroundStyle(theme.titleText)
+          .frame(width: 46, height: 46)
+          .background(.white.opacity(0.18), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+          .overlay {
+            RoundedRectangle(cornerRadius: 16, style: .continuous)
+              .stroke(.white.opacity(0.22), lineWidth: 1)
+          }
+      }
+      .padding(.horizontal, 18)
+      .padding(.vertical, 16)
+      .frame(maxWidth: .infinity)
+      .background {
+        let shape = RoundedRectangle(cornerRadius: 24, style: .continuous)
+        shape
+          .fill(.thinMaterial)
+          .overlay {
+            LinearGradient(
+              colors: [
+                accent.opacity(0.42),
+                accent.opacity(0.22),
+                accent.opacity(0.12)
+              ],
+              startPoint: .topLeading,
+              endPoint: .bottomTrailing
+            )
+            .clipShape(shape)
+          }
+      }
+      .overlay {
+        RoundedRectangle(cornerRadius: 24, style: .continuous)
+          .stroke(accent.opacity(0.36), lineWidth: 1)
+      }
+      .shadow(color: accent.opacity(0.2), radius: 18, y: 10)
+    }
+    .buttonStyle(.plain)
+    .disabled(!enabled)
+    .opacity(enabled ? 1 : 0.5)
+    .scaleEffect(enabled ? 1 : 0.98)
+    .animation(.easeOut(duration: 0.16), value: enabled)
   }
 }
 

--- a/ios/ElRoysManagerApp/Models/AppModels.swift
+++ b/ios/ElRoysManagerApp/Models/AppModels.swift
@@ -647,6 +647,17 @@ struct MenuItemPayload: Codable, Equatable, Hashable, Identifiable {
     try container.encode(showDescription, forKey: .showDescription)
     try container.encode(showRecipe, forKey: .showRecipe)
   }
+
+  mutating func normalizePersistentIdentifierForRuntime() {
+    let raw = id.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard raw.hasPrefix("local-") else {
+      id = raw
+      return
+    }
+    let suffix = String(raw.dropFirst("local-".count)).trimmingCharacters(in: .whitespacesAndNewlines)
+    guard let uuid = UUID(uuidString: suffix) else { return }
+    id = uuid.uuidString.lowercased()
+  }
 }
 
 struct MenuCategoryPayload: Codable, Equatable, Hashable, Identifiable {
@@ -1528,6 +1539,14 @@ struct EditableMenuDocument: Codable, Equatable {
 
   mutating func normalizeIdentifiersForRuntime() {
     cats = Self.normalizeIdentifiers(in: cats, menuId: menuId)
+  }
+
+  mutating func normalizePersistentItemIdentifiersForRuntime() {
+    for categoryIndex in cats.indices {
+      for itemIndex in cats[categoryIndex].items.indices {
+        cats[categoryIndex].items[itemIndex].normalizePersistentIdentifierForRuntime()
+      }
+    }
   }
 
   var uncategorizedItems: [MenuItemPayload] {

--- a/ios/ElRoysManagerApp/Models/AppModels.swift
+++ b/ios/ElRoysManagerApp/Models/AppModels.swift
@@ -1676,20 +1676,26 @@ struct EditableMenuDocument: Codable, Equatable {
   }
 
   mutating func upsertItem(_ item: MenuItemPayload, categoryKey: String, originalCategoryKey: String? = nil) {
-    if let originalCategoryKey, let sourceIndex = cats.firstIndex(where: { $0.key == originalCategoryKey }) {
-      cats[sourceIndex].items.removeAll { $0.id == item.id }
-      renumberItems(for: originalCategoryKey)
-    }
-
     if !cats.contains(where: { $0.key == categoryKey }) {
       addCategory(label: categoryKey.capitalized)
     }
     guard let targetIndex = cats.firstIndex(where: { $0.key == categoryKey }) else { return }
+    let sourceCategoryKey = originalCategoryKey
+      ?? itemRecord(for: item.id)?.categoryKey
     var next = item
     next.onMenu = categoryKey != Self.uncategorizedKey
-    if let existingIndex = cats[targetIndex].items.firstIndex(where: { $0.id == item.id }) {
+    next.visibility = next.onMenu ? "public" : "off_menu"
+
+    if sourceCategoryKey == categoryKey,
+       let existingIndex = cats[targetIndex].items.firstIndex(where: { $0.id == item.id }) {
+      next.displayOrder = cats[targetIndex].items[existingIndex].displayOrder
       cats[targetIndex].items[existingIndex] = next
     } else {
+      if let sourceCategoryKey,
+         let sourceIndex = cats.firstIndex(where: { $0.key == sourceCategoryKey }) {
+        cats[sourceIndex].items.removeAll { $0.id == item.id }
+        renumberItems(for: sourceCategoryKey)
+      }
       cats[targetIndex].items.append(next)
     }
     renumberItems(for: categoryKey)

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -1324,6 +1324,120 @@ final class MenuDocumentTests: XCTestCase {
   }
 
   @MainActor
+  func testPublishNormalizesLocalItemIDAfterSaveAndSend() async throws {
+    let localItemID = "local-d41a9ab2-3952-4bc2-a278-854f3ca684bf"
+    let persistentItemID = "d41a9ab2-3952-4bc2-a278-854f3ca684bf"
+    let notificationChangeIDs = ["beer::added::fresh-ipa"]
+    let initialWorkspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      revisions: WorkspaceRevisions(
+        liveRevision: 30,
+        draftRevision: nil,
+        lastSentRevision: 30,
+        notificationBaselineRevision: 30
+      ),
+      menuStatus: "Live",
+      hasUnsentChanges: false
+    )
+    let publishClient = StubPublishClient(
+      previewResponse: PublishResponse(
+        ok: true,
+        action: "preview",
+        ts: nil,
+        preview: try makePreviewPayload(
+          mode: "save-and-send",
+          selectionDefaults: [],
+          notificationChangeIDs: notificationChangeIDs
+        ),
+        currentRevisions: WorkspaceRevisions(
+          liveRevision: 30,
+          draftRevision: nil,
+          lastSentRevision: 30,
+          notificationBaselineRevision: 30
+        ),
+        notificationStatus: nil,
+        warnings: nil,
+        warningMessage: nil,
+        successMessage: nil,
+        selectedChangeIds: nil
+      ),
+      publishResponse: PublishResponse(
+        ok: true,
+        action: "publish",
+        ts: 40,
+        preview: nil,
+        currentRevisions: WorkspaceRevisions(
+          liveRevision: 40,
+          draftRevision: nil,
+          lastSentRevision: 40,
+          notificationBaselineRevision: 40
+        ),
+        notificationStatus: NotificationStatus(
+          ok: true,
+          skipped: false,
+          partial: false,
+          statusCode: 200,
+          summary: nil,
+          results: nil
+        ),
+        warnings: nil,
+        warningMessage: nil,
+        successMessage: "Sent successfully.",
+        selectedChangeIds: notificationChangeIDs
+      )
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [initialWorkspace, initialWorkspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload()),
+        publishClient: publishClient
+      ),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+    model.upsertItem(
+      makeItem(id: localItemID, name: "Fresh IPA"),
+      categoryKey: "beer",
+      originalCategoryKey: nil
+    )
+
+    XCTAssertNotNil(model.currentEditorDocument?.itemRecord(for: localItemID))
+
+    await model.loadPublishPreview()
+    await model.publishSelectedChanges()
+
+    let publishSnapshot = try XCTUnwrap(publishClient.lastPublishSnapshot)
+    let publishedItemIDs = publishSnapshot.cats.flatMap { $0.items.map(\.id) }
+    XCTAssertTrue(publishedItemIDs.contains(localItemID))
+
+    let document = try XCTUnwrap(model.currentEditorDocument)
+    XCTAssertNil(document.itemRecord(for: localItemID))
+    XCTAssertEqual(document.itemRecord(for: persistentItemID)?.item.name, "Fresh IPA")
+  }
+
+  @MainActor
   func testRemoteDraftUpdateRequiresRefreshAndKeepsNonOverlappingLocalDrafts() async throws {
     let offlineStore = TestOfflineDraftStore()
     let sessionStore = TestSessionStore()
@@ -2270,6 +2384,8 @@ private final class StubPublishClient: PublishClienting {
   var publishResponse: PublishResponse?
   private(set) var previewCallCount = 0
   private(set) var publishCallCount = 0
+  private(set) var lastPreviewSnapshot: MenuSnapshotPayload?
+  private(set) var lastPublishSnapshot: MenuSnapshotPayload?
   private(set) var lastPreviewExpectedLiveRevision: Int?
   private(set) var lastPreviewExpectedDraftRevision: Int?
   private(set) var lastPreviewExpectedNotificationRevision: Int?
@@ -2284,6 +2400,7 @@ private final class StubPublishClient: PublishClienting {
 
   func preview(menuId: String, snapshot: MenuSnapshotPayload, expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
     previewCallCount += 1
+    lastPreviewSnapshot = snapshot
     lastPreviewExpectedLiveRevision = expectedLiveRevision
     lastPreviewExpectedDraftRevision = expectedDraftRevision
     lastPreviewExpectedNotificationRevision = expectedNotificationRevision
@@ -2295,6 +2412,7 @@ private final class StubPublishClient: PublishClienting {
 
   func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
     publishCallCount += 1
+    lastPublishSnapshot = snapshot
     lastPublishExpectedLiveRevision = expectedLiveRevision
     lastPublishExpectedDraftRevision = expectedDraftRevision
     lastPublishExpectedNotificationRevision = expectedNotificationRevision

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -916,7 +916,100 @@ final class MenuDocumentTests: XCTestCase {
   }
 
   @MainActor
+  func testSaveQuietlyRefreshesLocalLiveRevisionWhenServerOnlyReturnsTimestamp() async throws {
+    let sessionStore = TestSessionStore()
+    let initialWorkspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      meta: MenuMetaPayload(
+        lastUpdatedTs: 10,
+        lastSentTs: 10
+      ),
+      revisions: WorkspaceRevisions(
+        liveRevision: 10,
+        draftRevision: nil,
+        lastSentRevision: 10,
+        notificationBaselineRevision: 10
+      ),
+      menuStatus: "Live",
+      hasUnsentChanges: false
+    )
+    let refreshedWorkspace = makeWorkspace(
+      categories: initialWorkspace.cats,
+      meta: MenuMetaPayload(
+        lastUpdatedTs: 44,
+        lastSentTs: 10
+      ),
+      revisions: WorkspaceRevisions(
+        liveRevision: 44,
+        draftRevision: nil,
+        lastSentRevision: 10,
+        notificationBaselineRevision: 10
+      ),
+      menuStatus: "Live | Unsent",
+      hasUnsentChanges: true
+    )
+    let liveSaveClient = StubLiveSaveClient(
+      response: PublishResponse(
+        ok: true,
+        action: nil,
+        ts: 44,
+        preview: nil,
+        currentRevisions: nil,
+        notificationStatus: nil,
+        warnings: nil,
+        warningMessage: nil,
+        successMessage: nil,
+        selectedChangeIds: nil
+      )
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [initialWorkspace, refreshedWorkspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload()),
+        liveSaveClient: liveSaveClient
+      ),
+      sessionStore: sessionStore,
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+    guard var beer = model.currentEditorDocument?.itemRecord(for: "item-1")?.item else {
+      XCTFail("Expected seeded item")
+      return
+    }
+    beer.name = "House Pilsner"
+    model.upsertItem(beer, categoryKey: "beer", originalCategoryKey: "beer")
+
+    await model.saveLiveMenu()
+    await model.checkForRemoteMenuUpdate(menuId: "menu", force: true)
+
+    XCTAssertEqual(model.currentEditorWorkspace?.workspace.revisions.liveRevision, 44)
+    XCTAssertNil(model.editorRefreshRequirement)
+  }
+
+  @MainActor
   func testLoadPublishPreviewUsesDraftAndNotificationRevisionsIndependently() async throws {
+    let notificationChangeIDs = ["beer::added::ipa", "beer::removed::lager"]
     let baseWorkspace = makeWorkspace(categories: [
       MenuCategoryPayload(
         id: "beer",
@@ -962,7 +1055,8 @@ final class MenuDocumentTests: XCTestCase {
         ts: nil,
         preview: try makePreviewPayload(
           mode: "save-and-send",
-          selectionDefaults: ["beer::added::ipa"]
+          selectionDefaults: ["beer::added::ipa"],
+          notificationChangeIDs: notificationChangeIDs
         ),
         currentRevisions: WorkspaceRevisions(liveRevision: 10, draftRevision: 22, lastSentRevision: 10, notificationBaselineRevision: 10),
         notificationStatus: nil,
@@ -997,6 +1091,7 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(publishClient.lastPreviewExpectedDraftRevision, 22)
     XCTAssertEqual(publishClient.lastPreviewExpectedNotificationRevision, 10)
     XCTAssertEqual(model.currentEditorPreview?.selectionDefaults, ["beer::added::ipa"])
+    XCTAssertEqual(model.selectedPreviewChangeIDs, Set(notificationChangeIDs))
   }
 
   func testPublishPreviewSummarySeparatesSelectedClearedAndSaveOnlyChanges() throws {
@@ -1116,6 +1211,116 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(model.menuStatusLabel, "Live | Unsent")
     XCTAssertTrue(model.canLoadPublishPreview)
     XCTAssertFalse(model.canSaveQuietlyRemotely)
+  }
+
+  @MainActor
+  func testSendOnlyPublishRebaselinesStatusWithoutDependingOnImmediateReload() async throws {
+    let notificationChangeIDs = ["beer::added::ipa"]
+    let initialWorkspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      revisions: WorkspaceRevisions(
+        liveRevision: 30,
+        draftRevision: nil,
+        lastSentRevision: 20,
+        notificationBaselineRevision: 20
+      ),
+      menuStatus: "Live | Unsent",
+      hasUnsentChanges: true
+    )
+    let publishClient = StubPublishClient(
+      previewResponse: PublishResponse(
+        ok: true,
+        action: "preview",
+        ts: nil,
+        preview: try makePreviewPayload(
+          mode: "send",
+          selectionDefaults: [],
+          notificationChangeIDs: notificationChangeIDs
+        ),
+        currentRevisions: WorkspaceRevisions(
+          liveRevision: 30,
+          draftRevision: nil,
+          lastSentRevision: 20,
+          notificationBaselineRevision: 20
+        ),
+        notificationStatus: nil,
+        warnings: nil,
+        warningMessage: nil,
+        successMessage: nil,
+        selectedChangeIds: nil
+      ),
+      publishResponse: PublishResponse(
+        ok: true,
+        action: "publish",
+        ts: 40,
+        preview: nil,
+        currentRevisions: WorkspaceRevisions(
+          liveRevision: 30,
+          draftRevision: nil,
+          lastSentRevision: 40,
+          notificationBaselineRevision: 40
+        ),
+        notificationStatus: NotificationStatus(
+          ok: true,
+          skipped: false,
+          partial: false,
+          statusCode: 200,
+          summary: nil,
+          results: nil
+        ),
+        warnings: nil,
+        warningMessage: nil,
+        successMessage: "Sent successfully.",
+        selectedChangeIds: notificationChangeIDs
+      )
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [initialWorkspace, initialWorkspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload()),
+        publishClient: publishClient
+      ),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+    await model.loadPublishPreview()
+
+    XCTAssertTrue(model.hasServerUnsentChanges)
+    XCTAssertEqual(model.menuStatusLabel, "Live | Unsent")
+
+    await model.publishSelectedChanges()
+
+    XCTAssertEqual(publishClient.publishCallCount, 1)
+    XCTAssertEqual(publishClient.lastPublishExpectedLiveRevision, 30)
+    XCTAssertEqual(publishClient.lastPublishExpectedNotificationRevision, 20)
+    XCTAssertFalse(model.hasServerUnsentChanges)
+    XCTAssertEqual(model.menuStatusLabel, "Live")
+    XCTAssertNil(model.currentEditorPreview)
+    XCTAssertTrue(model.selectedPreviewChangeIDs.isEmpty)
+    XCTAssertFalse(model.canLoadPublishPreview)
+    XCTAssertEqual(model.notice?.message, "Sent successfully.")
   }
 
   @MainActor
@@ -1820,9 +2025,35 @@ final class MenuDocumentTests: XCTestCase {
 
   private func makePreviewPayload(
     mode: String,
-    selectionDefaults: [String]
+    selectionDefaults: [String],
+    notificationChangeIDs: [String] = []
   ) throws -> MenuPreviewPayload {
     let selectionJSON = selectionDefaults.map { "\"\($0)\"" }.joined(separator: ", ")
+    let notificationChangeJSON = notificationChangeIDs.enumerated().map { index, id in
+      """
+      {
+        "id": "\(id)",
+        "kind": "changed",
+        "text": "Change \(index + 1)",
+        "name": "Item \(index + 1)",
+        "section_id": "beer",
+        "section_label": "Beer",
+        "icon": "drop.fill"
+      }
+      """
+    }.joined(separator: ", ")
+    let sectionsJSON = notificationChangeIDs.isEmpty
+      ? ""
+      : """
+      "sections": [
+        {
+          "id": "beer",
+          "icon": "drop.fill",
+          "label": "Beer",
+          "changes": [\(notificationChangeJSON)]
+        }
+      ],
+      """
     let data = Data("""
     {
       "mode": "\(mode)",
@@ -1832,8 +2063,8 @@ final class MenuDocumentTests: XCTestCase {
       "has_notification_changes": true,
       "has_save_only_changes": false,
       "diff": [],
-      "sections": [],
-      "notification_changes": [],
+      \(sectionsJSON)
+      "notification_changes": [\(notificationChangeJSON)],
       "save_only_changes": [],
       "patch_message": "patch text",
       "truncated": false,

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -78,6 +78,40 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertFalse(document.uncategorizedItems[0].onMenu)
   }
 
+  func testUpsertingExistingItemInSameCategoryPreservesOrderWhenEightySixed() {
+    let workspace = makeWorkspace(categories: [
+      MenuCategoryPayload(
+        id: "beer",
+        menuId: "menu",
+        key: "beer",
+        label: "Beer",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 0,
+        items: [
+          makeItem(id: "item-1", name: "Pilsner"),
+          makeItem(id: "item-2", name: "Amber"),
+          makeItem(id: "item-3", name: "Stout")
+        ]
+      )
+    ])
+
+    var document = EditableMenuDocument(workspace: workspace)
+    guard var amber = document.itemRecord(for: "item-2")?.item else {
+      XCTFail("Expected amber item")
+      return
+    }
+
+    amber.isEightySixed = true
+    document.upsertItem(amber, categoryKey: "beer", originalCategoryKey: "beer")
+
+    XCTAssertEqual(document.category(for: "beer")?.items.map(\.id), ["item-1", "item-2", "item-3"])
+    XCTAssertEqual(document.category(for: "beer")?.items.map(\.displayOrder), [0, 1, 2])
+    XCTAssertTrue(document.itemRecord(for: "item-2")?.item.isEightySixed == true)
+  }
+
   func testEditableDocumentNormalizesDuplicateAndMissingIdentifiers() {
     let workspace = makeWorkspace(categories: [
       MenuCategoryPayload(
@@ -796,6 +830,92 @@ final class MenuDocumentTests: XCTestCase {
   }
 
   @MainActor
+  func testSaveQuietlyIgnoresStaleDraftRevisionWhenNoSharedDraftExists() async throws {
+    let sessionStore = TestSessionStore()
+    let workspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      meta: MenuMetaPayload(
+        draftSavedTs: 22,
+        draftSavedByUserId: "staff-2",
+        draftSavedByName: "Old Draft",
+        draftSavedSource: "web"
+      ),
+      revisions: WorkspaceRevisions(
+        liveRevision: 10,
+        draftRevision: nil,
+        lastSentRevision: 10,
+        notificationBaselineRevision: 10
+      ),
+      menuStatus: "Live",
+      hasUnsentChanges: false
+    )
+    let liveSaveClient = StubLiveSaveClient(
+      response: PublishResponse(
+        ok: true,
+        action: nil,
+        ts: 44,
+        preview: nil,
+        currentRevisions: WorkspaceRevisions(
+          liveRevision: 44,
+          draftRevision: nil,
+          lastSentRevision: 10,
+          notificationBaselineRevision: 10
+        ),
+        notificationStatus: nil,
+        warnings: nil,
+        warningMessage: nil,
+        successMessage: nil,
+        selectedChangeIds: nil
+      )
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [workspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload()),
+        liveSaveClient: liveSaveClient
+      ),
+      sessionStore: sessionStore,
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+    guard var beer = model.currentEditorDocument?.itemRecord(for: "item-1")?.item else {
+      XCTFail("Expected seeded item")
+      return
+    }
+    beer.name = "House Pilsner"
+    model.upsertItem(beer, categoryKey: "beer", originalCategoryKey: "beer")
+
+    XCTAssertTrue(model.canSaveQuietlyRemotely)
+
+    await model.saveLiveMenu()
+
+    XCTAssertEqual(liveSaveClient.saveCallCount, 1)
+    XCTAssertEqual(liveSaveClient.lastExpectedLiveRevision, 10)
+    XCTAssertNil(liveSaveClient.lastExpectedDraftRevision)
+  }
+
+  @MainActor
   func testLoadPublishPreviewUsesDraftAndNotificationRevisionsIndependently() async throws {
     let baseWorkspace = makeWorkspace(categories: [
       MenuCategoryPayload(
@@ -877,6 +997,73 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(publishClient.lastPreviewExpectedDraftRevision, 22)
     XCTAssertEqual(publishClient.lastPreviewExpectedNotificationRevision, 10)
     XCTAssertEqual(model.currentEditorPreview?.selectionDefaults, ["beer::added::ipa"])
+  }
+
+  func testPublishPreviewSummarySeparatesSelectedClearedAndSaveOnlyChanges() throws {
+    let data = Data("""
+    {
+      "mode": "save-and-send",
+      "has_changes": true,
+      "has_local_draft": true,
+      "has_shared_draft": true,
+      "has_notification_changes": true,
+      "has_save_only_changes": true,
+      "diff": [],
+      "sections": [
+        {
+          "id": "beer",
+          "icon": "🍺",
+          "label": "Beer",
+          "changes": [
+            {
+              "id": "beer::added::ipa",
+              "kind": "added",
+              "text": "Added IPA",
+              "name": "IPA",
+              "section_id": "beer",
+              "section_label": "Beer",
+              "icon": "🍺"
+            },
+            {
+              "id": "beer::eightySixed::stout",
+              "kind": "eightySixed",
+              "text": "86'd Stout",
+              "name": "Stout",
+              "section_id": "beer",
+              "section_label": "Beer",
+              "icon": "🍺"
+            }
+          ]
+        }
+      ],
+      "notification_changes": [],
+      "save_only_changes": [
+        {
+          "id": "save-only-1",
+          "label": "Price updated",
+          "message": "Price updated"
+        }
+      ],
+      "patch_message": "Patch text",
+      "truncated": false,
+      "selection_defaults": ["beer::added::ipa"],
+      "metadata": {
+        "server_owned": true,
+        "contract": "menu-publish-preview.v2",
+        "current_featured_ids": []
+      }
+    }
+    """.utf8)
+    let preview = try JSONDecoder.backend.decode(MenuPreviewPayload.self, from: data)
+
+    let summary = PublishPreviewSummary(
+      preview: preview,
+      selectedChangeIDs: ["beer::added::ipa"]
+    )
+
+    XCTAssertEqual(summary.selectedNotificationChanges.map(\.id), ["beer::added::ipa"])
+    XCTAssertEqual(summary.clearedNotificationChanges.map(\.id), ["beer::eightySixed::stout"])
+    XCTAssertEqual(summary.saveOnlyChanges.map(\.id), ["save-only-1"])
   }
 
   @MainActor

--- a/server/_menu-live.js
+++ b/server/_menu-live.js
@@ -1,5 +1,3 @@
-import { randomUUID } from 'node:crypto';
-
 import {
   readProfile,
   requireAuthenticatedUser,
@@ -17,6 +15,7 @@ import {
 } from './_supabase.js';
 import {
   assertExpectedRevision,
+  normalizePersistentItemId,
   readMenuMeta,
   readRevisionState,
 } from './_menu-write.js';
@@ -112,7 +111,7 @@ function normalizeItemRow(item, categoryId, displayOrder, { forceOffMenu = false
   const name = toClientItemName(row);
   if (!name) return null;
   const rawId = asString(row.id);
-  const itemId = rawId && !rawId.startsWith('local-') ? rawId : randomUUID();
+  const itemId = normalizePersistentItemId(rawId);
   const showDescriptionRaw = Object.prototype.hasOwnProperty.call(row, 'showDescription')
     ? row.showDescription
     : row.show_description;

--- a/server/_menu-publish.js
+++ b/server/_menu-publish.js
@@ -10,6 +10,7 @@ import {
   assertExpectedRevision,
   inferAuditSource,
   insertUpdateLog,
+  normalizePersistentItemId,
   patchMenuMetaForMenu,
   patchMenuMetaForMenuWithCompatibility,
   readMenuMeta,
@@ -78,7 +79,7 @@ function snapshotLastSentState(snapshot = {}) {
   return Object.fromEntries(cats.map(category => [
     category.key,
     (Array.isArray(category.items) ? category.items : []).map(item => ({
-      id: item.id,
+      id: normalizePersistentItemId(item?.id),
       name: item.name || '',
       eightySixed: !!item.is_eighty_sixed,
       onMenu: item.on_menu !== false,

--- a/server/_menu-write.js
+++ b/server/_menu-write.js
@@ -1,3 +1,5 @@
+import { randomUUID } from 'node:crypto';
+
 import {
   requireAuthenticatedUser,
   requireMenuAccess,
@@ -50,6 +52,18 @@ function normalizeRecipe(recipe = []) {
   return [];
 }
 
+function isUuid(value = '') {
+  return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(String(value || '').trim());
+}
+
+export function normalizePersistentItemId(value = '') {
+  const raw = String(value || '').trim();
+  if (!raw) return randomUUID();
+  if (!raw.startsWith('local-')) return raw;
+  const localSuffix = raw.slice('local-'.length).trim();
+  return isUuid(localSuffix) ? localSuffix.toLowerCase() : randomUUID();
+}
+
 function normalizeSnapshot(snapshot = {}) {
   const cats = Array.isArray(snapshot?.cats) ? snapshot.cats : [];
   return {
@@ -63,7 +77,7 @@ function normalizeSnapshot(snapshot = {}) {
       placeholder: String(category?.placeholder || ''),
       display_order: Number.isFinite(Number(category?.display_order)) ? Number(category.display_order) : categoryIndex,
       items: (Array.isArray(category?.items) ? category.items : []).map((item, itemIndex) => ({
-        id: String(item?.id || ''),
+        id: normalizePersistentItemId(item?.id),
         name: String(item?.name || '').trim(),
         desc: String(item?.desc || ''),
         recipe: normalizeRecipe(item?.recipe),

--- a/tests/phase8-server-write-boundaries.test.cjs
+++ b/tests/phase8-server-write-boundaries.test.cjs
@@ -39,6 +39,97 @@ test('consolidated manager and admin routes export request handlers', async () =
   assert.equal(typeof adminSettings.default, 'function');
 });
 
+test('server live-save write path normalizes local item ids before persisting items', async () => {
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+
+  const module = await importApiModule('server/_menu-write.js');
+  const originalFetch = global.fetch;
+  const fetchCalls = [];
+
+  global.fetch = async (url, options = {}) => {
+    const href = String(url);
+    fetchCalls.push({ url: href, options });
+
+    if (href.includes('/menu_meta?')) {
+      return {
+        ok: true,
+        async json() {
+          return [{ last_updated_ts: 10 }];
+        },
+      };
+    }
+
+    if (href.includes('/categories?on_conflict=')) {
+      return {
+        ok: true,
+        async json() {
+          return [];
+        },
+      };
+    }
+
+    if (href.includes('/categories?menu_id=')) {
+      return {
+        ok: true,
+        async json() {
+          return [{ id: 'category-uuid-1', key: 'snacks' }];
+        },
+      };
+    }
+
+    if (href.includes('/items?category_id=in.(')) {
+      return {
+        ok: true,
+        async json() {
+          return [];
+        },
+      };
+    }
+
+    if (href.endsWith('/rest/v1/items')) {
+      return {
+        ok: true,
+        async json() {
+          return [];
+        },
+      };
+    }
+
+    throw new Error(`Unexpected fetch: ${href}`);
+  };
+
+  try {
+    await module.saveLiveMenuForMenu({
+      menuId: '00000000-0000-0000-0000-000000000021',
+      snapshot: {
+        cats: [{
+          id: 'local-category-1',
+          key: 'snacks',
+          label: 'Snacks',
+          items: [{
+            id: 'local-d41a9ab2-3952-4bc2-a278-854f3ca684bf',
+            name: 'Fries',
+            desc: 'Crispy fries',
+          }],
+        }],
+        meta: {},
+      },
+      expectedLiveRevision: 10,
+      actor: { id: 'user-1', name: 'Tester', role: 'manager' },
+    });
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  const itemPersistCall = fetchCalls.find(call => call.url.endsWith('/rest/v1/items'));
+  assert.ok(itemPersistCall, 'expected item persistence request');
+  const payload = JSON.parse(itemPersistCall.options.body);
+  assert.equal(payload.length, 1);
+  assert.ok(!payload[0].id.startsWith('local-'));
+  assert.match(payload[0].id, /^[0-9a-f-]{36}$/i);
+});
+
 test('publish service boundary prefers the server-owned publish command when provided', async () => {
   const sandbox = loadAppSandbox();
   let publishCalls = 0;


### PR DESCRIPTION
## What changed
- fixed the iOS menu editor save/send flow so send-only publishes rebaseline local status immediately instead of waiting on a stale reload
- fixed the server menu save/publish pipeline to normalize `local-...` item ids before persisting or building queue baselines
- added regressions for iOS send-only status rebasing and server-side local-id normalization
- included the current iOS auth-gate findings notes and the branch's existing `.gitignore` housekeeping commit

## Why it changed
Two related save/send bugs were showing up in production-like flows:
- sending from the iOS `Send` sheet could leave the editor in `LIVE | UNSENT` because the client was depending on an immediate workspace reload that could still be stale
- `Save & Send` with newly created items could fail with `invalid input syntax for type uuid` because the publish/save path was still trying to persist client-local ids like `local-...` into UUID-backed item rows

## Impact
- iOS menu editors should return to `Live` immediately after a successful send-only publish
- new items can now move through `Save & Send` without requiring a quiet save first
- server queue baseline state stays aligned with the persisted item ids, reducing false unsent/update states after publish

## Root cause
The client and server save paths were inconsistent:
- iOS publish success was handled optimistically only through a follow-up reload, not the publish response itself
- quiet save normalized local ids, but the shared save/publish write path did not

## Validation
- `xcodebuild test -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,name=iPhone 17' -only-testing:ElRoysManagerAppTests`
- `node --test tests/*.test.cjs tests/boundaries/*.test.cjs`
