### PR TITLE
[codex] Issue 324: add Untappd import and category governance

### DIFF
--- a/api/manager.js
+++ b/api/manager.js
@@ -27,6 +27,7 @@ import {
 } from '../server/_specials-command.js';
 import { getSupabaseServerConfig } from '../server/_supabase.js';
 import { lookupProductByBarcode } from '../server/_product-lookup.js';
+import { previewUntappdBeerImport, searchUntappdBeers } from '../server/_untappd.js';
 import { parseRequestBody, readAction, readQueryValue } from '../server/_request.js';
 
 const SPECIALS_ACTIONS = new Set(['ensure', 'add', 'remove', 'move', 'note', 'confirm']);
@@ -151,6 +152,19 @@ export default async function handler(req, res) {
         await requireRole(req, 'manager', 'admin');
         const barcode = String(body?.barcode || body?.upc || '').trim();
         return res.json(await lookupProductByBarcode(barcode));
+      }
+      case 'untappd_search': {
+        await requireRole(req, 'manager', 'admin');
+        const query = String(body?.query || body?.q || '').trim();
+        return res.json({ beers: await searchUntappdBeers(query) });
+      }
+      case 'untappd_preview': {
+        await requireRole(req, 'manager', 'admin');
+        const bid = String(body?.bid || body?.beer_id || '').trim();
+        const includeBrewery = Boolean(body?.includeBrewery || body?.include_brewery);
+        return res.json({
+          preview: await previewUntappdBeerImport(bid, { includeBrewery }),
+        });
       }
       default:
         if (SPECIALS_ACTIONS.has(action)) {

--- a/app.js
+++ b/app.js
@@ -7864,9 +7864,22 @@ function toggleAddCategoryForm() {
   const btn  = document.getElementById('show-add-cat-btn');
   if (!form) return;
   const opening = form.style.display === 'none';
-  form.style.display = opening ? '' : 'none';
-  if (btn) btn.textContent = opening ? '− Cancel' : '+ Add Category';
-  if (opening) document.getElementById('new-cat-title')?.focus();
+  if (!opening) {
+    cancelAddCategoryForm();
+    return;
+  }
+  form.style.display = '';
+  if (btn) btn.textContent = '− Cancel';
+  document.getElementById('new-cat-title')?.focus();
+}
+
+function cancelAddCategoryForm() {
+  const form = document.getElementById('catmgr-add-form');
+  const btn  = document.getElementById('show-add-cat-btn');
+  if (form) form.style.display = 'none';
+  if (btn) btn.textContent = '+ Add Category';
+  const untappdEl = document.getElementById('new-cat-untappd-enabled');
+  if (untappdEl) untappdEl.checked = false;
 }
 
 async function confirmAddCategory() {
@@ -7888,11 +7901,7 @@ async function confirmAddCategory() {
   });
   const iconEl = document.getElementById('new-cat-icon');
   if (iconEl) iconEl.value = '🍸';
-  const untappdEl = document.getElementById('new-cat-untappd-enabled');
-  if (untappdEl) untappdEl.checked = false;
-  document.getElementById('catmgr-add-form').style.display = 'none';
-  const btn = document.getElementById('show-add-cat-btn');
-  if (btn) btn.textContent = '+ Add Category';
+  cancelAddCategoryForm();
   markSaveOnlyDraftChange({
     key: `category:${id}:add`,
     label: `Added category ${title}`,

--- a/app.js
+++ b/app.js
@@ -213,22 +213,22 @@ function colorAt(palette, index) {
 
 function buildDefaultCategoryDefs(palette) {
   return [
-    { id: 'beer', icon: '🍺', color: colorAt(palette, 0), title: 'Beers on Tap', sub: 'Current draft offerings', placeholder: 'e.g. Modelo Especial...' },
-    { id: 'canned', icon: '🍻', color: colorAt(palette, 4), title: 'Canned & Bottled', sub: 'Canned & bottled offerings', placeholder: 'e.g. Modelo Especial (can), Topo Chico...' },
-    { id: 'cocktails', icon: '🍹', color: colorAt(palette, 5), title: 'Cocktails', sub: 'Craft cocktail offerings', placeholder: 'e.g. Paloma, Spicy Margarita...' },
-    { id: 'tequila', icon: '🌶️', color: colorAt(palette, 1), title: 'Infused Tequila', sub: 'Rotating infused marg tequila', placeholder: 'e.g. Jalapeño-Pineapple Blanco...' },
-    { id: 'frozen', icon: '🧊', color: colorAt(palette, 2), title: 'Frozen Marg', sub: 'Current frozen margarita flavor', placeholder: 'e.g. Strawberry Basil...' },
-    { id: 'special', icon: '⭐', color: colorAt(palette, 3), title: 'Monthly Specials', sub: 'Featured cocktails & promos', placeholder: 'e.g. The Valentina — raspberry, grapefruit...' },
+    { id: 'beer', icon: '🍺', color: colorAt(palette, 0), title: 'Beers on Tap', sub: 'Current draft offerings', placeholder: 'e.g. Modelo Especial...', untappdEnabled: false },
+    { id: 'canned', icon: '🍻', color: colorAt(palette, 4), title: 'Canned & Bottled', sub: 'Canned & bottled offerings', placeholder: 'e.g. Modelo Especial (can), Topo Chico...', untappdEnabled: false },
+    { id: 'cocktails', icon: '🍹', color: colorAt(palette, 5), title: 'Cocktails', sub: 'Craft cocktail offerings', placeholder: 'e.g. Paloma, Spicy Margarita...', untappdEnabled: false },
+    { id: 'tequila', icon: '🌶️', color: colorAt(palette, 1), title: 'Infused Tequila', sub: 'Rotating infused marg tequila', placeholder: 'e.g. Jalapeño-Pineapple Blanco...', untappdEnabled: false },
+    { id: 'frozen', icon: '🧊', color: colorAt(palette, 2), title: 'Frozen Marg', sub: 'Current frozen margarita flavor', placeholder: 'e.g. Strawberry Basil...', untappdEnabled: false },
+    { id: 'special', icon: '⭐', color: colorAt(palette, 3), title: 'Monthly Specials', sub: 'Featured cocktails & promos', placeholder: 'e.g. The Valentina — raspberry, grapefruit...', untappdEnabled: false },
   ];
 }
 
 function buildDefaultFoodCategoryDefs(palette) {
   return [
-    { key: 'starters', label: '🥗 Starters', icon: '🥗', color: colorAt(palette, 4), sub: '', placeholder: 'e.g. Chips & Salsa...' },
-    { key: 'tacos', label: '🌮 Tacos', icon: '🌮', color: colorAt(palette, 0), sub: '', placeholder: 'e.g. Al Pastor...' },
-    { key: 'entrees', label: '🍽 Entrees', icon: '🍽', color: colorAt(palette, 1), sub: '', placeholder: 'e.g. Enchiladas...' },
-    { key: 'sides', label: '🫘 Sides', icon: '🫘', color: colorAt(palette, 2), sub: '', placeholder: 'e.g. Mexican Rice...' },
-    { key: 'desserts', label: '🍮 Desserts', icon: '🍮', color: colorAt(palette, 3), sub: '', placeholder: 'e.g. Flan...' },
+    { key: 'starters', label: '🥗 Starters', icon: '🥗', color: colorAt(palette, 4), sub: '', placeholder: 'e.g. Chips & Salsa...', untappdEnabled: false },
+    { key: 'tacos', label: '🌮 Tacos', icon: '🌮', color: colorAt(palette, 0), sub: '', placeholder: 'e.g. Al Pastor...', untappdEnabled: false },
+    { key: 'entrees', label: '🍽 Entrees', icon: '🍽', color: colorAt(palette, 1), sub: '', placeholder: 'e.g. Enchiladas...', untappdEnabled: false },
+    { key: 'sides', label: '🫘 Sides', icon: '🫘', color: colorAt(palette, 2), sub: '', placeholder: 'e.g. Mexican Rice...', untappdEnabled: false },
+    { key: 'desserts', label: '🍮 Desserts', icon: '🍮', color: colorAt(palette, 3), sub: '', placeholder: 'e.g. Flan...', untappdEnabled: false },
   ];
 }
 
@@ -984,6 +984,20 @@ let _previewSelectionState = {};
 let _lastAddItemCategoryId = '';
 const ADD_ITEM_MODAL_MANUAL_MODE = 'manual';
 const ADD_ITEM_MODAL_SCAN_MODE = 'scan';
+function createAddItemModalUntappdState(overrides = {}) {
+  return {
+    pending: false,
+    query: '',
+    results: [],
+    selectedBid: '',
+    preview: null,
+    includeBrewery: false,
+    error: '',
+    requestId: 0,
+    ...overrides,
+  };
+}
+
 function createAddItemModalState(overrides = {}) {
   return {
     isOpen: false,
@@ -997,6 +1011,7 @@ function createAddItemModalState(overrides = {}) {
     manualBarcode: '',
     scanState: 'idle',
     scannerService: null,
+    untappd: createAddItemModalUntappdState(),
     ...overrides,
   };
 }
@@ -1452,6 +1467,29 @@ function getManagedCategoryDefs() {
   ));
 }
 
+function normalizeCategoryUntappdEnabled(category = null) {
+  if (!category || typeof category !== 'object') return false;
+  return category.untappdEnabled === true || category.untappd_enabled === true;
+}
+
+function shouldShowCategoryUntappdControl(category = null) {
+  const categoryId = typeof category === 'string' ? category : category?.id;
+  return currentUserCanEditCategories() &&
+    MENU_TYPE !== 'food' &&
+    categoryId !== UNCATEGORIZED_ID &&
+    !isLegacySpecialCategory(categoryId);
+}
+
+function categorySupportsUntappdImport(category = null) {
+  const categoryId = typeof category === 'string' ? category : category?.id;
+  if (!categoryId || categoryId === UNCATEGORIZED_ID || MENU_TYPE === 'food') return false;
+  const categoryDef = typeof category === 'string'
+    ? CATEGORY_DEFS.find(candidate => candidate.id === category)
+    : category;
+  if (!categoryDef || isLegacySpecialCategory(categoryDef)) return false;
+  return normalizeCategoryUntappdEnabled(categoryDef);
+}
+
 function getUncategorizedCategoryDef() {
   return {
     id: UNCATEGORIZED_ID,
@@ -1461,6 +1499,7 @@ function getUncategorizedCategoryDef() {
     color: 'rgba(120,120,120,0.12)',
     sub: 'Items for specials & autocomplete — not shown on public menu',
     placeholder: 'Add to pool…',
+    untappdEnabled: false,
   };
 }
 
@@ -1494,6 +1533,41 @@ function createAddItemModalFields(overrides = {}) {
   };
 }
 
+function getSelectedAddItemModalCategoryDef(categoryId = _addItemModalState.fields?.categoryId) {
+  return getAddItemModalCategoryDefs().find(cat => cat.id === categoryId) || getUncategorizedCategoryDef();
+}
+
+function getAddItemModalNamePlaceholder(categoryId = _addItemModalState.fields?.categoryId) {
+  return categorySupportsUntappdImport(categoryId) ? 'Brewery + Beer' : 'Item name…';
+}
+
+function getAddItemModalUntappdAttribution() {
+  return 'Data provided by Untappd';
+}
+
+function formatUntappdResultMeta(entry = {}) {
+  const parts = [];
+  if (entry?.breweryName) parts.push(String(entry.breweryName));
+  if (entry?.style) parts.push(String(entry.style));
+  const abv = Number(entry?.abv);
+  if (Number.isFinite(abv)) parts.push(`${abv}% ABV`);
+  return parts.join(' • ');
+}
+
+function getSelectedAddItemUntappdResult() {
+  const bid = String(_addItemModalState?.untappd?.selectedBid || '').trim();
+  if (!bid) return null;
+  return (_addItemModalState?.untappd?.results || []).find(result => String(result?.bid || '').trim() === bid) || null;
+}
+
+function buildAddItemUntappdImportedName(preview = null, selectedResult = null, includeBrewery = false) {
+  const previewName = String(preview?.name || '').trim();
+  if (!previewName) return '';
+  if (!includeBrewery) return previewName;
+  const breweryName = String(selectedResult?.breweryName || preview?.breweryName || '').trim();
+  return breweryName ? `${breweryName} ${previewName}` : previewName;
+}
+
 function getAddItemCategoryLabel(catId) {
   return getAddItemModalCategoryDefs().find(cat => cat.id === catId)?.title || 'this category';
 }
@@ -1520,6 +1594,7 @@ function syncAddItemModalWarnings() {
 
 function getAddItemModalViewState() {
   const fields = _addItemModalState.fields || createAddItemModalFields();
+  const untappd = _addItemModalState.untappd || createAddItemModalUntappdState();
   return {
     isOpen: !!_addItemModalState.isOpen,
     mode: _addItemModalState.mode || ADD_ITEM_MODAL_MANUAL_MODE,
@@ -1530,6 +1605,15 @@ function getAddItemModalViewState() {
     manualBarcode: _addItemModalState.manualBarcode || '',
     scanState: _addItemModalState.scanState || 'idle',
     scanUnsupported: _addItemModalState.scanState === 'unsupported',
+    untappd: {
+      pending: !!untappd.pending,
+      query: untappd.query || '',
+      results: Array.isArray(untappd.results) ? untappd.results.map(result => ({ ...result })) : [],
+      selectedBid: untappd.selectedBid || '',
+      preview: untappd.preview ? { ...untappd.preview } : null,
+      includeBrewery: !!untappd.includeBrewery,
+      error: untappd.error || '',
+    },
     fields: {
       name: fields.name || '',
       categoryId: fields.categoryId || '',
@@ -1727,6 +1811,7 @@ async function beginAddItemBarcodeLookup(rawBarcode) {
   _addItemModalState.mode = ADD_ITEM_MODAL_MANUAL_MODE;
   _addItemModalState.entryMode = ADD_ITEM_MODAL_SCAN_MODE;
   _addItemModalState.scanState = 'idle';
+  _addItemModalState.untappd = createAddItemModalUntappdState();
   const categoryId = String(_addItemModalState.fields?.categoryId || getAddItemModalDefaultCategoryId());
   _addItemModalState.fields = createAddItemModalFields({ categoryId });
   syncAddItemModalWarnings();
@@ -1768,6 +1853,156 @@ function submitAddItemModalBarcodeLookup() {
   return beginAddItemBarcodeLookup(barcode);
 }
 
+async function runAddItemUntappdSearch(rawQuery = '') {
+  if (!_addItemModalState.isOpen || _addItemModalState.mode !== ADD_ITEM_MODAL_MANUAL_MODE) {
+    return { ok: false, reason: 'inactive' };
+  }
+  const categoryId = String(_addItemModalState.fields?.categoryId || '');
+  if (!categorySupportsUntappdImport(categoryId)) {
+    return { ok: false, reason: 'unsupported' };
+  }
+
+  const query = String(rawQuery || _addItemModalState.fields?.name || '').trim();
+  if (!query) {
+    _addItemModalState.untappd = createAddItemModalUntappdState({
+      error: 'Enter a beer name to search Untappd.',
+    });
+    renderAddItemModal({ focusFieldId: 'add-item-name-input' });
+    return { ok: false, reason: 'required' };
+  }
+
+  const requestId = Number(_addItemModalState.untappd?.requestId || 0) + 1;
+  _addItemModalState.untappd = createAddItemModalUntappdState({
+    pending: true,
+    query,
+    requestId,
+  });
+  renderAddItemModal();
+
+  const results = await searchUntappdBeers(query, {
+    headers: getAuthorizedApiHeaders(),
+  });
+  if (!_addItemModalState.isOpen || Number(_addItemModalState.untappd?.requestId || 0) !== requestId) {
+    return { ok: false, reason: 'stale' };
+  }
+
+  if (!Array.isArray(results)) {
+    _addItemModalState.untappd = createAddItemModalUntappdState({
+      query,
+      error: 'Untappd is unavailable right now.',
+      requestId,
+    });
+    renderAddItemModal({ focusFieldId: 'add-item-name-input' });
+    return { ok: false, reason: 'unavailable' };
+  }
+
+  if (!results.length) {
+    _addItemModalState.untappd = createAddItemModalUntappdState({
+      query,
+      error: 'No Untappd matches found.',
+      requestId,
+    });
+    renderAddItemModal({ focusFieldId: 'add-item-name-input' });
+    return { ok: false, reason: 'not-found' };
+  }
+
+  _addItemModalState.untappd = createAddItemModalUntappdState({
+    query,
+    results,
+    requestId,
+  });
+
+  if (results.length === 1) {
+    return previewAddItemUntappdSelection(results[0].bid);
+  }
+
+  renderAddItemModal();
+  return { ok: true, results };
+}
+
+async function previewAddItemUntappdSelection(bid) {
+  if (!_addItemModalState.isOpen) return { ok: false, reason: 'closed' };
+  const query = String(_addItemModalState.untappd?.query || '').trim();
+  const results = Array.isArray(_addItemModalState.untappd?.results) ? _addItemModalState.untappd.results.slice() : [];
+  const requestId = Number(_addItemModalState.untappd?.requestId || 0) + 1;
+  _addItemModalState.untappd = createAddItemModalUntappdState({
+    pending: true,
+    query,
+    results,
+    selectedBid: String(bid || ''),
+    includeBrewery: !!_addItemModalState.untappd?.includeBrewery,
+    requestId,
+  });
+  renderAddItemModal();
+
+  const preview = await previewUntappdBeerImport(bid, {
+    includeBrewery: true,
+    headers: getAuthorizedApiHeaders(),
+  });
+  if (!_addItemModalState.isOpen || Number(_addItemModalState.untappd?.requestId || 0) !== requestId) {
+    return { ok: false, reason: 'stale' };
+  }
+
+  if (!preview) {
+    _addItemModalState.untappd = createAddItemModalUntappdState({
+      query,
+      results,
+      selectedBid: String(bid || ''),
+      error: 'Untappd preview is unavailable right now.',
+      requestId,
+    });
+    renderAddItemModal({ focusFieldId: 'add-item-name-input' });
+    return { ok: false, reason: 'preview-unavailable' };
+  }
+
+  _addItemModalState.untappd = createAddItemModalUntappdState({
+    query,
+    results,
+    selectedBid: String(bid || ''),
+    preview,
+    includeBrewery: !!_addItemModalState.untappd?.includeBrewery,
+    requestId,
+  });
+  renderAddItemModal();
+  return { ok: true, preview };
+}
+
+function setAddItemUntappdIncludeBrewery(enabled) {
+  if (!_addItemModalState.isOpen) return;
+  if (!_addItemModalState.untappd) _addItemModalState.untappd = createAddItemModalUntappdState();
+  _addItemModalState.untappd.includeBrewery = !!enabled;
+  renderAddItemModal();
+}
+
+function cancelAddItemUntappdFlow() {
+  if (!_addItemModalState.isOpen) return;
+  _addItemModalState.untappd = createAddItemModalUntappdState();
+  renderAddItemModal({ focusFieldId: 'add-item-name-input' });
+}
+
+function applyAddItemUntappdImport() {
+  if (!_addItemModalState.isOpen || !_addItemModalState.fields) return { ok: false, reason: 'closed' };
+  const preview = _addItemModalState.untappd?.preview;
+  if (!preview) return { ok: false, reason: 'missing-preview' };
+  const selectedResult = getSelectedAddItemUntappdResult();
+  _addItemModalState.fields.name = buildAddItemUntappdImportedName(
+    preview,
+    selectedResult,
+    !!_addItemModalState.untappd?.includeBrewery
+  );
+  _addItemModalState.fields.desc = String(preview.description || '').trim();
+  _addItemModalState.untappd = createAddItemModalUntappdState();
+  syncAddItemModalWarnings();
+  renderAddItemModal({ focusFieldId: 'add-item-name-input' });
+  return {
+    ok: true,
+    imported: {
+      name: _addItemModalState.fields.name,
+      desc: _addItemModalState.fields.desc,
+    },
+  };
+}
+
 function syncAddItemModalUiState() {
   const body = document.body;
   if (!body?.classList || typeof body.classList.toggle !== 'function') return;
@@ -1786,6 +2021,14 @@ function renderAddItemModal(options = {}) {
   const view = getAddItemModalViewState();
   const { fields } = view;
   const isScanMode = view.mode === ADD_ITEM_MODAL_SCAN_MODE;
+  const untappd = view.untappd || createAddItemModalUntappdState();
+  const untappdEnabled = categorySupportsUntappdImport(fields.categoryId);
+  const selectedUntappdResult = untappd.results.find(result => String(result?.bid || '') === String(untappd.selectedBid || '')) || null;
+  const importedUntappdName = buildAddItemUntappdImportedName(
+    untappd.preview,
+    selectedUntappdResult,
+    untappd.includeBrewery
+  );
   const canConfirm = !!fields.name.trim() && !!fields.categoryId && !view.duplicateWarning;
   const modalSubtitle = isScanMode
     ? 'Scan a barcode to prefill item details, or use manual UPC lookup when camera scanning is unavailable.'
@@ -1851,17 +2094,94 @@ function renderAddItemModal(options = {}) {
           <button type="button" class="btn-small" onclick="addAddItemModalRecipeIngredient()">Add Ingredient</button>
         </div>
       </div>`;
+  const untappdPanelHtml = !untappdEnabled
+    ? ''
+    : (() => {
+        const attributionHtml = `<p class="add-item-inline-note add-item-untappd-attribution">${escHtml(getAddItemModalUntappdAttribution())}</p>`;
+        if (untappd.pending) {
+          return `<div class="add-item-modal-note" role="status">Searching Untappd…</div>`;
+        }
+        if (untappd.preview) {
+          return `
+            <div class="add-item-untappd-panel add-item-untappd-panel--preview">
+              <div class="add-item-untappd-header">
+                <strong>Untappd preview</strong>
+                <button type="button" class="btn-small" onclick="runAddItemUntappdSearch()">Rerun</button>
+              </div>
+              <div class="add-item-untappd-preview">
+                <div class="add-item-untappd-preview-label">Imported name</div>
+                <div class="add-item-untappd-preview-value">${escHtml(importedUntappdName || untappd.preview.name || '')}</div>
+                <div class="add-item-untappd-preview-label">Imported description</div>
+                <div class="add-item-untappd-preview-value">${escHtml(untappd.preview.description || '') || '<span class="add-item-inline-note">No description available.</span>'}</div>
+              </div>
+              <label class="catmgr-checkbox-row" for="add-item-untappd-brewery-toggle">
+                <input id="add-item-untappd-brewery-toggle" type="checkbox"${untappd.includeBrewery ? ' checked' : ''} onchange="setAddItemUntappdIncludeBrewery(this.checked)"/>
+                <span>Include brewery in name</span>
+              </label>
+              <div class="add-item-untappd-actions">
+                <button type="button" class="btn-small" onclick="cancelAddItemUntappdFlow()">Cancel</button>
+                <button type="button" class="btn-small" onclick="applyAddItemUntappdImport()">Apply</button>
+              </div>
+              ${attributionHtml}
+            </div>`;
+        }
+        if (untappd.results.length > 1) {
+          return `
+            <div class="add-item-untappd-panel add-item-untappd-panel--results">
+              <div class="add-item-untappd-header">
+                <strong>Choose an Untappd match</strong>
+                <button type="button" class="btn-small" onclick="runAddItemUntappdSearch()">Rerun</button>
+              </div>
+              <div class="add-item-untappd-result-list">
+                ${untappd.results.map(result => `
+                  <button type="button" class="add-item-untappd-result" onclick="previewAddItemUntappdSelection('${escHtml(result.bid)}')">
+                    <span class="add-item-untappd-result-name">${escHtml(result.name || '')}</span>
+                    <span class="add-item-untappd-result-meta">${escHtml(formatUntappdResultMeta(result) || result.breweryName || '')}</span>
+                  </button>
+                `).join('')}
+              </div>
+              <div class="add-item-untappd-actions">
+                <button type="button" class="btn-small" onclick="cancelAddItemUntappdFlow()">Cancel</button>
+              </div>
+              ${attributionHtml}
+            </div>`;
+        }
+        if (untappd.error) {
+          return `
+            <div class="add-item-untappd-panel add-item-untappd-panel--status">
+              <p class="add-item-modal-warning">${escHtml(untappd.error)}</p>
+              <div class="add-item-untappd-actions">
+                <button type="button" class="btn-small" onclick="cancelAddItemUntappdFlow()">Cancel</button>
+                <button type="button" class="btn-small" onclick="runAddItemUntappdSearch()">Rerun</button>
+              </div>
+              ${attributionHtml}
+            </div>`;
+        }
+        return '';
+      })();
+  const nameFieldHtml = untappdEnabled
+    ? `
+      <div class="add-item-field-block">
+        <span class="add-item-field-label">Name</span>
+        <div class="add-item-inline-row add-item-inline-row--untappd">
+          <input id="add-item-name-input" class="catmgr-input" type="text" value="${escHtml(fields.name)}" placeholder="${escHtml(getAddItemModalNamePlaceholder(fields.categoryId))}" oninput="updateAddItemModalField('name', this.value)"/>
+          <button type="button" class="btn-small" ${untappd.pending ? 'disabled' : ''} onclick="runAddItemUntappdSearch()">${untappd.pending ? 'Searching…' : 'Untappd'}</button>
+        </div>
+      </div>`
+    : `
+      <label class="add-item-field-block">
+        <span class="add-item-field-label">Name</span>
+        <input id="add-item-name-input" class="catmgr-input" type="text" value="${escHtml(fields.name)}" placeholder="${escHtml(getAddItemModalNamePlaceholder(fields.categoryId))}" oninput="updateAddItemModalField('name', this.value)"/>
+      </label>`;
   const manualBodyHtml = `
     ${lookupStatusHtml}
     <div class="add-item-modal-grid">
-      <label class="add-item-field-block">
-        <span class="add-item-field-label">Name</span>
-        <input id="add-item-name-input" class="catmgr-input" type="text" value="${escHtml(fields.name)}" placeholder="Item name…" oninput="updateAddItemModalField('name', this.value)"/>
-      </label>
+      ${nameFieldHtml}
       <label class="add-item-field-block">
         <span class="add-item-field-label">Category</span>
         <select id="add-item-category-input" class="catmgr-input" onchange="updateAddItemModalField('categoryId', this.value)">${categoryOptions}</select>
       </label>
+      ${untappdEnabled && untappdPanelHtml ? `<div class="add-item-field-block add-item-field-block--full">${untappdPanelHtml}</div>` : ''}
       <label class="add-item-field-block add-item-field-block--full">
         <span class="add-item-field-label">Description</span>
         <textarea id="add-item-desc-input" class="desc-input" rows="3" placeholder="Describe this item…" oninput="updateAddItemModalField('desc', this.value)">${escHtml(fields.desc)}</textarea>
@@ -1947,6 +2267,9 @@ function updateAddItemModalField(field, value) {
   if (!Object.prototype.hasOwnProperty.call(_addItemModalState.fields, field)) return;
   const focusState = captureAddItemModalFocusState();
   _addItemModalState.fields[field] = field === 'categoryId' ? String(value || '') : String(value || '');
+  if (field === 'categoryId' && !categorySupportsUntappdImport(_addItemModalState.fields.categoryId)) {
+    _addItemModalState.untappd = createAddItemModalUntappdState();
+  }
   syncAddItemModalWarnings();
   renderAddItemModal({ focusState });
 }
@@ -2088,6 +2411,10 @@ function currentUserCanManageMenu(menuId = MENU_ID, user = currentUser) {
   if (user.role === 'admin') return true;
   if (user.role !== 'manager') return false;
   return normalizeAccessibleMenuIds(user.accessibleMenuIds).includes(menuId);
+}
+
+function currentUserCanEditCategories(user = currentUser) {
+  return !!user && user.role === 'admin';
 }
 
 function currentUserCanEditRestaurantSpecials(restaurantId = RESTAURANT_ID, user = currentUser) {
@@ -2306,6 +2633,7 @@ function getDefaultCategoryDefsForMenuType(menuType = 'drinks') {
       title: cat.label || '',
       sub: cat.sub || '',
       placeholder: cat.placeholder || '',
+      untappdEnabled: cat.untappdEnabled === true || cat.untappd_enabled === true,
     }));
   }
   return DEFAULT_CATEGORY_DEFS.map(cat => ({ ...cat }));
@@ -3123,6 +3451,18 @@ function lookupOpenFoodFactsProduct(barcode, deps = {}) {
   const boundary = getUiModuleBoundary();
   if (typeof boundary?.lookupOpenFoodFactsProduct !== 'function') return Promise.resolve(null);
   return boundary.lookupOpenFoodFactsProduct(barcode, deps);
+}
+
+function searchUntappdBeers(query, deps = {}) {
+  const boundary = getUiModuleBoundary();
+  if (typeof boundary?.searchUntappdBeers !== 'function') return Promise.resolve(null);
+  return boundary.searchUntappdBeers(query, deps);
+}
+
+function previewUntappdBeerImport(bid, deps = {}) {
+  const boundary = getUiModuleBoundary();
+  if (typeof boundary?.previewUntappdBeerImport !== 'function') return Promise.resolve(null);
+  return boundary.previewUntappdBeerImport(bid, deps);
 }
 
 function createBarcodeScannerService(deps = {}) {
@@ -5589,6 +5929,7 @@ function hydrateState({ cats, meta, restaurant }) {
       title:       c.label,
       sub:         c.sub         || '',
       placeholder: c.placeholder || '',
+      untappdEnabled: normalizeCategoryUntappdEnabled(c),
     }));
   }
 
@@ -5662,6 +6003,7 @@ function applyPersistedDraftState(draftState = {}) {
     title: cat.label,
     sub: cat.sub || '',
     placeholder: cat.placeholder || '',
+    untappdEnabled: normalizeCategoryUntappdEnabled(cat),
   }));
 
   menuState = {};
@@ -6198,6 +6540,7 @@ function buildMenuCacheSnapshot() {
     color: cat.color || '',
     sub: cat.sub || '',
     placeholder: cat.placeholder || '',
+    untappd_enabled: normalizeCategoryUntappdEnabled(cat),
     display_order: index,
     items: (menuState[cat.id]?.items || []).map((item, itemIndex) => ({
       id: item.id,
@@ -6224,6 +6567,7 @@ function buildMenuCacheSnapshot() {
       color: '',
       sub: '',
       placeholder: '',
+      untappd_enabled: false,
       display_order: 9999,
       items: uncategorizedItems.map((item, itemIndex) => ({
         id: item.id,
@@ -6332,6 +6676,8 @@ function buildSnapshotCategoryStateMap(snapshot = {}) {
     if (!key || key === UNCATEGORIZED_ID) return;
     const nextCategory = cloneJsonCompatible(category, {});
     nextCategory.items = [];
+    nextCategory.untappd_enabled = normalizeCategoryUntappdEnabled(nextCategory);
+    delete nextCategory.untappdEnabled;
     map.set(key, nextCategory);
   });
   return map;
@@ -6848,7 +7194,11 @@ async function renderPublicViews() {
 
 function updateManagerToolsContext() {
   const ctx = document.getElementById('categories-menu-context');
-  if (ctx) ctx.textContent = _activeMenuName ? `Editing: ${_activeMenuName}` : '';
+  if (!ctx) return;
+  const baseLabel = _activeMenuName ? `Editing: ${_activeMenuName}` : '';
+  ctx.textContent = currentUserCanEditCategories()
+    ? baseLabel
+    : [baseLabel, 'Categories are admin-managed.'].filter(Boolean).join(' • ');
 }
 
 function renderManagerOverviewStats() {
@@ -7325,15 +7675,48 @@ function getNextCategoryColor() {
 
 function renderCategoriesTab() {
   const container = document.getElementById('catmgr-list');
+  const context = document.getElementById('categories-menu-context');
+  const addForm = document.getElementById('catmgr-add-form');
+  const addButton = document.getElementById('show-add-cat-btn');
+  const addUntappdRow = document.getElementById('new-cat-untappd-row');
   if (!container) return;
+  const canEdit = currentUserCanEditCategories();
   container.innerHTML = '';
+  if (context) {
+    const baseLabel = _activeMenuName ? `Editing: ${_activeMenuName}` : '';
+    context.textContent = canEdit
+      ? baseLabel
+      : [baseLabel, 'Categories are admin-managed.'].filter(Boolean).join(' • ');
+  }
+  if (addButton) {
+    addButton.style.display = canEdit ? '' : 'none';
+    addButton.hidden = !canEdit;
+    addButton.textContent = '+ Add Category';
+  }
+  if (addForm && !canEdit) addForm.style.display = 'none';
+  if (addUntappdRow) addUntappdRow.style.display = canEdit && MENU_TYPE !== 'food' ? '' : 'none';
   const managedCategories = getManagedCategoryDefs();
+  if (!canEdit) {
+    const note = document.createElement('div');
+    note.className = 'catmgr-readonly-note';
+    note.innerHTML = `
+      <strong>Admin-managed.</strong>
+      Managers can add and edit items here, but category changes are handled by admins.`;
+    container.appendChild(note);
+  }
   managedCategories.forEach((cat, idx) => {
     const card = document.createElement('div');
     card.className = 'catmgr-card';
     card.id = 'catmgr-' + cat.id;
     const isFirst = idx === 0;
     const isLast  = idx === managedCategories.length - 1;
+    const untappdRowHtml = shouldShowCategoryUntappdControl(cat)
+      ? `
+        <label class="catmgr-checkbox-row" for="ce-untappd-${escHtml(cat.id)}">
+          <input type="checkbox" id="ce-untappd-${escHtml(cat.id)}" name="category-untappd-${escHtml(cat.id)}"${normalizeCategoryUntappdEnabled(cat) ? ' checked' : ''}/>
+          <span>Enable Untappd import for this category</span>
+        </label>`
+      : '';
     card.innerHTML = `
       <div class="catmgr-row">
         <div class="catmgr-icon" style="background:${escHtml(cat.color)}">${escHtml(cat.icon)}</div>
@@ -7341,48 +7724,53 @@ function renderCategoriesTab() {
           <div class="catmgr-title">${escHtml(cat.title)}</div>
           <div class="catmgr-sub">${escHtml(cat.sub || '')}</div>
         </div>
-        <div class="catmgr-actions">
-          <button class="btn-small" onclick="moveCategoryUp('${escHtml(cat.id)}')" ${isFirst ? 'disabled' : ''} title="Move up" aria-label="Move ${escHtml(cat.title)} up">↑</button>
-          <button class="btn-small" onclick="moveCategoryDown('${escHtml(cat.id)}')" ${isLast ? 'disabled' : ''} title="Move down" aria-label="Move ${escHtml(cat.title)} down">↓</button>
-          <button class="btn-small" onclick="toggleCategoryEdit('${escHtml(cat.id)}')" aria-label="Edit ${escHtml(cat.title)}">✏️</button>
-          <button class="btn-small btn-danger" onclick="deleteCategory('${escHtml(cat.id)}')" aria-label="Delete ${escHtml(cat.title)}">×</button>
-        </div>
+        ${canEdit
+          ? `<div class="catmgr-actions">
+              <button class="btn-small" onclick="moveCategoryUp('${escHtml(cat.id)}')" ${isFirst ? 'disabled' : ''} title="Move up" aria-label="Move ${escHtml(cat.title)} up">↑</button>
+              <button class="btn-small" onclick="moveCategoryDown('${escHtml(cat.id)}')" ${isLast ? 'disabled' : ''} title="Move down" aria-label="Move ${escHtml(cat.title)} down">↓</button>
+              <button class="btn-small" onclick="toggleCategoryEdit('${escHtml(cat.id)}')" aria-label="Edit ${escHtml(cat.title)}">✏️</button>
+              <button class="btn-small btn-danger" onclick="deleteCategory('${escHtml(cat.id)}')" aria-label="Delete ${escHtml(cat.title)}">×</button>
+            </div>`
+          : '<div class="catmgr-readonly-pill">Admin-managed</div>'}
       </div>
-      <div class="catmgr-edit" id="catmgr-edit-${escHtml(cat.id)}" style="display:none">
-        <div class="catmgr-field-row">
-          <label for="ce-icon-${escHtml(cat.id)}">Icon</label>
-          <input type="text" class="catmgr-input catmgr-icon-input" id="ce-icon-${escHtml(cat.id)}" name="category-icon-${escHtml(cat.id)}" value="${escHtml(cat.icon)}" maxlength="4" placeholder="Emoji…" autocomplete="off" spellcheck="false"/>
-        </div>
-        <div class="catmgr-field-row">
-          <label for="ce-title-${escHtml(cat.id)}">Title</label>
-          <input type="text" class="catmgr-input" id="ce-title-${escHtml(cat.id)}" name="category-title-${escHtml(cat.id)}" value="${escHtml(cat.title)}" placeholder="Category title…" autocomplete="off"/>
-        </div>
-        <div class="catmgr-field-row">
-          <label for="ce-sub-${escHtml(cat.id)}">Subtitle</label>
-          <input type="text" class="catmgr-input" id="ce-sub-${escHtml(cat.id)}" name="category-subtitle-${escHtml(cat.id)}" value="${escHtml(cat.sub || '')}" placeholder="Short description…" autocomplete="off"/>
-        </div>
-        <div class="catmgr-field-row">
-          <label for="ce-ph-${escHtml(cat.id)}">Hint text</label>
-          <input type="text" class="catmgr-input" id="ce-ph-${escHtml(cat.id)}" name="category-hint-${escHtml(cat.id)}" value="${escHtml(cat.placeholder || '')}" placeholder="Add item input hint…" autocomplete="off"/>
-        </div>
-        <div class="catmgr-save-row">
-          <button class="btn-small" onclick="toggleCategoryEdit('${escHtml(cat.id)}')">Cancel</button>
-          <button class="btn-small" onclick="saveCategoryEdit('${escHtml(cat.id)}')">Save</button>
-        </div>
-      </div>`;
+      ${canEdit
+        ? `<div class="catmgr-edit" id="catmgr-edit-${escHtml(cat.id)}" style="display:none">
+            <div class="catmgr-field-row">
+              <label for="ce-icon-${escHtml(cat.id)}">Icon</label>
+              <input type="text" class="catmgr-input catmgr-icon-input" id="ce-icon-${escHtml(cat.id)}" name="category-icon-${escHtml(cat.id)}" value="${escHtml(cat.icon)}" maxlength="4" placeholder="Emoji…" autocomplete="off" spellcheck="false"/>
+            </div>
+            <div class="catmgr-field-row">
+              <label for="ce-title-${escHtml(cat.id)}">Title</label>
+              <input type="text" class="catmgr-input" id="ce-title-${escHtml(cat.id)}" name="category-title-${escHtml(cat.id)}" value="${escHtml(cat.title)}" placeholder="Category title…" autocomplete="off"/>
+            </div>
+            <div class="catmgr-field-row">
+              <label for="ce-sub-${escHtml(cat.id)}">Subtitle</label>
+              <input type="text" class="catmgr-input" id="ce-sub-${escHtml(cat.id)}" name="category-subtitle-${escHtml(cat.id)}" value="${escHtml(cat.sub || '')}" placeholder="Short description…" autocomplete="off"/>
+            </div>
+            <div class="catmgr-field-row">
+              <label for="ce-ph-${escHtml(cat.id)}">Hint text</label>
+              <input type="text" class="catmgr-input" id="ce-ph-${escHtml(cat.id)}" name="category-hint-${escHtml(cat.id)}" value="${escHtml(cat.placeholder || '')}" placeholder="Add item input hint…" autocomplete="off"/>
+            </div>
+            ${untappdRowHtml}
+            <div class="catmgr-save-row">
+              <button class="btn-small" onclick="toggleCategoryEdit('${escHtml(cat.id)}')">Cancel</button>
+              <button class="btn-small" onclick="saveCategoryEdit('${escHtml(cat.id)}')">Save</button>
+            </div>
+          </div>`
+        : ''}`;
     container.appendChild(card);
   });
 }
 
 function toggleCategoryEdit(catId) {
-  if (isLegacySpecialCategory(catId)) return;
+  if (!currentUserCanEditCategories() || isLegacySpecialCategory(catId)) return;
   const el = document.getElementById('catmgr-edit-' + catId);
   if (!el) return;
   el.style.display = el.style.display === 'none' ? '' : 'none';
 }
 
 async function saveCategoryEdit(catId) {
-  if (isLegacySpecialCategory(catId)) return;
+  if (!currentUserCanEditCategories() || isLegacySpecialCategory(catId)) return;
   const cat = CATEGORY_DEFS.find(c => c.id === catId);
   if (!cat) return;
   const icon  = document.getElementById('ce-icon-'  + catId)?.value.trim() || cat.icon;
@@ -7390,7 +7778,14 @@ async function saveCategoryEdit(catId) {
   if (!title) { showToast('Title is required.', 'error'); return; }
   const sub   = document.getElementById('ce-sub-'   + catId)?.value.trim() || '';
   const ph    = document.getElementById('ce-ph-'    + catId)?.value.trim() || '';
-  cat.icon = icon; cat.title = title; cat.sub = sub; cat.placeholder = ph;
+  const untappdEnabled = shouldShowCategoryUntappdControl(cat)
+    ? document.getElementById('ce-untappd-' + catId)?.checked === true
+    : false;
+  cat.icon = icon;
+  cat.title = title;
+  cat.sub = sub;
+  cat.placeholder = ph;
+  cat.untappdEnabled = untappdEnabled;
   toggleCategoryEdit(catId);
   markSaveOnlyDraftChange({
     key: `category:${catId}:copy`,
@@ -7406,7 +7801,7 @@ async function saveCategoryEdit(catId) {
 }
 
 async function moveCategoryUp(catId) {
-  if (isLegacySpecialCategory(catId)) return;
+  if (!currentUserCanEditCategories() || isLegacySpecialCategory(catId)) return;
   const idx = CATEGORY_DEFS.findIndex(c => c.id === catId);
   if (idx <= 0) return;
   [CATEGORY_DEFS[idx-1], CATEGORY_DEFS[idx]] = [CATEGORY_DEFS[idx], CATEGORY_DEFS[idx-1]];
@@ -7423,7 +7818,7 @@ async function moveCategoryUp(catId) {
 }
 
 async function moveCategoryDown(catId) {
-  if (isLegacySpecialCategory(catId)) return;
+  if (!currentUserCanEditCategories() || isLegacySpecialCategory(catId)) return;
   const idx = CATEGORY_DEFS.findIndex(c => c.id === catId);
   if (idx < 0 || idx >= CATEGORY_DEFS.length - 1) return;
   [CATEGORY_DEFS[idx], CATEGORY_DEFS[idx+1]] = [CATEGORY_DEFS[idx+1], CATEGORY_DEFS[idx]];
@@ -7440,7 +7835,7 @@ async function moveCategoryDown(catId) {
 }
 
 async function deleteCategory(catId) {
-  if (isLegacySpecialCategory(catId)) return;
+  if (!currentUserCanEditCategories() || isLegacySpecialCategory(catId)) return;
   const cat = CATEGORY_DEFS.find(c => c.id === catId);
   if (!cat) return;
   const items = menuState[catId]?.items || [];
@@ -7464,6 +7859,7 @@ async function deleteCategory(catId) {
 }
 
 function toggleAddCategoryForm() {
+  if (!currentUserCanEditCategories()) return;
   const form = document.getElementById('catmgr-add-form');
   const btn  = document.getElementById('show-add-cat-btn');
   if (!form) return;
@@ -7474,15 +7870,17 @@ function toggleAddCategoryForm() {
 }
 
 async function confirmAddCategory() {
+  if (!currentUserCanEditCategories()) return;
   const icon  = document.getElementById('new-cat-icon')?.value.trim() || '🍸';
   const title = document.getElementById('new-cat-title')?.value.trim();
   if (!title) { showToast('Category title is required.', 'error'); return; }
   const sub = document.getElementById('new-cat-sub')?.value.trim() || '';
   const ph  = document.getElementById('new-cat-placeholder')?.value.trim() || `e.g. Add ${title} item…`;
+  const untappdEnabled = MENU_TYPE !== 'food' && document.getElementById('new-cat-untappd-enabled')?.checked === true;
   const id  = 'cat_' + Date.now().toString(36);
   const color = getNextCategoryColor();
   // _uuid is left undefined; persistState() will INSERT and capture the generated UUID
-  CATEGORY_DEFS.push({ id, icon, color, title, sub, placeholder: ph });
+  CATEGORY_DEFS.push({ id, icon, color, title, sub, placeholder: ph, untappdEnabled });
   menuState[id] = { items: [], lastSent: [] };
   // Reset form
   ['new-cat-icon','new-cat-title','new-cat-sub','new-cat-placeholder'].forEach(fid => {
@@ -7490,6 +7888,8 @@ async function confirmAddCategory() {
   });
   const iconEl = document.getElementById('new-cat-icon');
   if (iconEl) iconEl.value = '🍸';
+  const untappdEl = document.getElementById('new-cat-untappd-enabled');
+  if (untappdEl) untappdEl.checked = false;
   document.getElementById('catmgr-add-form').style.display = 'none';
   const btn = document.getElementById('show-add-cat-btn');
   if (btn) btn.textContent = '+ Add Category';

--- a/core/domain/category-defaults.js
+++ b/core/domain/category-defaults.js
@@ -15,19 +15,19 @@
   const defaults = {
     ICON_COLOR_PALETTE: palette.slice(),
     DEFAULT_CATEGORY_DEFS: [
-      { id: 'beer', icon: '🍺', color: palette[0], title: 'Beers on Tap', sub: 'Current draft offerings', placeholder: 'e.g. Modelo Especial...' },
-      { id: 'canned', icon: '🍻', color: palette[4], title: 'Canned & Bottled', sub: 'Canned & bottled offerings', placeholder: 'e.g. Modelo Especial (can), Topo Chico...' },
-      { id: 'cocktails', icon: '🍹', color: palette[5], title: 'Cocktails', sub: 'Craft cocktail offerings', placeholder: 'e.g. Paloma, Spicy Margarita...' },
-      { id: 'tequila', icon: '🌶️', color: palette[1], title: 'Infused Tequila', sub: 'Rotating infused marg tequila', placeholder: 'e.g. Jalapeño-Pineapple Blanco...' },
-      { id: 'frozen', icon: '🧊', color: palette[2], title: 'Frozen Marg', sub: 'Current frozen margarita flavor', placeholder: 'e.g. Strawberry Basil...' },
-      { id: 'special', icon: '⭐', color: palette[3], title: 'Monthly Specials', sub: 'Featured cocktails & promos', placeholder: 'e.g. The Valentina — raspberry, grapefruit...' },
+      { id: 'beer', icon: '🍺', color: palette[0], title: 'Beers on Tap', sub: 'Current draft offerings', placeholder: 'e.g. Modelo Especial...', untappdEnabled: false },
+      { id: 'canned', icon: '🍻', color: palette[4], title: 'Canned & Bottled', sub: 'Canned & bottled offerings', placeholder: 'e.g. Modelo Especial (can), Topo Chico...', untappdEnabled: false },
+      { id: 'cocktails', icon: '🍹', color: palette[5], title: 'Cocktails', sub: 'Craft cocktail offerings', placeholder: 'e.g. Paloma, Spicy Margarita...', untappdEnabled: false },
+      { id: 'tequila', icon: '🌶️', color: palette[1], title: 'Infused Tequila', sub: 'Rotating infused marg tequila', placeholder: 'e.g. Jalapeño-Pineapple Blanco...', untappdEnabled: false },
+      { id: 'frozen', icon: '🧊', color: palette[2], title: 'Frozen Marg', sub: 'Current frozen margarita flavor', placeholder: 'e.g. Strawberry Basil...', untappdEnabled: false },
+      { id: 'special', icon: '⭐', color: palette[3], title: 'Monthly Specials', sub: 'Featured cocktails & promos', placeholder: 'e.g. The Valentina — raspberry, grapefruit...', untappdEnabled: false },
     ],
     DEFAULT_FOOD_CATEGORY_DEFS: [
-      { key: 'starters', label: '🥗 Starters', icon: '🥗', color: palette[4], sub: '', placeholder: 'e.g. Chips & Salsa...' },
-      { key: 'tacos', label: '🌮 Tacos', icon: '🌮', color: palette[0], sub: '', placeholder: 'e.g. Al Pastor...' },
-      { key: 'entrees', label: '🍽 Entrees', icon: '🍽', color: palette[1], sub: '', placeholder: 'e.g. Enchiladas...' },
-      { key: 'sides', label: '🫘 Sides', icon: '🫘', color: palette[2], sub: '', placeholder: 'e.g. Mexican Rice...' },
-      { key: 'desserts', label: '🍮 Desserts', icon: '🍮', color: palette[3], sub: '', placeholder: 'e.g. Flan...' },
+      { key: 'starters', label: '🥗 Starters', icon: '🥗', color: palette[4], sub: '', placeholder: 'e.g. Chips & Salsa...', untappdEnabled: false },
+      { key: 'tacos', label: '🌮 Tacos', icon: '🌮', color: palette[0], sub: '', placeholder: 'e.g. Al Pastor...', untappdEnabled: false },
+      { key: 'entrees', label: '🍽 Entrees', icon: '🍽', color: palette[1], sub: '', placeholder: 'e.g. Enchiladas...', untappdEnabled: false },
+      { key: 'sides', label: '🫘 Sides', icon: '🫘', color: palette[2], sub: '', placeholder: 'e.g. Mexican Rice...', untappdEnabled: false },
+      { key: 'desserts', label: '🍮 Desserts', icon: '🍮', color: palette[3], sub: '', placeholder: 'e.g. Flan...', untappdEnabled: false },
     ],
   };
 

--- a/core/ui/manager/untappd.js
+++ b/core/ui/manager/untappd.js
@@ -1,0 +1,69 @@
+(function bootstrapUntappdLookup(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_UI_MODULES__ && typeof globalScope.__HF_UI_MODULES__ === 'object')
+    ? globalScope.__HF_UI_MODULES__
+    : {};
+
+  function cleanText(value) {
+    return String(value || '').replace(/\s+/g, ' ').trim();
+  }
+
+  async function postUntappdAction(action, payload = {}, deps = {}) {
+    const fetchImpl = typeof deps.fetch === 'function'
+      ? deps.fetch
+      : (typeof globalScope.fetch === 'function' ? globalScope.fetch.bind(globalScope) : null);
+    if (typeof fetchImpl !== 'function') return null;
+
+    const endpoint = cleanText(deps.endpoint || '/api/manager');
+    const headers = deps.headers && typeof deps.headers === 'object' ? deps.headers : {};
+
+    try {
+      const response = await fetchImpl(endpoint, {
+        method: 'POST',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          ...headers,
+        },
+        body: JSON.stringify({
+          action,
+          ...payload,
+        }),
+      });
+
+      if (!response || !response.ok) return null;
+      return response.json().catch(() => null);
+    } catch (_) {
+      return null;
+    }
+  }
+
+  modules.searchUntappdBeers = function searchUntappdBeersBoundary(query, deps = {}) {
+    const normalizedQuery = cleanText(query);
+    return postUntappdAction('untappd_search', { query: normalizedQuery }, deps)
+      .then(payload => {
+        const beers = Array.isArray(payload?.beers) ? payload.beers : [];
+        return beers
+          .map(entry => ({
+            bid: Number.isFinite(Number(entry?.bid)) ? Number(entry.bid) : entry?.bid,
+            name: cleanText(entry?.name || entry?.beer_name),
+            breweryName: cleanText(entry?.breweryName || entry?.brewery_name),
+            style: cleanText(entry?.style || entry?.beer_style),
+            abv: Number.isFinite(Number(entry?.abv)) ? Number(entry.abv) : null,
+          }))
+          .filter(entry => entry.bid !== undefined && entry.bid !== null && entry.name);
+      });
+  };
+
+  modules.previewUntappdBeerImport = function previewUntappdBeerImportBoundary(bid, deps = {}) {
+    const normalizedBid = Number.isFinite(Number(bid)) ? Number(bid) : cleanText(bid);
+    return postUntappdAction('untappd_preview', {
+      bid: normalizedBid,
+      includeBrewery: Boolean(deps.includeBrewery),
+    }, deps)
+      .then(payload => payload?.preview || null);
+  };
+
+  globalScope.__HF_UI_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -106,7 +106,8 @@ Use it to answer three questions:
 | Remove items | Full | Full | Staff editor clients | Both can remove items; web additionally has undo-toast affordances. |
 | Reorder items | Full | None | Staff editor clients | Web supports drag/drop reorder; no native iOS item reordering surface today. |
 | Upcharge editing | Full | None | Staff editor clients | Web exposes structured upcharges; iOS currently does not. |
-| Add / rename / delete categories | Full | Full | Staff editor clients | Present in both clients. |
+| Add / rename / delete categories | Full | Partial | Staff editor clients | Web keeps full category governance; iOS keeps category cards and item flows, but add/rename/delete are admin-only and hidden for non-admin staff. |
+| Untappd category import flag | Full | None | Admin clients | Web-only today; iOS decodes the shared payload field for parity but keeps Untappd UI out of v1. |
 | Recover off-menu / uncategorized items | Full | Full | Staff editor clients | Both clients preserve deleted-category items for recovery instead of silently destroying them. |
 | Reorder categories | Full | None | Staff editor clients | Web supports category reordering; iOS currently does not. |
 | Database / all-items view | Full | None | Staff editor clients | Web manager has a broader database surface; iOS does not. |

--- a/docs/parity-spec-tracker.md
+++ b/docs/parity-spec-tracker.md
@@ -129,6 +129,10 @@ Quiet-only changes:
   from local diff versus live.
 - Mirror web preview sections, grouped selection behavior, and dynamic action
   language.
+- Keep category cards and item flows available to all staff, but make category
+  add/rename/delete admin-only and read-only for non-admin workspaces.
+- Decode the shared Untappd category payload flag for parity, but keep Untappd
+  UI out of the iOS v1 editor.
 
 ### Public And Guest Surfaces
 

--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -152,6 +152,10 @@ final class AppModel {
     return bootstrap?.restaurants.first(where: { $0.id == restaurantId })
   }
 
+  var canEditCategories: Bool {
+    currentEditorWorkspace?.workspace.permissions.canAdmin ?? false
+  }
+
   private var editorCapabilities: WorkspaceCapabilities? {
     currentEditorWorkspace?.workspace.capabilities
   }
@@ -562,14 +566,17 @@ final class AppModel {
   }
 
   func addCategory(label: String) {
+    guard canEditCategories else { return }
     mutateEditorDocument { $0.addCategory(label: label) }
   }
 
   func renameCategory(key: String, label: String) {
+    guard canEditCategories else { return }
     mutateEditorDocument { $0.renameCategory(key: key, label: label) }
   }
 
   func deleteCategory(key: String) {
+    guard canEditCategories else { return }
     mutateEditorDocument { $0.deleteCategory(key: key) }
   }
 

--- a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
@@ -20,6 +20,10 @@ struct MenuEditorScreen: View {
     menu.isFoodMenu ? theme.foodAccent : theme.drinkAccent
   }
 
+  private var canEditCategories: Bool {
+    model.canEditCategories
+  }
+
   var body: some View {
     ZStack {
       MenuEditorBackground(theme: theme)
@@ -45,6 +49,7 @@ struct MenuEditorScreen: View {
             menu: menu,
             theme: theme,
             menuAccent: menuAccent,
+            canEditCategories: canEditCategories,
             onAddItem: presentNewItem,
             onAddCategory: { showingAddCategory = true },
             onSaveQuietly: saveQuietly,
@@ -63,6 +68,7 @@ struct MenuEditorScreen: View {
                 category: category,
                 theme: theme,
                 menuAccent: menuAccent,
+                canEditCategories: canEditCategories,
                 onRename: {
                   renameTarget = category
                   renameText = category.label
@@ -457,6 +463,7 @@ private struct MenuEditorActionPanel: View {
   let menu: MenuRecord
   let theme: MenuEditorTheme
   let menuAccent: Color
+  let canEditCategories: Bool
   let onAddItem: () -> Void
   let onAddCategory: () -> Void
   let onSaveQuietly: () -> Void
@@ -475,10 +482,12 @@ private struct MenuEditorActionPanel: View {
         }
         .buttonStyle(.plain)
 
-        Button(action: onAddCategory) {
-          MenuEditorActionLabel(title: "Add Category", subtitle: "Create a new section", icon: "square.split.1x2.fill", accent: menuAccent)
+        if canEditCategories {
+          Button(action: onAddCategory) {
+            MenuEditorActionLabel(title: "Add Category", subtitle: "Create a new section", icon: "square.split.1x2.fill", accent: menuAccent)
+          }
+          .buttonStyle(.plain)
         }
-        .buttonStyle(.plain)
       }
 
       HStack(spacing: 12) {
@@ -565,6 +574,7 @@ private struct MenuEditorCategoryCard: View {
   let category: MenuCategoryPayload
   let theme: MenuEditorTheme
   let menuAccent: Color
+  let canEditCategories: Bool
   let onRename: () -> Void
   let onDelete: () -> Void
   let onSelectItem: (MenuItemPayload) -> Void
@@ -594,13 +604,15 @@ private struct MenuEditorCategoryCard: View {
           .padding(.horizontal, 8)
           .background(menuAccent.opacity(0.15), in: Capsule())
           .foregroundStyle(menuAccent)
-        Menu {
-          Button("Rename", action: onRename)
-          Button("Delete Category", role: .destructive, action: onDelete)
-        } label: {
-          Image(systemName: "ellipsis.circle.fill")
-            .font(.system(size: 20))
-            .foregroundStyle(theme.subtleText)
+        if canEditCategories {
+          Menu {
+            Button("Rename", action: onRename)
+            Button("Delete Category", role: .destructive, action: onDelete)
+          } label: {
+            Image(systemName: "ellipsis.circle.fill")
+              .font(.system(size: 20))
+              .foregroundStyle(theme.subtleText)
+          }
         }
       }
 

--- a/ios/ElRoysManagerApp/Models/AppModels.swift
+++ b/ios/ElRoysManagerApp/Models/AppModels.swift
@@ -659,6 +659,7 @@ struct MenuCategoryPayload: Codable, Equatable, Hashable, Identifiable {
   var sub: String
   var placeholder: String
   var displayOrder: Int
+  var untappdEnabled: Bool
   var items: [MenuItemPayload]
 
   enum CodingKeys: String, CodingKey {
@@ -671,6 +672,8 @@ struct MenuCategoryPayload: Codable, Equatable, Hashable, Identifiable {
     case sub
     case placeholder
     case displayOrder
+    case untappdEnabled
+    case untappd_enabled
     case items
   }
 
@@ -684,6 +687,7 @@ struct MenuCategoryPayload: Codable, Equatable, Hashable, Identifiable {
     sub: String,
     placeholder: String,
     displayOrder: Int,
+    untappdEnabled: Bool = false,
     items: [MenuItemPayload]
   ) {
     self.id = id
@@ -695,6 +699,7 @@ struct MenuCategoryPayload: Codable, Equatable, Hashable, Identifiable {
     self.sub = sub
     self.placeholder = placeholder
     self.displayOrder = displayOrder
+    self.untappdEnabled = untappdEnabled
     self.items = items
   }
 
@@ -709,7 +714,25 @@ struct MenuCategoryPayload: Codable, Equatable, Hashable, Identifiable {
     self.sub = try container.decodeString(forKey: .sub)
     self.placeholder = try container.decodeString(forKey: .placeholder)
     self.displayOrder = try container.decodeInt(forKey: .displayOrder)
+    self.untappdEnabled = try container.decodeIfPresent(Bool.self, forKey: .untappdEnabled)
+      ?? container.decodeIfPresent(Bool.self, forKey: .untappd_enabled)
+      ?? false
     self.items = (try? container.decode([MenuItemPayload].self, forKey: .items)) ?? []
+  }
+
+  func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    try container.encode(id, forKey: .id)
+    try container.encodeIfPresent(menuId, forKey: .menuId)
+    try container.encode(key, forKey: .key)
+    try container.encode(label, forKey: .label)
+    try container.encode(icon, forKey: .icon)
+    try container.encode(color, forKey: .color)
+    try container.encode(sub, forKey: .sub)
+    try container.encode(placeholder, forKey: .placeholder)
+    try container.encode(displayOrder, forKey: .displayOrder)
+    try container.encode(untappdEnabled, forKey: .untappdEnabled)
+    try container.encode(items, forKey: .items)
   }
 }
 

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -337,6 +337,37 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(payload.restaurantTools?.siblingCatalog.first?.visibility, "off_menu")
   }
 
+  func testCategoryPayloadDefaultsUntappdEnabledToFalse() throws {
+    let data = Data("""
+    {
+      "id": "cat-1",
+      "key": "beer",
+      "label": "Beer",
+      "items": []
+    }
+    """.utf8)
+
+    let category = try JSONDecoder.backend.decode(MenuCategoryPayload.self, from: data)
+
+    XCTAssertFalse(category.untappdEnabled)
+  }
+
+  func testCategoryPayloadDecodesUntappdEnabledFromSnakeCase() throws {
+    let data = Data("""
+    {
+      "id": "cat-1",
+      "key": "beer",
+      "label": "Beer",
+      "untappd_enabled": true,
+      "items": []
+    }
+    """.utf8)
+
+    let category = try JSONDecoder.backend.decode(MenuCategoryPayload.self, from: data)
+
+    XCTAssertTrue(category.untappdEnabled)
+  }
+
   func testWorkspacePayloadDecodesQueueStatusFields() throws {
     let data = Data("""
     {
@@ -380,6 +411,87 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(payload.workspace.hasUnsentChanges, true)
     XCTAssertEqual(payload.workspace.revisions.liveRevision, 200)
     XCTAssertEqual(payload.workspace.revisions.notificationBaselineRevision, 150)
+  }
+
+  @MainActor
+  func testCanEditCategoriesTracksAdminPermission() {
+    let adminWorkspace = makeWorkspace(
+      permissions: WorkspacePermissions(
+        canManage: true,
+        canAdmin: true,
+        canEditRestaurantSpecials: false,
+        canReadRestaurantTools: false
+      )
+    )
+    let managerWorkspace = makeWorkspace(
+      permissions: WorkspacePermissions(
+        canManage: true,
+        canAdmin: false,
+        canEditRestaurantSpecials: false,
+        canReadRestaurantTools: false
+      )
+    )
+
+    let adminModel = AppModel(
+      environment: AppEnvironment(name: .preview, baseURL: exampleURL, publicOrigin: exampleURL, displayName: "Preview"),
+      services: makeServices(workspaceClient: StubWorkspaceClient(payloads: []), historyClient: StubHistoryClient(payload: makeHistoryPayload())),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    let managerModel = AppModel(
+      environment: AppEnvironment(name: .preview, baseURL: exampleURL, publicOrigin: exampleURL, displayName: "Preview"),
+      services: makeServices(workspaceClient: StubWorkspaceClient(payloads: []), historyClient: StubHistoryClient(payload: makeHistoryPayload())),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+
+    adminModel.currentEditorWorkspace = adminWorkspace
+    managerModel.currentEditorWorkspace = managerWorkspace
+
+    XCTAssertTrue(adminModel.canEditCategories)
+    XCTAssertFalse(managerModel.canEditCategories)
+  }
+
+  @MainActor
+  func testCategoryMutationsAreIgnoredForNonAdmins() {
+    let workspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      permissions: WorkspacePermissions(
+        canManage: true,
+        canAdmin: false,
+        canEditRestaurantSpecials: false,
+        canReadRestaurantTools: false
+      )
+    )
+    let model = AppModel(
+      environment: AppEnvironment(name: .preview, baseURL: exampleURL, publicOrigin: exampleURL, displayName: "Preview"),
+      services: makeServices(workspaceClient: StubWorkspaceClient(payloads: []), historyClient: StubHistoryClient(payload: makeHistoryPayload())),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.currentEditorWorkspace = workspace
+    model.currentEditorDocument = EditableMenuDocument(workspace: workspace)
+
+    model.addCategory(label: "Wine")
+    model.renameCategory(key: "beer", label: "Draft Beer")
+    model.deleteCategory(key: "beer")
+
+    XCTAssertFalse(model.canEditCategories)
+    XCTAssertEqual(model.currentEditorDocument?.visibleCategories.count, 1)
+    XCTAssertEqual(model.currentEditorDocument?.category(for: "beer")?.label, "Beer")
   }
 
   func testHistoryPayloadDecodesWhenSourceFieldsAreMissing() throws {
@@ -1511,7 +1623,8 @@ final class MenuDocumentTests: XCTestCase {
     sharedDraft: SharedDraftInfo? = nil,
     revisions: WorkspaceRevisions = WorkspaceRevisions(liveRevision: 10, draftRevision: nil, lastSentRevision: 10, notificationBaselineRevision: 10),
     menuStatus: String = "",
-    hasUnsentChanges: Bool? = nil
+    hasUnsentChanges: Bool? = nil,
+    permissions: WorkspacePermissions = WorkspacePermissions(canManage: true, canAdmin: true, canEditRestaurantSpecials: false, canReadRestaurantTools: false)
   ) -> MenuWorkspacePayload {
     let resolvedSharedDraft = sharedDraft ?? SharedDraftInfo(
       exists: hasSharedDraft,
@@ -1532,7 +1645,7 @@ final class MenuDocumentTests: XCTestCase {
         sharedDraft: resolvedSharedDraft,
         menuStatus: menuStatus,
         hasUnsentChanges: hasUnsentChanges,
-        permissions: WorkspacePermissions(canManage: true, canAdmin: false, canEditRestaurantSpecials: false, canReadRestaurantTools: false),
+        permissions: permissions,
         capabilities: WorkspaceCapabilities(
           canSaveDraft: true,
           canSaveLiveMenu: true,

--- a/manager/index.html
+++ b/manager/index.html
@@ -301,6 +301,10 @@
                 <label for="new-cat-placeholder">Placeholder</label>
                 <input type="text" id="new-cat-placeholder" name="new-category-hint" class="catmgr-input" placeholder="Shown when adding items, e.g. &quot;Margarita…&quot;" autocomplete="off"/>
               </div>
+              <label class="catmgr-checkbox-row" id="new-cat-untappd-row" for="new-cat-untappd-enabled" style="display:none">
+                <input type="checkbox" id="new-cat-untappd-enabled" name="new-category-untappd-enabled"/>
+                <span>Enable Untappd import for this category</span>
+              </label>
               <div class="catmgr-add-btn-row">
                 <button class="btn-small" onclick="confirmAddCategory()">Add Category</button>
                 <button class="btn-small" onclick="document.getElementById('catmgr-add-form').style.display='none'">Cancel</button>
@@ -436,6 +440,7 @@
 <script src="/core/ui/manager/sections.js"></script>
 <script src="/core/ui/manager/editors.js"></script>
 <script src="/core/ui/manager/open-food-facts.js"></script>
+<script src="/core/ui/manager/untappd.js"></script>
 <script src="/core/ui/manager/barcode-scanner.js"></script>
 <script src="/core/ui/admin/workspace.js"></script>
 <script src="/core/ui/admin/switcher.js"></script>

--- a/manager/index.html
+++ b/manager/index.html
@@ -307,7 +307,7 @@
               </label>
               <div class="catmgr-add-btn-row">
                 <button class="btn-small" onclick="confirmAddCategory()">Add Category</button>
-                <button class="btn-small" onclick="document.getElementById('catmgr-add-form').style.display='none'">Cancel</button>
+                <button class="btn-small" onclick="cancelAddCategoryForm()">Cancel</button>
               </div>
             </div>
             <button class="btn-small" id="show-add-cat-btn" onclick="toggleAddCategoryForm()">+ Add Category</button>

--- a/server/_category-governance.js
+++ b/server/_category-governance.js
@@ -1,0 +1,133 @@
+import { readMenuStateBundle } from './_menu-read.js';
+
+const UNCATEGORIZED_ID = '__uncategorized__';
+const GOVERNED_FIELDS = [
+  'key',
+  'label',
+  'icon',
+  'color',
+  'sub',
+  'placeholder',
+  'display_order',
+  'untappd_enabled',
+];
+
+function asArray(value) {
+  return Array.isArray(value) ? value : [];
+}
+
+function asString(value) {
+  return typeof value === 'string' ? value.trim() : '';
+}
+
+function normalizeDisplayOrder(value, fallback = 0) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function normalizeGovernedCategory(category = {}, fallbackIndex = 0) {
+  const key = asString(category?.key);
+  if (!key || key === UNCATEGORIZED_ID) return null;
+  return {
+    key,
+    label: asString(category?.label) || key,
+    icon: asString(category?.icon),
+    color: asString(category?.color),
+    sub: asString(category?.sub),
+    placeholder: asString(category?.placeholder),
+    display_order: normalizeDisplayOrder(category?.display_order, fallbackIndex),
+    untappd_enabled: category?.untappd_enabled === true || category?.untappdEnabled === true,
+  };
+}
+
+function buildGovernedCategoryMap(categories = []) {
+  const map = new Map();
+  asArray(categories).forEach((category, index) => {
+    const normalized = normalizeGovernedCategory(category, index);
+    if (!normalized || map.has(normalized.key)) return;
+    map.set(normalized.key, normalized);
+  });
+  return map;
+}
+
+function categoriesDiffer(left = null, right = null) {
+  if (!left || !right) return true;
+  return GOVERNED_FIELDS.some(field => {
+    if (field === 'untappd_enabled') return !!left[field] !== !!right[field];
+    return left[field] !== right[field];
+  });
+}
+
+function createAllowedResult() {
+  return {
+    allowed: true,
+    changed_categories: [],
+  };
+}
+
+export function detectForbiddenCategoryMutations({
+  actor = null,
+  currentCategories = [],
+  nextCategories = [],
+} = {}) {
+  if (actor?.role === 'admin') return createAllowedResult();
+
+  const nextCategoryArray = asArray(nextCategories);
+  if (!nextCategoryArray.length) return createAllowedResult();
+
+  const currentMap = buildGovernedCategoryMap(currentCategories);
+  const nextMap = buildGovernedCategoryMap(nextCategoryArray);
+  const changedCategoryKeys = [];
+  const observedKeys = new Set();
+
+  [...currentMap.keys(), ...nextMap.keys()].forEach(key => {
+    if (!key || observedKeys.has(key)) return;
+    observedKeys.add(key);
+    const currentCategory = currentMap.get(key) || null;
+    const nextCategory = nextMap.get(key) || null;
+    if (categoriesDiffer(currentCategory, nextCategory)) {
+      changedCategoryKeys.push(key);
+    }
+  });
+
+  if (!changedCategoryKeys.length) return createAllowedResult();
+  return {
+    allowed: false,
+    changed_categories: changedCategoryKeys,
+  };
+}
+
+export function buildCategoryGovernanceError(result = null) {
+  return {
+    status: 403,
+    message: 'Category changes are admin-only.',
+    body: {
+      ok: false,
+      status: 'category_governance_denied',
+      code: 'category_governance_denied',
+      error: 'Category changes are admin-only.',
+      changed_categories: Array.isArray(result?.changed_categories) ? result.changed_categories : [],
+    },
+  };
+}
+
+export async function assertCategoryGovernanceAllowed({
+  actor = null,
+  menuId = '',
+  snapshot = {},
+} = {}) {
+  if (actor?.role === 'admin') return createAllowedResult();
+  const nextCategories = asArray(snapshot?.cats);
+  if (!menuId || !nextCategories.length) return createAllowedResult();
+
+  const liveBundle = await readMenuStateBundle(menuId);
+  const result = detectForbiddenCategoryMutations({
+    actor,
+    currentCategories: liveBundle?.cats || [],
+    nextCategories,
+  });
+  if (!result.allowed) {
+    throw buildCategoryGovernanceError(result);
+  }
+  return result;
+}

--- a/server/_category-governance.js
+++ b/server/_category-governance.js
@@ -65,6 +65,12 @@ function createAllowedResult() {
   };
 }
 
+function readGovernanceBaselineCategories(bundle = {}) {
+  const draftCategories = bundle?.meta?.draft_state?.cats;
+  if (Array.isArray(draftCategories)) return draftCategories;
+  return asArray(bundle?.cats);
+}
+
 export function detectForbiddenCategoryMutations({
   actor = null,
   currentCategories = [],
@@ -123,7 +129,7 @@ export async function assertCategoryGovernanceAllowed({
   const liveBundle = await readMenuStateBundle(menuId);
   const result = detectForbiddenCategoryMutations({
     actor,
-    currentCategories: liveBundle?.cats || [],
+    currentCategories: readGovernanceBaselineCategories(liveBundle),
     nextCategories,
   });
   if (!result.allowed) {

--- a/server/_category-governance.js
+++ b/server/_category-governance.js
@@ -121,9 +121,16 @@ export async function assertCategoryGovernanceAllowed({
   actor = null,
   menuId = '',
   snapshot = {},
+  requireCategorySnapshot = false,
 } = {}) {
   if (actor?.role === 'admin') return createAllowedResult();
   const nextCategories = asArray(snapshot?.cats);
+  if (requireCategorySnapshot && !Array.isArray(snapshot?.cats)) {
+    throw {
+      status: 400,
+      message: 'Snapshot payload must include cats[]',
+    };
+  }
   if (!menuId || !nextCategories.length) return createAllowedResult();
 
   const liveBundle = await readMenuStateBundle(menuId);

--- a/server/_menu-draft.js
+++ b/server/_menu-draft.js
@@ -4,6 +4,7 @@ import {
   requireMenuAccess,
 } from './_auth.js';
 import { isSupportedMenuId } from './_menu-read.js';
+import { assertCategoryGovernanceAllowed } from './_category-governance.js';
 import {
   inferAuditSource,
   saveDraftStateForMenu,
@@ -92,6 +93,15 @@ export async function saveSharedDraftCommand(req) {
     name: String(profile?.name || '').trim(),
     role,
   }, body?.source || '');
+  await assertCategoryGovernanceAllowed({
+    actor: {
+      id: uid,
+      name: String(profile?.name || '').trim(),
+      role,
+    },
+    menuId,
+    snapshot,
+  });
   const draftExists = hasSharedDraft(snapshot);
 
   let saveResult;

--- a/server/_menu-live.js
+++ b/server/_menu-live.js
@@ -442,6 +442,7 @@ export async function saveLiveMenuCommand(req) {
     actor,
     menuId,
     snapshot: snapshotPayload,
+    requireCategorySnapshot: true,
   });
 
   const expectedLiveRevision = firstDefined(

--- a/server/_menu-live.js
+++ b/server/_menu-live.js
@@ -20,6 +20,7 @@ import {
   readMenuMeta,
   readRevisionState,
 } from './_menu-write.js';
+import { assertCategoryGovernanceAllowed } from './_category-governance.js';
 
 const UNCATEGORIZED_ID = '__uncategorized__';
 
@@ -161,6 +162,7 @@ function normalizeCategoryRows(menuId, categories = []) {
       color: asString(row.color),
       sub: asString(row.sub),
       placeholder: asString(row.placeholder),
+      untappd_enabled: row?.untappd_enabled === true || row?.untappdEnabled === true,
       rawId: asString(row.id),
       items: asArray(row.items),
     });
@@ -177,6 +179,7 @@ function normalizeCategoryRows(menuId, categories = []) {
     color: category.color,
     sub: category.sub,
     placeholder: category.placeholder,
+    untappd_enabled: category.untappd_enabled === true,
     display_order: index,
     id: category.rawId && !category.rawId.startsWith('local-') ? category.rawId : undefined,
   }));
@@ -190,6 +193,7 @@ function normalizeCategoryRows(menuId, categories = []) {
         color: uncategorized.color,
         sub: uncategorized.sub,
         placeholder: uncategorized.placeholder,
+        untappd_enabled: false,
         display_order: 9999,
         id: uncategorized.rawId && !uncategorized.rawId.startsWith('local-') ? uncategorized.rawId : undefined,
       }
@@ -245,6 +249,7 @@ async function upsertCategories(menuId, normalizedCategories, categoriesByKey) {
     color: '',
     sub: '',
     placeholder: '',
+    untappd_enabled: false,
     display_order: 9999,
   };
   rows.push(uncategorizedSeed);
@@ -427,6 +432,18 @@ export async function saveLiveMenuCommand(req) {
     throw { status: 403, message: 'Forbidden' };
   }
   await requireMenuAccess(uid, role, menuId);
+
+  const actor = {
+    id: uid,
+    name: String(profile?.name || '').trim(),
+    role,
+  };
+  const snapshotPayload = asObject(payload?.snapshot) || payload;
+  await assertCategoryGovernanceAllowed({
+    actor,
+    menuId,
+    snapshot: snapshotPayload,
+  });
 
   const expectedLiveRevision = firstDefined(
     payload?.expected_live_revision,

--- a/server/_menu-publish.js
+++ b/server/_menu-publish.js
@@ -24,6 +24,7 @@ import {
   getKnownMenuById,
   readCurrentFeaturedIdsForRestaurant,
 } from './_menu-read.js';
+import { assertCategoryGovernanceAllowed } from './_category-governance.js';
 import {
   buildCategoryQueueState,
   normalizeName,
@@ -576,6 +577,12 @@ export async function previewMenuUpdateForMenu({
     throw { status: 400, message: 'Unsupported menu_id' };
   }
 
+  await assertCategoryGovernanceAllowed({
+    actor,
+    menuId,
+    snapshot,
+  });
+
   const meta = await readMenuMeta(menuId);
   const currentRevisions = assertPublishRevisions({
     expectedLiveRevision,
@@ -619,6 +626,12 @@ export async function publishMenuUpdateForMenu({
   if (!knownMenu) {
     throw { status: 400, message: 'Unsupported menu_id' };
   }
+
+  await assertCategoryGovernanceAllowed({
+    actor,
+    menuId,
+    snapshot,
+  });
 
   const meta = await readMenuMeta(menuId);
   const currentRevisions = assertPublishRevisions({

--- a/server/_menu-publish.js
+++ b/server/_menu-publish.js
@@ -582,6 +582,7 @@ export async function previewMenuUpdateForMenu({
     actor,
     menuId,
     snapshot,
+    requireCategorySnapshot: true,
   });
 
   const meta = await readMenuMeta(menuId);
@@ -632,6 +633,7 @@ export async function publishMenuUpdateForMenu({
     actor,
     menuId,
     snapshot,
+    requireCategorySnapshot: true,
   });
 
   const meta = await readMenuMeta(menuId);

--- a/server/_menu-read.js
+++ b/server/_menu-read.js
@@ -226,6 +226,13 @@ function sanitizePublicCategory(category = {}) {
   };
 }
 
+function normalizeWorkspaceCategory(category = {}) {
+  return {
+    ...category,
+    untappd_enabled: category?.untappd_enabled === true || category?.untappdEnabled === true,
+  };
+}
+
 function sanitizePublicRestaurant(restaurant = null) {
   if (!restaurant || typeof restaurant !== 'object') return null;
   const design = restaurant.design && typeof restaurant.design === 'object' ? restaurant.design : {};
@@ -252,6 +259,9 @@ function sanitizePublicMeta(meta = {}) {
 }
 
 export function createMenuWorkspacePayload(bundle, { actor = null, restaurantTools = null } = {}) {
+  const normalizedCats = Array.isArray(bundle?.cats)
+    ? bundle.cats.map(normalizeWorkspaceCategory)
+    : [];
   const accessibleMenuIds = getActorAccessibleMenuIds(actor);
   const menuId = bundle?.menu?.id || '';
   const restaurantId = bundle?.menu?.restaurantId || '';
@@ -283,7 +293,7 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
     ? draftMeta.last_sent_state
     : {};
   const queueState = buildCategoryQueueState({
-    snapshot: { cats: bundle?.cats || [] },
+    snapshot: { cats: normalizedCats },
     lastSentState,
   });
   const currentFeaturedIds = Array.isArray(bundle?.featuredCurrentIds)
@@ -320,7 +330,7 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
   };
 
   return {
-    cats: bundle?.cats || [],
+    cats: normalizedCats,
     meta: bundle?.meta || {},
     restaurant: bundle?.restaurant || null,
     restaurantTools: restaurantTools || null,

--- a/server/_menu-write.js
+++ b/server/_menu-write.js
@@ -61,6 +61,7 @@ function normalizeSnapshot(snapshot = {}) {
       color: String(category?.color || ''),
       sub: String(category?.sub || ''),
       placeholder: String(category?.placeholder || ''),
+      untappd_enabled: category?.untappd_enabled === true || category?.untappdEnabled === true,
       display_order: Number.isFinite(Number(category?.display_order)) ? Number(category.display_order) : categoryIndex,
       items: (Array.isArray(category?.items) ? category.items : []).map((item, itemIndex) => ({
         id: String(item?.id || ''),
@@ -252,6 +253,7 @@ async function upsertCategories(menuId, normalizedSnapshot) {
     color: category.color,
     sub: category.sub,
     placeholder: category.placeholder,
+    untappd_enabled: category.untappd_enabled === true,
     display_order: category.display_order,
   }));
   if (categoryRows.length) {

--- a/server/_untappd.js
+++ b/server/_untappd.js
@@ -19,11 +19,25 @@ function cleanText(value = '') {
   return String(value || '').replace(/\s+/g, ' ').trim();
 }
 
+function normalizeNoiseToken(value = '') {
+  return cleanText(value)
+    .toLowerCase()
+    .replace(/^[^a-z0-9]+|[^a-z0-9]+$/g, '');
+}
+
 function normalizeBid(value) {
   const text = cleanText(value);
   if (!text) return '';
   const numeric = Number(text);
   return Number.isFinite(numeric) ? numeric : text;
+}
+
+function isPackagingCountToken(token = '', index = 0, tokens = []) {
+  const lower = normalizeNoiseToken(token);
+  if (!/^\d+(?:\.\d+)?$/.test(lower)) return false;
+  const previous = normalizeNoiseToken(tokens[index - 1] || '');
+  const next = normalizeNoiseToken(tokens[index + 1] || '');
+  return NOISE_WORDS.has(previous) || NOISE_WORDS.has(next);
 }
 
 function normalizeUntappdQuery(query = '') {
@@ -32,13 +46,14 @@ function normalizeUntappdQuery(query = '') {
     .map(token => token.trim())
     .filter(Boolean);
 
-  const filtered = tokens.filter(token => {
-    const lower = token.toLowerCase();
+  const filtered = tokens.filter((token, index, entries) => {
+    const lower = normalizeNoiseToken(token);
+    if (!lower) return false;
     if (NOISE_WORDS.has(lower)) return false;
-    if (/^\d+$/.test(lower)) return false;
     if (/^\d+(?:\.\d+)?(?:oz|ml)$/.test(lower)) return false;
     if (/^\d+(?:\.\d+)?-?(?:pk|pack)$/.test(lower)) return false;
     if (/^\d+(?:\.\d+)?(?:oz|ml)?-?(?:pk|pack)$/.test(lower)) return false;
+    if (isPackagingCountToken(token, index, entries)) return false;
     return true;
   });
 

--- a/server/_untappd.js
+++ b/server/_untappd.js
@@ -1,0 +1,211 @@
+const UNTAPPD_BASE_URL = 'https://api.untappd.com/v4/';
+const SEARCH_LIMIT = 5;
+
+const NOISE_WORDS = new Set([
+  'draft',
+  'tap',
+  'can',
+  'bottle',
+  'tallboy',
+  'crowler',
+  'growler',
+  'oz',
+  'ml',
+  'pk',
+  'pack',
+]);
+
+function cleanText(value = '') {
+  return String(value || '').replace(/\s+/g, ' ').trim();
+}
+
+function normalizeBid(value) {
+  const text = cleanText(value);
+  if (!text) return '';
+  const numeric = Number(text);
+  return Number.isFinite(numeric) ? numeric : text;
+}
+
+function normalizeUntappdQuery(query = '') {
+  const tokens = cleanText(query)
+    .split(' ')
+    .map(token => token.trim())
+    .filter(Boolean);
+
+  const filtered = tokens.filter(token => {
+    const lower = token.toLowerCase();
+    if (NOISE_WORDS.has(lower)) return false;
+    if (/^\d+$/.test(lower)) return false;
+    if (/^\d+(?:\.\d+)?(?:oz|ml)$/.test(lower)) return false;
+    if (/^\d+(?:\.\d+)?-?(?:pk|pack)$/.test(lower)) return false;
+    if (/^\d+(?:\.\d+)?(?:oz|ml)?-?(?:pk|pack)$/.test(lower)) return false;
+    return true;
+  });
+
+  return filtered.join(' ').replace(/\s+/g, ' ').trim();
+}
+
+function requireUntappdConfig() {
+  const clientId = cleanText(process.env.UNTAPPD_CLIENT_ID);
+  const clientSecret = cleanText(process.env.UNTAPPD_CLIENT_SECRET);
+  const userAgent = cleanText(process.env.UNTAPPD_USER_AGENT);
+  if (!clientId || !clientSecret || !userAgent) {
+    throw { status: 503, message: 'Untappd is unavailable right now.' };
+  }
+  return { clientId, clientSecret, userAgent };
+}
+
+function buildUntappdUrl(pathname, params = {}) {
+  const url = new URL(String(pathname || '').replace(/^\/+/, ''), UNTAPPD_BASE_URL);
+  Object.entries(params).forEach(([key, value]) => {
+    if (value === undefined || value === null || value === '') return;
+    url.searchParams.set(key, String(value));
+  });
+  return url;
+}
+
+function getBeerInfo(payload = {}) {
+  return payload?.response?.beer || payload?.beer || null;
+}
+
+function getBeerSearchItems(payload = {}) {
+  const items = payload?.response?.beers?.items
+    || payload?.beers?.items
+    || payload?.beers
+    || [];
+  return Array.isArray(items) ? items : [];
+}
+
+function extractBeerBid(beer = {}) {
+  const bid = normalizeBid(beer?.bid ?? beer?.beer_bid ?? beer?.beer?.bid);
+  return bid;
+}
+
+function extractBeerName(beer = {}) {
+  return cleanText(
+    beer?.beer_name
+    || beer?.beer_name_short
+    || beer?.beer?.beer_name
+    || beer?.name
+  );
+}
+
+function extractBreweryName(entry = {}) {
+  return cleanText(
+    entry?.brewery?.brewery_name
+    || entry?.brewery_name
+    || entry?.beer?.brewery?.brewery_name
+    || entry?.beer?.brewery_name
+  );
+}
+
+function extractStyleName(beer = {}) {
+  return cleanText(
+    beer?.beer_style
+    || beer?.style
+    || beer?.style_name
+    || beer?.beer_style_name
+    || beer?.beer?.beer_style
+  );
+}
+
+function extractAbvValue(beer = {}) {
+  const raw = beer?.beer_abv ?? beer?.abv ?? beer?.beer?.beer_abv;
+  const numeric = Number(raw);
+  return Number.isFinite(numeric) ? numeric : null;
+}
+
+function buildPreviewDescription(beer = {}) {
+  const style = extractStyleName(beer);
+  const abv = extractAbvValue(beer);
+  const parts = [];
+  if (style) parts.push(style);
+  if (abv !== null) parts.push(`${String(Number(abv))}% ABV`);
+  return parts.join(' • ');
+}
+
+async function readUntappdJson(url, userAgent) {
+  const response = await fetch(url, {
+    headers: {
+      Accept: 'application/json',
+      'User-Agent': userAgent,
+    },
+  });
+
+  if (!response.ok) {
+    throw { status: 502, message: 'Untappd is unavailable right now.' };
+  }
+
+  return response.json().catch(() => null);
+}
+
+function mapSearchResults(payload = {}) {
+  return getBeerSearchItems(payload)
+    .map(entry => {
+      const beer = entry?.beer || entry || {};
+      const bid = extractBeerBid(beer);
+      const name = extractBeerName(beer);
+      if (!bid || !name) return null;
+      const breweryName = extractBreweryName(entry);
+      return {
+        bid,
+        name,
+        breweryName: breweryName || '',
+        style: extractStyleName(beer),
+        abv: extractAbvValue(beer),
+      };
+    })
+    .filter(Boolean)
+    .slice(0, SEARCH_LIMIT);
+}
+
+export function normalizeUntappdSearchQuery(query = '') {
+  return normalizeUntappdQuery(query);
+}
+
+export async function searchUntappdBeers(query = '') {
+  const normalizedQuery = normalizeUntappdQuery(query);
+  if (!normalizedQuery) return [];
+
+  const { clientId, clientSecret, userAgent } = requireUntappdConfig();
+  const url = buildUntappdUrl('/search/beer', {
+    q: normalizedQuery,
+    limit: SEARCH_LIMIT,
+    sort: 'checkin',
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+  const payload = await readUntappdJson(url, userAgent);
+  return mapSearchResults(payload);
+}
+
+export async function previewUntappdBeerImport(bid, { includeBrewery = false } = {}) {
+  const normalizedBid = normalizeBid(bid);
+  if (!normalizedBid) return null;
+
+  const { clientId, clientSecret, userAgent } = requireUntappdConfig();
+  const url = buildUntappdUrl(`/beer/info/${encodeURIComponent(String(normalizedBid))}`, {
+    compact: 'true',
+    client_id: clientId,
+    client_secret: clientSecret,
+  });
+  const payload = await readUntappdJson(url, userAgent);
+  const beer = getBeerInfo(payload);
+  if (!beer) return null;
+
+  const name = extractBeerName(beer);
+  if (!name) return null;
+
+  const result = {
+    bid: normalizeBid(beer?.bid ?? beer?.beer_bid ?? normalizedBid),
+    name,
+    description: buildPreviewDescription(beer),
+  };
+
+  if (includeBrewery) {
+    const breweryName = extractBreweryName(beer);
+    if (breweryName) result.breweryName = breweryName;
+  }
+
+  return result;
+}

--- a/style.css
+++ b/style.css
@@ -742,11 +742,23 @@
   .add-item-field-label { font-size: 12px; font-weight: 700; letter-spacing: 0.04em; color: var(--muted); text-transform: uppercase; }
   .add-item-inline-row { display: grid; grid-template-columns: minmax(0, 1fr) minmax(0, 120px) auto; gap: 8px; align-items: center; }
   .add-item-inline-row--barcode { grid-template-columns: minmax(0, 1fr) auto; }
+  .add-item-inline-row--untappd { grid-template-columns: minmax(0, 1fr) auto; }
   .add-item-inline-note { margin: 0; color: var(--muted); font-size: 12px; }
   .add-item-pill-list { display: flex; flex-wrap: wrap; gap: 8px; }
   .add-item-pill { display: inline-flex; align-items: center; gap: 8px; padding: 8px 10px; border-radius: 999px; background: var(--surface); border: 1px solid var(--border); font-size: 12px; color: var(--text); }
   .add-item-pill-remove { border: none; background: transparent; color: var(--muted); cursor: pointer; font-size: 16px; line-height: 1; padding: 0; }
   .add-item-modal-warning { margin-bottom: 14px; padding: 10px 12px; border-radius: 10px; background: rgba(190,67,48,0.12); border: 1px solid rgba(190,67,48,0.26); color: var(--terra-dk); font-size: 13px; }
+  .add-item-untappd-panel { padding: 14px; border-radius: 14px; background: rgba(18,133,120,0.06); border: 1px solid rgba(18,133,120,0.16); }
+  .add-item-untappd-header { display: flex; align-items: center; justify-content: space-between; gap: 12px; margin-bottom: 12px; color: var(--text); }
+  .add-item-untappd-result-list { display: flex; flex-direction: column; gap: 8px; }
+  .add-item-untappd-result { width: 100%; text-align: left; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); color: var(--text); padding: 12px; display: flex; flex-direction: column; gap: 4px; cursor: pointer; }
+  .add-item-untappd-result-name { font-family: var(--font-heading); font-size: 15px; }
+  .add-item-untappd-result-meta { color: var(--muted); font-size: 12px; }
+  .add-item-untappd-preview { display: grid; gap: 6px; margin-bottom: 12px; }
+  .add-item-untappd-preview-label { color: var(--muted); font-size: 11px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; }
+  .add-item-untappd-preview-value { color: var(--text); font-size: 14px; line-height: 1.5; }
+  .add-item-untappd-actions { display: flex; gap: 8px; justify-content: flex-end; margin-top: 12px; }
+  .add-item-untappd-attribution { margin-top: 12px; }
   .add-item-scan-panel { display: flex; flex-direction: column; gap: 14px; }
   .add-item-scan-panel--unsupported { padding: 14px; border-radius: 16px; background: rgba(72, 63, 54, 0.04); border: 1px dashed rgba(72, 63, 54, 0.2); }
   .add-item-scan-copy { display: flex; flex-direction: column; gap: 6px; }
@@ -757,6 +769,15 @@
   .add-item-scanner-overlay::before { content: ""; width: min(78%, 340px); aspect-ratio: 1.85 / 1; border: 2px solid rgba(253,244,236,0.85); border-radius: 16px; box-shadow: 0 0 0 999px rgba(14, 17, 21, 0.18); }
   .add-item-scanner-overlay-copy { position: absolute; bottom: 18px; left: 18px; right: 18px; color: rgba(253,244,236,0.94); font-size: 12px; letter-spacing: 0.08em; text-transform: uppercase; text-align: center; }
   .manager-category-note { margin: 12px 0 0; color: var(--muted); font-size: 12px; line-height: 1.5; }
+
+  @media (max-width: 640px) {
+    .add-item-modal-grid { grid-template-columns: 1fr; }
+    .add-item-inline-row,
+    .add-item-inline-row--barcode,
+    .add-item-inline-row--untappd { grid-template-columns: 1fr; }
+    .add-item-untappd-header,
+    .add-item-untappd-actions { align-items: stretch; flex-direction: column; }
+  }
 
   .logout-link { background: none; border: none; color: var(--muted); font-family: var(--font-body); font-size: 12px; cursor: pointer; margin-top: 20px; display: block; text-align: center; width: 100%; padding: 8px; transition: color 0.2s; }
   .logout-link:hover { color: var(--text); }
@@ -935,10 +956,14 @@
   .catmgr-input { flex: 1; background: var(--surface); border: 1px solid var(--border); border-radius: 7px; color: var(--text); font-family: var(--font-body); font-size: 13px; padding: 7px 10px; outline: none; transition: border-color 0.2s; }
   .catmgr-input:focus { border-color: var(--fire); }
   .catmgr-icon-input { max-width: 60px; text-align: center; font-size: 18px; }
+  .catmgr-checkbox-row { display: flex; align-items: center; gap: 10px; margin-top: 12px; color: var(--text); font-size: 13px; }
+  .catmgr-checkbox-row input[type="checkbox"] { accent-color: var(--ember); }
   .catmgr-save-row { display: flex; gap: 6px; justify-content: flex-end; margin-top: 12px; }
   .catmgr-add-form { background: var(--card); border: 1px solid var(--border); border-radius: 12px; padding: 14px; margin-bottom: 10px; }
   .catmgr-add-form h3 { font-size: 11px; font-weight: 500; color: var(--muted); letter-spacing: 1px; text-transform: uppercase; margin-bottom: 4px; }
   .catmgr-add-btn-row { display: flex; gap: 8px; margin-top: 16px; }
+  .catmgr-readonly-note { margin-bottom: 12px; padding: 12px 14px; border-radius: 12px; background: rgba(72, 63, 54, 0.05); border: 1px solid rgba(72, 63, 54, 0.12); color: var(--text); font-size: 13px; line-height: 1.5; }
+  .catmgr-readonly-pill { display: inline-flex; align-items: center; padding: 6px 10px; border-radius: 999px; background: rgba(72, 63, 54, 0.08); color: var(--muted); font-size: 11px; font-weight: 700; letter-spacing: 0.05em; text-transform: uppercase; }
 
   /* ── DESIGN SECTION (admin tab) ── */
   .design-row { display: flex; align-items: flex-start; gap: 10px; margin-bottom: 10px; }

--- a/supabase/migrations/20260418000000_v0.8.13_categories_untappd.sql
+++ b/supabase/migrations/20260418000000_v0.8.13_categories_untappd.sql
@@ -1,0 +1,2 @@
+ALTER TABLE public.categories
+  ADD COLUMN IF NOT EXISTS untappd_enabled boolean NOT NULL DEFAULT false;

--- a/tests/helpers/runtime.cjs
+++ b/tests/helpers/runtime.cjs
@@ -14,6 +14,7 @@ const DEFAULT_RUNTIME_SCRIPTS = [
   'core/ui/manager/sections.js',
   'core/ui/manager/editors.js',
   'core/ui/manager/open-food-facts.js',
+  'core/ui/manager/untappd.js',
   'core/ui/manager/barcode-scanner.js',
   'core/ui/admin/workspace.js',
   'core/ui/admin/switcher.js',

--- a/tests/phase16-add-item-modal.test.cjs
+++ b/tests/phase16-add-item-modal.test.cjs
@@ -278,6 +278,217 @@ test('duplicate blocking clears once the manager changes the conflicting draft',
   assert.equal(getState(sandbox, 'menuState.cocktails.items[0].name'), 'modelo especial');
 });
 
+test('untappd import UI is gated by the selected drinks category and hidden on food menus', () => {
+  const sandbox = loadAppSandbox();
+  const { modalHost } = setupManagerAddItemDom(sandbox);
+  seedManagerMenuState(sandbox, {
+    CATEGORY_DEFS: [
+      {
+        id: 'beer',
+        label: 'Beer',
+        title: 'Beer',
+        icon: '🍺',
+        color: 'rgba(245,210,66,0.22)',
+        sub: 'Drafts and cans',
+        placeholder: 'Add beer…',
+        untappdEnabled: true,
+      },
+      {
+        id: 'cocktails',
+        label: 'Cocktails',
+        title: 'Cocktails',
+        icon: '🍹',
+        color: 'rgba(180,100,220,0.15)',
+        sub: 'Classics and house drinks',
+        placeholder: 'Add cocktail…',
+        untappdEnabled: false,
+      },
+    ],
+  });
+
+  sandbox.openAddItemModal();
+  assert.match(modalHost.innerHTML, /Brewery \+ Beer/);
+  assert.match(modalHost.innerHTML, />Untappd</);
+
+  sandbox.updateAddItemModalField('categoryId', 'cocktails');
+
+  assert.doesNotMatch(modalHost.innerHTML, /Brewery \+ Beer/);
+  assert.doesNotMatch(modalHost.innerHTML, />Untappd</);
+
+  const foodSandbox = loadAppSandbox();
+  const { modalHost: foodModalHost } = setupManagerAddItemDom(foodSandbox);
+  seedManagerMenuState(foodSandbox, {
+    MENU_TYPE: 'food',
+    CATEGORY_DEFS: [
+      {
+        id: 'starters',
+        label: 'Starters',
+        title: 'Starters',
+        icon: '🥗',
+        color: 'rgba(245,210,66,0.22)',
+        sub: '',
+        placeholder: 'Add starter…',
+        untappdEnabled: true,
+      },
+    ],
+    menuState: {
+      starters: { items: [], lastSent: [] },
+      __uncategorized__: { items: [], lastSent: [] },
+    },
+  });
+
+  foodSandbox.openAddItemModal();
+
+  assert.doesNotMatch(foodModalHost.innerHTML, />Untappd</);
+  assert.doesNotMatch(foodModalHost.innerHTML, /Brewery \+ Beer/);
+});
+
+test('blank Untappd searches show inline validation without mutating the draft fields', async () => {
+  const sandbox = loadAppSandbox();
+  const { modalHost } = setupManagerAddItemDom(sandbox);
+  seedManagerMenuState(sandbox, {
+    CATEGORY_DEFS: [
+      {
+        id: 'beer',
+        label: 'Beer',
+        title: 'Beer',
+        icon: '🍺',
+        color: 'rgba(245,210,66,0.22)',
+        sub: 'Drafts and cans',
+        placeholder: 'Add beer…',
+        untappdEnabled: true,
+      },
+    ],
+    menuState: {
+      beer: { items: [], lastSent: [] },
+      __uncategorized__: { items: [], lastSent: [] },
+    },
+  });
+
+  sandbox.openAddItemModal();
+  const result = await sandbox.runAddItemUntappdSearch();
+
+  assert.equal(result.ok, false);
+  assert.equal(result.reason, 'required');
+  assert.equal(getState(sandbox, '_addItemModalState.fields.name'), '');
+  assert.match(modalHost.innerHTML, /Enter a beer name to search Untappd/i);
+});
+
+test('untappd chooser previews matches and apply only overwrites name and description', async () => {
+  const sandbox = loadAppSandbox();
+  const { modalHost } = setupManagerAddItemDom(sandbox);
+  seedManagerMenuState(sandbox, {
+    CATEGORY_DEFS: [
+      {
+        id: 'beer',
+        label: 'Beer',
+        title: 'Beer',
+        icon: '🍺',
+        color: 'rgba(245,210,66,0.22)',
+        sub: 'Drafts and cans',
+        placeholder: 'Add beer…',
+        untappdEnabled: true,
+      },
+    ],
+    menuState: {
+      beer: { items: [], lastSent: [] },
+      __uncategorized__: { items: [], lastSent: [] },
+    },
+  });
+  sandbox.__HF_UI_MODULES__.searchUntappdBeers = async () => ([
+    { bid: 1, name: 'All Day IPA', breweryName: 'Founders', style: 'IPA', abv: 4.7 },
+    { bid: 2, name: 'Two Hearted Ale', breweryName: "Bell's", style: 'IPA', abv: 7 },
+  ]);
+  sandbox.__HF_UI_MODULES__.previewUntappdBeerImport = async bid => ({
+    bid,
+    name: 'Two Hearted Ale',
+    breweryName: "Bell's",
+    description: 'IPA • 7% ABV',
+  });
+
+  sandbox.openAddItemModal();
+  sandbox.updateAddItemModalField('name', 'Two Hearted');
+  sandbox.updateAddItemModalField('price', '$8');
+  sandbox.addAddItemModalRecipeIngredient('Orange');
+  sandbox.addAddItemModalUpcharge('Tallboy', '+$2');
+
+  await sandbox.runAddItemUntappdSearch();
+  assert.match(modalHost.innerHTML, /Choose an Untappd match/i);
+  assert.match(modalHost.innerHTML, /All Day IPA/);
+  assert.match(modalHost.innerHTML, /7% ABV/);
+
+  await sandbox.previewAddItemUntappdSelection(2);
+  assert.match(modalHost.innerHTML, /Imported name/i);
+  assert.match(modalHost.innerHTML, /Two Hearted Ale/);
+
+  sandbox.setAddItemUntappdIncludeBrewery(true);
+  const applyResult = sandbox.applyAddItemUntappdImport();
+
+  assert.equal(applyResult.ok, true);
+  assert.equal(getState(sandbox, '_addItemModalState.fields.name'), "Bell's Two Hearted Ale");
+  assert.equal(getState(sandbox, '_addItemModalState.fields.desc'), 'IPA • 7% ABV');
+  assert.equal(getState(sandbox, '_addItemModalState.fields.price'), '$8');
+  assert.equal(JSON.stringify(getState(sandbox, '_addItemModalState.fields.recipe')), JSON.stringify(['Orange']));
+  assert.equal(JSON.stringify(getState(sandbox, '_addItemModalState.fields.upcharges')), JSON.stringify([{ label: 'Tallboy', price: '+$2' }]));
+  assert.equal(getState(sandbox, '_addItemModalState.untappd.preview === null'), true);
+});
+
+test('untappd no-match, rerun, and cancel preserve the typed draft', async () => {
+  const sandbox = loadAppSandbox();
+  const { modalHost } = setupManagerAddItemDom(sandbox);
+  let searchCount = 0;
+  seedManagerMenuState(sandbox, {
+    CATEGORY_DEFS: [
+      {
+        id: 'beer',
+        label: 'Beer',
+        title: 'Beer',
+        icon: '🍺',
+        color: 'rgba(245,210,66,0.22)',
+        sub: 'Drafts and cans',
+        placeholder: 'Add beer…',
+        untappdEnabled: true,
+      },
+    ],
+    menuState: {
+      beer: { items: [], lastSent: [] },
+      __uncategorized__: { items: [], lastSent: [] },
+    },
+  });
+  sandbox.__HF_UI_MODULES__.searchUntappdBeers = async query => {
+    searchCount += 1;
+    if (searchCount === 1) return [];
+    return [
+      { bid: 9, name: `${query} Lager`, breweryName: 'Example Brewery', style: 'Lager', abv: 5 },
+      { bid: 10, name: `${query} Pils`, breweryName: 'Example Brewery', style: 'Pilsner', abv: 5.2 },
+    ];
+  };
+
+  sandbox.openAddItemModal();
+  sandbox.updateAddItemModalField('name', 'Missing Beer');
+  sandbox.updateAddItemModalField('desc', 'Keep this description');
+  sandbox.updateAddItemModalField('price', '$7');
+
+  await sandbox.runAddItemUntappdSearch();
+  assert.match(modalHost.innerHTML, /No Untappd matches found/i);
+  assert.equal(getState(sandbox, '_addItemModalState.fields.desc'), 'Keep this description');
+  assert.equal(getState(sandbox, '_addItemModalState.fields.price'), '$7');
+
+  sandbox.updateAddItemModalField('name', 'Fresh Beer');
+  await sandbox.runAddItemUntappdSearch();
+
+  assert.match(modalHost.innerHTML, /Choose an Untappd match/i);
+  assert.match(modalHost.innerHTML, /Fresh Beer Lager/);
+  assert.equal(searchCount, 2);
+
+  sandbox.cancelAddItemUntappdFlow();
+
+  assert.equal(getState(sandbox, '_addItemModalState.fields.name'), 'Fresh Beer');
+  assert.equal(getState(sandbox, '_addItemModalState.fields.desc'), 'Keep this description');
+  assert.equal(getState(sandbox, '_addItemModalState.fields.price'), '$7');
+  assert.doesNotMatch(modalHost.innerHTML, /Choose an Untappd match|No Untappd matches found/i);
+});
+
 test('food menus hide the recipe editor in the add-item modal', () => {
   const sandbox = loadAppSandbox();
   const { modalHost } = setupManagerAddItemDom(sandbox);

--- a/tests/phase17-scanner-modules.test.cjs
+++ b/tests/phase17-scanner-modules.test.cjs
@@ -43,6 +43,54 @@ test('open food facts lookup returns null for unknown products and network failu
   assert.equal(await failedSandbox.__HF_UI_MODULES__.lookupOpenFoodFactsProduct('0000'), null);
 });
 
+test('untappd lookup boundary only talks to the manager API and returns shaped results', async () => {
+  let request = null;
+  const sandbox = loadSandboxWithScripts(['core/ui/manager/untappd.js'], {
+    fetch: async (url, options) => {
+      request = { url, options };
+      return createFetchResponse(200, {
+        beers: [
+          { bid: 101, beer_name: 'West Coast IPA', brewery_name: 'Example Brewery' },
+        ],
+      });
+    },
+  });
+
+  const result = await sandbox.__HF_UI_MODULES__.searchUntappdBeers('  West Coast IPA draft 16 oz can  ');
+
+  assert.equal(request.url, '/api/manager');
+  assert.equal(request.options.method, 'POST');
+  assert.equal(request.options.headers['Content-Type'], 'application/json');
+  assert.deepEqual(JSON.parse(request.options.body), {
+    action: 'untappd_search',
+    query: 'West Coast IPA draft 16 oz can',
+  });
+  assert.equal(result.length, 1);
+  assert.equal(JSON.stringify(result), JSON.stringify([
+    { bid: 101, name: 'West Coast IPA', breweryName: 'Example Brewery', style: '', abv: null },
+  ]));
+});
+
+test('untappd preview boundary falls back to null on bad transport responses', async () => {
+  let request = null;
+  const sandbox = loadSandboxWithScripts(['core/ui/manager/untappd.js'], {
+    fetch: async (url, options) => {
+      request = { url, options };
+      return createFetchResponse(500, { error: 'nope' });
+    },
+  });
+
+  const result = await sandbox.__HF_UI_MODULES__.previewUntappdBeerImport(42, { includeBrewery: true });
+
+  assert.equal(request.url, '/api/manager');
+  assert.deepEqual(JSON.parse(request.options.body), {
+    action: 'untappd_preview',
+    bid: 42,
+    includeBrewery: true,
+  });
+  assert.equal(result, null);
+});
+
 test('barcode scanner prefers the native BarcodeDetector path and releases the stream after detection', async () => {
   let trackStopCount = 0;
   const stream = {

--- a/tests/phase22-category-governance.test.cjs
+++ b/tests/phase22-category-governance.test.cjs
@@ -202,6 +202,125 @@ test('category governance helper flags non-admin category mutations and ignores 
   assert.deepEqual(itemOnly.changed_categories, []);
 });
 
+test('category governance compares managers against shared-draft categories when present', async () => {
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+
+  const governance = await importApiModule('server/_category-governance.js');
+  const originalFetch = global.fetch;
+
+  global.fetch = async url => {
+    const href = String(url);
+
+    if (href.includes('/menus?id=eq.00000000-0000-0000-0000-000000000020')) {
+      return {
+        ok: true,
+        async json() {
+          return [{
+            id: '00000000-0000-0000-0000-000000000020',
+            name: "Leroy's Lounge Drinks",
+            slug: 'leroys-lounge-drinks',
+            type: 'drinks',
+            restaurant_id: '00000000-0000-0000-0000-000000000010',
+          }];
+        },
+      };
+    }
+
+    if (href.includes('/categories?menu_id=eq.00000000-0000-0000-0000-000000000020')) {
+      return {
+        ok: true,
+        async json() {
+          return [{
+            id: 'cat-1',
+            menu_id: '00000000-0000-0000-0000-000000000020',
+            key: 'beer',
+            label: 'Beer',
+            icon: '🍺',
+            color: '',
+            sub: '',
+            placeholder: 'Add beer…',
+            display_order: 0,
+            items: [{ id: 'beer-1', name: 'Pilsner' }],
+          }];
+        },
+      };
+    }
+
+    if (href.includes('/menu_meta?menu_id=eq.00000000-0000-0000-0000-000000000020')) {
+      return {
+        ok: true,
+        async json() {
+          return [{
+            draft_state: {
+              cats: [{
+                id: 'cat-1',
+                key: 'beer',
+                label: 'Draft Beer',
+                icon: '🍺',
+                color: '',
+                sub: '',
+                placeholder: 'Add beer…',
+                display_order: 0,
+                untappd_enabled: false,
+                items: [{ id: 'beer-1', name: 'Pilsner' }],
+              }],
+            },
+          }];
+        },
+      };
+    }
+
+    if (href.includes('/restaurants?id=eq.00000000-0000-0000-0000-000000000010')) {
+      return {
+        ok: true,
+        async json() {
+          return [{
+            id: '00000000-0000-0000-0000-000000000010',
+            name: "Leroy's Lounge",
+            slug: 'leroyslounge',
+            design: {},
+            use_custom_design: true,
+          }];
+        },
+      };
+    }
+
+    if (href.includes('/featured_groups?')) {
+      return {
+        ok: true,
+        async json() {
+          return [];
+        },
+      };
+    }
+
+    throw new Error(`Unexpected fetch: ${href}`);
+  };
+
+  try {
+    await assert.doesNotReject(() => governance.assertCategoryGovernanceAllowed({
+      actor: { role: 'manager' },
+      menuId: '00000000-0000-0000-0000-000000000020',
+      snapshot: {
+        cats: [{
+          key: 'beer',
+          label: 'Draft Beer',
+          icon: '🍺',
+          color: '',
+          sub: '',
+          placeholder: 'Add beer…',
+          display_order: 0,
+          untappd_enabled: false,
+          items: [{ id: 'beer-1', name: 'Fresh Pilsner' }],
+        }],
+      },
+    }));
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
 test('manager categories section stays visible but read-only', () => {
   const sandbox = loadAppSandbox();
   const { list, addButton } = setupCategoryManagerDom(sandbox);
@@ -255,4 +374,26 @@ test('food menus hide Untappd category controls', () => {
 
   assert.doesNotMatch(renderedHtml, /Enable Untappd import for this category/);
   assert.equal(untappdRow.style.display, 'none');
+});
+
+test('canceling the add-category form resets the Untappd toggle to its default state', () => {
+  const sandbox = loadAppSandbox();
+  const { addForm, addButton, untappdCheckbox } = setupCategoryManagerDom(sandbox);
+  seedCategorySandbox(sandbox, {
+    currentUser: {
+      role: 'admin',
+      name: 'Alex',
+      accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'],
+    },
+  });
+
+  addForm.style.display = '';
+  addButton.textContent = '− Cancel';
+  untappdCheckbox.checked = true;
+
+  sandbox.cancelAddCategoryForm();
+
+  assert.equal(addForm.style.display, 'none');
+  assert.equal(addButton.textContent, '+ Add Category');
+  assert.equal(untappdCheckbox.checked, false);
 });

--- a/tests/phase22-category-governance.test.cjs
+++ b/tests/phase22-category-governance.test.cjs
@@ -321,6 +321,36 @@ test('category governance compares managers against shared-draft categories when
   }
 });
 
+test('category governance can require an explicit cats payload before live or publish writes', async () => {
+  const governance = await importApiModule('server/_category-governance.js');
+  let fetchCount = 0;
+  const originalFetch = global.fetch;
+  global.fetch = async () => {
+    fetchCount += 1;
+    return {
+      ok: true,
+      async json() {
+        return [];
+      },
+    };
+  };
+
+  try {
+    await assert.rejects(
+      () => governance.assertCategoryGovernanceAllowed({
+        actor: { role: 'manager' },
+        menuId: '00000000-0000-0000-0000-000000000020',
+        snapshot: {},
+        requireCategorySnapshot: true,
+      }),
+      error => error?.status === 400 && /cats\[\]/i.test(error?.message || '')
+    );
+    assert.equal(fetchCount, 0);
+  } finally {
+    global.fetch = originalFetch;
+  }
+});
+
 test('manager categories section stays visible but read-only', () => {
   const sandbox = loadAppSandbox();
   const { list, addButton } = setupCategoryManagerDom(sandbox);

--- a/tests/phase22-category-governance.test.cjs
+++ b/tests/phase22-category-governance.test.cjs
@@ -1,0 +1,258 @@
+const assert = require('node:assert/strict');
+const path = require('node:path');
+const test = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+const {
+  createElement,
+  getState,
+  loadAppSandbox,
+  setState,
+} = require('./helpers/runtime.cjs');
+
+const ROOT = path.join(__dirname, '..');
+
+async function importApiModule(relativePath) {
+  const fileUrl = pathToFileURL(path.join(ROOT, relativePath)).href;
+  return import(`${fileUrl}?phase22=${Date.now()}-${Math.random()}`);
+}
+
+function setupCategoryManagerDom(sandbox) {
+  const doc = sandbox.document;
+  const list = doc._registerElement('catmgr-list', createElement('div', 'catmgr-list'));
+  const addForm = doc._registerElement('catmgr-add-form', createElement('div', 'catmgr-add-form'));
+  const addButton = doc._registerElement('show-add-cat-btn', createElement('button', 'show-add-cat-btn'));
+  const context = doc._registerElement('categories-menu-context', createElement('div', 'categories-menu-context'));
+  const untappdRow = doc._registerElement('new-cat-untappd-row', createElement('label', 'new-cat-untappd-row'));
+  const untappdCheckbox = doc._registerElement('new-cat-untappd-enabled', createElement('input', 'new-cat-untappd-enabled'));
+  addForm.style.display = 'none';
+  addButton.style.display = '';
+  addButton.hidden = false;
+  untappdRow.style.display = 'none';
+  untappdCheckbox.checked = false;
+  return { list, addForm, addButton, context, untappdRow, untappdCheckbox };
+}
+
+function seedCategorySandbox(sandbox, overrides = {}) {
+  setState(sandbox, {
+    MENU_ID: '00000000-0000-0000-0000-000000000020',
+    MENU_TYPE: 'drinks',
+    currentUser: {
+      role: 'manager',
+      name: 'Taylor',
+      accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'],
+    },
+    CATEGORY_DEFS: [
+      {
+        id: 'beer',
+        title: 'Beer',
+        label: 'Beer',
+        icon: '🍺',
+        color: 'rgba(245,210,66,0.22)',
+        sub: 'Drafts and cans',
+        placeholder: 'Add beer…',
+      },
+      {
+        id: 'cocktails',
+        title: 'Cocktails',
+        label: 'Cocktails',
+        icon: '🍹',
+        color: 'rgba(180,100,220,0.15)',
+        sub: 'Classics and house drinks',
+        placeholder: 'Add cocktail…',
+        untappdEnabled: true,
+      },
+    ],
+    menuState: {
+      beer: { items: [], lastSent: [] },
+      cocktails: { items: [], lastSent: [] },
+      __uncategorized__: { items: [], lastSent: [] },
+      _meta: {},
+    },
+    ...overrides,
+  });
+}
+
+test('workspace payload defaults untappd_enabled to false and preserves explicit values', async () => {
+  const menuRead = await importApiModule('server/_menu-read.js');
+  const payload = menuRead.createMenuWorkspacePayload({
+    menu: {
+      id: '00000000-0000-0000-0000-000000000020',
+      restaurantId: '00000000-0000-0000-0000-000000000010',
+      type: 'drinks',
+      name: "Leroy's Lounge Drinks",
+      slug: 'leroys-lounge-drinks',
+    },
+    cats: [
+      {
+        id: 'cat-1',
+        key: 'beer',
+        label: 'Beer',
+        icon: '🍺',
+        color: '',
+        sub: '',
+        placeholder: 'Add beer…',
+        display_order: 0,
+        items: [],
+      },
+      {
+        id: 'cat-2',
+        key: 'canned',
+        label: 'Canned',
+        icon: '🍻',
+        color: '',
+        sub: '',
+        placeholder: 'Add canned…',
+        display_order: 1,
+        untappd_enabled: true,
+        items: [],
+      },
+    ],
+    meta: {},
+    restaurant: null,
+  }, {
+    actor: {
+      id: 'user-1',
+      role: 'admin',
+      name: 'Alex',
+      accessibleMenuIds: [],
+    },
+  });
+
+  assert.equal(payload.cats[0].untappd_enabled, false);
+  assert.equal(payload.cats[1].untappd_enabled, true);
+});
+
+test('web menu cache snapshot includes untappd_enabled and defaults missing values to false', () => {
+  const sandbox = loadAppSandbox();
+  seedCategorySandbox(sandbox);
+
+  const snapshot = sandbox.buildMenuCacheSnapshot();
+
+  assert.equal(snapshot.cats[0].untappd_enabled, false);
+  assert.equal(snapshot.cats[1].untappd_enabled, true);
+});
+
+test('category governance helper flags non-admin category mutations and ignores item-only changes', async () => {
+  const governance = await importApiModule('server/_category-governance.js');
+  const result = governance.detectForbiddenCategoryMutations({
+    actor: { role: 'manager' },
+    currentCategories: [
+      {
+        key: 'beer',
+        label: 'Beer',
+        icon: '🍺',
+        color: 'rgba(1,2,3,0.1)',
+        sub: '',
+        placeholder: 'Add beer…',
+        display_order: 0,
+        untappd_enabled: false,
+        items: [{ id: 'beer-1', name: 'Pilsner' }],
+      },
+    ],
+    nextCategories: [
+      {
+        key: 'beer',
+        label: 'Draft Beer',
+        icon: '🍺',
+        color: 'rgba(1,2,3,0.1)',
+        sub: '',
+        placeholder: 'Add beer…',
+        display_order: 0,
+        untappd_enabled: true,
+        items: [{ id: 'beer-1', name: 'Renamed Pilsner' }],
+      },
+    ],
+  });
+
+  assert.equal(result.allowed, false);
+  assert.deepEqual(result.changed_categories, ['beer']);
+
+  const itemOnly = governance.detectForbiddenCategoryMutations({
+    actor: { role: 'manager' },
+    currentCategories: [
+      {
+        key: 'beer',
+        label: 'Beer',
+        icon: '🍺',
+        color: 'rgba(1,2,3,0.1)',
+        sub: '',
+        placeholder: 'Add beer…',
+        display_order: 0,
+        untappd_enabled: false,
+        items: [{ id: 'beer-1', name: 'Pilsner' }],
+      },
+    ],
+    nextCategories: [
+      {
+        key: 'beer',
+        label: 'Beer',
+        icon: '🍺',
+        color: 'rgba(1,2,3,0.1)',
+        sub: '',
+        placeholder: 'Add beer…',
+        display_order: 0,
+        untappd_enabled: false,
+        items: [{ id: 'beer-1', name: 'Renamed Pilsner' }],
+      },
+    ],
+  });
+
+  assert.equal(itemOnly.allowed, true);
+  assert.deepEqual(itemOnly.changed_categories, []);
+});
+
+test('manager categories section stays visible but read-only', () => {
+  const sandbox = loadAppSandbox();
+  const { list, addButton } = setupCategoryManagerDom(sandbox);
+  seedCategorySandbox(sandbox);
+
+  sandbox.renderCategoriesTab();
+  const renderedHtml = list.children.map(child => child.innerHTML || '').join('\n');
+
+  assert.match(renderedHtml, /admin-managed/i);
+  assert.doesNotMatch(renderedHtml, /moveCategoryUp/);
+  assert.doesNotMatch(renderedHtml, /toggleCategoryEdit/);
+  assert.doesNotMatch(renderedHtml, /deleteCategory/);
+  assert.equal(addButton.style.display, 'none');
+  assert.equal(getState(sandbox, 'getAddItemModalCategoryDefs().length > 1'), true);
+});
+
+test('admin drinks categories expose the Untappd toggle', () => {
+  const sandbox = loadAppSandbox();
+  const { list, addButton, untappdRow } = setupCategoryManagerDom(sandbox);
+  seedCategorySandbox(sandbox, {
+    currentUser: {
+      role: 'admin',
+      name: 'Alex',
+      accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'],
+    },
+  });
+
+  sandbox.renderCategoriesTab();
+  const renderedHtml = list.children.map(child => child.innerHTML || '').join('\n');
+
+  assert.match(renderedHtml, /Enable Untappd import for this category/);
+  assert.match(renderedHtml, /ce-untappd-beer/);
+  assert.equal(addButton.style.display, '');
+  assert.equal(untappdRow.style.display, '');
+});
+
+test('food menus hide Untappd category controls', () => {
+  const sandbox = loadAppSandbox();
+  const { list, untappdRow } = setupCategoryManagerDom(sandbox);
+  seedCategorySandbox(sandbox, {
+    MENU_TYPE: 'food',
+    currentUser: {
+      role: 'admin',
+      name: 'Alex',
+      accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'],
+    },
+  });
+
+  sandbox.renderCategoriesTab();
+  const renderedHtml = list.children.map(child => child.innerHTML || '').join('\n');
+
+  assert.doesNotMatch(renderedHtml, /Enable Untappd import for this category/);
+  assert.equal(untappdRow.style.display, 'none');
+});

--- a/tests/phase22-untappd-boundaries.test.cjs
+++ b/tests/phase22-untappd-boundaries.test.cjs
@@ -1,0 +1,207 @@
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+const test = require('node:test');
+const { pathToFileURL } = require('node:url');
+
+const ROOT = path.join(__dirname, '..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
+async function importApiModule(relativePath) {
+  const fileUrl = pathToFileURL(path.join(ROOT, relativePath)).href;
+  return import(`${fileUrl}?wave22=${Date.now()}-${Math.random()}`);
+}
+
+function withEnv(overrides, fn) {
+  const snapshot = {};
+  const keys = Object.keys(overrides);
+  keys.forEach(key => {
+    snapshot[key] = process.env[key];
+    if (overrides[key] === undefined) delete process.env[key];
+    else process.env[key] = overrides[key];
+  });
+  return Promise.resolve()
+    .then(fn)
+    .finally(() => {
+      keys.forEach(key => {
+        if (snapshot[key] === undefined) delete process.env[key];
+        else process.env[key] = snapshot[key];
+      });
+    });
+}
+
+test('api/manager wires Untappd actions through the shared server gateway', () => {
+  const source = read('api/manager.js');
+
+  assert.match(source, /from '\.\.\/server\/_untappd\.js'/);
+  assert.match(source, /untappd_search/);
+  assert.match(source, /untappd_preview/);
+  assert.match(source, /searchUntappdBeers/);
+  assert.match(source, /previewUntappdBeerImport/);
+});
+
+test('server untappd gateway normalizes search terms and caps results at five', async () => {
+  const untappd = await importApiModule('server/_untappd.js');
+  let calledUrl = null;
+
+  const previousFetch = global.fetch;
+  global.fetch = async url => {
+    calledUrl = String(url);
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        response: {
+          beers: {
+            items: Array.from({ length: 8 }, (_, index) => ({
+              beer: {
+                bid: index + 1,
+                beer_name: `Beer ${index + 1}`,
+                beer_style: 'IPA',
+                beer_abv: 6.5,
+              },
+              brewery: {
+                brewery_name: 'Test Brewery',
+              },
+            })),
+          },
+        },
+      }),
+    };
+  };
+
+  try {
+    await withEnv({
+      UNTAPPD_CLIENT_ID: 'client-id',
+      UNTAPPD_CLIENT_SECRET: 'client-secret',
+      UNTAPPD_USER_AGENT: 'El Roys Menu (client-id)',
+    }, async () => {
+      const result = await untappd.searchUntappdBeers('Draft Can Tallboy 16 oz 6 pk West Coast IPA');
+
+      assert.match(calledUrl, /\/v4\/search\/beer\?/);
+      assert.match(calledUrl, /q=West\+Coast\+IPA/);
+      assert.match(calledUrl, /limit=5/);
+      assert.match(calledUrl, /sort=checkin/);
+      assert.equal(result.length, 5);
+      assert.deepEqual(result[0], {
+        bid: 1,
+        name: 'Beer 1',
+        breweryName: 'Test Brewery',
+        style: 'IPA',
+        abv: 6.5,
+      });
+    });
+  } finally {
+    global.fetch = previousFetch;
+  }
+});
+
+test('server untappd gateway returns an empty list for no search matches', async () => {
+  const untappd = await importApiModule('server/_untappd.js');
+  const previousFetch = global.fetch;
+  global.fetch = async () => ({
+    ok: true,
+    status: 200,
+    json: async () => ({ response: { beers: { items: [] } } }),
+  });
+
+  try {
+    await withEnv({
+      UNTAPPD_CLIENT_ID: 'client-id',
+      UNTAPPD_CLIENT_SECRET: 'client-secret',
+      UNTAPPD_USER_AGENT: 'El Roys Menu (client-id)',
+    }, async () => {
+      assert.deepEqual(await untappd.searchUntappdBeers('unlikely beer name'), []);
+    });
+  } finally {
+    global.fetch = previousFetch;
+  }
+});
+
+test('server untappd preview shapes description from style and abv only', async () => {
+  const untappd = await importApiModule('server/_untappd.js');
+  const previousFetch = global.fetch;
+  const fetchCalls = [];
+  global.fetch = async url => {
+    fetchCalls.push(String(url));
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({
+        response: {
+          beer: {
+            bid: 501,
+            beer_name: 'Big Mosaic',
+            beer_style: 'IPA',
+            beer_abv: 6.7,
+            brewery: {
+              brewery_name: 'Example Brewery',
+            },
+          },
+        },
+      }),
+    };
+  };
+
+  try {
+    await withEnv({
+      UNTAPPD_CLIENT_ID: 'client-id',
+      UNTAPPD_CLIENT_SECRET: 'client-secret',
+      UNTAPPD_USER_AGENT: 'El Roys Menu (client-id)',
+    }, async () => {
+      const result = await untappd.previewUntappdBeerImport(501, { includeBrewery: true });
+
+      assert.equal(fetchCalls.length, 1);
+      assert.match(fetchCalls[0], /\/v4\/beer\/info\/501\?/);
+      assert.deepEqual(result, {
+        bid: 501,
+        name: 'Big Mosaic',
+        breweryName: 'Example Brewery',
+        description: 'IPA • 6.7% ABV',
+      });
+    });
+  } finally {
+    global.fetch = previousFetch;
+  }
+});
+
+test('server untappd gateway returns null for preview misses and missing env fails closed with 503', async () => {
+  const untappd = await importApiModule('server/_untappd.js');
+  const previousFetch = global.fetch;
+  let fetchCount = 0;
+  global.fetch = async () => {
+    fetchCount += 1;
+    return {
+      ok: true,
+      status: 200,
+      json: async () => ({ response: {} }),
+    };
+  };
+
+  try {
+    await withEnv({
+      UNTAPPD_CLIENT_ID: 'client-id',
+      UNTAPPD_CLIENT_SECRET: 'client-secret',
+      UNTAPPD_USER_AGENT: 'El Roys Menu (client-id)',
+    }, async () => {
+      assert.equal(await untappd.previewUntappdBeerImport(999), null);
+    });
+
+    await withEnv({
+      UNTAPPD_CLIENT_ID: undefined,
+      UNTAPPD_CLIENT_SECRET: undefined,
+      UNTAPPD_USER_AGENT: undefined,
+    }, async () => {
+      await assert.rejects(
+        () => untappd.searchUntappdBeers('West Coast IPA'),
+        error => error.status === 503
+      );
+      assert.equal(fetchCount, 1);
+    });
+  } finally {
+    global.fetch = previousFetch;
+  }
+});

--- a/tests/phase22-untappd-boundaries.test.cjs
+++ b/tests/phase22-untappd-boundaries.test.cjs
@@ -99,6 +99,23 @@ test('server untappd gateway normalizes search terms and caps results at five', 
   }
 });
 
+test('server untappd gateway preserves numeric beer names while stripping packaging noise', async () => {
+  const untappd = await importApiModule('server/_untappd.js');
+
+  assert.equal(
+    untappd.normalizeUntappdSearchQuery('805 16 oz 6 pk can'),
+    '805'
+  );
+  assert.equal(
+    untappd.normalizeUntappdSearchQuery('90 Minute IPA bottle'),
+    '90 Minute IPA'
+  );
+  assert.equal(
+    untappd.normalizeUntappdSearchQuery('420 Extra Pale Ale draft'),
+    '420 Extra Pale Ale'
+  );
+});
+
 test('server untappd gateway returns an empty list for no search matches', async () => {
   const untappd = await importApiModule('server/_untappd.js');
   const previousFetch = global.fetch;

--- a/tests/phase8-server-write-boundaries.test.cjs
+++ b/tests/phase8-server-write-boundaries.test.cjs
@@ -115,3 +115,16 @@ test('category deletion no longer performs direct Supabase writes before the ser
   assert.match(deleteCategorySource, /invalidateDiff\(\)/);
   assert.match(deleteCategorySource, /updateDraftIndicator\(\)/);
 });
+
+test('draft, live, preview, and publish boundaries enforce shared category governance before saving', () => {
+  const draft = read('server/_menu-draft.js');
+  const live = read('server/_menu-live.js');
+  const publish = read('server/_menu-publish.js');
+
+  assert.match(draft, /from '\.\/_category-governance\.js'/);
+  assert.match(draft, /assertCategoryGovernanceAllowed\(/);
+  assert.match(live, /from '\.\/_category-governance\.js'/);
+  assert.match(live, /assertCategoryGovernanceAllowed\(/);
+  assert.match(publish, /from '\.\/_category-governance\.js'/);
+  assert.match(publish, /assertCategoryGovernanceAllowed\(/);
+});

--- a/tests/phase8-server-write-boundaries.test.cjs
+++ b/tests/phase8-server-write-boundaries.test.cjs
@@ -216,6 +216,8 @@ test('draft, live, preview, and publish boundaries enforce shared category gover
   assert.match(draft, /assertCategoryGovernanceAllowed\(/);
   assert.match(live, /from '\.\/_category-governance\.js'/);
   assert.match(live, /assertCategoryGovernanceAllowed\(/);
+  assert.match(live, /requireCategorySnapshot:\s*true/);
   assert.match(publish, /from '\.\/_category-governance\.js'/);
   assert.match(publish, /assertCategoryGovernanceAllowed\(/);
+  assert.match(publish, /requireCategorySnapshot:\s*true/);
 });


### PR DESCRIPTION
## What changed
- adds the `untappd_enabled` category field end to end, including the Supabase migration, server normalization, web snapshots, and iOS payload decoding
- enforces admin-only category governance across draft save, live save, preview, and publish so managers and stale clients cannot mutate category structure or category-level config
- rejects live/preview/publish snapshots that omit `cats[]`, preventing destructive empty-snapshot syncs before any write path continues
- adds a server-owned Untappd search/preview gateway plus a web add-item modal flow for admin-enabled drinks categories
- updates the manager categories UI to stay visible but read-only for managers, while keeping item editing intact
- updates iOS and docs for read-only non-admin category handling and shared contract parity

## Why this changed
Issue 324 needs two things at once: a web-only Untappd-assisted import path for drinks, and a hard server boundary around admin-owned category configuration.

## Impact
- admins can enable Untappd per drinks category
- managers can only use Untappd where an admin has enabled it
- Untappd fails closed when env vars are missing, so the feature stays dormant by default
- managers can no longer add, rename, reorder, or delete categories from web or iOS
- live/preview/publish requests now require an explicit category snapshot instead of accepting an accidental `{}` payload

## Root cause
Category mutations were still client-driven and manager-editable, so older or non-admin clients could overwrite admin-owned category state. This change moves enforcement to the server and makes the Untappd lookup server-owned as well.

## Follow-up after review
- compares non-admin category governance against shared-draft categories when a shared draft exists, so item-only saves on top of an admin-authored draft do not get blocked
- preserves numeric beer names like `805`, `90 Minute IPA`, and `420 Extra Pale Ale` during Untappd search normalization
- resets the new-category Untappd toggle on cancel so the next category starts from the intended default-off state
- requires `cats[]` on live/preview/publish requests before any save path continues, closing the remaining destructive empty-snapshot hole

## Validation
- `node --test tests/phase8-server-write-boundaries.test.cjs tests/phase16-add-item-modal.test.cjs tests/phase22-category-governance.test.cjs tests/phase22-untappd-boundaries.test.cjs`
- earlier branch validation: `node --test tests/phase17-scanner-modules.test.cjs tests/phase21-menu-queue-diff-boundaries.test.cjs`
- earlier branch validation: `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild test -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,name=iPhone 17,OS=26.4.1' -only-testing:ElRoysManagerAppTests/MenuDocumentTests`

## Note
Untappd access is still pending review because the API is not actually public, so this PR should stay scoped as exploratory until we decide whether to keep, replace, or trim the Untappd-specific path.
