### PR TITLE
[codex] Optimize SwiftUI home/editor rendering performance

### DIFF
--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -104,6 +104,7 @@ final class AppModel {
   var currentEditorPreview: MenuPreviewPayload?
   var currentToolsMenus: [String: MenuWorkspacePayload] = [:]
   var currentToolsHistories: [String: HistoryPayload] = [:]
+  var homeDataVersion = 0
 
   var currentMenuId: String?
   var selectedPreviewChangeIDs: Set<String> = []
@@ -209,6 +210,7 @@ final class AppModel {
     do {
       let anonymousBootstrap = try await services.bootstrap.fetch(accessToken: nil)
       bootstrap = anonymousBootstrap
+      homeDataVersion += 1
       await restoreSession()
     } catch {
       notice = AppNotice(tone: .danger, title: "Bootstrap Failed", message: error.localizedDescription)
@@ -274,6 +276,7 @@ final class AppModel {
     currentEditorPreview = nil
     currentToolsMenus = [:]
     currentToolsHistories = [:]
+    homeDataVersion += 1
     currentMenuId = nil
     editorRefreshRequirement = nil
     editorHasServerUnsentChanges = false
@@ -410,6 +413,7 @@ final class AppModel {
       }
       model.currentToolsMenus = menus
       model.currentToolsHistories = histories
+      model.homeDataVersion += 1
       model.currentMenuId = menuIds.first
     }
   }
@@ -728,6 +732,7 @@ final class AppModel {
   private func refreshAuthenticatedBootstrap(accessToken: String, adoptedSession: AuthSession) async throws {
     let refreshed = try await services.bootstrap.fetch(accessToken: accessToken)
     bootstrap = refreshed
+    homeDataVersion += 1
     let actor = refreshed.actor
     authSession = AuthSession(
       accessToken: adoptedSession.accessToken,

--- a/ios/ElRoysManagerApp/Features/Home/HomeViews.swift
+++ b/ios/ElRoysManagerApp/Features/Home/HomeViews.swift
@@ -7,8 +7,29 @@ struct RestaurantChooserView: View {
   private let initialRestaurantSlug: String?
   @State private var selectedRestaurantSlug: String
   @State private var expandedUpdateID: String?
+  @State private var homeData = HomeDerivedData.empty
   @Namespace private var switcherNamespace
   @Namespace private var bottomNavNamespace
+
+  private struct HomeDerivedData {
+    var updates: [HomeUpdate]
+    var featuredSpecials: [String]
+    var drinksCount: Int?
+    var foodCount: Int?
+    var hasLoadedRestaurantData: Bool
+    var drinksEditorDestination: AppDestination?
+    var foodEditorDestination: AppDestination?
+
+    static let empty = HomeDerivedData(
+      updates: [],
+      featuredSpecials: [],
+      drinksCount: nil,
+      foodCount: nil,
+      hasLoadedRestaurantData: false,
+      drinksEditorDestination: nil,
+      foodEditorDestination: nil
+    )
+  }
 
   init(model: AppModel, initialRestaurantSlug: String? = nil) {
     self.model = model
@@ -19,18 +40,18 @@ struct RestaurantChooserView: View {
   var body: some View {
     let theme = activeTheme
     let restaurant = selectedRestaurant
-    let currentUpdates = restaurant.flatMap(realUpdates(for:)) ?? []
-    let currentFeaturedSpecials = restaurant.flatMap(realFeaturedSpecials(for:)) ?? []
-    let drinksCount = restaurant.flatMap { activeItemCount(for: $0, type: "drinks") }
-    let foodCount = restaurant.flatMap { activeItemCount(for: $0, type: "food") }
-    let hasLoadedRestaurantData = restaurant.map(hasLoadedToolsData(for:)) ?? false
+    let currentHomeData = homeData
 
     ZStack {
       HomeBackground(theme: theme)
 
       ScrollView(showsIndicators: false) {
         VStack(alignment: .leading, spacing: 20) {
-          HomeHeader(model: model, theme: theme)
+          HomeHeader(
+            theme: theme,
+            environment: model.environment,
+            onSignOut: { model.signOut() }
+          )
 
           HomeRestaurantSwitcher(
             options: restaurantSwitcherOptions,
@@ -46,25 +67,25 @@ struct RestaurantChooserView: View {
           )
 
           HomeRecentUpdatesCard(
-            updates: currentUpdates,
+            updates: currentHomeData.updates,
             expandedUpdateID: $expandedUpdateID,
-            hasLoadedData: hasLoadedRestaurantData,
+            hasLoadedData: currentHomeData.hasLoadedRestaurantData,
             theme: theme
           )
 
           HomeEditGrid(
-            model: model,
-            restaurant: restaurant,
             theme: theme,
-            drinksCount: drinksCount,
-            foodCount: foodCount
+            drinksCount: currentHomeData.drinksCount,
+            foodCount: currentHomeData.foodCount,
+            drinksDestination: currentHomeData.drinksEditorDestination,
+            foodDestination: currentHomeData.foodEditorDestination
           )
 
           HomeViewRows(restaurant: restaurant, theme: theme)
 
           HomeRestaurantToolsCard(
             restaurant: restaurant,
-            featuredSpecials: currentFeaturedSpecials,
+            featuredSpecials: currentHomeData.featuredSpecials,
             theme: theme
           )
 
@@ -82,15 +103,24 @@ struct RestaurantChooserView: View {
     }
     .onAppear {
       if restaurantSwitcherOptions.contains(where: { $0.slug == selectedRestaurantSlug }) {
+        refreshHomeData()
         return
       }
       if let bootSlug = initialRestaurantSlug,
          restaurantSwitcherOptions.contains(where: { $0.slug == bootSlug })
       {
         selectedRestaurantSlug = bootSlug
+        refreshHomeData()
         return
       }
       selectedRestaurantSlug = restaurantSwitcherOptions.first?.slug ?? "leroys-lounge"
+      refreshHomeData()
+    }
+    .onChange(of: selectedRestaurantSlug) { _, _ in
+      refreshHomeData()
+    }
+    .onChange(of: model.homeDataVersion) { _, _ in
+      refreshHomeData()
     }
     .navigationTitle("Home")
     .navigationBarTitleDisplayMode(.inline)
@@ -224,6 +254,24 @@ struct RestaurantChooserView: View {
     guard date != .distantPast else { return "" }
     return DateFormatter.tickerStamp.string(from: date).uppercased()
   }
+
+  private func refreshHomeData() {
+    guard let restaurant = selectedRestaurant else {
+      homeData = .empty
+      return
+    }
+    let drinksMenu = model.menu(for: restaurant.id, type: "drinks")
+    let foodMenu = model.menu(for: restaurant.id, type: "food")
+    homeData = HomeDerivedData(
+      updates: realUpdates(for: restaurant) ?? [],
+      featuredSpecials: realFeaturedSpecials(for: restaurant) ?? [],
+      drinksCount: activeItemCount(for: restaurant, type: "drinks"),
+      foodCount: activeItemCount(for: restaurant, type: "food"),
+      hasLoadedRestaurantData: hasLoadedToolsData(for: restaurant),
+      drinksEditorDestination: drinksMenu.map(AppDestination.editor),
+      foodEditorDestination: foodMenu.map(AppDestination.editor)
+    )
+  }
 }
 
 struct RestaurantHubView: View {
@@ -239,8 +287,9 @@ struct RestaurantHubView: View {
 // MARK: - Header
 
 private struct HomeHeader: View {
-  @Bindable var model: AppModel
   let theme: HomeTheme
+  let environment: AppEnvironment
+  let onSignOut: () -> Void
 
   var body: some View {
     HStack(alignment: .center, spacing: 14) {
@@ -256,14 +305,14 @@ private struct HomeHeader: View {
 
         HomeLiveStrip(
           theme: theme,
-          environment: model.environment
+          environment: environment
         )
       }
       .frame(maxWidth: .infinity, alignment: .leading)
 
       Menu {
         Button(role: .destructive) {
-          model.signOut()
+          onSignOut()
         } label: {
           Label("Sign Out", systemImage: "rectangle.portrait.and.arrow.right")
         }
@@ -342,23 +391,35 @@ private struct HomeLiveStrip: View {
 }
 
 private struct PulsingDot: View {
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.scenePhase) private var scenePhase
   let color: Color
 
   var body: some View {
-    TimelineView(.animation) { context in
-      let t = context.date.timeIntervalSinceReferenceDate
-      let phase = (sin(t * 2.6) + 1) / 2
-      ZStack {
-        Circle()
-          .fill(color.opacity(0.25 + 0.35 * phase))
-          .frame(width: 12, height: 12)
-          .blur(radius: 3)
-        Circle()
-          .fill(color)
-          .frame(width: 5.5, height: 5.5)
+    Group {
+      if reduceMotion || scenePhase != .active {
+        dot(phase: 0.5)
+      } else {
+        TimelineView(.periodic(from: .now, by: 1.0 / 12.0)) { context in
+          let t = context.date.timeIntervalSinceReferenceDate
+          dot(phase: (sin(t * 2.6) + 1) / 2)
+        }
       }
     }
     .frame(width: 12, height: 12)
+  }
+
+  @ViewBuilder
+  private func dot(phase: Double) -> some View {
+    ZStack {
+      Circle()
+        .fill(color.opacity(0.25 + 0.35 * phase))
+        .frame(width: 12, height: 12)
+        .blur(radius: 3)
+      Circle()
+        .fill(color)
+        .frame(width: 5.5, height: 5.5)
+    }
   }
 }
 
@@ -602,16 +663,16 @@ private struct HomeDiffLine: View {
 // MARK: - Edit tiles
 
 private struct HomeEditGrid: View {
-  @Bindable var model: AppModel
-  let restaurant: RestaurantRecord?
   let theme: HomeTheme
   let drinksCount: Int?
   let foodCount: Int?
+  let drinksDestination: AppDestination?
+  let foodDestination: AppDestination?
 
   var body: some View {
     HStack(spacing: 12) {
       editTile(
-        action: restaurant.flatMap { model.menu(for: $0.id, type: "drinks") }.map(AppDestination.editor),
+        action: drinksDestination,
         tile: HomeEditTile(
           chapter: "VOL. 01",
           kind: theme.motif == .chevron ? "LIQUID" : "BEBIDAS",
@@ -622,7 +683,7 @@ private struct HomeEditGrid: View {
         )
       )
       editTile(
-        action: restaurant.flatMap { model.menu(for: $0.id, type: "food") }.map(AppDestination.editor),
+        action: foodDestination,
         tile: HomeEditTile(
           chapter: "VOL. 02",
           kind: theme.motif == .chevron ? "PLATES" : "COCINA",
@@ -980,30 +1041,43 @@ private struct HomeBottomNav: View {
 
 /// Slowly rotating conic-gradient border — the "door token" medallion.
 private struct HomeMedallionBorder: View {
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  @Environment(\.scenePhase) private var scenePhase
   let theme: HomeTheme
 
   var body: some View {
-    TimelineView(.animation(minimumInterval: 1.0 / 30.0)) { context in
-      let t = context.date.timeIntervalSinceReferenceDate
-      let angle = Angle.degrees(t.truncatingRemainder(dividingBy: 12) / 12 * 360)
-      Circle()
-        .strokeBorder(
-          AngularGradient(
-            gradient: Gradient(colors: [
-              theme.medallionGlowA.opacity(0.9),
-              theme.medallionGlowB.opacity(0.95),
-              theme.medallionGlowA.opacity(0.4),
-              theme.medallionGlowB.opacity(0.85),
-              theme.medallionGlowA.opacity(0.9),
-            ]),
-            center: .center,
-            angle: angle
-          ),
-          lineWidth: 1.4
-        )
-        .blur(radius: 0.2)
+    Group {
+      if reduceMotion || scenePhase != .active {
+        medallion(at: .degrees(0))
+      } else {
+        TimelineView(.periodic(from: .now, by: 1.0 / 15.0)) { context in
+          let t = context.date.timeIntervalSinceReferenceDate
+          let angle = Angle.degrees(t.truncatingRemainder(dividingBy: 12) / 12 * 360)
+          medallion(at: angle)
+        }
+      }
     }
     .allowsHitTesting(false)
+  }
+
+  @ViewBuilder
+  private func medallion(at angle: Angle) -> some View {
+    Circle()
+      .strokeBorder(
+        AngularGradient(
+          gradient: Gradient(colors: [
+            theme.medallionGlowA.opacity(0.9),
+            theme.medallionGlowB.opacity(0.95),
+            theme.medallionGlowA.opacity(0.4),
+            theme.medallionGlowB.opacity(0.85),
+            theme.medallionGlowA.opacity(0.9),
+          ]),
+          center: .center,
+          angle: angle
+        ),
+        lineWidth: 1.4
+      )
+      .blur(radius: 0.2)
   }
 }
 

--- a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
@@ -70,7 +70,7 @@ struct MenuEditorScreen: View {
               canEditCategories: canEditCategories,
               onAddCategory: { showingAddCategory = true }
             )
-            ForEach(Array(document.visibleCategories.enumerated()), id: \.offset) { _, category in
+            ForEach(document.visibleCategories) { category in
               MenuEditorCategoryCard(
                 menu: menu,
                 category: category,
@@ -380,12 +380,12 @@ private struct PublishPreviewSheet: View {
               Text("Notification Toggles")
                 .font(EditorTypography.body(15, weight: .bold))
                 .foregroundStyle(theme.titleText)
-              ForEach(Array(preview.sections.enumerated()), id: \.offset) { _, section in
+              ForEach(preview.sections) { section in
                 VStack(alignment: .leading, spacing: 8) {
                   Text(section.label)
                     .font(EditorTypography.body(13, weight: .semibold))
                     .foregroundStyle(theme.subtleText)
-                  ForEach(Array(section.changes.enumerated()), id: \.offset) { _, change in
+                  ForEach(section.changes) { change in
                     Toggle(isOn: Binding(
                       get: { model.selectedPreviewChangeIDs.contains(change.id) },
                       set: { model.updatePreviewSelection(change.id, selected: $0) }
@@ -966,12 +966,12 @@ private struct MenuEditorOffMenuRecoveryCard: View {
         .font(EditorTypography.display(22, weight: .bold))
         .foregroundStyle(theme.titleText)
 
-      ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+      ForEach(items) { item in
         VStack(alignment: .leading, spacing: 10) {
           EditorItemRow(item: item, theme: theme)
           ScrollView(.horizontal, showsIndicators: false) {
             HStack(spacing: 8) {
-              ForEach(Array(categories.enumerated()), id: \.offset) { _, category in
+              ForEach(categories) { category in
                 Button(category.label) {
                   onRestore(item, category)
                 }
@@ -1318,7 +1318,7 @@ private struct ItemEditorSheet: View {
           TextField("Price", text: $draft.price)
             .keyboardType(.decimalPad)
           Picker("Category", selection: $draft.categoryKey) {
-            ForEach(Array((model.currentEditorDocument?.visibleCategories ?? []).enumerated()), id: \.offset) { _, category in
+            ForEach(model.currentEditorDocument?.visibleCategories ?? []) { category in
               Text(category.label).tag(category.key)
             }
             if !(model.currentEditorDocument?.visibleCategories.contains(where: { $0.key == draft.categoryKey }) ?? true) {


### PR DESCRIPTION
## What changed

- Replaced index-based `ForEach` identity in the menu editor with stable model identity for categories/items/preview sections.
- Added `homeDataVersion` to `AppModel` and incremented it when Home-relevant data changes.
- Refactored Home screen composition to cache derived Home data in local state and refresh only on restaurant selection or `homeDataVersion` changes.
- Narrowed Home subview inputs to reduce broad observation fan-out (`HomeHeader` and `HomeEditGrid` no longer observe the full app model).
- Throttled always-on Home animations and respected reduced motion/inactive scene for pulsing indicators and medallion effects.

## Why it changed

The Home and editor flows were doing extra render work due to unstable list identity and broad model observation. This patch reduces avoidable invalidation/diff churn and lowers persistent animation overhead.

## User/developer impact

- Smoother updates when categories/items/preview rows change in the editor.
- Less unnecessary Home screen recomputation.
- Lower idle animation workload and better accessibility behavior when Reduce Motion is enabled.
- No behavior change to menu data semantics or auth/access controls.

## Root cause

Performance risk came from three combined sources:

1. Unstable list identity (`id: \.offset`) in dynamic editor collections.
2. Broad `@Bindable` reads causing larger-than-needed Home invalidation.
3. Continuous timeline animation work regardless of accessibility and scene activity.

## Validation

- `xcodebuild -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'generic/platform=iOS Simulator' build`
- Result: `BUILD SUCCEEDED`
