### PR TITLE
[codex] Fix swipe to 86 review follow-ups

### DIFF
--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -586,8 +586,16 @@ final class AppModel {
     mutateEditorDocument { $0.removeItemToOffMenu(itemID: itemID, from: categoryKey) }
   }
 
+  func moveItemToOffMenu(_ item: MenuItemPayload, from categoryKey: String) {
+    mutateEditorDocument { $0.moveItemToOffMenu(item, from: categoryKey) }
+  }
+
   func restoreItemFromOffMenu(itemID: String, to categoryKey: String) {
     mutateEditorDocument { $0.restoreItemFromOffMenu(itemID: itemID, to: categoryKey) }
+  }
+
+  func moveVisibleItems(in categoryKey: String, from source: IndexSet, to destination: Int) {
+    mutateEditorDocument { $0.moveVisibleItems(in: categoryKey, from: source, to: destination) }
   }
 
   func deleteItem(itemID: String, categoryKey: String) {

--- a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
@@ -802,13 +802,45 @@ private struct MenuEditorCategoryCard: View {
         }
       }
 
-      ForEach(Array(visibleItems.enumerated()), id: \.offset) { _, item in
+      if visibleItems.isEmpty {
+        Text("No menu items yet.")
+          .font(EditorTypography.body(14, weight: .medium))
+          .foregroundStyle(theme.subtleText)
+          .frame(maxWidth: .infinity, alignment: .leading)
+          .padding(.vertical, 6)
+      } else {
+        MenuEditorSwipeList(
+          items: visibleItems,
+          theme: theme,
+          onSelectItem: onSelectItem,
+          onToggleEightySix: onToggleEightySix,
+          onMoveOffMenu: onMoveOffMenu
+        )
+      }
+    }
+    .menuEditorSurface(colors: [theme.categoryTop, theme.categoryBottom], border: theme.categoryBorder)
+  }
+}
+
+private struct MenuEditorSwipeList: View {
+  let items: [MenuItemPayload]
+  let theme: MenuEditorTheme
+  let onSelectItem: (MenuItemPayload) -> Void
+  let onToggleEightySix: (MenuItemPayload) -> Void
+  let onMoveOffMenu: (MenuItemPayload) -> Void
+
+  var body: some View {
+    List {
+      ForEach(items, id: \.id) { item in
         Button {
           onSelectItem(item)
         } label: {
           EditorItemRow(item: item, theme: theme)
         }
         .buttonStyle(.plain)
+        .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
+        .listRowBackground(Color.clear)
+        .listRowSeparator(.hidden)
         .swipeActions(edge: .leading, allowsFullSwipe: true) {
           Button {
             onToggleEightySix(item)
@@ -826,7 +858,35 @@ private struct MenuEditorCategoryCard: View {
         }
       }
     }
-    .menuEditorSurface(colors: [theme.categoryTop, theme.categoryBottom], border: theme.categoryBorder)
+    .listStyle(.plain)
+    .scrollContentBackground(.hidden)
+    .scrollDisabled(true)
+    .environment(\.defaultMinListRowHeight, 1)
+    .frame(height: estimatedListHeight)
+  }
+
+  private var estimatedListHeight: CGFloat {
+    max(items.reduce(CGFloat.zero) { partialResult, item in
+      partialResult + estimatedRowHeight(for: item)
+    }, 44)
+  }
+
+  private func estimatedRowHeight(for item: MenuItemPayload) -> CGFloat {
+    var height: CGFloat = 72
+    if item.showDescription, !item.desc.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      height += estimatedTextHeight(for: item.desc, lineHeight: 17, charactersPerLine: 34)
+    }
+    if item.showRecipe, !item.recipe.joined(separator: " ").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+      height += estimatedTextHeight(for: item.recipe.joined(separator: " • "), lineHeight: 15, charactersPerLine: 38)
+    }
+    return height
+  }
+
+  private func estimatedTextHeight(for text: String, lineHeight: CGFloat, charactersPerLine: Int) -> CGFloat {
+    let normalized = text.trimmingCharacters(in: .whitespacesAndNewlines)
+    guard !normalized.isEmpty else { return 0 }
+    let lines = max(1, Int(ceil(Double(normalized.count) / Double(max(charactersPerLine, 1)))))
+    return CGFloat(lines) * lineHeight
   }
 }
 

--- a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
@@ -18,6 +18,7 @@ struct MenuEditorScreen: View {
   @State private var renameTarget: MenuCategoryPayload?
   @State private var renameText = ""
   @State private var showingDiscardDraftConfirm = false
+  @State private var reorderingCategoryKey: String?
 
   private var theme: MenuEditorTheme {
     .theme(for: menu)
@@ -78,6 +79,7 @@ struct MenuEditorScreen: View {
                   model.deleteCategory(key: category.key)
                 },
                 onSelectItem: { item in
+                  reorderingCategoryKey = nil
                   editingDraft = EditableItemDraft(item: item, categoryKey: category.key, isFoodMenu: menu.isFoodMenu)
                   activeSheet = .itemEditor
                 },
@@ -88,8 +90,12 @@ struct MenuEditorScreen: View {
                     isEightySixed: !item.isEightySixed
                   )
                 },
-                onMoveOffMenu: { item in
-                  model.moveItemToOffMenu(itemID: item.id, from: category.key)
+                isReordering: reorderingCategoryKey == category.key,
+                onToggleReorder: {
+                  reorderingCategoryKey = reorderingCategoryKey == category.key ? nil : category.key
+                },
+                onMoveVisibleItems: { source, destination in
+                  model.moveVisibleItems(in: category.key, from: source, to: destination)
                 }
               )
             }
@@ -159,6 +165,7 @@ struct MenuEditorScreen: View {
       activeSheet = nil
       showingAddCategory = false
       renameTarget = nil
+      reorderingCategoryKey = nil
     }
     .sheet(item: Binding(
       get: { model.editorRefreshRequirement == nil ? activeSheet : nil },
@@ -766,7 +773,9 @@ private struct MenuEditorCategoryCard: View {
   let onDelete: () -> Void
   let onSelectItem: (MenuItemPayload) -> Void
   let onToggleEightySix: (MenuItemPayload) -> Void
-  let onMoveOffMenu: (MenuItemPayload) -> Void
+  let isReordering: Bool
+  let onToggleReorder: () -> Void
+  let onMoveVisibleItems: (IndexSet, Int) -> Void
 
   private var visibleItems: [MenuItemPayload] {
     category.items.filter(\.onMenu)
@@ -793,6 +802,8 @@ private struct MenuEditorCategoryCard: View {
           .background(menuAccent.opacity(0.15), in: Capsule())
           .foregroundStyle(menuAccent)
         Menu {
+          Button(isReordering ? "Done Reordering" : "Reorder Items", action: onToggleReorder)
+            .disabled(visibleItems.count < 2 && !isReordering)
           Button("Rename", action: onRename)
           Button("Delete Category", role: .destructive, action: onDelete)
         } label: {
@@ -812,9 +823,10 @@ private struct MenuEditorCategoryCard: View {
         MenuEditorSwipeList(
           items: visibleItems,
           theme: theme,
+          isReordering: isReordering,
           onSelectItem: onSelectItem,
           onToggleEightySix: onToggleEightySix,
-          onMoveOffMenu: onMoveOffMenu
+          onMoveVisibleItems: onMoveVisibleItems
         )
       }
     }
@@ -823,46 +835,71 @@ private struct MenuEditorCategoryCard: View {
 }
 
 private struct MenuEditorSwipeList: View {
+  @State private var measuredRowHeights: [String: CGFloat] = [:]
   let items: [MenuItemPayload]
   let theme: MenuEditorTheme
+  let isReordering: Bool
   let onSelectItem: (MenuItemPayload) -> Void
   let onToggleEightySix: (MenuItemPayload) -> Void
-  let onMoveOffMenu: (MenuItemPayload) -> Void
+  let onMoveVisibleItems: (IndexSet, Int) -> Void
 
   var body: some View {
     List {
       ForEach(items, id: \.id) { item in
-        Button {
-          onSelectItem(item)
-        } label: {
-          EditorItemRow(item: item, theme: theme)
-        }
-        .buttonStyle(.plain)
+        row(for: item)
         .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
         .listRowBackground(Color.clear)
         .listRowSeparator(.hidden)
-        .swipeActions(edge: .leading, allowsFullSwipe: true) {
-          Button {
-            onToggleEightySix(item)
-          } label: {
-            Label(item.isEightySixed ? "Restore" : "86", systemImage: item.isEightySixed ? "arrow.uturn.backward.circle.fill" : "nosign.app.fill")
-          }
-          .tint(item.isEightySixed ? theme.successAccent : theme.warningAccent)
-        }
-        .swipeActions(edge: .trailing) {
-          Button(role: .destructive) {
-            onMoveOffMenu(item)
-          } label: {
-            Label("Off Menu", systemImage: "tray.and.arrow.down.fill")
+        .background {
+          GeometryReader { proxy in
+            Color.clear
+              .preference(key: MenuEditorRowHeightPreferenceKey.self, value: [item.id: proxy.size.height])
           }
         }
+        .moveDisabled(!isReordering || items.count < 2)
       }
+      .onMove(perform: onMoveVisibleItems)
     }
+    .environment(\.editMode, .constant(isReordering ? .active : .inactive))
     .listStyle(.plain)
     .scrollContentBackground(.hidden)
     .scrollDisabled(true)
     .environment(\.defaultMinListRowHeight, 1)
-    .frame(height: estimatedListHeight)
+    .onPreferenceChange(MenuEditorRowHeightPreferenceKey.self) { measuredRowHeights = $0 }
+    .frame(height: listHeight)
+  }
+
+  @ViewBuilder
+  private func row(for item: MenuItemPayload) -> some View {
+    if isReordering {
+      EditorItemRow(item: item, theme: theme)
+        .contentShape(Rectangle())
+    } else {
+      Button {
+        onSelectItem(item)
+      } label: {
+        EditorItemRow(item: item, theme: theme)
+      }
+      .buttonStyle(.plain)
+      .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+        Button {
+          onToggleEightySix(item)
+        } label: {
+          Label(item.isEightySixed ? "Restore" : "86", systemImage: item.isEightySixed ? "arrow.uturn.backward.circle.fill" : "nosign.app.fill")
+        }
+        .tint(item.isEightySixed ? theme.successAccent : theme.warningAccent)
+      }
+    }
+  }
+
+  private var listHeight: CGFloat {
+    max(estimatedListHeight, measuredListHeight)
+  }
+
+  private var measuredListHeight: CGFloat {
+    let heights = items.compactMap { measuredRowHeights[$0.id] }
+    guard heights.count == items.count else { return 0 }
+    return max(heights.reduce(CGFloat.zero, +), 44)
   }
 
   private var estimatedListHeight: CGFloat {
@@ -887,6 +924,14 @@ private struct MenuEditorSwipeList: View {
     guard !normalized.isEmpty else { return 0 }
     let lines = max(1, Int(ceil(Double(normalized.count) / Double(max(charactersPerLine, 1)))))
     return CGFloat(lines) * lineHeight
+  }
+}
+
+private struct MenuEditorRowHeightPreferenceKey: PreferenceKey {
+  static var defaultValue: [String: CGFloat] = [:]
+
+  static func reduce(value: inout [String: CGFloat], nextValue: () -> [String: CGFloat]) {
+    value.merge(nextValue(), uniquingKeysWith: { _, next in next })
   }
 }
 
@@ -1264,6 +1309,14 @@ private struct ItemEditorSheet: View {
           }
         }
 
+        if draft.itemID != nil, draft.categoryKey != EditableMenuDocument.uncategorizedKey {
+          Section("Menu Placement") {
+            Button("Move To Off Menu", role: .destructive) {
+              moveToOffMenu()
+            }
+          }
+        }
+
         Section("Visibility") {
           Toggle("Show Description", isOn: $draft.showDescription)
           Toggle("86'd", isOn: $draft.isEightySixed)
@@ -1316,23 +1369,51 @@ private struct ItemEditorSheet: View {
   }
 
   private func save() {
+    guard let item = makeItem(categoryKey: draft.categoryKey) else { return }
+    model.upsertItem(item, categoryKey: draft.categoryKey, originalCategoryKey: draft.originalCategoryKey)
+
+    if draft.keepAdding {
+      let preservedCategory = draft.categoryKey
+      let isFood = draft.isFoodMenu
+      draft = EditableItemDraft()
+      draft.categoryKey = preservedCategory
+      draft.isFoodMenu = isFood
+    } else {
+      dismiss()
+    }
+  }
+
+  private func moveToOffMenu() {
+    let sourceCategoryKey = draft.originalCategoryKey ?? draft.categoryKey
+    guard sourceCategoryKey != EditableMenuDocument.uncategorizedKey else {
+      dismiss()
+      return
+    }
+    guard let item = makeItem(categoryKey: sourceCategoryKey, validateDuplicateName: false) else { return }
+    model.moveItemToOffMenu(item, from: sourceCategoryKey)
+    dismiss()
+  }
+
+  private func makeItem(categoryKey: String, validateDuplicateName: Bool = true) -> MenuItemPayload? {
     let trimmedName = draft.name.trimmingCharacters(in: .whitespacesAndNewlines)
-    let trimmedCategoryKey = draft.categoryKey.trimmingCharacters(in: .whitespacesAndNewlines)
+    let trimmedCategoryKey = categoryKey.trimmingCharacters(in: .whitespacesAndNewlines)
     guard !trimmedCategoryKey.isEmpty else {
       model.notice = AppNotice(
         tone: .warning,
         title: "Category Required",
         message: "Select a category for this item before saving."
       )
-      return
+      return nil
     }
     guard !trimmedName.isEmpty else {
       model.notice = AppNotice(tone: .warning, title: "Name Required", message: "Every menu item needs a non-empty name.")
-      return
+      return nil
     }
-    guard model.canUseItemName(trimmedName, in: trimmedCategoryKey, excluding: draft.itemID) else {
-      model.notice = AppNotice(tone: .warning, title: "Duplicate Item", message: "That category already has an item with the same name.")
-      return
+    if validateDuplicateName {
+      guard model.canUseItemName(trimmedName, in: trimmedCategoryKey, excluding: draft.itemID) else {
+        model.notice = AppNotice(tone: .warning, title: "Duplicate Item", message: "That category already has an item with the same name.")
+        return nil
+      }
     }
 
     let recipe = draft.isFoodMenu ? [] : draft.recipeText
@@ -1340,7 +1421,7 @@ private struct ItemEditorSheet: View {
       .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
       .filter { !$0.isEmpty }
 
-    let item = MenuItemPayload(
+    return MenuItemPayload(
       id: draft.itemID ?? "local-\(UUID().uuidString.lowercased())",
       name: trimmedName,
       desc: draft.description.trimmingCharacters(in: .whitespacesAndNewlines),
@@ -1354,16 +1435,5 @@ private struct ItemEditorSheet: View {
       showDescription: draft.showDescription,
       showRecipe: draft.isFoodMenu ? false : draft.showRecipe
     )
-    model.upsertItem(item, categoryKey: trimmedCategoryKey, originalCategoryKey: draft.originalCategoryKey)
-
-    if draft.keepAdding {
-      let preservedCategory = trimmedCategoryKey
-      let isFood = draft.isFoodMenu
-      draft = EditableItemDraft()
-      draft.categoryKey = preservedCategory
-      draft.isFoodMenu = isFood
-    } else {
-      dismiss()
-    }
   }
 }

--- a/ios/ElRoysManagerApp/Models/AppModels.swift
+++ b/ios/ElRoysManagerApp/Models/AppModels.swift
@@ -1682,6 +1682,22 @@ struct EditableMenuDocument: Codable, Equatable {
     renumberItems(for: Self.uncategorizedKey)
   }
 
+  mutating func moveItemToOffMenu(_ updatedItem: MenuItemPayload, from categoryKey: String) {
+    guard categoryKey != Self.uncategorizedKey else { return }
+    guard let categoryIndex = cats.firstIndex(where: { $0.key == categoryKey }) else { return }
+    guard let itemIndex = cats[categoryIndex].items.firstIndex(where: { $0.id == updatedItem.id }) else { return }
+    ensureUncategorizedCategory()
+    guard let uncategorizedIndex = cats.firstIndex(where: { $0.key == Self.uncategorizedKey }) else { return }
+    var item = updatedItem
+    item.onMenu = false
+    item.visibility = "off_menu"
+    cats[categoryIndex].items.remove(at: itemIndex)
+    cats[uncategorizedIndex].items.removeAll { $0.id == item.id }
+    cats[uncategorizedIndex].items.append(item)
+    renumberItems(for: categoryKey)
+    renumberItems(for: Self.uncategorizedKey)
+  }
+
   mutating func restoreItemFromOffMenu(itemID: String, to categoryKey: String) {
     guard categoryKey != Self.uncategorizedKey else { return }
     guard let sourceIndex = cats.firstIndex(where: { $0.key == Self.uncategorizedKey }) else { return }
@@ -1692,6 +1708,19 @@ struct EditableMenuDocument: Codable, Equatable {
     cats[targetIndex].items.append(item)
     renumberItems(for: categoryKey)
     renumberItems(for: Self.uncategorizedKey)
+  }
+
+  mutating func moveVisibleItems(in categoryKey: String, from source: IndexSet, to destination: Int) {
+    guard categoryKey != Self.uncategorizedKey else { return }
+    guard let categoryIndex = cats.firstIndex(where: { $0.key == categoryKey }) else { return }
+
+    var visibleItems = cats[categoryIndex].items.filter(\.onMenu)
+    let hiddenItems = cats[categoryIndex].items.filter { !$0.onMenu }
+    guard visibleItems.count > 1 else { return }
+
+    visibleItems.moveItems(fromOffsets: source, toOffset: destination)
+    cats[categoryIndex].items = visibleItems + hiddenItems
+    renumberItems(for: categoryKey)
   }
 
   mutating func upsertItem(_ item: MenuItemPayload, categoryKey: String, originalCategoryKey: String? = nil) {

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -78,6 +78,60 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertFalse(document.uncategorizedItems[0].onMenu)
   }
 
+  func testMoveUpdatedItemToOffMenuAllowsDuplicateHiddenNames() {
+    let hiddenDuplicate = MenuItemPayload(
+      id: "item-hidden",
+      name: "Reserve",
+      desc: "",
+      recipe: [],
+      price: "$16",
+      isEightySixed: false,
+      displayOrder: 0,
+      onMenu: false,
+      visibility: "off_menu",
+      upcharges: [],
+      showDescription: true,
+      showRecipe: false
+    )
+    let workspace = makeWorkspace(categories: [
+      MenuCategoryPayload(
+        id: "beer",
+        menuId: "menu",
+        key: "beer",
+        label: "Beer",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 0,
+        items: [makeItem(id: "item-1", name: "Pilsner")]
+      ),
+      MenuCategoryPayload(
+        id: "uncategorized",
+        menuId: "menu",
+        key: EditableMenuDocument.uncategorizedKey,
+        label: "Uncategorized",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 1,
+        items: [hiddenDuplicate]
+      )
+    ])
+
+    var document = EditableMenuDocument(workspace: workspace)
+    var editedItem = makeItem(id: "item-1", name: "Reserve", desc: "Moved from taps")
+    editedItem.displayOrder = 0
+    document.moveItemToOffMenu(editedItem, from: "beer")
+
+    XCTAssertTrue(document.category(for: "beer")?.items.isEmpty == true)
+    XCTAssertEqual(document.uncategorizedItems.filter { $0.name == "Reserve" }.count, 2)
+    XCTAssertEqual(document.itemRecord(for: "item-1")?.categoryKey, EditableMenuDocument.uncategorizedKey)
+    XCTAssertEqual(document.itemRecord(for: "item-1")?.item.desc, "Moved from taps")
+    XCTAssertEqual(document.itemRecord(for: "item-1")?.item.onMenu, false)
+  }
+
   func testUpsertingExistingItemInSameCategoryPreservesOrderWhenEightySixed() {
     let workspace = makeWorkspace(categories: [
       MenuCategoryPayload(
@@ -110,6 +164,49 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(document.category(for: "beer")?.items.map(\.id), ["item-1", "item-2", "item-3"])
     XCTAssertEqual(document.category(for: "beer")?.items.map(\.displayOrder), [0, 1, 2])
     XCTAssertTrue(document.itemRecord(for: "item-2")?.item.isEightySixed == true)
+  }
+
+  func testMoveVisibleItemsReordersWithinCategoryAndKeepsHiddenItemsAtEnd() {
+    let hiddenItem = MenuItemPayload(
+      id: "item-hidden",
+      name: "Cellar Reserve",
+      desc: "",
+      recipe: [],
+      price: "$18",
+      isEightySixed: false,
+      displayOrder: 3,
+      onMenu: false,
+      visibility: "off_menu",
+      upcharges: [],
+      showDescription: true,
+      showRecipe: false
+    )
+    let workspace = makeWorkspace(categories: [
+      MenuCategoryPayload(
+        id: "beer",
+        menuId: "menu",
+        key: "beer",
+        label: "Beer",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 0,
+        items: [
+          makeItem(id: "item-1", name: "Pilsner"),
+          makeItem(id: "item-2", name: "Amber"),
+          makeItem(id: "item-3", name: "Stout"),
+          hiddenItem
+        ]
+      )
+    ])
+
+    var document = EditableMenuDocument(workspace: workspace)
+    document.moveVisibleItems(in: "beer", from: IndexSet(integer: 0), to: 3)
+
+    XCTAssertEqual(document.category(for: "beer")?.items.map(\.id), ["item-2", "item-3", "item-1", "item-hidden"])
+    XCTAssertEqual(document.category(for: "beer")?.items.map(\.displayOrder), [0, 1, 2, 3])
+    XCTAssertEqual(document.category(for: "beer")?.items.last?.onMenu, false)
   }
 
   func testEditableDocumentNormalizesDuplicateAndMissingIdentifiers() {
@@ -197,7 +294,42 @@ final class MenuDocumentTests: XCTestCase {
     let cardSource = String(source[cardRange.lowerBound..<recoveryRange.lowerBound])
 
     XCTAssertTrue(cardSource.contains("List {"))
-    XCTAssertTrue(cardSource.contains(".swipeActions(edge: .leading, allowsFullSwipe: true)"))
+    XCTAssertTrue(cardSource.contains("Reorder Items"))
+  }
+
+  func testMenuEditorSwipeListUsesTrailingEightySixActionOnly() throws {
+    let source = try String(contentsOf: menuViewsSourceURL(), encoding: .utf8)
+    let swipeRange = try XCTUnwrap(source.range(of: "private struct MenuEditorSwipeList"))
+    let recoveryRange = try XCTUnwrap(source.range(of: "private struct MenuEditorOffMenuRecoveryCard"))
+    let swipeSource = String(source[swipeRange.lowerBound..<recoveryRange.lowerBound])
+
+    XCTAssertTrue(swipeSource.contains(".swipeActions(edge: .trailing, allowsFullSwipe: true)"))
+    XCTAssertFalse(swipeSource.contains(".swipeActions(edge: .leading"))
+    XCTAssertFalse(swipeSource.contains("Label(\"Off Menu\""))
+    XCTAssertTrue(swipeSource.contains(".onMove"))
+  }
+
+  func testMenuEditorSwipeListMeasuresRenderedRowsInsteadOfFixedEstimate() throws {
+    let source = try String(contentsOf: menuViewsSourceURL(), encoding: .utf8)
+    let swipeRange = try XCTUnwrap(source.range(of: "private struct MenuEditorSwipeList"))
+    let recoveryRange = try XCTUnwrap(source.range(of: "private struct MenuEditorOffMenuRecoveryCard"))
+    let swipeSource = String(source[swipeRange.lowerBound..<recoveryRange.lowerBound])
+
+    XCTAssertTrue(source.contains("private struct MenuEditorRowHeightPreferenceKey"))
+    XCTAssertFalse(swipeSource.contains(".frame(height: estimatedListHeight)"))
+  }
+
+  func testEditableDocumentDefinesVisibleItemReorderMutation() throws {
+    let source = try String(contentsOf: appModelsSourceURL(), encoding: .utf8)
+    XCTAssertTrue(source.contains("mutating func moveVisibleItems(in categoryKey: String, from source: IndexSet, to destination: Int)"))
+  }
+
+  func testItemEditorSheetExposesMoveToOffMenuAction() throws {
+    let source = try String(contentsOf: menuViewsSourceURL(), encoding: .utf8)
+    let sheetRange = try XCTUnwrap(source.range(of: "private struct ItemEditorSheet"))
+    let sheetSource = String(source[sheetRange.lowerBound...])
+
+    XCTAssertTrue(sheetSource.contains("Move To Off Menu"))
   }
 
   func testOfflineDraftStoreRoundTripsByUserAndMenu() throws {
@@ -2209,6 +2341,13 @@ private func menuViewsSourceURL(filePath: StaticString = #filePath) -> URL {
     .deletingLastPathComponent()
     .deletingLastPathComponent()
     .appendingPathComponent("ElRoysManagerApp/Features/Menu/MenuViews.swift")
+}
+
+private func appModelsSourceURL(filePath: StaticString = #filePath) -> URL {
+  URL(fileURLWithPath: "\(filePath)")
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .appendingPathComponent("ElRoysManagerApp/Models/AppModels.swift")
 }
 
 private enum TestError: LocalizedError {

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -190,6 +190,16 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(preview.exactRouteURL(for: foodMenu).absoluteString, "https://example.com/leroyslounge")
   }
 
+  func testMenuEditorCategoryCardUsesListForSwipeableRows() throws {
+    let source = try String(contentsOf: menuViewsSourceURL(), encoding: .utf8)
+    let cardRange = try XCTUnwrap(source.range(of: "private struct MenuEditorCategoryCard"))
+    let recoveryRange = try XCTUnwrap(source.range(of: "private struct MenuEditorOffMenuRecoveryCard"))
+    let cardSource = String(source[cardRange.lowerBound..<recoveryRange.lowerBound])
+
+    XCTAssertTrue(cardSource.contains("List {"))
+    XCTAssertTrue(cardSource.contains(".swipeActions(edge: .leading, allowsFullSwipe: true)"))
+  }
+
   func testOfflineDraftStoreRoundTripsByUserAndMenu() throws {
     let rootURL = FileManager.default.temporaryDirectory
       .appendingPathComponent(UUID().uuidString, isDirectory: true)
@@ -2192,6 +2202,13 @@ final class MenuDocumentTests: XCTestCase {
     """.utf8)
     return try JSONDecoder.backend.decode(MenuPreviewPayload.self, from: data)
   }
+}
+
+private func menuViewsSourceURL(filePath: StaticString = #filePath) -> URL {
+  URL(fileURLWithPath: "\(filePath)")
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .appendingPathComponent("ElRoysManagerApp/Features/Menu/MenuViews.swift")
 }
 
 private enum TestError: LocalizedError {


### PR DESCRIPTION
## What changed
- fixed the new `Move To Off Menu` flow so edited items can still move into the hidden bucket even when off-menu already contains duplicate names
- replaced the embedded swipe list's fixed estimated height with measured row heights so tall rows are not clipped
- added regression coverage for the updated off-menu move path and the measured list-height behavior

## Why it changed
The swipe-to-86 follow-up branch introduced two review issues:
- `Move To Off Menu` rebuilt the item through duplicate validation for `__uncategorized__`, which blocked legitimate moves when duplicate hidden items already existed
- the embedded `List` used a guessed frame height, which could truncate long rows with wrapped descriptions or recipes

## Impact
- staff can move edited items off-menu again without duplicate-name false positives in the hidden bucket
- category cards size to their rendered content more reliably while keeping native swipe and drag-handle behavior

## Validation
- `xcodebuild test -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'id=61CFA6DC-C165-415A-A0C1-A475FB3BECE1' -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testMoveUpdatedItemToOffMenuAllowsDuplicateHiddenNames -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testMenuEditorSwipeListMeasuresRenderedRowsInsteadOfFixedEstimate -quiet`
- `xcodebuild test -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'id=61CFA6DC-C165-415A-A0C1-A475FB3BECE1' -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testRemoveItemToOffMenuCreatesUncategorizedWhenMissing -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testMoveUpdatedItemToOffMenuAllowsDuplicateHiddenNames -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testMoveVisibleItemsReordersWithinCategoryAndKeepsHiddenItemsAtEnd -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testMenuEditorCategoryCardUsesListForSwipeableRows -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testMenuEditorSwipeListUsesTrailingEightySixActionOnly -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testMenuEditorSwipeListMeasuresRenderedRowsInsteadOfFixedEstimate -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testItemEditorSheetExposesMoveToOffMenuAction -quiet`
