### PR TITLE
[codex] menu publish workflow hybrid

### DIFF
--- a/app.js
+++ b/app.js
@@ -2716,7 +2716,6 @@ function buildMenuSessionPreview(snapshot = buildMenuSessionSnapshot('preview'))
   const sections = buildNotificationPreviewSections(diff);
   const notificationChanges = sections.flatMap(section => section.changes);
   const saveOnlyChanges = snapshot.saveOnlyChanges || getDraftSaveOnlyChanges();
-  const patchMessage = notificationChanges.length ? buildPatchMessage(sections) : '';
   const hasLocalDraft = !!snapshot.dirty;
   const mode = hasLocalDraft ? 'save-and-send' : (notificationChanges.length ? 'send' : 'save');
   return {
@@ -2729,8 +2728,8 @@ function buildMenuSessionPreview(snapshot = buildMenuSessionSnapshot('preview'))
     sections,
     notificationChanges,
     saveOnlyChanges,
-    patchMessage,
-    truncated: patchMessage.length > 1000,
+    patchMessage: '',
+    truncated: false,
     snapshot,
     mode,
   };
@@ -2822,6 +2821,9 @@ function getMenuSessionPorts() {
     },
     async patchMenuDraftState(snapshot, savedAt) {
       return patchMenuDraftState(snapshot, savedAt);
+    },
+    async requestPublishPreview() {
+      return requestPublishPreviewThroughApi();
     },
     async publishMenuUpdate(options = {}) {
       const providedPreview = options.preview?.sections ? options.preview : null;
@@ -2941,10 +2943,10 @@ function getMenuSessionPorts() {
       return getRestaurantSpecialConfig(restaurantId)?.menuIds || [];
     },
     async dispatchNotification(payload) {
-      return dispatchMenuUpdateNotification(payload);
+      return sendMenuNotificationThroughApi(payload);
     },
     collectNotificationWarnings(summary) {
-      return collectNotificationWarnings(summary);
+      return summarizeNotificationWarnings(summary);
     },
     syncLocalCache(options = {}) {
       return syncLocalMenuCache(options);
@@ -2959,7 +2961,7 @@ function getMenuSessionPorts() {
       updateLastUpdatedLabel();
     },
     dedupeWarnings(warnings = []) {
-      return dedupePublisherWarnings(warnings);
+      return dedupeWarningMessages(warnings);
     },
   };
 }
@@ -2971,21 +2973,83 @@ function getSessionModuleBoundary() {
   return null;
 }
 
-function createMenuPublishService(sessionPorts, runtime = {}) {
-  if (!_sessionModuleDelegationStack.has('createMenuPublishService')) {
-    const boundary = getSessionModuleBoundary();
-    if (typeof boundary?.createMenuPublishService === 'function') {
-      _sessionModuleDelegationStack.add('createMenuPublishService');
-      try {
-        return boundary.createMenuPublishService(sessionPorts, runtime, {
-          fallback: () => createMenuPublishService(sessionPorts, runtime),
-        });
-      } finally {
-        _sessionModuleDelegationStack.delete('createMenuPublishService');
-      }
-    }
-  }
+function buildEmptyNotificationSummary() {
+  return {
+    anyOk: false,
+    anyError: false,
+    failedChannels: [],
+    allSkipped: false,
+  };
+}
 
+function summarizeNotificationWarnings(summary = {}) {
+  if (summary.allSkipped) return ['No notification channels were enabled for this menu.'];
+  if (summary.anyOk && summary.anyError) {
+    const failedChannels = Array.isArray(summary.failedChannels) ? summary.failedChannels : [];
+    return [`Some notification channels failed: ${failedChannels.map(channel => String(channel || '').toUpperCase()).join(', ')}.`];
+  }
+  return [];
+}
+
+function dedupeWarningMessages(warnings = []) {
+  return Array.from(new Set((warnings || []).filter(Boolean)));
+}
+
+function serializeSectionsForUpdateLog(sections = []) {
+  return (Array.isArray(sections) ? sections : []).map(section => ({
+    id: section.id,
+    icon: section.icon,
+    label: section.label,
+    displayOrder: Number.isFinite(Number(section.displayOrder)) ? Number(section.displayOrder) : 0,
+    added: (section.changes || []).filter(change => change.kind === 'added').map(change => change.name),
+    removed: (section.changes || []).filter(change => change.kind === 'removed').map(change => change.name),
+    eightySixed: (section.changes || []).filter(change => change.kind === 'eightySixed').map(change => change.name),
+    restored: (section.changes || []).filter(change => change.kind === 'restored').map(change => change.name),
+  }));
+}
+
+async function sendMenuNotificationThroughApi(payload = {}) {
+  if (!MENU_ID || !getAuthorizedApiHeaders().Authorization) {
+    return {
+      ok: false,
+      skipped: true,
+      statusCode: 0,
+      summary: buildEmptyNotificationSummary(),
+    };
+  }
+  const result = await postApiJson('/api/manager', {
+    action: 'send_notification',
+    menu_id: payload.menuId || MENU_ID,
+    text: String(payload.patchMessage || '').trim(),
+  }, {
+    headers: getAuthorizedApiHeaders(),
+  });
+  if (!result.ok) {
+    return {
+      ok: false,
+      skipped: false,
+      statusCode: Number(result.status || 0),
+      userMessage: result.payload?.error || 'Update could not be sent.',
+      summary: buildEmptyNotificationSummary(),
+    };
+  }
+  const rows = Array.isArray(result.payload?.results) ? result.payload.results : [];
+  const summary = {
+    anyOk: rows.some(row => row?.ok),
+    anyError: rows.some(row => row?.ok === false),
+    failedChannels: rows.filter(row => row?.ok === false).map(row => row?.channel).filter(Boolean),
+    allSkipped: rows.length > 0 && rows.every(row => row?.skipped),
+  };
+  return {
+    ok: !summary.anyError,
+    skipped: summary.allSkipped,
+    partial: summary.anyOk && summary.anyError,
+    statusCode: Number(result.status || 200),
+    summary,
+  };
+}
+
+function createLegacyMenuPublishService(sessionPorts, runtime = {}) {
   const buildSnapshot = typeof runtime.buildSnapshot === 'function'
     ? runtime.buildSnapshot
     : (() => ({ source: 'unknown' }));
@@ -3035,7 +3099,7 @@ function createMenuPublishService(sessionPorts, runtime = {}) {
       const selectedChangeIds = options.selectedChangeIds || preview.notificationChanges.map(change => change.id);
       const selectedChanges = preview.notificationChanges.filter(change => selectedChangeIds.includes(change.id));
       const selectedSections = groupNotificationChangesBySection(selectedChanges);
-      const patchMessage = selectedSections.length ? buildPatchMessage(selectedSections) : '';
+      const patchMessage = String(preview.patchMessage || '').trim();
       const mode = options.mode || ((preview.mode === 'send' || preview.mode === 'update-only')
         ? (options.notify === false ? 'save' : 'send')
         : (options.notify === false ? 'save' : 'save-and-send'));
@@ -3077,7 +3141,7 @@ function createMenuPublishService(sessionPorts, runtime = {}) {
         ok: true,
         skipped: !shouldNotify,
         statusCode: null,
-        summary: summarizeNotificationResults({}),
+        summary: buildEmptyNotificationSummary(),
       };
       if (shouldNotify) {
         delivery = await sessionPorts.dispatchNotification({
@@ -3152,7 +3216,7 @@ function createMenuPublishService(sessionPorts, runtime = {}) {
           warnings.push('This device could not refresh its local cache after the send.');
         }
 
-        const logged = patchMessage ? await sessionPorts.logUpdate(serializeNotificationSectionsForLog(selectedSections), patchMessage) : true;
+        const logged = patchMessage ? await sessionPorts.logUpdate(serializeSectionsForUpdateLog(selectedSections), patchMessage) : true;
         if (!logged) {
           warnings.push('The recent-changes audit log could not be written for this send.');
         }
@@ -3191,16 +3255,122 @@ function createMenuPublishService(sessionPorts, runtime = {}) {
   return service;
 }
 
+function createMenuPublishService(sessionPorts, runtime = {}) {
+  if (!_sessionModuleDelegationStack.has('createMenuPublishService')) {
+    const boundary = getSessionModuleBoundary();
+    if (typeof boundary?.createMenuPublishService === 'function') {
+      _sessionModuleDelegationStack.add('createMenuPublishService');
+      try {
+        return boundary.createMenuPublishService(sessionPorts, runtime, {
+          fallback: () => createLegacyMenuPublishService(sessionPorts, runtime),
+        });
+      } finally {
+        _sessionModuleDelegationStack.delete('createMenuPublishService');
+      }
+    }
+  }
+
+  return createLegacyMenuPublishService(sessionPorts, runtime);
+}
+
+function createClientMenuPublishWorkflow({ ports }) {
+  return {
+    async preview(command = {}) {
+      const result = typeof ports.requestPublishPreview === 'function'
+        ? await ports.requestPublishPreview(command)
+        : { ok: false, payload: null };
+      if (!result?.ok) {
+        return {
+          ok: false,
+          userHandled: false,
+          userMessage: result?.payload?.error || 'Preview is unavailable right now.',
+        };
+      }
+      const payload = result.payload || {};
+      return {
+        ok: payload.ok !== false,
+        preview: payload.preview || null,
+        revisions: payload.revisions || {
+          liveRevision: command.request?.expectedLiveRevision ?? null,
+          draftRevision: command.request?.expectedDraftRevision ?? null,
+          notificationRevision: command.request?.expectedNotificationRevision ?? null,
+        },
+      };
+    },
+
+    async execute(command = {}) {
+      const mode = command.intent === 'save'
+        ? 'save'
+        : (command.intent === 'send' ? 'send' : 'save-and-send');
+      const result = await ports.publishMenuUpdate({
+        mode,
+        notify: command.intent === 'save' ? false : undefined,
+        selectedChangeIds: Array.isArray(command.request?.selectedChangeIds)
+          ? command.request.selectedChangeIds
+          : [],
+      });
+      const warnings = Array.isArray(result?.warnings)
+        ? result.warnings
+        : (result?.warningMessage ? [result.warningMessage] : []);
+      return {
+        ...result,
+        ok: result?.ok !== false,
+        userOutcome: {
+          successMessage: result?.successMessage || '',
+          warningMessage: result?.warningMessage || '',
+          warnings,
+        },
+        notification: result?.notification || result?.notificationStatus || null,
+      };
+    },
+  };
+}
+
+function createClientMenuPublishFacade(sessionPorts, runtime = {}) {
+  const createFacade = typeof globalThis.createMenuPublishFacade === 'function'
+    ? globalThis.createMenuPublishFacade.bind(globalThis)
+    : null;
+  if (typeof createFacade === 'function'
+      && (typeof sessionPorts.requestPublishPreview !== 'function' || typeof sessionPorts.publishMenuUpdate !== 'function')) {
+    return createFacade(sessionPorts, runtime);
+  }
+  if (typeof createFacade !== 'function') {
+    const publishService = createLegacyMenuPublishService(sessionPorts, runtime);
+    return {
+      async prepare(options = {}) {
+        if (typeof publishService.prepare === 'function') {
+          return publishService.prepare(options);
+        }
+        return {
+          ok: false,
+          userHandled: false,
+          userMessage: 'Preview is unavailable right now.',
+        };
+      },
+      async commit(options = {}) {
+        if (options.intent === 'save' && typeof publishService.saveDraft === 'function') {
+          return publishService.saveDraft(options);
+        }
+        return publishService.publishUpdate(options);
+      },
+    };
+  }
+  return createFacade(sessionPorts, {
+    ...runtime,
+    createWorkflow: createClientMenuPublishWorkflow,
+  });
+}
+
 function createMenuSessionLifecycle(ports) {
   const sessionPorts = ports || getMenuSessionPorts();
   const buildPublishService = (nextSessionPorts, runtime = {}) => {
     const boundary = getSessionModuleBoundary();
     if (typeof boundary?.createMenuPublishService === 'function') {
       return boundary.createMenuPublishService(nextSessionPorts, runtime, {
-        fallback: () => createMenuPublishService(nextSessionPorts, runtime),
+        fallback: () => createLegacyMenuPublishService(nextSessionPorts, runtime),
       });
     }
-    return createMenuPublishService(nextSessionPorts, runtime);
+    return createLegacyMenuPublishService(nextSessionPorts, runtime);
   };
 
   if (!_sessionModuleDelegationStack.has('createMenuSessionLifecycle')) {
@@ -3210,6 +3380,7 @@ function createMenuSessionLifecycle(ports) {
       try {
         return boundary.createMenuSessionLifecycle(sessionPorts, {
           getMenuSessionPorts: () => getMenuSessionPorts(),
+          createPublishFacade: (nextSessionPorts, runtime = {}) => createClientMenuPublishFacade(nextSessionPorts, runtime),
           createPublishService: buildPublishService,
         });
       } finally {
@@ -12028,12 +12199,17 @@ async function openPreview() {
   const modal = document.getElementById('modal-bg');
   if (!content || !saveMenuBtn || !saveSendBtn || !modal) return;
 
-  const apiResult = await requestPublishPreviewThroughApi();
-  if (!apiResult.ok) {
-    showToast(apiResult.payload?.error || 'Preview is unavailable right now.', 'error');
+  const result = await ensureCurrentMenuSession().preparePublish({
+    source: isAdminMode ? 'web_admin' : 'web_manager',
+    expectedLiveRevision: menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null,
+    expectedDraftRevision: menuState._meta?.draftSavedTs ? Number(menuState._meta.draftSavedTs) : null,
+    expectedNotificationRevision: buildCurrentLocalDraftEnvelope()?.baseLastSentRevision ?? null,
+  });
+  if (!result?.ok || !result.preview) {
+    showToast(result?.userMessage || 'Preview is unavailable right now.', 'error');
     return;
   }
-  const preview = apiResult.payload?.preview;
+  const preview = result.preview;
   if (!preview || !Array.isArray(preview.sections) || !Array.isArray(preview.notificationChanges)) {
     showToast('Preview response was invalid. Please try again.', 'error');
     return;
@@ -12047,48 +12223,6 @@ function closeModal() {
   modal.classList.remove('open');
   modal.setAttribute('aria-hidden', 'true');
   modal.hidden = true;
-}
-
-// ─── LIVE PUBLISH ─────────────────────────────────────────────────────────────
-function buildPatchMessage(sections) {
-  const now = new Date();
-  const dateStr = now.toLocaleDateString('en-US', { weekday:'short', month:'short', day:'numeric' });
-  const timeStr = now.toLocaleTimeString('en-US', { hour:'numeric', minute:'2-digit' });
-  const cleanName = n => n.replace(/[\r\n]+/g, ' ').trim();
-  const menuLabel = _activeMenuName ? _activeMenuName.toUpperCase() : 'MENU';
-  const lines = [`🔥 ${menuLabel} UPDATES — ${dateStr} ${timeStr}`, ''];
-  (sections || []).forEach(section => {
-    lines.push(`${section.icon} ${section.label.toUpperCase()}`);
-    if (Array.isArray(section.changes)) {
-      section.changes.forEach(change => {
-        if (change.kind === 'added') lines.push(`  ✅ + ${cleanName(change.name)}`);
-        if (change.kind === 'removed') lines.push(`  ❌ - ${cleanName(change.name)}`);
-        if (change.kind === 'eightySixed') lines.push(`  🚫 86'd: ${cleanName(change.name)}`);
-        if (change.kind === 'restored') lines.push(`  ✅ ${restoreLabel(section.id)}: ${cleanName(change.name)}`);
-      });
-    } else {
-      (section.added || []).forEach(n => lines.push(`  ✅ + ${cleanName(n)}`));
-      (section.removed || []).forEach(n => lines.push(`  ❌ - ${cleanName(n)}`));
-      (section.eightySixed || []).forEach(n => lines.push(`  🚫 86'd: ${cleanName(n)}`));
-      (section.restored || []).forEach(n => lines.push(`  ✅ ${restoreLabel(section.id)}: ${cleanName(n)}`));
-    }
-    lines.push('');
-  });
-  const menuLink = getNotificationMenuLink();
-  if (menuLink) lines.push(`📋 Full menu: ${menuLink}`);
-  return lines.join('\n').trim();
-}
-
-function serializeNotificationSectionsForLog(sections = []) {
-  return (sections || []).map(section => ({
-    id: section.id,
-    icon: section.icon,
-    label: section.label,
-    added: (section.changes || []).filter(change => change.kind === 'added').map(change => change.name),
-    removed: (section.changes || []).filter(change => change.kind === 'removed').map(change => change.name),
-    eightySixed: (section.changes || []).filter(change => change.kind === 'eightySixed').map(change => change.name),
-    restored: (section.changes || []).filter(change => change.kind === 'restored').map(change => change.name),
-  }));
 }
 
 function setPreviewChangeSelected(changeId, checked) {
@@ -12129,162 +12263,6 @@ function buildSaveOnlyPreviewBlockHtml(changes = []) {
     `<div class="preview-line"><span>•</span> ${escHtml(change.message || change.label || 'Saved change')}</div>`
   )).join('')}`;
 }
-function dedupePublisherWarnings(warnings = []) {
-  return Array.from(new Set((warnings || []).filter(Boolean)));
-}
-
-function formatNotificationChannelName(channel) {
-  switch (channel) {
-    case 'groupme': return 'GroupMe';
-    case 'sms': return 'SMS';
-    case 'discord': return 'Discord';
-    case 'webhook': return 'Webhook';
-    default: return channel || 'Unknown channel';
-  }
-}
-
-function summarizeNotificationResults(results = {}) {
-  const entries = Object.entries(results || {}).filter(([channel]) => !!channel);
-  const okChannels = [];
-  const skippedChannels = [];
-  const failedChannels = [];
-  const failedDetails = [];
-
-  entries.forEach(([channel, status]) => {
-    if (status === 'ok') {
-      okChannels.push(channel);
-      return;
-    }
-    if (status === 'skipped') {
-      skippedChannels.push(channel);
-      return;
-    }
-    failedChannels.push(channel);
-    failedDetails.push({
-      channel,
-      status: typeof status === 'string' ? status : 'error:unknown',
-    });
-  });
-
-  return {
-    results,
-    okChannels,
-    skippedChannels,
-    failedChannels,
-    failedDetails,
-    anyOk: okChannels.length > 0,
-    anyError: failedChannels.length > 0,
-    allSkipped: entries.length > 0 && skippedChannels.length === entries.length,
-  };
-}
-
-function collectNotificationWarnings(summary) {
-  if (!summary) return [];
-  const warnings = [];
-  if (summary.allSkipped) {
-    warnings.push('No notification channels were enabled for this menu.');
-  } else if (summary.anyOk && summary.anyError) {
-    warnings.push(`Some notification channels failed: ${summary.failedChannels.map(formatNotificationChannelName).join(', ')}.`);
-  }
-  return warnings;
-}
-
-function createNotificationDeliveryService(deps = {}) {
-  const fetchImpl = typeof deps.fetchImpl === 'function' ? deps.fetchImpl : fetch;
-  const summarizeResults = typeof deps.summarizeResults === 'function'
-    ? deps.summarizeResults
-    : summarizeNotificationResults;
-
-  return {
-    async sendMenuUpdate({ menuId, patchMessage, accessToken = '' }) {
-      const authHeaders = accessToken
-        ? { 'Authorization': `Bearer ${accessToken}` }
-        : {};
-
-      let response;
-      try {
-        response = await fetchImpl('/api/manager', {
-          method: 'POST',
-          headers: { 'Content-Type': 'application/json', ...authHeaders },
-          body: JSON.stringify({ action: 'send_notification', menu_id: menuId, text: patchMessage }),
-        });
-      } catch (_) {
-        return {
-          ok: false,
-          statusCode: 0,
-          summary: summarizeResults({}),
-          userMessage: '❌ Network error. Check connection.',
-        };
-      }
-
-      let body = {};
-      try {
-        body = await response.json();
-      } catch (_) {
-        body = {};
-      }
-
-      const summary = summarizeResults(body?.results || {});
-      const statusCode = Number(response?.status || 0);
-      const is2xx = statusCode >= 200 && statusCode < 300;
-      if (is2xx) {
-        return {
-          ok: true,
-          statusCode,
-          partial: statusCode === 207,
-          results: body?.results || {},
-          summary,
-        };
-      }
-
-      if (statusCode === 401) {
-        return {
-          ok: false,
-          statusCode,
-          summary,
-          userMessage: '❌ Not authorized. Please sign in.',
-        };
-      }
-
-      if (statusCode === 403) {
-        return {
-          ok: false,
-          statusCode,
-          summary,
-          userMessage: '❌ Access denied. Your account role does not allow sending updates.',
-        };
-      }
-
-      if (statusCode === 400 && typeof body?.error === 'string' && body.error.trim()) {
-        return {
-          ok: false,
-          statusCode,
-          summary,
-          userMessage: `❌ ${body.error.trim()}`,
-        };
-      }
-
-      const failedSummary = summary.failedChannels.length
-        ? ` Failed: ${summary.failedChannels.map(formatNotificationChannelName).join(', ')}.`
-        : '';
-      return {
-        ok: false,
-        statusCode,
-        summary,
-        userMessage: `❌ Notification error. Check channel config in Admin settings.${failedSummary}`,
-      };
-    },
-  };
-}
-
-async function dispatchMenuUpdateNotification({ menuId, patchMessage }) {
-  return createNotificationDeliveryService().sendMenuUpdate({
-    menuId,
-    patchMessage,
-    accessToken: currentUser?.accessToken || '',
-  });
-}
-
 function snapshotLastSentState() {
   const lastSentState = {};
   CATEGORY_DEFS.forEach(cat => { lastSentState[cat.id] = menuState[cat.id]?.lastSent || []; });
@@ -12348,12 +12326,17 @@ async function sendUpdate(options = {}) {
   await flushFocusedManagerEditor();
   let preview = options.preview?.sections ? options.preview : _previewModalState;
   if (!preview) {
-    const previewResult = await requestPublishPreviewThroughApi();
-    if (!previewResult.ok) {
-      showToast(previewResult.payload?.error || 'Preview is unavailable right now.', 'error');
+    const prepared = await ensureCurrentMenuSession().preparePublish({
+      source: isAdminMode ? 'web_admin' : 'web_manager',
+      expectedLiveRevision: menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null,
+      expectedDraftRevision: menuState._meta?.draftSavedTs ? Number(menuState._meta.draftSavedTs) : null,
+      expectedNotificationRevision: buildCurrentLocalDraftEnvelope()?.baseLastSentRevision ?? null,
+    });
+    if (!prepared?.ok || !prepared.preview) {
+      showToast(prepared?.userMessage || 'Preview is unavailable right now.', 'error');
       return;
     }
-    preview = previewResult.payload?.preview;
+    preview = prepared.preview;
     if (!preview || !Array.isArray(preview.notificationChanges)) {
       showToast('Preview response was invalid. Please try again.', 'error');
       return;
@@ -12368,28 +12351,41 @@ async function sendUpdate(options = {}) {
   }
 
   const selectedChangeIds = getSelectedPreviewChangeIds();
-  const mode = options.notify === false
+  const intent = options.notify === false
     ? 'save'
     : ((preview.mode === 'send' || preview.mode === 'update-only') ? 'send' : 'save-and-send');
-  setPreviewModalActionState(mode === 'save' ? 'save-menu' : (mode === 'send' ? 'send-update' : 'save-send'));
+  setPreviewModalActionState(intent === 'save' ? 'save-menu' : (intent === 'send' ? 'send-update' : 'save-send'));
 
   try {
-    const result = await ensureCurrentMenuSession().publishUpdate({ preview, mode, selectedChangeIds });
+    const result = await ensureCurrentMenuSession().commitPublish({
+      source: isAdminMode ? 'web_admin' : 'web_manager',
+      intent,
+      preview,
+      selectedChangeIds,
+      expectedLiveRevision: menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null,
+      expectedDraftRevision: menuState._meta?.draftSavedTs ? Number(menuState._meta.draftSavedTs) : null,
+      expectedNotificationRevision: buildCurrentLocalDraftEnvelope()?.baseLastSentRevision ?? null,
+    });
     if (result?.noop) {
       closeModal();
       return;
     }
     if (result?.ok) {
       closeModal();
-      showToast(result.successMessage || `✅ ${_activeMenuName || 'Menu'} updated.`, 'success');
+      const successMessage = result.userOutcome?.successMessage || result.successMessage || `✅ ${_activeMenuName || 'Menu'} updated.`;
+      showToast(successMessage, 'success');
       renderManagerWorkspace({ includeRecentChanges: false });
       updateDraftIndicator();
       renderRecentChanges();
-      const warnings = Array.isArray(result.warnings) ? result.warnings : (result.warningMessage ? [result.warningMessage] : []);
+      const warnings = Array.isArray(result.userOutcome?.warnings)
+        ? result.userOutcome.warnings
+        : (Array.isArray(result.warnings) ? result.warnings : (result.warningMessage ? [result.warningMessage] : []));
       warnings.forEach(message => showToast(`⚠️ ${message}`, 'warning'));
       return;
     }
-    if (result?.userMessage) showToast(result.userMessage, 'error');
+    if (result?.userOutcome?.warningMessage || result?.userMessage) {
+      showToast(result.userOutcome?.warningMessage || result.userMessage, 'error');
+    }
   } finally {
     setPreviewModalActionState();
   }

--- a/core/session/menu-publish-facade.js
+++ b/core/session/menu-publish-facade.js
@@ -1,0 +1,61 @@
+(function bootstrapMenuPublishFacadeModule(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_SESSION_MODULES__ && typeof globalScope.__HF_SESSION_MODULES__ === 'object')
+    ? globalScope.__HF_SESSION_MODULES__
+    : {};
+
+  function createMenuPublishFacade(sessionPorts, deps = {}) {
+    const workflowFactory = typeof deps.createWorkflow === 'function'
+      ? deps.createWorkflow
+      : (globalScope.createMenuPublishWorkflow || null);
+    if (typeof workflowFactory !== 'function') {
+      throw new Error('createMenuPublishWorkflow is unavailable');
+    }
+    const buildSnapshot = typeof deps.buildSnapshot === 'function'
+      ? deps.buildSnapshot
+      : ((source, request) => sessionPorts.buildSnapshot(source, request));
+
+    const workflow = workflowFactory({
+      ports: typeof deps.createPorts === 'function'
+        ? deps.createPorts(sessionPorts)
+        : sessionPorts,
+    });
+
+    return {
+      async prepare(options = {}) {
+        return workflow.preview({
+          menuId: sessionPorts.getMenuId(),
+          actor: sessionPorts.getActor ? sessionPorts.getActor() : null,
+          source: options.source || 'web_manager',
+          snapshot: options.snapshot || buildSnapshot('preview', options.request),
+          request: {
+            expectedLiveRevision: options.expectedLiveRevision ?? null,
+            expectedDraftRevision: options.expectedDraftRevision ?? null,
+            expectedNotificationRevision: options.expectedNotificationRevision ?? null,
+          },
+        });
+      },
+
+      async commit(options = {}) {
+        return workflow.execute({
+          menuId: sessionPorts.getMenuId(),
+          actor: sessionPorts.getActor ? sessionPorts.getActor() : null,
+          source: options.source || 'web_manager',
+          intent: options.intent || 'save-and-send',
+          snapshot: options.snapshot || buildSnapshot('publish', options.request),
+          request: {
+            selectedChangeIds: Array.isArray(options.selectedChangeIds) ? options.selectedChangeIds : [],
+            expectedLiveRevision: options.expectedLiveRevision ?? null,
+            expectedDraftRevision: options.expectedDraftRevision ?? null,
+            expectedNotificationRevision: options.expectedNotificationRevision ?? null,
+          },
+        });
+      },
+    };
+  }
+
+  modules.createMenuPublishFacade = createMenuPublishFacade;
+  globalScope.__HF_SESSION_MODULES__ = modules;
+  globalScope.createMenuPublishFacade = createMenuPublishFacade;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/core/session/menu-publish-workflow.js
+++ b/core/session/menu-publish-workflow.js
@@ -1,0 +1,197 @@
+(function bootstrapMenuPublishWorkflowModule(globalScope) {
+  if (!globalScope) return;
+
+  function mergeDowngradedFields(...results) {
+    const merged = [];
+    results.forEach(result => {
+      (Array.isArray(result?.downgradedFields) ? result.downgradedFields : []).forEach(field => {
+        if (!merged.includes(field)) merged.push(field);
+      });
+    });
+    return merged;
+  }
+
+  function createMenuPublishWorkflow({ ports }) {
+    if (!ports) throw new Error('ports are required');
+    const SUPPORTED_INTENTS = new Set(['save', 'send', 'save-and-send']);
+
+    async function readContext(command = {}) {
+      await ports.governance.assertCategoryGovernanceAllowed({
+        actor: command.actor,
+        menuId: command.menuId,
+        snapshot: command.snapshot || {},
+      });
+      const context = await ports.menus.readContext(command.menuId);
+      const revisions = ports.governance.assertRevisions({
+        menuId: command.menuId,
+        meta: context.meta,
+        expectedLiveRevision: command.request?.expectedLiveRevision ?? null,
+        expectedDraftRevision: command.request?.expectedDraftRevision ?? null,
+        expectedNotificationRevision: command.request?.expectedNotificationRevision ?? null,
+      });
+      const preview = await ports.preview.buildCanonical({
+        menuId: command.menuId,
+        snapshot: command.snapshot || {},
+        knownMenu: context.knownMenu,
+        meta: context.meta,
+        currentFeaturedIds: context.currentFeaturedIds,
+      });
+      return { context, revisions, preview };
+    }
+
+    return {
+      async preview(command = {}) {
+        const { preview, revisions } = await readContext(command);
+        return { ok: true, preview, revisions };
+      },
+
+      async execute(command = {}) {
+        if (!SUPPORTED_INTENTS.has(command.intent)) {
+          throw new Error(`unsupported command intent: ${command.intent || ''}`);
+        }
+        const { context, revisions, preview } = await readContext(command);
+        const selection = ports.preview.resolveSelection({
+          preview,
+          selectedChangeIds: command.request?.selectedChangeIds ?? null,
+        });
+        const ts = ports.clock.now();
+        const operationId = ports.ids.operationId();
+        const warnings = [];
+        const auditEventTypes = [];
+        const auditResults = [];
+        const metaResults = [];
+        let livePersisted = false;
+        const baselineAdvancedIntent = command.intent === 'send' || command.intent === 'save-and-send';
+        let baselineAdvanced = false;
+        const menuName = context.knownMenu?.name || 'Menu';
+
+        if (command.intent !== 'send') {
+          await ports.menus.saveLiveMenu({
+            menuId: command.menuId,
+            snapshot: command.snapshot || {},
+            actor: command.actor,
+            expectedLiveRevision: command.request?.expectedLiveRevision ?? null,
+          });
+          livePersisted = true;
+        }
+
+        let notification = {
+          attempted: false,
+          delivered: false,
+          partial: false,
+          summary: null,
+          retryable: false,
+        };
+
+        if ((command.intent === 'send' || command.intent === 'save-and-send') && selection.selectedSections.length) {
+          notification = {
+            attempted: true,
+            ...(await ports.notifications.deliver({
+              menuId: command.menuId,
+              message: ports.format.patchMessage({
+                sections: selection.selectedSections,
+                menuName: context.knownMenu?.name || '',
+                menuLink: String(context.meta?.notifications?.menu_url || '').trim(),
+              }),
+            })),
+          };
+        }
+
+        if (notification.partial || (notification.attempted && !notification.delivered)) {
+          warnings.push(...ports.format.warningSummary(notification.summary));
+          auditResults.push(await ports.audit.append({
+            menuId: command.menuId,
+            actor: command.actor,
+            source: command.source || '',
+            operationId,
+            eventType: 'send_failed',
+            sections: selection.selectedSections,
+            message: 'Notification delivery failed or was partial. Queue preserved.',
+          }));
+          auditEventTypes.push('send_failed');
+          metaResults.push(await ports.menus.patchMeta({
+            menuId: command.menuId,
+            patch: {
+              last_updated_ts: livePersisted ? ts : (context.meta?.last_updated_ts || null),
+            },
+            optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
+          }));
+        } else {
+          if (command.intent === 'save') {
+            auditResults.push(await ports.audit.append({
+              menuId: command.menuId,
+              actor: command.actor,
+              source: command.source || '',
+              operationId,
+              eventType: 'quiet_save',
+              sections: selection.selectedSections,
+              message: preview.hasNotificationChanges ? 'Saved live quietly. Queue preserved.' : 'Saved live quietly.',
+            }));
+            auditEventTypes.push('quiet_save');
+          }
+          baselineAdvanced = baselineAdvancedIntent;
+          metaResults.push(await ports.menus.patchMeta({
+            menuId: command.menuId,
+            patch: {
+              last_updated_ts: livePersisted ? ts : (context.meta?.last_updated_ts || null),
+              last_sent_ts: baselineAdvanced ? ts : (context.meta?.last_sent_ts || null),
+              last_sent_state: baselineAdvanced ? { committed: true } : (context.meta?.last_sent_state || {}),
+              last_sent_categories: baselineAdvanced ? (preview.diff || []).map(section => section.id) : (context.meta?.last_sent_categories || []),
+              last_sent_featured: baselineAdvanced ? (preview.metadata?.currentFeaturedIds || context.currentFeaturedIds || []) : (context.meta?.last_sent_featured || []),
+              draft_state: livePersisted ? {} : (context.meta?.draft_state || {}),
+              draft_saved_ts: livePersisted ? null : (context.meta?.draft_saved_ts || null),
+              draft_saved_by_user_id: livePersisted ? null : (context.meta?.draft_saved_by_user_id ?? undefined),
+              draft_saved_by_name: livePersisted ? '' : (context.meta?.draft_saved_by_name ?? undefined),
+              draft_saved_source: livePersisted ? '' : (context.meta?.draft_saved_source ?? undefined),
+            },
+            optionalFields: ['last_sent_featured', 'draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
+          }));
+        }
+
+        let successMessage = `✅ ${menuName} saved live.`;
+        if (notification.attempted && notification.delivered && baselineAdvanced) {
+          successMessage = `✅ ${menuName} saved and sent!`;
+        } else if (command.intent === 'send' && !notification.attempted) {
+          successMessage = `✅ ${menuName} send skipped.`;
+        }
+
+        return {
+          ok: true,
+          ts,
+          operationId,
+          preview,
+          revisions,
+          livePersistence: {
+            attempted: command.intent !== 'send',
+            persisted: livePersisted,
+          },
+          queue: {
+            baselineAdvanced,
+            selectedChangeIds: selection.selectedChangeIds,
+            clearedChangeIds: selection.clearedChangeIds,
+            featuredSiblingMenusSynced: [],
+          },
+          audit: {
+            loggedEvents: auditEventTypes,
+            warnings: [],
+          },
+          notification,
+          userOutcome: {
+            successMessage,
+            warningMessage: warnings[0] || '',
+            warnings,
+          },
+          compatibility: {
+            contract: 'menu-publish-workflow.v1',
+            downgradedFields: mergeDowngradedFields(...metaResults, ...auditResults),
+          },
+        };
+      },
+    };
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { createMenuPublishWorkflow };
+  }
+  globalScope.createMenuPublishWorkflow = createMenuPublishWorkflow;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/core/session/menu-publish-workflow.js
+++ b/core/session/menu-publish-workflow.js
@@ -11,6 +11,27 @@
     return merged;
   }
 
+  function buildLastSentStateFromSnapshot(snapshot = {}) {
+    const categories = Array.isArray(snapshot?.cats) ? snapshot.cats : [];
+    return Object.fromEntries(categories
+      .map(category => {
+        const key = String(category?.key || '').trim();
+        if (!key) return null;
+        const items = Array.isArray(category?.items) ? category.items : [];
+        return [
+          key,
+          items.map(item => ({
+            id: String(item?.id || '').trim(),
+            name: String(item?.name || ''),
+            eightySixed: !!(item?.is_eighty_sixed ?? item?.eightySixed),
+            onMenu: item?.on_menu !== false && item?.onMenu !== false,
+            visibility: String(item?.visibility || 'public'),
+          })),
+        ];
+      })
+      .filter(Boolean));
+  }
+
   function createMenuPublishWorkflow({ ports }) {
     if (!ports) throw new Error('ports are required');
     const SUPPORTED_INTENTS = new Set(['save', 'send', 'save-and-send']);
@@ -64,6 +85,14 @@
         const baselineAdvancedIntent = command.intent === 'send' || command.intent === 'save-and-send';
         let baselineAdvanced = false;
         const menuName = context.knownMenu?.name || 'Menu';
+        const siblingMenuIds = Array.isArray(context.siblingMenuIds) ? context.siblingMenuIds : [];
+        const featuredIds = Array.isArray(preview.metadata?.currentFeaturedIds)
+          ? preview.metadata.currentFeaturedIds
+          : (Array.isArray(context.currentFeaturedIds) ? context.currentFeaturedIds : []);
+        const lastSentState = preview.metadata?.lastSentState && typeof preview.metadata.lastSentState === 'object'
+          ? preview.metadata.lastSentState
+          : buildLastSentStateFromSnapshot(command.snapshot || {});
+        let featuredSiblingMenusSynced = [];
 
         if (command.intent !== 'send') {
           await ports.menus.saveLiveMenu({
@@ -113,6 +142,11 @@
             menuId: command.menuId,
             patch: {
               last_updated_ts: livePersisted ? ts : (context.meta?.last_updated_ts || null),
+              draft_state: livePersisted ? {} : (context.meta?.draft_state || {}),
+              draft_saved_ts: livePersisted ? null : (context.meta?.draft_saved_ts || null),
+              draft_saved_by_user_id: livePersisted ? null : (context.meta?.draft_saved_by_user_id ?? undefined),
+              draft_saved_by_name: livePersisted ? '' : (context.meta?.draft_saved_by_name ?? undefined),
+              draft_saved_source: livePersisted ? '' : (context.meta?.draft_saved_source ?? undefined),
             },
             optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
           }));
@@ -135,9 +169,9 @@
             patch: {
               last_updated_ts: livePersisted ? ts : (context.meta?.last_updated_ts || null),
               last_sent_ts: baselineAdvanced ? ts : (context.meta?.last_sent_ts || null),
-              last_sent_state: baselineAdvanced ? { committed: true } : (context.meta?.last_sent_state || {}),
+              last_sent_state: baselineAdvanced ? lastSentState : (context.meta?.last_sent_state || {}),
               last_sent_categories: baselineAdvanced ? (preview.diff || []).map(section => section.id) : (context.meta?.last_sent_categories || []),
-              last_sent_featured: baselineAdvanced ? (preview.metadata?.currentFeaturedIds || context.currentFeaturedIds || []) : (context.meta?.last_sent_featured || []),
+              last_sent_featured: baselineAdvanced ? featuredIds : (context.meta?.last_sent_featured || []),
               draft_state: livePersisted ? {} : (context.meta?.draft_state || {}),
               draft_saved_ts: livePersisted ? null : (context.meta?.draft_saved_ts || null),
               draft_saved_by_user_id: livePersisted ? null : (context.meta?.draft_saved_by_user_id ?? undefined),
@@ -146,6 +180,41 @@
             },
             optionalFields: ['last_sent_featured', 'draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
           }));
+          if (baselineAdvanced && siblingMenuIds.length && typeof ports.menus.patchSiblingFeatured === 'function') {
+            await ports.menus.patchSiblingFeatured({
+              menuIds: siblingMenuIds,
+              featuredIds,
+            });
+            featuredSiblingMenusSynced = siblingMenuIds.slice();
+          }
+          if (selection.selectedSections.length && notification.attempted && notification.delivered) {
+            auditResults.push(await ports.audit.append({
+              menuId: command.menuId,
+              actor: command.actor,
+              source: command.source || '',
+              operationId,
+              eventType: 'send_notification',
+              sections: selection.selectedSections,
+              message: ports.format.patchMessage({
+                sections: selection.selectedSections,
+                menuName: context.knownMenu?.name || '',
+                menuLink: String(context.meta?.notifications?.menu_url || '').trim(),
+              }) || 'Sent menu update notification.',
+            }));
+            auditEventTypes.push('send_notification');
+          }
+          if (selection.clearedSections.length) {
+            auditResults.push(await ports.audit.append({
+              menuId: command.menuId,
+              actor: command.actor,
+              source: command.source || '',
+              operationId,
+              eventType: 'clear_without_send',
+              sections: selection.clearedSections,
+              message: `Cleared ${selection.clearedSections.reduce((count, section) => count + ((section.changes || []).length), 0)} queued line(s) without sending.`,
+            }));
+            auditEventTypes.push('clear_without_send');
+          }
         }
 
         let successMessage = `✅ ${menuName} saved live.`;
@@ -169,7 +238,7 @@
             baselineAdvanced,
             selectedChangeIds: selection.selectedChangeIds,
             clearedChangeIds: selection.clearedChangeIds,
-            featuredSiblingMenusSynced: [],
+            featuredSiblingMenusSynced,
           },
           audit: {
             loggedEvents: auditEventTypes,

--- a/core/session/menu-session.js
+++ b/core/session/menu-session.js
@@ -11,6 +11,11 @@
       : (() => globalScope.getMenuSessionPorts?.());
     const sessionPorts = ports || resolveSessionPorts();
     let request = sessionPorts.buildRequest();
+    const createPublishFacade = typeof runtime.createPublishFacade === 'function'
+      ? runtime.createPublishFacade
+      : (typeof globalScope.createMenuPublishFacade === 'function'
+          ? globalScope.createMenuPublishFacade.bind(globalScope)
+          : null);
     const createPublishService = typeof runtime.createPublishService === 'function'
       ? runtime.createPublishService
       : (typeof globalScope.createMenuPublishService === 'function'
@@ -26,38 +31,65 @@
       return sessionPorts.buildSnapshot(source, request);
     }
 
-    let publishService = null;
+    let publishFacade = null;
 
-    function getPublishService() {
-      if (publishService) return publishService;
+    function getUnavailableResult(options = {}) {
+      return {
+        ok: false,
+        userHandled: false,
+        userMessage: 'Publish service is unavailable.',
+        preview: options.preview?.sections ? options.preview : sessionPorts.buildPreview(buildSnapshot('preview')),
+        snapshot: buildSnapshot('publish-unavailable'),
+      };
+    }
+
+    function getPublishFacade() {
+      if (publishFacade) return publishFacade;
+      if (createPublishFacade) {
+        publishFacade = createPublishFacade(sessionPorts, {
+          ...runtime,
+          buildSnapshot,
+        });
+        return publishFacade;
+      }
       if (createPublishService) {
-        publishService = createPublishService(sessionPorts, {
+        const publishService = createPublishService(sessionPorts, {
+          ...runtime,
           buildSnapshot,
           buildPreview: () => sessionPorts.buildPreview(buildSnapshot('preview')),
         });
-        return publishService;
+        publishFacade = {
+          async prepare(options = {}) {
+            if (typeof publishService.prepare === 'function') {
+              return publishService.prepare(options);
+            }
+            return getUnavailableResult(options);
+          },
+          async commit(options = {}) {
+            if (options.intent === 'save' && typeof publishService.saveDraft === 'function') {
+              return publishService.saveDraft(options);
+            }
+            if (typeof publishService.publishUpdate === 'function') {
+              return publishService.publishUpdate(options);
+            }
+            return getUnavailableResult(options);
+          },
+        };
+        return publishFacade;
       }
-      publishService = {
-        async saveDraft(options = {}) {
+      publishFacade = {
+        async prepare(options = {}) {
           return {
-            ok: false,
-            userHandled: false,
-            userMessage: 'Publish service is unavailable.',
-            preview: options.preview?.sections ? options.preview : sessionPorts.buildPreview(buildSnapshot('preview')),
-            snapshot: buildSnapshot('publish-unavailable'),
+            ...getUnavailableResult(options),
           };
         },
-        async publishUpdate(options = {}) {
+        async commit(options = {}) {
           return {
-            ok: false,
-            userHandled: false,
-            userMessage: 'Publish service is unavailable.',
-            preview: options.preview?.sections ? options.preview : sessionPorts.buildPreview(buildSnapshot('preview')),
-            snapshot: buildSnapshot('publish-unavailable'),
+            ...getUnavailableResult(options),
           };
         },
       };
-      return publishService;
+      return publishFacade;
     }
 
     const session = {
@@ -127,13 +159,19 @@
         syncRequest();
         return sessionPorts.buildPreview(buildSnapshot('preview'));
       },
+      async preparePublish(options = {}) {
+        const nextRequest = syncRequest(options);
+        return getPublishFacade().prepare({ ...options, request: nextRequest });
+      },
+      async commitPublish(options = {}) {
+        const nextRequest = syncRequest(options);
+        return getPublishFacade().commit({ ...options, request: nextRequest });
+      },
       async saveDraft(options = {}) {
-        syncRequest(options);
-        return getPublishService().saveDraft(options);
+        return session.commitPublish({ ...options, intent: 'save' });
       },
       async publishUpdate(options = {}) {
-        syncRequest(options);
-        return getPublishService().publishUpdate(options);
+        return session.commitPublish(options);
       },
       async save(options = {}) {
         return session.saveDraft(options);

--- a/core/session/publish-service.js
+++ b/core/session/publish-service.js
@@ -6,86 +6,67 @@
     : {};
 
   function createMenuPublishServiceImpl(sessionPorts, runtime = {}, options = {}) {
-    const buildSnapshot = typeof runtime.buildSnapshot === 'function'
-      ? runtime.buildSnapshot
-      : (() => ({ source: 'unknown' }));
-    const buildPreview = typeof runtime.buildPreview === 'function'
-      ? runtime.buildPreview
-      : (() => sessionPorts.buildPreview(buildSnapshot('preview')));
-    const buildFallbackService = typeof options.fallback === 'function'
-      ? options.fallback
+    const createPublishFacade = typeof runtime.createPublishFacade === 'function'
+      ? runtime.createPublishFacade
+      : (typeof globalScope.createMenuPublishFacade === 'function'
+          ? globalScope.createMenuPublishFacade.bind(globalScope)
+          : null);
+    const facade = typeof createPublishFacade === 'function'
+      ? createPublishFacade(sessionPorts, runtime)
       : null;
+    let fallbackService = null;
 
-    // Resolve the legacy fallback once during boundary construction so we do not
-    // recurse back through the boundary later when publish is invoked.
-    const fallbackService = buildFallbackService ? buildFallbackService() : null;
-    const resolveDraftChangeCount = snapshot => {
-      const diff = Array.isArray(snapshot?.notifyDiff) ? snapshot.notifyDiff : [];
-      const saveOnlyChanges = Array.isArray(snapshot?.saveOnlyChanges) ? snapshot.saveOnlyChanges : [];
-      const diffLineCount = typeof globalScope.countDiffLines === 'function'
-        ? globalScope.countDiffLines(diff)
-        : diff.reduce((count, section) => (
-            count + (section.added?.length || 0) +
-            (section.removed?.length || 0) +
-            (section.eightySixed?.length || 0) +
-            (section.restored?.length || 0)
-          ), 0);
-      return diffLineCount + saveOnlyChanges.length;
-    };
-    const buildSaveDraftNoop = (preview, snapshot, source = 'draft-noop') => ({
-      ok: false,
-      noop: true,
-      preview,
-      snapshot: buildSnapshot(source),
-    });
+    function getFallbackService() {
+      if (fallbackService !== null) return fallbackService;
+      fallbackService = typeof options.fallback === 'function'
+        ? options.fallback()
+        : undefined;
+      return fallbackService;
+    }
 
     return {
-      async saveDraft(options = {}) {
-        const snapshot = buildSnapshot('draft');
-        const preview = options.preview?.sections ? options.preview : buildPreview();
-        const hasLocalDraft = !!snapshot?.dirty || !!preview?.hasLocalDraft;
-        const hasChanges = !!preview?.hasChanges || resolveDraftChangeCount(snapshot) > 0;
-
-        if (!hasLocalDraft || !hasChanges) {
-          return buildSaveDraftNoop(preview, snapshot);
+      async saveDraft(opts = {}) {
+        if (facade && typeof facade.commit === 'function') {
+          return facade.commit({ ...opts, intent: 'save' });
         }
-
-        const request = {
-          ...options,
-          preview,
-          mode: 'save',
-          notify: false,
-        };
-
-        if (typeof sessionPorts.publishMenuUpdate === 'function') {
-          return sessionPorts.publishMenuUpdate(request);
+        const fallback = getFallbackService();
+        if (fallback && typeof fallback.saveDraft === 'function') {
+          return fallback.saveDraft(opts);
         }
-        if (fallbackService && typeof fallbackService.publishUpdate === 'function') {
-          return fallbackService.publishUpdate(request);
-        }
-
         return {
           ok: false,
           userHandled: false,
           userMessage: 'Publish service is unavailable.',
-          preview,
-          snapshot: buildSnapshot('save-unavailable'),
         };
       },
 
-      async publishUpdate(options = {}) {
-        if (typeof sessionPorts.publishMenuUpdate === 'function') {
-          return sessionPorts.publishMenuUpdate(options);
+      async publishUpdate(opts = {}) {
+        if (facade && typeof facade.commit === 'function') {
+          return facade.commit(opts);
         }
-        if (fallbackService && typeof fallbackService.publishUpdate === 'function') {
-          return fallbackService.publishUpdate(options);
+        const fallback = getFallbackService();
+        if (fallback && typeof fallback.publishUpdate === 'function') {
+          return fallback.publishUpdate(opts);
         }
         return {
           ok: false,
           userHandled: false,
           userMessage: 'Publish service is unavailable.',
-          preview: options.preview?.sections ? options.preview : buildPreview(),
-          snapshot: buildSnapshot('publish-unavailable'),
+        };
+      },
+
+      async prepare(opts = {}) {
+        if (facade && typeof facade.prepare === 'function') {
+          return facade.prepare(opts);
+        }
+        const fallback = getFallbackService();
+        if (fallback && typeof fallback.prepare === 'function') {
+          return fallback.prepare(opts);
+        }
+        return {
+          ok: false,
+          userHandled: false,
+          userMessage: 'Publish service is unavailable.',
         };
       },
     };
@@ -93,7 +74,7 @@
 
   modules.createMenuPublishService = function createMenuPublishServiceBoundary(sessionPorts, runtime = {}, options = {}) {
     if (options && typeof options.impl === 'function') {
-      return options.impl(sessionPorts, runtime);
+      return options.impl(sessionPorts, runtime, options);
     }
     return createMenuPublishServiceImpl(sessionPorts, runtime, options);
   };

--- a/docs/superpowers/plans/2026-04-20-menu-publish-workflow-hybrid.md
+++ b/docs/superpowers/plans/2026-04-20-menu-publish-workflow-hybrid.md
@@ -1,0 +1,1109 @@
+# Menu Publish Workflow Hybrid Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current split publish orchestration with a deep shared workflow core plus a small client-facing `prepare()` / `commit()` facade for preview and publish actions.
+
+**Architecture:** Add a pure `core/session/menu-publish-workflow.js` module that owns preview resolution, revision checks, queue advancement, featured sibling sync, audit logging, and notification outcome handling behind explicit ports. Keep the web caller small by adding a `core/session/menu-publish-facade.js` module that exposes `prepare()` and `commit()` to `app.js`, while `server/_menu-publish.js` becomes the owned remote adapter that wires the workflow to Supabase-backed menu/meta/history operations and the external notification gateway.
+
+**Tech Stack:** Vanilla JS, Node `node:test`, existing runtime sandbox helpers in `tests/helpers/runtime.cjs`, Vercel server routes, Supabase REST, no build step.
+
+---
+
+## File Map
+
+| File | Responsibility |
+|---|---|
+| `core/session/menu-publish-workflow.js` | New deep workflow core. Exposes `createMenuPublishWorkflow({ ports })` with `preview()` and `execute()` over explicit ports. No direct DOM, fetch, or Supabase access. |
+| `core/session/menu-publish-facade.js` | New client-facing adapter. Exposes `createMenuPublishFacade(sessionPorts, deps)` with `prepare()` and `commit()` for `app.js` and `core/session/menu-session.js`. |
+| `core/session/menu-session.js` | Delegates publish-related lifecycle calls through the facade instead of bouncing directly between shallow wrappers. |
+| `core/session/publish-service.js` | Shrinks to a thin compatibility adapter around the new facade so existing session tests can migrate without changing all callers at once. |
+| `server/_menu-publish.js` | Wires server-owned ports into the shared workflow core and preserves exported `previewMenuUpdateForMenu()` / `publishMenuUpdateForMenu()` request helpers. |
+| `api/manager.js` | Keeps the existing request boundary, but routes preview/publish actions through the new server adapter shape with no duplicated mode inference. |
+| `app.js` | Stops owning publish policy. Uses `prepare()` to open the preview modal and `commit()` to execute save/send/save-and-send. Deletes client-only patch-message and notification-delivery fallback logic once the facade owns those flows. |
+| `tests/boundaries/menu-publish-workflow.boundary.test.cjs` | New workflow boundary tests for preview/execute behavior over in-memory ports. |
+| `tests/boundaries/publish.boundary.test.cjs` | Updated facade/session tests to assert `prepare()` / `commit()` behavior instead of shallow `publishMenuUpdate` delegation. |
+| `tests/phase19-menu-preview-boundaries.test.cjs` | Updated server boundary tests to assert the workflow-backed preview/commit contract. |
+| `tests/helpers/runtime.cjs` | Loads the new `core/session/menu-publish-facade.js` and `core/session/menu-publish-workflow.js` scripts into the sandbox. |
+| `docs/current-architecture-flowchart.md` | Update the publish flow description so the new deep module and facade are documented. |
+
+---
+
+### Task 1: Add workflow-core boundary tests
+
+**Files:**
+- Create: `tests/boundaries/menu-publish-workflow.boundary.test.cjs`
+- Test: `tests/boundaries/menu-publish-workflow.boundary.test.cjs`
+
+- [ ] **Step 1: Write the failing workflow boundary test file**
+
+```js
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const ROOT = path.join(__dirname, '..', '..');
+
+async function importWorkflow() {
+  const fileUrl = pathToFileURL(path.join(ROOT, 'core/session/menu-publish-workflow.js')).href;
+  return import(`${fileUrl}?plan=${Date.now()}-${Math.random()}`);
+}
+
+function createPorts(overrides = {}) {
+  return {
+    menus: {
+      async readContext(menuId) {
+        return {
+          knownMenu: {
+            id: menuId,
+            name: 'Main Menu',
+            restaurantId: 'restaurant-main',
+          },
+          meta: {
+            last_updated_ts: 10,
+            draft_saved_ts: 11,
+            last_sent_ts: 9,
+            notifications: { menu_url: 'https://example.com/menu' },
+            last_sent_state: {},
+            last_sent_featured: [],
+          },
+          currentFeaturedIds: ['featured-1'],
+        };
+      },
+      async saveLiveMenu() {},
+      async patchMeta() { return { downgradedFields: [] }; },
+      async patchSiblingFeatured() { return []; },
+    },
+    governance: {
+      async assertCategoryGovernanceAllowed() {},
+      assertRevisions() {
+        return {
+          liveRevision: 10,
+          draftRevision: 11,
+          notificationRevision: 9,
+        };
+      },
+    },
+    preview: {
+      async buildCanonical() {
+        return {
+          hasChanges: true,
+          hasLocalDraft: true,
+          hasSharedDraft: false,
+          hasNotificationChanges: true,
+          saveOnlyChanges: [{ id: 'quiet-1', label: 'Quiet', message: 'Quiet change' }],
+          notificationChanges: [{
+            id: 'beer::added::lager',
+            sectionId: 'beer',
+            sectionLabel: 'Beer',
+            icon: '🍺',
+            displayOrder: 0,
+            kind: 'added',
+            name: 'Lager',
+            text: '+ Lager',
+          }],
+          diff: [{ id: 'beer', label: 'Beer', icon: '🍺', added: ['Lager'], removed: [], eightySixed: [], restored: [] }],
+          mode: 'save-and-send',
+          truncated: false,
+          metadata: { currentFeaturedIds: ['featured-1'] },
+        };
+      },
+      resolveSelection() {
+        return {
+          selectedChangeIds: ['beer::added::lager'],
+          selectedSections: [{
+            id: 'beer',
+            label: 'Beer',
+            icon: '🍺',
+            changes: [{ id: 'beer::added::lager', kind: 'added', name: 'Lager', text: '+ Lager' }],
+          }],
+          clearedChangeIds: [],
+          clearedSections: [],
+        };
+      },
+    },
+    notifications: {
+      async deliver() {
+        return {
+          delivered: true,
+          partial: false,
+          summary: { okChannels: ['groupme'], skippedChannels: [], failedChannels: [] },
+          retryable: false,
+        };
+      },
+    },
+    audit: {
+      async append() { return { downgradedFields: [] }; },
+    },
+    clock: { now() { return 1000; } },
+    ids: { operationId() { return 'op-1'; } },
+    format: {
+      patchMessage() { return 'PATCH'; },
+      warningSummary() { return []; },
+    },
+    ...overrides,
+  };
+}
+
+test('workflow preview returns canonical preview plus current revisions', async () => {
+  const { createMenuPublishWorkflow } = await importWorkflow();
+  const workflow = createMenuPublishWorkflow({ ports: createPorts() });
+
+  const result = await workflow.preview({
+    menuId: 'menu-main',
+    actor: { id: 'user-1', role: 'manager' },
+    source: 'web_manager',
+    snapshot: { cats: [] },
+    request: {},
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.preview.mode, 'save-and-send');
+  assert.deepEqual(result.revisions, {
+    liveRevision: 10,
+    draftRevision: 11,
+    notificationRevision: 9,
+  });
+});
+
+test('workflow execute advances queue baseline after successful send', async () => {
+  const saveCalls = [];
+  const patchCalls = [];
+  const { createMenuPublishWorkflow } = await importWorkflow();
+  const workflow = createMenuPublishWorkflow({
+    ports: createPorts({
+      menus: {
+        ...createPorts().menus,
+        async saveLiveMenu(input) { saveCalls.push(input); },
+        async patchMeta(input) { patchCalls.push(input); return { downgradedFields: [] }; },
+      },
+    }),
+  });
+
+  const result = await workflow.execute({
+    menuId: 'menu-main',
+    actor: { id: 'user-1', role: 'manager' },
+    source: 'web_manager',
+    intent: 'save-and-send',
+    snapshot: { cats: [] },
+    request: {
+      selectedChangeIds: ['beer::added::lager'],
+      expectedLiveRevision: 10,
+      expectedDraftRevision: 11,
+      expectedNotificationRevision: 9,
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.livePersistence.persisted, true);
+  assert.equal(result.queue.baselineAdvanced, true);
+  assert.equal(result.notification.delivered, true);
+  assert.equal(saveCalls.length, 1);
+  assert.ok(patchCalls.some(call => call.patch.last_sent_ts === 1000));
+});
+
+test('workflow preserves queue when notification delivery is partial', async () => {
+  const { createMenuPublishWorkflow } = await importWorkflow();
+  const workflow = createMenuPublishWorkflow({
+    ports: createPorts({
+      notifications: {
+        async deliver() {
+          return {
+            delivered: false,
+            partial: true,
+            summary: { okChannels: ['groupme'], skippedChannels: [], failedChannels: ['sms'] },
+            retryable: true,
+          };
+        },
+      },
+      format: {
+        patchMessage() { return 'PATCH'; },
+        warningSummary() { return ['Some notification channels failed: sms.']; },
+      },
+    }),
+  });
+
+  const result = await workflow.execute({
+    menuId: 'menu-main',
+    actor: { id: 'user-1', role: 'manager' },
+    source: 'web_manager',
+    intent: 'save-and-send',
+    snapshot: { cats: [] },
+    request: {
+      selectedChangeIds: ['beer::added::lager'],
+      expectedLiveRevision: 10,
+      expectedDraftRevision: 11,
+      expectedNotificationRevision: 9,
+    },
+  });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.notification.partial, true);
+  assert.equal(result.queue.baselineAdvanced, false);
+  assert.ok(result.userOutcome.warnings.some(message => message.includes('failed')));
+});
+```
+
+- [ ] **Step 2: Run the new test file to verify it fails**
+
+Run: `node --test tests/boundaries/menu-publish-workflow.boundary.test.cjs`
+
+Expected: FAIL with an import error for `core/session/menu-publish-workflow.js` or `createMenuPublishWorkflow is not a function`.
+
+- [ ] **Step 3: Commit the failing-test checkpoint**
+
+```bash
+git add tests/boundaries/menu-publish-workflow.boundary.test.cjs
+git commit -m "test: add publish workflow boundary coverage"
+```
+
+---
+
+### Task 2: Implement the deep shared workflow core
+
+**Files:**
+- Create: `core/session/menu-publish-workflow.js`
+- Test: `tests/boundaries/menu-publish-workflow.boundary.test.cjs`
+
+- [ ] **Step 1: Write the minimal workflow implementation**
+
+```js
+(function bootstrapMenuPublishWorkflowModule(globalScope) {
+  if (!globalScope) return;
+
+  function mergeDowngradedFields(...results) {
+    const merged = [];
+    results.forEach(result => {
+      (Array.isArray(result?.downgradedFields) ? result.downgradedFields : []).forEach(field => {
+        if (!merged.includes(field)) merged.push(field);
+      });
+    });
+    return merged;
+  }
+
+  function createMenuPublishWorkflow({ ports }) {
+    if (!ports) throw new Error('ports are required');
+
+    async function readContext(command = {}) {
+      await ports.governance.assertCategoryGovernanceAllowed({
+        actor: command.actor,
+        menuId: command.menuId,
+        snapshot: command.snapshot || {},
+      });
+      const context = await ports.menus.readContext(command.menuId);
+      const revisions = ports.governance.assertRevisions({
+        menuId: command.menuId,
+        meta: context.meta,
+        expectedLiveRevision: command.request?.expectedLiveRevision ?? null,
+        expectedDraftRevision: command.request?.expectedDraftRevision ?? null,
+        expectedNotificationRevision: command.request?.expectedNotificationRevision ?? null,
+      });
+      const preview = await ports.preview.buildCanonical({
+        menuId: command.menuId,
+        snapshot: command.snapshot || {},
+        knownMenu: context.knownMenu,
+        meta: context.meta,
+        currentFeaturedIds: context.currentFeaturedIds,
+      });
+      return { context, revisions, preview };
+    }
+
+    return {
+      async preview(command = {}) {
+        const { preview, revisions } = await readContext(command);
+        return { ok: true, preview, revisions };
+      },
+
+      async execute(command = {}) {
+        const { context, revisions, preview } = await readContext(command);
+        const selection = ports.preview.resolveSelection({
+          preview,
+          selectedChangeIds: command.request?.selectedChangeIds ?? null,
+        });
+        const ts = ports.clock.now();
+        const operationId = ports.ids.operationId();
+        const warnings = [];
+        const auditResults = [];
+        let livePersisted = false;
+        let baselineAdvanced = false;
+
+        if (command.intent !== 'send') {
+          await ports.menus.saveLiveMenu({
+            menuId: command.menuId,
+            snapshot: command.snapshot || {},
+            actor: command.actor,
+            expectedLiveRevision: command.request?.expectedLiveRevision ?? null,
+          });
+          livePersisted = true;
+        }
+
+        let notification = {
+          attempted: false,
+          delivered: false,
+          partial: false,
+          summary: null,
+          retryable: false,
+        };
+
+        if ((command.intent === 'send' || command.intent === 'save-and-send') && selection.selectedSections.length) {
+          notification = {
+            attempted: true,
+            ...(await ports.notifications.deliver({
+              menuId: command.menuId,
+              message: ports.format.patchMessage({
+                sections: selection.selectedSections,
+                menuName: context.knownMenu?.name || '',
+                menuLink: String(context.meta?.notifications?.menu_url || '').trim(),
+              }),
+            })),
+          };
+        }
+
+        if (notification.partial || (notification.attempted && !notification.delivered)) {
+          warnings.push(...ports.format.warningSummary(notification.summary));
+          auditResults.push(await ports.audit.append({
+            menuId: command.menuId,
+            actor: command.actor,
+            source: command.source || '',
+            operationId,
+            eventType: 'send_failed',
+            sections: selection.selectedSections,
+            message: 'Notification delivery failed or was partial. Queue preserved.',
+          }));
+          await ports.menus.patchMeta({
+            menuId: command.menuId,
+            patch: {
+              last_updated_ts: livePersisted ? ts : (context.meta?.last_updated_ts || null),
+            },
+            optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
+          });
+        } else {
+          if (command.intent === 'save') {
+            auditResults.push(await ports.audit.append({
+              menuId: command.menuId,
+              actor: command.actor,
+              source: command.source || '',
+              operationId,
+              eventType: 'quiet_save',
+              sections: selection.selectedSections,
+              message: preview.hasNotificationChanges ? 'Saved live quietly. Queue preserved.' : 'Saved live quietly.',
+            }));
+          }
+          if (notification.delivered || command.intent === 'send' || command.intent === 'save-and-send') {
+            baselineAdvanced = command.intent !== 'save';
+          }
+          await ports.menus.patchMeta({
+            menuId: command.menuId,
+            patch: {
+              last_updated_ts: livePersisted ? ts : (context.meta?.last_updated_ts || null),
+              last_sent_ts: baselineAdvanced ? ts : (context.meta?.last_sent_ts || null),
+              last_sent_state: baselineAdvanced ? { committed: true } : (context.meta?.last_sent_state || {}),
+              last_sent_categories: baselineAdvanced ? (preview.diff || []).map(section => section.id) : (context.meta?.last_sent_categories || []),
+              last_sent_featured: baselineAdvanced ? (preview.metadata?.currentFeaturedIds || context.currentFeaturedIds || []) : (context.meta?.last_sent_featured || []),
+              draft_state: livePersisted ? {} : (context.meta?.draft_state || {}),
+              draft_saved_ts: livePersisted ? null : (context.meta?.draft_saved_ts || null),
+              draft_saved_by_user_id: livePersisted ? null : (context.meta?.draft_saved_by_user_id ?? undefined),
+              draft_saved_by_name: livePersisted ? '' : (context.meta?.draft_saved_by_name ?? undefined),
+              draft_saved_source: livePersisted ? '' : (context.meta?.draft_saved_source ?? undefined),
+            },
+            optionalFields: ['last_sent_featured', 'draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
+          });
+        }
+
+        return {
+          ok: true,
+          ts,
+          operationId,
+          preview,
+          revisions,
+          livePersistence: {
+            attempted: command.intent !== 'send',
+            persisted: livePersisted,
+          },
+          queue: {
+            baselineAdvanced,
+            selectedChangeIds: selection.selectedChangeIds,
+            clearedChangeIds: selection.clearedChangeIds,
+            featuredSiblingMenusSynced: baselineAdvanced ? ['restaurant-siblings'] : [],
+          },
+          audit: {
+            loggedEvents: auditResults.length ? ['quiet_save'] : [],
+            warnings: [],
+          },
+          notification,
+          userOutcome: {
+            successMessage: baselineAdvanced ? '✅ Main Menu saved and sent!' : '✅ Main Menu saved live.',
+            warningMessage: warnings[0] || '',
+            warnings,
+          },
+          compatibility: {
+            contract: 'menu-publish-workflow.v1',
+            downgradedFields: mergeDowngradedFields(...auditResults),
+          },
+        };
+      },
+    };
+  }
+
+  if (typeof module !== 'undefined' && module.exports) {
+    module.exports = { createMenuPublishWorkflow };
+  }
+  globalScope.createMenuPublishWorkflow = createMenuPublishWorkflow;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+- [ ] **Step 2: Run the workflow test file and make it pass**
+
+Run: `node --test tests/boundaries/menu-publish-workflow.boundary.test.cjs`
+
+Expected: PASS with 3 passing tests.
+
+- [ ] **Step 3: Commit the workflow core**
+
+```bash
+git add core/session/menu-publish-workflow.js tests/boundaries/menu-publish-workflow.boundary.test.cjs
+git commit -m "feat: add shared menu publish workflow core"
+```
+
+---
+
+### Task 3: Add the client `prepare()` / `commit()` facade and runtime loading
+
+**Files:**
+- Create: `core/session/menu-publish-facade.js`
+- Modify: `core/session/publish-service.js`
+- Modify: `core/session/menu-session.js`
+- Modify: `tests/helpers/runtime.cjs`
+- Modify: `tests/boundaries/publish.boundary.test.cjs`
+- Test: `tests/boundaries/publish.boundary.test.cjs`
+
+- [ ] **Step 1: Extend the runtime helper so tests load the new modules**
+
+```js
+const DEFAULT_RUNTIME_SCRIPTS = [
+  'core/domain/constants.js',
+  'core/domain/category-defaults.js',
+  'core/auth/auth-api.js',
+  'core/auth/auth-session-service.js',
+  'core/auth/auth-overlay-template.js',
+  'core/auth/auth-overlay-controller.js',
+  'core/ui/manager/workspace.js',
+  'core/ui/manager/sections.js',
+  'core/ui/manager/editors.js',
+  'core/ui/manager/open-food-facts.js',
+  'core/ui/manager/untappd.js',
+  'core/ui/manager/barcode-scanner.js',
+  'core/ui/admin/workspace.js',
+  'core/ui/admin/switcher.js',
+  'core/ui/public/footer-actions.js',
+  'core/ui/public/renderer-default.js',
+  'core/session/menu-publish-workflow.js',
+  'core/session/menu-publish-facade.js',
+  'core/session/publish-service.js',
+  'core/session/menu-session.js',
+  'core/data/menu-state-loader.js',
+  'core/session/poll-scheduler.js',
+  'routes/shared/public-route-core.js',
+  'app.js',
+];
+```
+
+- [ ] **Step 2: Rewrite the publish boundary test around `prepare()` / `commit()`**
+
+```js
+test('menu publish facade prepares and commits through the workflow boundary', async () => {
+  const sandbox = loadAppSandbox();
+  const prepareCalls = [];
+  const commitCalls = [];
+
+  sandbox.createMenuPublishWorkflow = ({ ports }) => ({
+    async preview(command) {
+      prepareCalls.push({ ports: !!ports, command });
+      return {
+        ok: true,
+        preview: {
+          hasChanges: true,
+          hasLocalDraft: true,
+          hasNotificationChanges: true,
+          notificationChanges: [{ id: 'beer::added::lager' }],
+          sections: [{ id: 'beer', changes: [] }],
+          mode: 'save-and-send',
+        },
+        revisions: {
+          liveRevision: 10,
+          draftRevision: 11,
+          notificationRevision: 9,
+        },
+      };
+    },
+    async execute(command) {
+      commitCalls.push(command);
+      return {
+        ok: true,
+        preview: {
+          hasChanges: true,
+          hasLocalDraft: true,
+          hasNotificationChanges: true,
+          notificationChanges: [{ id: 'beer::added::lager' }],
+          sections: [{ id: 'beer', changes: [] }],
+          mode: 'save-and-send',
+        },
+        userOutcome: {
+          successMessage: 'published',
+          warningMessage: '',
+          warnings: [],
+        },
+        notification: {
+          attempted: true,
+          delivered: true,
+          partial: false,
+          summary: { okChannels: ['groupme'], skippedChannels: [], failedChannels: [] },
+          retryable: false,
+        },
+        queue: {
+          baselineAdvanced: true,
+          selectedChangeIds: ['beer::added::lager'],
+          clearedChangeIds: [],
+          featuredSiblingMenusSynced: [],
+        },
+        livePersistence: { attempted: true, persisted: true },
+      };
+    },
+  });
+
+  const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts());
+  const preview = await lifecycle.preparePublish();
+  const result = await lifecycle.commitPublish({ selectedChangeIds: ['beer::added::lager'] });
+
+  assert.equal(preview.ok, true);
+  assert.equal(result.ok, true);
+  assert.equal(prepareCalls.length, 1);
+  assert.equal(commitCalls.length, 1);
+});
+```
+
+- [ ] **Step 3: Implement the facade**
+
+```js
+(function bootstrapMenuPublishFacadeModule(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_SESSION_MODULES__ && typeof globalScope.__HF_SESSION_MODULES__ === 'object')
+    ? globalScope.__HF_SESSION_MODULES__
+    : {};
+
+  function createMenuPublishFacade(sessionPorts, deps = {}) {
+    const workflowFactory = typeof deps.createWorkflow === 'function'
+      ? deps.createWorkflow
+      : (globalScope.createMenuPublishWorkflow || null);
+    if (typeof workflowFactory !== 'function') {
+      throw new Error('createMenuPublishWorkflow is unavailable');
+    }
+
+    const workflow = workflowFactory({
+      ports: typeof deps.createPorts === 'function'
+        ? deps.createPorts(sessionPorts)
+        : sessionPorts,
+    });
+
+    return {
+      async prepare(options = {}) {
+        return workflow.preview({
+          menuId: sessionPorts.getMenuId(),
+          actor: sessionPorts.getActor ? sessionPorts.getActor() : null,
+          source: options.source || 'web_manager',
+          snapshot: options.snapshot || sessionPorts.buildSnapshot('preview'),
+          request: {
+            expectedLiveRevision: options.expectedLiveRevision ?? null,
+            expectedDraftRevision: options.expectedDraftRevision ?? null,
+            expectedNotificationRevision: options.expectedNotificationRevision ?? null,
+          },
+        });
+      },
+
+      async commit(options = {}) {
+        return workflow.execute({
+          menuId: sessionPorts.getMenuId(),
+          actor: sessionPorts.getActor ? sessionPorts.getActor() : null,
+          source: options.source || 'web_manager',
+          intent: options.intent || 'save-and-send',
+          snapshot: options.snapshot || sessionPorts.buildSnapshot('publish'),
+          request: {
+            selectedChangeIds: Array.isArray(options.selectedChangeIds) ? options.selectedChangeIds : [],
+            expectedLiveRevision: options.expectedLiveRevision ?? null,
+            expectedDraftRevision: options.expectedDraftRevision ?? null,
+            expectedNotificationRevision: options.expectedNotificationRevision ?? null,
+          },
+        });
+      },
+    };
+  }
+
+  modules.createMenuPublishFacade = createMenuPublishFacade;
+  globalScope.__HF_SESSION_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+- [ ] **Step 4: Update the session modules to use the facade**
+
+```js
+// core/session/menu-session.js
+const createPublishFacade = typeof runtime.createPublishFacade === 'function'
+  ? runtime.createPublishFacade
+  : (typeof globalScope.createMenuPublishFacade === 'function'
+      ? globalScope.createMenuPublishFacade.bind(globalScope)
+      : null);
+
+let publishFacade = null;
+function getPublishFacade() {
+  if (!publishFacade) publishFacade = createPublishFacade(sessionPorts, runtime);
+  return publishFacade;
+}
+
+async preparePublish(options = {}) {
+  syncRequest(options);
+  return getPublishFacade().prepare(options);
+},
+
+async commitPublish(options = {}) {
+  syncRequest(options);
+  return getPublishFacade().commit(options);
+},
+
+async publishUpdate(options = {}) {
+  return session.commitPublish(options);
+},
+```
+
+```js
+// core/session/publish-service.js
+function createMenuPublishServiceImpl(sessionPorts, runtime = {}, options = {}) {
+  const facade = typeof runtime.createPublishFacade === 'function'
+    ? runtime.createPublishFacade(sessionPorts, runtime)
+    : null;
+
+  return {
+    async saveDraft(opts = {}) {
+      return facade.commit({ ...opts, intent: 'save' });
+    },
+    async publishUpdate(opts = {}) {
+      return facade.commit(opts);
+    },
+    async prepare(opts = {}) {
+      return facade.prepare(opts);
+    },
+  };
+}
+```
+
+- [ ] **Step 5: Run the publish boundary tests**
+
+Run: `node --test tests/boundaries/publish.boundary.test.cjs`
+
+Expected: PASS with the new `preparePublish()` / `commitPublish()` assertions.
+
+- [ ] **Step 6: Commit the facade integration**
+
+```bash
+git add core/session/menu-publish-facade.js core/session/publish-service.js core/session/menu-session.js tests/helpers/runtime.cjs tests/boundaries/publish.boundary.test.cjs
+git commit -m "feat: add menu publish facade for session callers"
+```
+
+---
+
+### Task 4: Move the server boundary onto the workflow core
+
+**Files:**
+- Modify: `server/_menu-publish.js`
+- Modify: `tests/phase19-menu-preview-boundaries.test.cjs`
+- Test: `tests/phase19-menu-preview-boundaries.test.cjs`
+
+- [ ] **Step 1: Update the server boundary test to assert the workflow-backed contract**
+
+```js
+test('wave 4 publish command module exports workflow-backed preview and publish helpers', async () => {
+  const publishModuleSource = read('server/_menu-publish.js');
+  const publishModule = await importApiModule('server/_menu-publish.js');
+
+  assert.equal(typeof publishModule.previewMenuUpdateForMenu, 'function');
+  assert.equal(typeof publishModule.publishMenuUpdateForMenu, 'function');
+  assert.match(publishModuleSource, /createMenuPublishWorkflow/);
+  assert.match(publishModuleSource, /createServerMenuPublishPorts/);
+  assert.match(publishModuleSource, /menu-publish-workflow\.v1/);
+  assert.match(publishModuleSource, /serverOwned:\s*true/);
+  assert.doesNotMatch(publishModuleSource, /function normalizePublishMode/);
+  assert.doesNotMatch(publishModuleSource, /function mergeDowngradedFields/);
+});
+```
+
+- [ ] **Step 2: Replace the bespoke orchestration in `server/_menu-publish.js` with workflow ports**
+
+```js
+import '../core/session/menu-publish-workflow.js';
+import { deliverMenuNotification } from './_notification-delivery.js';
+import {
+  assertExpectedRevision,
+  inferAuditSource,
+  insertUpdateLog,
+  patchMenuMetaForMenu,
+  patchMenuMetaForMenuWithCompatibility,
+  readMenuMeta,
+  saveLiveMenuForMenu,
+} from './_menu-write.js';
+
+function createServerMenuPublishPorts() {
+  return {
+    menus: {
+      async readContext(menuId) {
+        const knownMenu = getKnownMenuById(menuId);
+        const meta = await readMenuMeta(menuId);
+        const currentFeaturedIds = await readCurrentFeaturedIdsForRestaurant(knownMenu.restaurantId);
+        return { knownMenu, meta, currentFeaturedIds };
+      },
+      async saveLiveMenu(input) {
+        return saveLiveMenuForMenu(input);
+      },
+      async patchMeta({ menuId, patch, optionalFields = [] }) {
+        return patchMenuMetaForMenuWithCompatibility(menuId, patch, { optionalFields });
+      },
+      async patchSiblingFeatured({ menuIds, featuredIds }) {
+        return Promise.all(menuIds.map(menuId => patchMenuMetaForMenu(menuId, { last_sent_featured: featuredIds })));
+      },
+    },
+    governance: {
+      async assertCategoryGovernanceAllowed(input) {
+        return assertCategoryGovernanceAllowed({ ...input, requireCategorySnapshot: true });
+      },
+      assertRevisions({ menuId, meta, expectedLiveRevision, expectedDraftRevision, expectedNotificationRevision }) {
+        assertExpectedRevision(expectedLiveRevision, meta?.last_updated_ts, 'live_revision', { menuId });
+        assertExpectedRevision(expectedDraftRevision, meta?.draft_saved_ts, 'draft_revision', { menuId });
+        assertExpectedRevision(expectedNotificationRevision, meta?.last_sent_ts, 'notification_revision', { menuId });
+        return {
+          liveRevision: meta?.last_updated_ts || null,
+          draftRevision: meta?.draft_saved_ts || null,
+          notificationRevision: meta?.last_sent_ts || null,
+        };
+      },
+    },
+    preview: {
+      buildCanonical: buildCanonicalPreviewForMenu,
+      resolveSelection({ preview, selectedChangeIds }) {
+        return resolveSelection(preview, selectedChangeIds, []);
+      },
+    },
+    notifications: {
+      async deliver({ menuId, message }) {
+        const delivery = await deliverMenuNotification(menuId, truncateNotificationText(message));
+        return {
+          delivered: delivery.status < 400,
+          partial: delivery.status === 207,
+          summary: delivery.summary,
+          retryable: delivery.status >= 400 || delivery.status === 207,
+        };
+      },
+    },
+    audit: {
+      async append(event) {
+        return insertUpdateLog({
+          menuId: event.menuId,
+          actor: event.actor,
+          diff: serializeNotificationSectionsForLog(event.sections),
+          message: event.message,
+          source: inferAuditSource(event.actor, event.source),
+          operationId: event.operationId,
+          eventType: event.eventType,
+        });
+      },
+    },
+    clock: { now: () => Date.now() },
+    ids: { operationId: () => randomUUID() },
+    format: {
+      patchMessage: buildPatchMessage,
+      warningSummary: collectNotificationWarnings,
+    },
+  };
+}
+
+function createServerPublishWorkflow() {
+  return globalThis.createMenuPublishWorkflow({
+    ports: createServerMenuPublishPorts(),
+  });
+}
+```
+
+- [ ] **Step 3: Rewrite the exported server helpers around the workflow**
+
+```js
+export async function previewMenuUpdateForMenu(command) {
+  const workflow = createServerPublishWorkflow();
+  const result = await workflow.preview({
+    menuId: command.menuId,
+    actor: command.actor,
+    source: command.source,
+    snapshot: command.snapshot || {},
+    request: {
+      expectedLiveRevision: command.expectedLiveRevision ?? null,
+      expectedDraftRevision: command.expectedDraftRevision ?? null,
+      expectedNotificationRevision: command.expectedNotificationRevision ?? null,
+    },
+  });
+
+  return {
+    ok: true,
+    action: 'preview',
+    preview: result.preview,
+    current_revisions: result.revisions,
+    reconnect: null,
+    compatibility: {
+      contract: 'menu-publish-workflow.v1',
+      serverOwned: true,
+    },
+  };
+}
+
+export async function publishMenuUpdateForMenu(command) {
+  const workflow = createServerPublishWorkflow();
+  const result = await workflow.execute({
+    menuId: command.menuId,
+    actor: command.actor,
+    source: command.source,
+    intent: command.mode === 'save' ? 'save' : (command.mode === 'send' ? 'send' : 'save-and-send'),
+    snapshot: command.snapshot || {},
+    request: {
+      selectedChangeIds: Array.isArray(command.selectedChangeIds) ? command.selectedChangeIds : [],
+      expectedLiveRevision: command.expectedLiveRevision ?? null,
+      expectedDraftRevision: command.expectedDraftRevision ?? null,
+      expectedNotificationRevision: command.expectedNotificationRevision ?? null,
+    },
+  });
+
+  return {
+    ok: result.ok,
+    ts: result.ts,
+    preview: result.preview,
+    current_revisions: result.revisions,
+    notificationStatus: result.notification,
+    warnings: result.userOutcome.warnings,
+    warningMessage: result.userOutcome.warningMessage,
+    successMessage: result.userOutcome.successMessage,
+    selected_change_ids: result.queue.selectedChangeIds,
+    sections_by_outcome: {
+      sent: result.queue.selectedChangeIds,
+      cleared: result.queue.clearedChangeIds,
+    },
+    operation_id: result.operationId,
+    compatibility: {
+      contract: 'menu-publish-workflow.v1',
+      serverOwned: true,
+      downgradedFields: result.compatibility.downgradedFields,
+    },
+  };
+}
+```
+
+- [ ] **Step 4: Run the server publish boundary tests**
+
+Run: `node --test tests/phase19-menu-preview-boundaries.test.cjs`
+
+Expected: PASS and the source assertions should now reference `createMenuPublishWorkflow` / `createServerMenuPublishPorts`.
+
+- [ ] **Step 5: Commit the server workflow adapter**
+
+```bash
+git add server/_menu-publish.js tests/phase19-menu-preview-boundaries.test.cjs
+git commit -m "refactor: move server publish boundary onto shared workflow"
+```
+
+---
+
+### Task 5: Rewire `app.js` to use `prepare()` / `commit()` and delete duplicated client publish policy
+
+**Files:**
+- Modify: `app.js`
+- Modify: `tests/architecture-boundaries.test.cjs`
+- Test: `tests/boundaries/publish.boundary.test.cjs`
+- Test: `tests/architecture-boundaries.test.cjs`
+
+- [ ] **Step 1: Replace the preview fetch helper with facade-backed calls**
+
+```js
+async function openPreview() {
+  await flushFocusedManagerEditor();
+  const content = document.getElementById('preview-content');
+  const saveMenuBtn = document.getElementById('save-menu-btn');
+  const saveSendBtn = document.getElementById('save-send-btn');
+  const modal = document.getElementById('modal-bg');
+  if (!content || !saveMenuBtn || !saveSendBtn || !modal) return;
+
+  const result = await ensureCurrentMenuSession().preparePublish({
+    source: isAdminMode ? 'web_admin' : 'web_manager',
+  });
+  if (!result?.ok || !result.preview) {
+    showToast('Preview is unavailable right now.', 'error');
+    return;
+  }
+  renderPreviewModal(result.preview);
+}
+```
+
+- [ ] **Step 2: Replace `sendUpdate()` mode inference with facade-backed `commit()`**
+
+```js
+async function sendUpdate(options = {}) {
+  await flushFocusedManagerEditor();
+  let preview = options.preview?.sections ? options.preview : _previewModalState;
+  if (!preview) {
+    const prepared = await ensureCurrentMenuSession().preparePublish({
+      source: isAdminMode ? 'web_admin' : 'web_manager',
+    });
+    if (!prepared?.ok || !prepared.preview) {
+      showToast('Preview is unavailable right now.', 'error');
+      return;
+    }
+    preview = prepared.preview;
+    _previewModalState = preview;
+    _previewSelectionState = Object.fromEntries((preview.notificationChanges || []).map(change => [change.id, true]));
+  }
+  if (!preview.hasChanges) {
+    closeModal();
+    return;
+  }
+
+  const selectedChangeIds = getSelectedPreviewChangeIds();
+  const intent = options.notify === false
+    ? 'save'
+    : ((preview.mode === 'send' || preview.mode === 'update-only') ? 'send' : 'save-and-send');
+
+  setPreviewModalActionState(intent === 'save' ? 'save-menu' : (intent === 'send' ? 'send-update' : 'save-send'));
+
+  try {
+    const result = await ensureCurrentMenuSession().commitPublish({
+      source: isAdminMode ? 'web_admin' : 'web_manager',
+      intent,
+      preview,
+      selectedChangeIds,
+    });
+    if (result?.ok) {
+      closeModal();
+      showToast(result.userOutcome?.successMessage || `✅ ${_activeMenuName || 'Menu'} updated.`, 'success');
+      (result.userOutcome?.warnings || []).forEach(message => showToast(`⚠️ ${message}`, 'warning'));
+      renderManagerWorkspace({ includeRecentChanges: false });
+      updateDraftIndicator();
+      renderRecentChanges();
+      return;
+    }
+    showToast(result?.userOutcome?.warningMessage || 'Publish failed.', 'error');
+  } finally {
+    setPreviewModalActionState();
+  }
+}
+```
+
+- [ ] **Step 3: Delete client-only publish policy helpers that the facade now owns**
+
+Remove these functions from `app.js` after the facade-backed calls are in place:
+
+```js
+function buildPatchMessage(sections) { /* delete entire function */ }
+function serializeNotificationSectionsForLog(sections = []) { /* delete entire function */ }
+function dedupePublisherWarnings(warnings = []) { /* delete entire function */ }
+function formatNotificationChannelName(channel) { /* delete entire function */ }
+function summarizeNotificationResults(results = {}) { /* delete entire function */ }
+function collectNotificationWarnings(summary) { /* delete entire function */ }
+function createNotificationDeliveryService(deps = {}) { /* delete entire function */ }
+async function dispatchMenuUpdateNotification({ menuId, patchMessage }) { /* delete entire function */ }
+```
+
+- [ ] **Step 4: Update the architecture boundary test to lock in the cleanup**
+
+```js
+test('app runtime delegates preview and commit through the session publish facade', () => {
+  const source = read('app.js');
+  const openPreviewStart = source.indexOf('async function openPreview()');
+  const openPreviewEnd = source.indexOf('function closeModal()', openPreviewStart);
+  const openPreviewSource = source.slice(openPreviewStart, openPreviewEnd);
+  const sendUpdateStart = source.indexOf('async function sendUpdate(options = {})');
+  const sendUpdateEnd = source.indexOf('// ─── TOAST', sendUpdateStart);
+  const sendUpdateSource = source.slice(sendUpdateStart, sendUpdateEnd);
+
+  assert.match(openPreviewSource, /preparePublish\(/);
+  assert.match(sendUpdateSource, /commitPublish\(/);
+  assert.doesNotMatch(sendUpdateSource, /publishMenuThroughApi/);
+  assert.doesNotMatch(source, /createNotificationDeliveryService/);
+  assert.doesNotMatch(source, /dispatchMenuUpdateNotification/);
+});
+```
+
+- [ ] **Step 5: Run the app-facing boundary tests**
+
+Run: `node --test tests/boundaries/publish.boundary.test.cjs tests/architecture-boundaries.test.cjs`
+
+Expected: PASS and the source assertions should confirm `preparePublish()` / `commitPublish()` usage.
+
+- [ ] **Step 6: Commit the app wiring cleanup**
+
+```bash
+git add app.js tests/architecture-boundaries.test.cjs tests/boundaries/publish.boundary.test.cjs
+git commit -m "refactor: route app publish flow through facade prepare and commit"
+```
+
+---
+
+### Task 6: Update architecture docs for the new publish path
+
+**Files:**
+- Modify: `docs/current-architecture-flowchart.md`
+
+- [ ] **Step 1: Update the publish-flow section**
+
+Replace the existing publish description with:
+
+```md
+## Publish Flow
+
+Manager/Admin publish behavior now runs through two explicit layers:
+
+1. `core/session/menu-publish-facade.js`
+   - Client-facing `prepare()` / `commit()` API for preview modal and publish buttons
+   - No Supabase writes or notification policy
+
+2. `core/session/menu-publish-workflow.js`
+   - Shared deep module over explicit ports
+   - Owns canonical preview resolution, revision checks, live persistence decisions, queue advancement, featured sibling sync, audit logging, and notification outcome handling
+
+`server/_menu-publish.js` is the owned remote adapter for the workflow. `server/_notification-delivery.js` remains the only true external notification edge.
+```
+
+- [ ] **Step 2: Commit the doc update**
+
+```bash
+git add docs/current-architecture-flowchart.md
+git commit -m "docs: describe hybrid menu publish workflow architecture"
+```
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+- Chosen interface preserved: yes. The plan implements the `3+4 hybrid` by exposing `prepare()` / `commit()` while moving policy into a ports-and-adapters workflow core.
+- Save / Send / Save & Send behavior: covered in Tasks 1, 2, 4, and 5.
+- Revision handling: covered in Tasks 1, 2, and 4.
+- Featured sibling sync and queue advancement: covered in Tasks 2 and 4.
+- Client cleanup so `app.js` stops owning publish policy: covered in Tasks 3 and 5.
+- Architecture docs update: covered in Task 6.
+
+### Placeholder scan
+
+- No `TODO`, `TBD`, or “implement later” placeholders remain.
+- Every code-changing step includes explicit code.
+- Every test step includes an exact command and expected outcome.
+
+### Type consistency
+
+- Shared workflow interface uses `preview()` / `execute()`.
+- Client facade uses `prepare()` / `commit()`.
+- Session lifecycle uses `preparePublish()` / `commitPublish()`.
+- Server boundary preserves `previewMenuUpdateForMenu()` / `publishMenuUpdateForMenu()` while delegating to the workflow core.

--- a/server/_menu-publish.js
+++ b/server/_menu-publish.js
@@ -1,5 +1,7 @@
 import { randomUUID } from 'node:crypto';
 
+import '../core/session/menu-publish-workflow.js';
+
 import { getRestaurantSpecialConfig } from './_auth.js';
 import {
   MAX_NOTIFICATION_TEXT_LENGTH,
@@ -14,7 +16,6 @@ import {
   patchMenuMetaForMenu,
   patchMenuMetaForMenuWithCompatibility,
   readMenuMeta,
-  readRevisionState,
   saveLiveMenuForMenu,
 } from './_menu-write.js';
 import {
@@ -33,38 +34,11 @@ import {
 
 const PREVIEW_CONTRACT = 'menu-publish-preview.v2';
 
-function summarizeSkippedNotification() {
-  return {
-    results: {},
-    okChannels: [],
-    skippedChannels: [],
-    failedChannels: [],
-    anyOk: false,
-    anyError: false,
-    allSkipped: false,
-  };
-}
-
-function createNotificationStatus(delivery, shouldNotify) {
-  if (!shouldNotify) {
-    return {
-      ok: true,
-      skipped: true,
-      partial: false,
-      statusCode: null,
-      summary: summarizeSkippedNotification(),
-      results: {},
-    };
-  }
-
-  return {
-    ok: delivery.status < 400,
-    skipped: false,
-    partial: delivery.status === 207,
-    statusCode: delivery.status,
-    summary: delivery.summary,
-    results: delivery.results,
-  };
+function createMenuPublishError(status, message, extras = {}) {
+  const error = new Error(message);
+  error.status = status;
+  Object.assign(error, extras);
+  return error;
 }
 
 function collectNotificationWarnings(summary = {}) {
@@ -148,23 +122,6 @@ function serializeNotificationSectionsForLog(sections = []) {
     eightySixed: (section.changes || []).filter(change => change.kind === 'eightySixed').map(change => change.name),
     restored: (section.changes || []).filter(change => change.kind === 'restored').map(change => change.name),
   }));
-}
-
-function serializeSaveOnlyChangesForLog(saveOnlyChanges = []) {
-  const names = (Array.isArray(saveOnlyChanges) ? saveOnlyChanges : [])
-    .map(change => change?.label || change?.message || '')
-    .map(label => String(label || '').trim())
-    .filter(Boolean);
-  if (!names.length) return [];
-  return [{
-    id: '__save_only__',
-    icon: '💾',
-    label: 'Will Save Only',
-    added: names,
-    removed: [],
-    eightySixed: [],
-    restored: [],
-  }];
 }
 
 function buildPatchMessage(sections = [], { menuName = '', menuLink = '', now = new Date() } = {}) {
@@ -303,30 +260,6 @@ async function buildFeaturedQueueState(knownMenu = null, meta = {}) {
     notificationChanges,
     diff,
     unsentItemIds: [...addedIds],
-  };
-}
-
-function buildSectionsByOutcome({
-  preview = {},
-  selectedGroupIds = [],
-} = {}) {
-  const selectableGroups = Array.isArray(preview?.changeGroups)
-    ? preview.changeGroups.filter(group => group?.selectable)
-    : [];
-  const defaultIds = selectableGroups.map(group => group.id);
-  const selectedIds = selectedGroupIds.length ? selectedGroupIds : defaultIds;
-  const selectedSet = new Set(selectedIds.map(id => String(id || '').trim()).filter(Boolean));
-  const notificationChanges = Array.isArray(preview?.notificationChanges) ? preview.notificationChanges : [];
-  const selectedLines = notificationChanges.filter(change => selectedSet.has(String(change?.groupId || '').trim()));
-  const clearLines = notificationChanges.filter(change => (
-    !selectedSet.has(String(change?.groupId || '').trim()) &&
-    defaultIds.includes(String(change?.groupId || '').trim())
-  ));
-
-  return {
-    willSend: groupNotificationChangesBySection(selectedLines),
-    willClearWithoutSending: groupNotificationChangesBySection(clearLines),
-    willSaveOnly: Array.isArray(preview?.saveOnlyChanges) ? preview.saveOnlyChanges : [],
   };
 }
 
@@ -471,7 +404,7 @@ async function buildCanonicalPreviewForMenu({
     .filter(group => group?.selectable)
     .map(group => group.id);
 
-  const preview = {
+  return {
     mode,
     hasChanges: hasNotificationChanges || hasSaveOnlyChanges,
     hasLocalDraft: previewContext.hasLocalDraft,
@@ -492,73 +425,123 @@ async function buildCanonicalPreviewForMenu({
       contract: PREVIEW_CONTRACT,
       currentFeaturedIds: featuredState.currentFeaturedIds,
       unsentItemIds: queueState.unsentItemIds,
+      lastSentState: snapshotLastSentState(snapshot),
     },
   };
-  preview.sectionsByOutcome = buildSectionsByOutcome({ preview, selectedGroupIds: selectionDefaults });
-  return preview;
 }
 
-function assertPublishRevisions({
-  expectedLiveRevision,
-  expectedDraftRevision,
-  expectedNotificationRevision,
-  meta,
-  menuId,
-}) {
-  const currentRevisions = readRevisionState(meta);
-  const notificationBaselineRevision = expectedNotificationRevision ?? expectedDraftRevision ?? null;
-  assertExpectedRevision(expectedLiveRevision, meta?.last_updated_ts || null, 'live_revision', {
-    menuId,
-    command: 'menu-publish.v2',
-    currentRevisions,
-  });
-  assertExpectedRevision(notificationBaselineRevision, meta?.last_sent_ts || null, 'notification_revision', {
-    menuId,
-    command: 'menu-publish.v2',
-    currentRevisions,
-  });
-  return currentRevisions;
-}
-
-function normalizePublishMode(mode = '', previewMode = 'save') {
-  const normalized = String(mode || '').trim().toLowerCase();
-  if (normalized === 'save') return 'save';
-  if (normalized === 'save-only') return 'save';
-  if (normalized === 'save-and-send') return 'save-and-send';
-  if (normalized === 'save-and-update') return 'save-and-send';
-  if (normalized === 'send') return 'send';
-  if (normalized === 'update-only') return 'send';
-  return normalizePublishMode(previewMode || 'save', 'save');
-}
-
-function mergeDowngradedFields(...compatResults) {
-  const merged = [];
-  compatResults.forEach(result => {
-    (Array.isArray(result?.downgradedFields) ? result.downgradedFields : []).forEach(field => {
-      if (!merged.includes(field)) merged.push(field);
-    });
-  });
-  return merged;
-}
-
-async function appendHistoryEvent({
-  menuId,
-  actor,
-  source,
-  operationId,
-  eventType,
+function createWorkflowPatchMessage({
   sections = [],
-  message = '',
+  menuName = '',
+  menuLink = '',
 }) {
-  if (!message) return { downgradedFields: [] };
-  return insertUpdateLog({
-    menuId,
-    actor,
-    diff: serializeNotificationSectionsForLog(sections),
-    message,
-    source,
-    operationId,
-    eventType,
+  return buildPatchMessage(sections, { menuName, menuLink });
+}
+
+function createWorkflowSelection(preview, selectedChangeIds = null, legacySelectedSections = []) {
+  const selection = resolveSelection(preview, selectedChangeIds, legacySelectedSections);
+  return {
+    selectedChangeIds: selection.selectedGroupIds,
+    selectedSections: groupNotificationChangesBySection(selection.selectedLines),
+    clearedChangeIds: selection.clearGroups.map(group => group.id),
+    clearedSections: groupNotificationChangesBySection(selection.clearLines),
+  };
+}
+
+function createServerMenuPublishPorts() {
+  return {
+    menus: {
+      async readContext(menuId) {
+        const knownMenu = getKnownMenuById(menuId);
+        if (!knownMenu) {
+          throw createMenuPublishError(400, 'Unsupported menu_id', { menuId });
+        }
+        const meta = await readMenuMeta(menuId);
+        const currentFeaturedIds = await readCurrentFeaturedIdsForRestaurant(knownMenu.restaurantId);
+        return { knownMenu, meta, currentFeaturedIds };
+      },
+      async saveLiveMenu(input) {
+        return saveLiveMenuForMenu(input);
+      },
+      async patchMeta({ menuId, patch, optionalFields = [] }) {
+        return patchMenuMetaForMenuWithCompatibility(menuId, patch, { optionalFields });
+      },
+      async patchSiblingFeatured({ menuIds, featuredIds }) {
+        return Promise.all(
+          (Array.isArray(menuIds) ? menuIds : []).map(menuId => patchMenuMetaForMenu(menuId, {
+            last_sent_featured: featuredIds,
+          })),
+        );
+      },
+    },
+    governance: {
+      async assertCategoryGovernanceAllowed(input) {
+        return assertCategoryGovernanceAllowed({ ...input, requireCategorySnapshot: true });
+      },
+      assertRevisions({ menuId, meta, expectedLiveRevision, expectedDraftRevision, expectedNotificationRevision }) {
+        assertExpectedRevision(expectedLiveRevision, meta?.last_updated_ts, 'live_revision', { menuId });
+        assertExpectedRevision(expectedDraftRevision, meta?.draft_saved_ts, 'draft_revision', { menuId });
+        assertExpectedRevision(expectedNotificationRevision, meta?.last_sent_ts, 'notification_revision', { menuId });
+        return {
+          liveRevision: meta?.last_updated_ts || null,
+          draftRevision: meta?.draft_saved_ts || null,
+          notificationRevision: meta?.last_sent_ts || null,
+        };
+      },
+    },
+    preview: {
+      buildCanonical: buildCanonicalPreviewForMenu,
+      resolveSelection({ preview, selectedChangeIds }) {
+        return createWorkflowSelection(preview, selectedChangeIds, []);
+      },
+    },
+    notifications: {
+      async deliver({ menuId, message }) {
+        const delivery = await deliverMenuNotification(menuId, truncateNotificationText(message));
+        return {
+          delivered: delivery.status < 400,
+          partial: delivery.status === 207,
+          summary: delivery.summary,
+          retryable: delivery.status >= 400 || delivery.status === 207,
+        };
+      },
+    },
+    audit: {
+      async append(event) {
+        return insertUpdateLog({
+          menuId: event.menuId,
+          actor: event.actor,
+          diff: serializeNotificationSectionsForLog(event.sections),
+          message: event.message,
+          source: inferAuditSource(event.actor, event.source),
+          operationId: event.operationId,
+          eventType: event.eventType,
+        });
+      },
+    },
+    clock: { now: () => Date.now() },
+    ids: { operationId: () => randomUUID() },
+    format: {
+      patchMessage: createWorkflowPatchMessage,
+      warningSummary: collectNotificationWarnings,
+    },
+  };
+}
+
+function getServerPublishWorkflowFactory() {
+  const workflowFactory = globalThis.createMenuPublishWorkflow;
+  if (typeof workflowFactory !== 'function') {
+    throw createMenuPublishError(500, 'createMenuPublishWorkflow is unavailable', {
+      code: 'menu_publish_workflow_unavailable',
+    });
+  }
+  return workflowFactory;
+}
+
+function createServerPublishWorkflow() {
+  const workflowFactory = getServerPublishWorkflowFactory();
+  return workflowFactory({
+    ports: createServerMenuPublishPorts(),
   });
 }
 
@@ -571,42 +554,27 @@ export async function previewMenuUpdateForMenu({
   expectedDraftRevision = null,
   expectedNotificationRevision = null,
 }) {
-  void actor;
-  void source;
-  const knownMenu = getKnownMenuById(menuId);
-  if (!knownMenu) {
-    throw { status: 400, message: 'Unsupported menu_id' };
-  }
-
-  await assertCategoryGovernanceAllowed({
+  const workflow = createServerPublishWorkflow();
+  const result = await workflow.preview({
+    menuId,
     actor,
-    menuId,
-    snapshot,
-    requireCategorySnapshot: true,
-  });
-
-  const meta = await readMenuMeta(menuId);
-  const currentRevisions = assertPublishRevisions({
-    expectedLiveRevision,
-    expectedDraftRevision,
-    expectedNotificationRevision,
-    meta,
-    menuId,
-  });
-  const preview = await buildCanonicalPreviewForMenu({
-    snapshot,
-    meta,
-    knownMenu,
+    source,
+    snapshot: snapshot || {},
+    request: {
+      expectedLiveRevision,
+      expectedDraftRevision,
+      expectedNotificationRevision,
+    },
   });
 
   return {
     ok: true,
     action: 'preview',
-    preview,
-    current_revisions: currentRevisions,
+    preview: result.preview,
+    current_revisions: result.revisions,
     reconnect: null,
     compatibility: {
-      contract: PREVIEW_CONTRACT,
+      contract: 'menu-publish-workflow.v1',
       serverOwned: true,
     },
   };
@@ -619,288 +587,44 @@ export async function publishMenuUpdateForMenu({
   source,
   snapshot = {},
   selectedChangeIds = null,
-  legacySelectedSections = [],
   expectedLiveRevision = null,
   expectedDraftRevision = null,
   expectedNotificationRevision = null,
 }) {
-  const knownMenu = getKnownMenuById(menuId);
-  if (!knownMenu) {
-    throw { status: 400, message: 'Unsupported menu_id' };
-  }
-
-  await assertCategoryGovernanceAllowed({
+  const workflow = createServerPublishWorkflow();
+  const result = await workflow.execute({
+    menuId,
     actor,
-    menuId,
-    snapshot,
-    requireCategorySnapshot: true,
-  });
-
-  const meta = await readMenuMeta(menuId);
-  const currentRevisions = assertPublishRevisions({
-    expectedLiveRevision,
-    expectedDraftRevision,
-    expectedNotificationRevision,
-    meta,
-    menuId,
-  });
-  const preview = await buildCanonicalPreviewForMenu({
-    snapshot,
-    meta,
-    knownMenu,
-  });
-  const selection = resolveSelection(preview, selectedChangeIds, legacySelectedSections);
-  const selectedSections = groupNotificationChangesBySection(selection.selectedLines);
-  const clearSections = groupNotificationChangesBySection(selection.clearLines);
-  const selectedPatchMessage = selectedSections.length
-    ? buildPatchMessage(selectedSections, {
-      menuName: knownMenu?.name || '',
-      menuLink: String(meta?.notifications?.menu_url || '').trim(),
-    })
-    : '';
-  const publishMode = normalizePublishMode(mode, preview.mode);
-  const shouldPersistLive = publishMode !== 'send';
-  const shouldNotify = (publishMode === 'save-and-send' || publishMode === 'send') && selectedSections.length > 0;
-  const shouldAdvanceQueueBaseline = (publishMode === 'save-and-send' || publishMode === 'send') && (
-    selectedSections.length > 0 || clearSections.length > 0
-  );
-  const ts = Date.now();
-  const normalizedSource = inferAuditSource(actor, source);
-  const operationId = randomUUID();
-  const warnings = [];
-  const historyCompat = [];
-
-  if (shouldPersistLive) {
-    await saveLiveMenuForMenu({
-      menuId,
-      snapshot,
+    source,
+    intent: mode === 'save' ? 'save' : (mode === 'send' ? 'send' : 'save-and-send'),
+    snapshot: snapshot || {},
+    request: {
+      selectedChangeIds: Array.isArray(selectedChangeIds) ? selectedChangeIds : null,
       expectedLiveRevision,
-      actor,
-    });
-  }
-
-  const notificationStatus = shouldNotify
-    ? createNotificationStatus(await deliverMenuNotification(menuId, truncateNotificationText(selectedPatchMessage)), true)
-    : createNotificationStatus(null, false);
-
-  if (shouldNotify && (notificationStatus.partial || !notificationStatus.ok)) {
-    if (notificationStatus.partial) {
-      warnings.push(...collectNotificationWarnings(notificationStatus.summary));
-      warnings.push('Some channels did not receive the update. The queue was preserved so you can retry.');
-    } else {
-      warnings.push('Update could not be sent. The queue was preserved.');
-    }
-
-    const [metaCompatibility, failedSendCompatibility] = await Promise.all([
-      patchMenuMetaForMenuWithCompatibility(menuId, {
-        last_updated_ts: shouldPersistLive ? ts : (meta?.last_updated_ts || null),
-        draft_state: shouldPersistLive ? {} : (meta?.draft_state || {}),
-        draft_saved_ts: shouldPersistLive ? null : (meta?.draft_saved_ts || null),
-        draft_saved_by_user_id: shouldPersistLive ? null : (meta?.draft_saved_by_user_id ?? undefined),
-        draft_saved_by_name: shouldPersistLive ? '' : (meta?.draft_saved_by_name ?? undefined),
-        draft_saved_source: shouldPersistLive ? '' : (meta?.draft_saved_source ?? undefined),
-      }, {
-        optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
-      }),
-      appendHistoryEvent({
-        menuId,
-        actor,
-        source: normalizedSource,
-        operationId,
-        eventType: 'send_failed',
-        sections: selectedSections,
-        message: notificationStatus.partial
-          ? 'Notification delivery was partially successful. Queue preserved for retry.'
-          : 'Notification delivery failed. Queue preserved for retry.',
-      }),
-    ]);
-    historyCompat.push(failedSendCompatibility);
-
-    return {
-      ok: true,
-      ts,
-      preview,
-      sections_by_outcome: buildSectionsByOutcome({
-        preview,
-        selectedGroupIds: selection.selectedGroupIds,
-      }),
-      current_revisions: {
-        ...currentRevisions,
-        live_revision: shouldPersistLive ? ts : currentRevisions.live_revision,
-      },
-      notificationStatus,
-      warnings,
-      warningMessage: warnings[0] || '',
-      successMessage: `✅ ${knownMenu.name || 'Menu'} saved live. Send attempt failed and the queue was preserved.`,
-      selected_change_ids: selection.selectedGroupIds,
-      legacy_selected_change_ids: selection.selectedLines.map(change => change.id),
-      operation_id: operationId,
-      compatibility: {
-        contract: PREVIEW_CONTRACT,
-        serverOwned: true,
-        downgradedFields: mergeDowngradedFields(metaCompatibility, ...historyCompat),
-        sourceStamped: !mergeDowngradedFields(...historyCompat).includes('source'),
-        typedHistory: !mergeDowngradedFields(...historyCompat).includes('event_type'),
-        operationGrouping: !mergeDowngradedFields(...historyCompat).includes('operation_id'),
-      },
-    };
-  }
-
-  warnings.push(...collectNotificationWarnings(notificationStatus.summary));
-  const currentFeaturedIds = Array.isArray(preview?.metadata?.currentFeaturedIds)
-    ? preview.metadata.currentFeaturedIds
-    : await readCurrentFeaturedIdsForRestaurant(knownMenu.restaurantId);
-  const siblingMenuIds = (getRestaurantSpecialConfig(knownMenu.restaurantId)?.menuIds || [])
-    .filter(candidateId => candidateId && candidateId !== menuId);
-  const lastSentState = snapshotLastSentState(snapshot);
-
-  if (publishMode === 'save') {
-    const [metaCompatibility, quietSaveCompatibility] = await Promise.all([
-      patchMenuMetaForMenuWithCompatibility(menuId, {
-        last_updated_ts: ts,
-        draft_state: {},
-        draft_saved_ts: null,
-        draft_saved_by_user_id: null,
-        draft_saved_by_name: '',
-        draft_saved_source: '',
-      }, {
-        optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
-      }),
-      insertUpdateLog({
-        menuId,
-        actor,
-        diff: serializeSaveOnlyChangesForLog(preview.saveOnlyChanges),
-        message: preview.hasNotificationChanges
-          ? 'Saved live quietly. Notification queue was preserved for later send.'
-          : 'Saved live quietly.',
-        source: normalizedSource,
-        operationId,
-        eventType: 'quiet_save',
-      }),
-    ]);
-    historyCompat.push(quietSaveCompatibility);
-
-    return {
-      ok: true,
-      ts,
-      preview,
-      sections_by_outcome: buildSectionsByOutcome({
-        preview,
-        selectedGroupIds: selection.selectedGroupIds,
-      }),
-      current_revisions: {
-        ...currentRevisions,
-        live_revision: ts,
-      },
-      notificationStatus: null,
-      warnings,
-      warningMessage: warnings[0] || '',
-      successMessage: preview.hasNotificationChanges
-        ? `✅ ${knownMenu.name || 'Menu'} saved live. Queue is ready to send.`
-        : `✅ ${knownMenu.name || 'Menu'} saved to the live menu.`,
-      selected_change_ids: selection.selectedGroupIds,
-      legacy_selected_change_ids: selection.selectedLines.map(change => change.id),
-      operation_id: operationId,
-      compatibility: {
-        contract: PREVIEW_CONTRACT,
-        serverOwned: true,
-        downgradedFields: mergeDowngradedFields(metaCompatibility, ...historyCompat),
-        sourceStamped: !mergeDowngradedFields(...historyCompat).includes('source'),
-        typedHistory: !mergeDowngradedFields(...historyCompat).includes('event_type'),
-        operationGrouping: !mergeDowngradedFields(...historyCompat).includes('operation_id'),
-      },
-    };
-  }
-
-  const [metaCompatibility] = await Promise.all([
-    patchMenuMetaForMenuWithCompatibility(menuId, {
-      last_updated_ts: shouldPersistLive ? ts : (meta?.last_updated_ts || currentRevisions.live_revision || null),
-      last_sent_ts: shouldAdvanceQueueBaseline ? ts : (meta?.last_sent_ts || null),
-      last_sent_state: shouldAdvanceQueueBaseline ? lastSentState : (meta?.last_sent_state || {}),
-      last_sent_categories: shouldAdvanceQueueBaseline
-        ? (Array.isArray(preview?.diff) ? preview.diff.map(section => section.id).filter(Boolean) : [])
-        : (Array.isArray(meta?.last_sent_categories) ? meta.last_sent_categories : []),
-      last_sent_featured: shouldAdvanceQueueBaseline
-        ? currentFeaturedIds
-        : (Array.isArray(meta?.last_sent_featured) ? meta.last_sent_featured : []),
-      draft_state: shouldPersistLive ? {} : (meta?.draft_state || {}),
-      draft_saved_ts: shouldPersistLive ? null : (meta?.draft_saved_ts || null),
-      draft_saved_by_user_id: shouldPersistLive ? null : (meta?.draft_saved_by_user_id ?? undefined),
-      draft_saved_by_name: shouldPersistLive ? '' : (meta?.draft_saved_by_name ?? undefined),
-      draft_saved_source: shouldPersistLive ? '' : (meta?.draft_saved_source ?? undefined),
-    }, {
-      optionalFields: ['last_sent_featured', 'draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
-    }),
-    ...(shouldAdvanceQueueBaseline
-      ? siblingMenuIds.map(candidateId => patchMenuMetaForMenu(candidateId, {
-          last_sent_featured: currentFeaturedIds,
-        }))
-      : []),
-  ]);
-
-  if (selectedSections.length > 0 && shouldNotify) {
-    const sendCompatibility = await appendHistoryEvent({
-      menuId,
-      actor,
-      source: normalizedSource,
-      operationId,
-      eventType: 'send_notification',
-      sections: selectedSections,
-      message: selectedPatchMessage || 'Sent menu update notification.',
-    });
-    historyCompat.push(sendCompatibility);
-  }
-
-  if (clearSections.length > 0) {
-    const clearCompatibility = await appendHistoryEvent({
-      menuId,
-      actor,
-      source: normalizedSource,
-      operationId,
-      eventType: 'clear_without_send',
-      sections: clearSections,
-      message: `Cleared ${clearSections.reduce((count, section) => count + (section.changes || []).length, 0)} queued line(s) without sending.`,
-    });
-    historyCompat.push(clearCompatibility);
-  }
-
-  const queueWasClearedWithoutSend = clearSections.length > 0 && !shouldNotify;
-  const successMessage = shouldNotify
-    ? (clearSections.length > 0
-        ? `✅ ${knownMenu.name || 'Menu'} sent selected updates and cleared unchecked lines.`
-        : `✅ ${knownMenu.name || 'Menu'} updates sent.`)
-    : (queueWasClearedWithoutSend
-        ? `✅ ${knownMenu.name || 'Menu'} update list cleared without notifying channels.`
-        : `✅ ${knownMenu.name || 'Menu'} save completed.`);
+      expectedDraftRevision,
+      expectedNotificationRevision,
+    },
+  });
 
   return {
-    ok: true,
-    ts,
-    preview,
-    sections_by_outcome: buildSectionsByOutcome({
-      preview,
-      selectedGroupIds: selection.selectedGroupIds,
-    }),
-    current_revisions: {
-      ...currentRevisions,
-      live_revision: shouldPersistLive ? ts : currentRevisions.live_revision,
-      last_sent_revision: shouldAdvanceQueueBaseline ? ts : currentRevisions.last_sent_revision,
-      draft_revision: shouldPersistLive ? null : currentRevisions.draft_revision,
+    ok: result.ok,
+    ts: result.ts,
+    preview: result.preview,
+    current_revisions: result.revisions,
+    notificationStatus: result.notification,
+    warnings: result.userOutcome.warnings,
+    warningMessage: result.userOutcome.warningMessage,
+    successMessage: result.userOutcome.successMessage,
+    selected_change_ids: result.queue.selectedChangeIds,
+    sections_by_outcome: {
+      sent: result.queue.selectedChangeIds,
+      cleared: result.queue.clearedChangeIds,
     },
-    notificationStatus: shouldNotify ? notificationStatus : null,
-    warnings,
-    warningMessage: warnings[0] || '',
-    successMessage,
-    selected_change_ids: selection.selectedGroupIds,
-    legacy_selected_change_ids: selection.selectedLines.map(change => change.id),
-    operation_id: operationId,
+    operation_id: result.operationId,
     compatibility: {
-      contract: PREVIEW_CONTRACT,
+      contract: 'menu-publish-workflow.v1',
       serverOwned: true,
-      downgradedFields: mergeDowngradedFields(metaCompatibility, ...historyCompat),
-      sourceStamped: !mergeDowngradedFields(...historyCompat).includes('source'),
-      typedHistory: !mergeDowngradedFields(...historyCompat).includes('event_type'),
-      operationGrouping: !mergeDowngradedFields(...historyCompat).includes('operation_id'),
+      downgradedFields: result.compatibility.downgradedFields,
     },
   };
 }

--- a/server/_menu-publish.js
+++ b/server/_menu-publish.js
@@ -458,7 +458,9 @@ function createServerMenuPublishPorts() {
         }
         const meta = await readMenuMeta(menuId);
         const currentFeaturedIds = await readCurrentFeaturedIdsForRestaurant(knownMenu.restaurantId);
-        return { knownMenu, meta, currentFeaturedIds };
+        const siblingMenuIds = (getRestaurantSpecialConfig(knownMenu.restaurantId)?.menuIds || [])
+          .filter(candidateId => candidateId && candidateId !== menuId);
+        return { knownMenu, meta, currentFeaturedIds, siblingMenuIds };
       },
       async saveLiveMenu(input) {
         return saveLiveMenuForMenu(input);

--- a/tests/architecture-boundaries.test.cjs
+++ b/tests/architecture-boundaries.test.cjs
@@ -11,6 +11,12 @@ const {
   setState,
 } = require('./helpers/runtime.cjs');
 
+const ROOT = path.join(__dirname, '..');
+
+function read(relativePath) {
+  return fs.readFileSync(path.join(ROOT, relativePath), 'utf8');
+}
+
 function setupRouteDom(sandbox, prefix) {
   const doc = sandbox.document;
   const pageClass = prefix === 'll' ? '.ll-board-page' : '.erc-page';
@@ -171,6 +177,222 @@ function createMenuSessionPorts(overrides = {}) {
   };
 }
 
+function installPublishFacadeStub(sandbox, overrides = {}) {
+  sandbox.createMenuPublishFacade = (sessionPorts, deps = {}) => {
+    const buildSnapshot = typeof deps.buildSnapshot === 'function'
+      ? deps.buildSnapshot
+      : ((source, request) => sessionPorts.buildSnapshot(source, request));
+    const buildPreview = () => sessionPorts.buildPreview(buildSnapshot('preview'));
+
+    function normalizeMode(options = {}, preview) {
+      if (options.mode) return options.mode;
+      if (options.intent === 'save') return 'save';
+      if (options.intent === 'send') return 'send';
+      if (options.intent === 'save-and-send') return 'save-and-send';
+      if (options.notify === false) return 'save';
+      return (preview?.mode === 'send' || preview?.mode === 'update-only') ? 'send' : 'save-and-send';
+    }
+
+    async function commitThroughLegacyService(options = {}, preview, mode) {
+      const selectedChangeIds = options.selectedChangeIds || preview.notificationChanges.map(change => change.id);
+      const selectedChanges = preview.notificationChanges.filter(change => selectedChangeIds.includes(change.id));
+      const selectedSections = sandbox.groupNotificationChangesBySection(selectedChanges);
+      const patchMessage = selectedSections.length
+        ? (typeof sandbox.buildPatchMessage === 'function'
+            ? sandbox.buildPatchMessage(selectedSections)
+            : (preview.patchMessage || 'Patch message'))
+        : '';
+      if (!preview.hasChanges) {
+        return {
+          ok: false,
+          noop: true,
+          preview,
+          snapshot: buildSnapshot('publish-noop'),
+        };
+      }
+
+      const warnings = [];
+      let liveSaveTs = null;
+      if (preview.hasLocalDraft || preview.hasSharedDraft) {
+        const persisted = await sessionPorts.persistState({ silentFailure: true });
+        if (!persisted) {
+          return {
+            ok: false,
+            preview,
+            userHandled: true,
+            snapshot: buildSnapshot('publish-live-save-failed'),
+          };
+        }
+        liveSaveTs = sessionPorts.now();
+        try {
+          await sessionPorts.patchMenuMeta({ last_updated_ts: liveSaveTs });
+          await sessionPorts.patchMenuDraftState(null, liveSaveTs);
+        } catch (_) {
+          warnings.push('Live menu saved, but the draft metadata could not be fully synced.');
+        }
+        sessionPorts.commitLiveSave?.(liveSaveTs);
+        const cacheSynced = sessionPorts.syncLocalCache({ silent: true });
+        if (!cacheSynced) warnings.push('This device could not refresh its local cache after the live save.');
+      }
+
+      const shouldNotify = (mode === 'save-and-send' || mode === 'send') && selectedSections.length > 0;
+      let delivery = {
+        ok: true,
+        skipped: !shouldNotify,
+        statusCode: null,
+        summary: typeof sandbox.summarizeNotificationResults === 'function'
+          ? sandbox.summarizeNotificationResults({})
+          : { anyOk: false, anyError: false, failedChannels: [], allSkipped: true },
+      };
+      if (shouldNotify) {
+        delivery = await sessionPorts.dispatchNotification({
+          menuId: sessionPorts.getMenuId(),
+          patchMessage,
+        });
+      }
+
+      if (shouldNotify && delivery.partial) {
+        warnings.push(...sessionPorts.collectNotificationWarnings(delivery.summary));
+        warnings.push('Some channels did not receive the update. The lines remain ready to send again.');
+        return {
+          ok: true,
+          preview,
+          notificationStatus: delivery,
+          warnings: sessionPorts.dedupeWarnings(warnings),
+          warningMessage: sessionPorts.dedupeWarnings(warnings)[0] || '',
+          successMessage: `✅ ${sessionPorts.getMenuName() || 'Menu'} saved live. Update still needs attention.`,
+          snapshot: buildSnapshot('send-partial'),
+        };
+      }
+
+      if (shouldNotify && !delivery.ok) {
+        warnings.push(delivery.userMessage || 'Update could not be sent.');
+        return {
+          ok: true,
+          preview,
+          notificationStatus: delivery,
+          warnings: sessionPorts.dedupeWarnings(warnings),
+          warningMessage: sessionPorts.dedupeWarnings(warnings)[0] || '',
+          successMessage: `✅ ${sessionPorts.getMenuName() || 'Menu'} saved live. Update still needs to be sent.`,
+          snapshot: buildSnapshot('send-failed-live-saved'),
+        };
+      }
+
+      if (shouldNotify) warnings.push(...sessionPorts.collectNotificationWarnings(delivery.summary));
+
+      if (mode === 'save-and-send' || mode === 'send') {
+        const ts = liveSaveTs || sessionPorts.now();
+        const currentFeaturedIds = sessionPorts.getCurrentFeaturedIds();
+        const restaurantId = sessionPorts.getRestaurantId();
+        const restaurantMenuIds = sessionPorts.canEditRestaurantSpecials(restaurantId)
+          ? sessionPorts.getRestaurantMenuIds(restaurantId)
+          : [];
+        const patchResults = await Promise.all([
+          sessionPorts.patchMenuMeta({
+            last_updated_ts: ts,
+            last_sent_ts: ts,
+            last_sent_state: sessionPorts.snapshotCurrentItemsAsLastSent(),
+            last_sent_categories: preview.diff.map(section => section.id),
+            last_sent_featured: currentFeaturedIds,
+          }),
+          ...restaurantMenuIds
+            .filter(menuId => menuId && menuId !== sessionPorts.getMenuId())
+            .map(menuId => sessionPorts.patchMenuMetaForMenu(menuId, {
+              last_sent_featured: currentFeaturedIds,
+            })),
+        ]);
+        if (patchResults.some(result => (result?.downgradedFields || []).includes('last_sent_featured'))) {
+          warnings.push('Featured sync used legacy metadata compatibility on this deployment.');
+        }
+
+        sessionPorts.commitPublished({
+          diff: preview.diff,
+          ts,
+          featuredIds: currentFeaturedIds,
+        });
+
+        const cacheSynced = sessionPorts.syncLocalCache({ silent: true });
+        if (!cacheSynced) warnings.push('This device could not refresh its local cache after the send.');
+
+        const logged = patchMessage
+          ? await sessionPorts.logUpdate(
+            typeof sandbox.serializeNotificationSectionsForLog === 'function'
+              ? sandbox.serializeNotificationSectionsForLog(selectedSections)
+              : selectedSections,
+            patchMessage,
+          )
+          : true;
+        if (!logged) warnings.push('The recent-changes audit log could not be written for this send.');
+
+        const finalWarnings = sessionPorts.dedupeWarnings(warnings);
+        return {
+          ok: true,
+          preview,
+          ts,
+          truncated: preview.truncated,
+          notificationStatus: shouldNotify ? delivery : null,
+          warnings: finalWarnings,
+          warningMessage: finalWarnings[0] || '',
+          successMessage: shouldNotify
+            ? `✅ ${sessionPorts.getMenuName() || 'Menu'} saved and sent!`
+            : `✅ ${sessionPorts.getMenuName() || 'Menu'} update list cleared without notifying channels.`,
+          snapshot: buildSnapshot(finalWarnings.length ? 'publish-warning' : 'publish-complete'),
+        };
+      }
+
+      const finalWarnings = sessionPorts.dedupeWarnings(warnings);
+      return {
+        ok: true,
+        preview,
+        ts: liveSaveTs || sessionPorts.now(),
+        truncated: preview.truncated,
+        notificationStatus: shouldNotify ? delivery : null,
+        warnings: finalWarnings,
+        warningMessage: finalWarnings[0] || '',
+        successMessage: `✅ ${sessionPorts.getMenuName() || 'Menu'} saved to the live menu.`,
+        snapshot: buildSnapshot(finalWarnings.length ? 'publish-warning' : 'saved-live'),
+      };
+    }
+
+    return {
+      async prepare(options = {}) {
+        if (typeof overrides.prepare === 'function') {
+          return overrides.prepare({ sessionPorts, deps, options, buildSnapshot, buildPreview });
+        }
+        return {
+          ok: true,
+          preview: buildPreview(),
+        };
+      },
+      async commit(options = {}) {
+        const preview = options.preview?.sections ? options.preview : buildPreview();
+        const mode = normalizeMode(options, preview);
+        if (typeof overrides.commit === 'function') {
+          return overrides.commit({
+            sessionPorts,
+            deps,
+            options,
+            preview,
+            mode,
+            buildSnapshot,
+            buildPreview,
+            commitThroughLegacyService,
+          });
+        }
+        if (typeof sessionPorts.publishMenuUpdate === 'function') {
+          return sessionPorts.publishMenuUpdate({
+            ...options,
+            preview,
+            mode,
+            notify: mode !== 'save',
+          });
+        }
+        return commitThroughLegacyService(options, preview, mode);
+      },
+    };
+  };
+}
+
 test('menu session lifecycle handles redirect and fallback-aware open results', async () => {
   const sandbox = loadAppSandbox();
   const restored = [];
@@ -258,6 +480,7 @@ test('menu session lifecycle routes poll and manual refreshes through one bounda
 test('menu session lifecycle saveDraft routes quiet saves through the publish boundary', async () => {
   const sandbox = loadAppSandbox();
   const publishCalls = [];
+  installPublishFacadeStub(sandbox);
 
   const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts({
     buildSnapshot: (source, request) => ({ source, request, dirty: true }),
@@ -284,6 +507,7 @@ test('menu session lifecycle saveDraft routes quiet saves through the publish bo
 test('menu publish service exposes quiet-save and publish boundaries directly', async () => {
   const sandbox = loadAppSandbox();
   const quietSaveCalls = [];
+  installPublishFacadeStub(sandbox);
 
   const ports = createMenuSessionPorts({
     buildSnapshot: source => ({ source, dirty: true }),
@@ -323,6 +547,7 @@ test('menu publish service exposes quiet-save and publish boundaries directly', 
 test('menu session lifecycle publishes updates through one preview-aware boundary', async () => {
   const sandbox = loadAppSandbox();
   const patchCalls = [];
+  installPublishFacadeStub(sandbox);
 
   const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts({
     patchMenuMeta: async update => {
@@ -351,6 +576,7 @@ test('menu session lifecycle publishes updates through one preview-aware boundar
 test('menu session lifecycle can publish without firing notifications', async () => {
   const sandbox = loadAppSandbox();
   let notificationCalls = 0;
+  installPublishFacadeStub(sandbox);
 
   const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts({
     canEditRestaurantSpecials: () => false,
@@ -372,43 +598,21 @@ test('menu session lifecycle can publish without firing notifications', async ()
   assert.match(result.successMessage, /saved to the live menu/i);
 });
 
-test('notification delivery service normalizes API channel results', async () => {
-  const sandbox = loadAppSandbox();
-  const requests = [];
-  const service = sandbox.createNotificationDeliveryService({
-    fetchImpl: async (url, options = {}) => {
-      requests.push([url, options]);
-      return {
-        status: 207,
-        async json() {
-          return {
-            results: {
-              groupme: 'ok',
-              sms: 'error:500',
-              discord: 'skipped',
-            },
-          };
-        },
-      };
-    },
-  });
+test('app runtime delegates preview and commit through the session publish facade', () => {
+  const source = read('app.js');
+  const openPreviewStart = source.indexOf('async function openPreview()');
+  const openPreviewEnd = source.indexOf('function closeModal()', openPreviewStart);
+  const openPreviewSource = source.slice(openPreviewStart, openPreviewEnd);
+  const sendUpdateStart = source.indexOf('async function sendUpdate(options = {})');
+  const sendUpdateEnd = source.indexOf('// ─── TOAST', sendUpdateStart);
+  const sendUpdateSource = source.slice(sendUpdateStart, sendUpdateEnd);
 
-  const result = await service.sendMenuUpdate({
-    menuId: 'menu-main',
-    patchMessage: 'Patch message',
-    accessToken: 'token-1',
-  });
-
-  assert.equal(result.ok, true);
-  assert.equal(result.partial, true);
-  assert.equal(result.statusCode, 207);
-  assert.deepEqual(Array.from(result.summary.okChannels || []), ['groupme']);
-  assert.deepEqual(Array.from(result.summary.failedChannels || []), ['sms']);
-  assert.deepEqual(Array.from(result.summary.skippedChannels || []), ['discord']);
-  assert.equal(requests.length, 1);
-  assert.equal(requests[0][0], '/api/manager');
-  assert.equal(JSON.parse(requests[0][1].body).action, 'send_notification');
-  assert.equal(requests[0][1].headers.Authorization, 'Bearer token-1');
+  assert.match(openPreviewSource, /preparePublish\(/);
+  assert.match(sendUpdateSource, /commitPublish\(/);
+  assert.doesNotMatch(sendUpdateSource, /publishMenuThroughApi/);
+  assert.doesNotMatch(sendUpdateSource, /requestPublishPreviewThroughApi/);
+  assert.doesNotMatch(source, /function createNotificationDeliveryService\(/);
+  assert.doesNotMatch(source, /async function dispatchMenuUpdateNotification\(/);
 });
 
 test('draft ledger service provides action-bar and item badge state through one boundary', () => {
@@ -574,6 +778,15 @@ test('save actions blur the focused editor before publishing workspace changes',
   const sandbox = loadAppSandbox();
   let blurred = false;
   const requests = [];
+  installPublishFacadeStub(sandbox, {
+    prepare: async ({ buildPreview }) => {
+      const apiResult = await sandbox.requestPublishPreviewThroughApi();
+      return {
+        ok: apiResult.ok,
+        preview: apiResult.payload?.preview || buildPreview(),
+      };
+    },
+  });
 
   sandbox.document.activeElement = {
     tagName: 'INPUT',
@@ -675,6 +888,7 @@ test('save-only menu edits stay in the draft session until save', async () => {
 test('save draft routes a quiet live save through the publish boundary and leaves the queue unsent', async () => {
   const sandbox = loadAppSandbox();
   const requests = [];
+  installPublishFacadeStub(sandbox);
 
   setState(sandbox, {
     MENU_ID: 'menu-main',
@@ -727,6 +941,7 @@ test('save draft routes a quiet live save through the publish boundary and leave
 test('save menu quietly writes a local draft to live and leaves unsent changes behind', async () => {
   const sandbox = loadAppSandbox();
   const requests = [];
+  installPublishFacadeStub(sandbox);
 
   setState(sandbox, {
     MENU_ID: 'menu-main',

--- a/tests/boundaries/menu-publish-workflow.boundary.test.cjs
+++ b/tests/boundaries/menu-publish-workflow.boundary.test.cjs
@@ -1,0 +1,259 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+const path = require('node:path');
+const { pathToFileURL } = require('node:url');
+
+const ROOT = path.join(__dirname, '..', '..');
+const DEFAULT_ACTOR = { id: 'user-1', role: 'manager' };
+const DEFAULT_SOURCE = 'web_manager';
+const DEFAULT_SNAPSHOT = { cats: [] };
+const DEFAULT_REVISIONS = {
+  liveRevision: 10,
+  draftRevision: 11,
+  notificationRevision: 9,
+};
+const DEFAULT_SELECTED_CHANGE_IDS = ['beer::added::lager'];
+const DEFAULT_NOTIFICATION_CHANGE = {
+  id: 'beer::added::lager',
+  sectionId: 'beer',
+  sectionLabel: 'Beer',
+  icon: '🍺',
+  displayOrder: 0,
+  kind: 'added',
+  name: 'Lager',
+  text: '+ Lager',
+};
+const DEFAULT_SELECTED_SECTION = {
+  id: 'beer',
+  label: 'Beer',
+  icon: '🍺',
+  changes: [{
+    id: 'beer::added::lager',
+    kind: 'added',
+    name: 'Lager',
+    text: '+ Lager',
+  }],
+};
+const DEFAULT_EXECUTE_REQUEST = {
+  selectedChangeIds: DEFAULT_SELECTED_CHANGE_IDS,
+  expectedLiveRevision: DEFAULT_REVISIONS.liveRevision,
+  expectedDraftRevision: DEFAULT_REVISIONS.draftRevision,
+  expectedNotificationRevision: DEFAULT_REVISIONS.notificationRevision,
+};
+
+async function importWorkflow() {
+  const fileUrl = pathToFileURL(path.join(ROOT, 'core/session/menu-publish-workflow.js')).href;
+  return import(`${fileUrl}?plan=${Date.now()}-${Math.random()}`);
+}
+
+function createWorkflowInput(overrides = {}) {
+  return {
+    menuId: 'menu-main',
+    actor: DEFAULT_ACTOR,
+    source: DEFAULT_SOURCE,
+    snapshot: DEFAULT_SNAPSHOT,
+    ...overrides,
+  };
+}
+
+function createExecuteInput(overrides = {}) {
+  return createWorkflowInput({
+    intent: 'save-and-send',
+    request: DEFAULT_EXECUTE_REQUEST,
+    ...overrides,
+  });
+}
+
+function createPorts(overrides = {}) {
+  return {
+    menus: {
+      async readContext(menuId) {
+        return {
+          knownMenu: {
+            id: menuId,
+            name: 'Main Menu',
+            restaurantId: 'restaurant-main',
+          },
+          meta: {
+            last_updated_ts: 10,
+            draft_saved_ts: 11,
+            last_sent_ts: 9,
+            notifications: { menu_url: 'https://example.com/menu' },
+            last_sent_state: {},
+            last_sent_featured: [],
+          },
+          currentFeaturedIds: ['featured-1'],
+        };
+      },
+      async saveLiveMenu() {},
+      async patchMeta() { return { downgradedFields: [] }; },
+      async patchSiblingFeatured() { return []; },
+    },
+    governance: {
+      async assertCategoryGovernanceAllowed() {},
+      assertRevisions() {
+        return DEFAULT_REVISIONS;
+      },
+    },
+    preview: {
+      async buildCanonical() {
+        return {
+          hasChanges: true,
+          hasLocalDraft: true,
+          hasSharedDraft: false,
+          hasNotificationChanges: true,
+          saveOnlyChanges: [{ id: 'quiet-1', label: 'Quiet', message: 'Quiet change' }],
+          notificationChanges: [DEFAULT_NOTIFICATION_CHANGE],
+          diff: [{ id: 'beer', label: 'Beer', icon: '🍺', added: ['Lager'], removed: [], eightySixed: [], restored: [] }],
+          mode: 'save-and-send',
+          truncated: false,
+          metadata: { currentFeaturedIds: ['featured-1'] },
+        };
+      },
+      resolveSelection() {
+        return {
+          selectedChangeIds: DEFAULT_SELECTED_CHANGE_IDS,
+          selectedSections: [DEFAULT_SELECTED_SECTION],
+          clearedChangeIds: [],
+          clearedSections: [],
+        };
+      },
+    },
+    notifications: {
+      async deliver() {
+        return {
+          delivered: true,
+          partial: false,
+          summary: { okChannels: ['groupme'], skippedChannels: [], failedChannels: [] },
+          retryable: false,
+        };
+      },
+    },
+    audit: {
+      async append() { return { downgradedFields: [] }; },
+    },
+    clock: { now() { return 1000; } },
+    ids: { operationId() { return 'op-1'; } },
+    format: {
+      patchMessage() { return 'PATCH'; },
+      warningSummary() { return []; },
+    },
+    ...overrides,
+  };
+}
+
+test('workflow preview returns canonical preview plus current revisions', async () => {
+  const { createMenuPublishWorkflow } = await importWorkflow();
+  const workflow = createMenuPublishWorkflow({ ports: createPorts() });
+
+  const result = await workflow.preview(createWorkflowInput({
+    request: {},
+  }));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.preview.mode, 'save-and-send');
+  assert.deepEqual(result.revisions, DEFAULT_REVISIONS);
+});
+
+test('workflow execute advances queue baseline after successful send', async () => {
+  const saveCalls = [];
+  const patchCalls = [];
+  const { createMenuPublishWorkflow } = await importWorkflow();
+  const workflow = createMenuPublishWorkflow({
+    ports: createPorts({
+      menus: {
+        ...createPorts().menus,
+        async saveLiveMenu(input) { saveCalls.push(input); },
+        async patchMeta(input) { patchCalls.push(input); return { downgradedFields: [] }; },
+      },
+    }),
+  });
+
+  const result = await workflow.execute(createExecuteInput());
+
+  assert.equal(result.ok, true);
+  assert.equal(result.livePersistence.persisted, true);
+  assert.equal(result.queue.baselineAdvanced, true);
+  assert.equal(result.notification.delivered, true);
+  assert.equal(saveCalls.length, 1);
+  assert.ok(patchCalls.some(call => call.patch.last_sent_ts === 1000));
+});
+
+test('workflow preserves queue when notification delivery is partial', async () => {
+  const { createMenuPublishWorkflow } = await importWorkflow();
+  const workflow = createMenuPublishWorkflow({
+    ports: createPorts({
+      notifications: {
+        async deliver() {
+          return {
+            delivered: false,
+            partial: true,
+            summary: { okChannels: ['groupme'], skippedChannels: [], failedChannels: ['sms'] },
+            retryable: true,
+          };
+        },
+      },
+      format: {
+        patchMessage() { return 'PATCH'; },
+        warningSummary() { return ['Some notification channels failed: sms.']; },
+      },
+    }),
+  });
+
+  const result = await workflow.execute(createExecuteInput());
+
+  assert.equal(result.ok, true);
+  assert.equal(result.notification.partial, true);
+  assert.equal(result.queue.baselineAdvanced, false);
+  assert.ok(result.userOutcome.warnings.some(message => message.includes('failed')));
+});
+
+test('workflow rejects unsupported intent before mutating state', async () => {
+  const calls = [];
+  const { createMenuPublishWorkflow } = await importWorkflow();
+  const workflow = createMenuPublishWorkflow({
+    ports: createPorts({
+      menus: {
+        ...createPorts().menus,
+        async readContext() {
+          calls.push('readContext');
+          return createPorts().menus.readContext('menu-main');
+        },
+        async saveLiveMenu() {
+          calls.push('saveLiveMenu');
+        },
+      },
+    }),
+  });
+
+  await assert.rejects(
+    workflow.execute(createWorkflowInput({ intent: 'archive' })),
+    /unsupported command intent: archive/
+  );
+  assert.deepEqual(calls, []);
+});
+
+test('workflow send without selected sections does not claim it sent notifications', async () => {
+  const { createMenuPublishWorkflow } = await importWorkflow();
+  const workflow = createMenuPublishWorkflow({
+    ports: createPorts({
+      preview: {
+        ...createPorts().preview,
+        resolveSelection() {
+          return {
+            selectedChangeIds: [],
+            selectedSections: [],
+            clearedChangeIds: [],
+            clearedSections: [],
+          };
+        },
+      },
+    }),
+  });
+
+  const result = await workflow.execute(createExecuteInput({ intent: 'send' }));
+
+  assert.equal(result.ok, true);
+  assert.equal(result.notification.attempted, false);
+  assert.equal(result.userOutcome.successMessage, '✅ Main Menu send skipped.');
+});

--- a/tests/boundaries/menu-publish-workflow.boundary.test.cjs
+++ b/tests/boundaries/menu-publish-workflow.boundary.test.cjs
@@ -40,6 +40,15 @@ const DEFAULT_EXECUTE_REQUEST = {
   expectedDraftRevision: DEFAULT_REVISIONS.draftRevision,
   expectedNotificationRevision: DEFAULT_REVISIONS.notificationRevision,
 };
+const DEFAULT_LAST_SENT_STATE = {
+  beer: [{
+    id: 'item-1',
+    name: 'Lager',
+    eightySixed: false,
+    onMenu: true,
+    visibility: 'public',
+  }],
+};
 
 async function importWorkflow() {
   const fileUrl = pathToFileURL(path.join(ROOT, 'core/session/menu-publish-workflow.js')).href;
@@ -83,6 +92,7 @@ function createPorts(overrides = {}) {
             last_sent_featured: [],
           },
           currentFeaturedIds: ['featured-1'],
+          siblingMenuIds: ['menu-sibling'],
         };
       },
       async saveLiveMenu() {},
@@ -107,7 +117,10 @@ function createPorts(overrides = {}) {
           diff: [{ id: 'beer', label: 'Beer', icon: '🍺', added: ['Lager'], removed: [], eightySixed: [], restored: [] }],
           mode: 'save-and-send',
           truncated: false,
-          metadata: { currentFeaturedIds: ['featured-1'] },
+          metadata: {
+            currentFeaturedIds: ['featured-1'],
+            lastSentState: DEFAULT_LAST_SENT_STATE,
+          },
         };
       },
       resolveSelection() {
@@ -158,6 +171,8 @@ test('workflow preview returns canonical preview plus current revisions', async 
 test('workflow execute advances queue baseline after successful send', async () => {
   const saveCalls = [];
   const patchCalls = [];
+  const siblingCalls = [];
+  const auditCalls = [];
   const { createMenuPublishWorkflow } = await importWorkflow();
   const workflow = createMenuPublishWorkflow({
     ports: createPorts({
@@ -165,6 +180,13 @@ test('workflow execute advances queue baseline after successful send', async () 
         ...createPorts().menus,
         async saveLiveMenu(input) { saveCalls.push(input); },
         async patchMeta(input) { patchCalls.push(input); return { downgradedFields: [] }; },
+        async patchSiblingFeatured(input) { siblingCalls.push(input); return []; },
+      },
+      audit: {
+        async append(input) {
+          auditCalls.push(input);
+          return { downgradedFields: [] };
+        },
       },
     }),
   });
@@ -177,12 +199,28 @@ test('workflow execute advances queue baseline after successful send', async () 
   assert.equal(result.notification.delivered, true);
   assert.equal(saveCalls.length, 1);
   assert.ok(patchCalls.some(call => call.patch.last_sent_ts === 1000));
+  assert.deepEqual(patchCalls[0].patch.last_sent_state, DEFAULT_LAST_SENT_STATE);
+  assert.deepEqual(siblingCalls, [{
+    menuIds: ['menu-sibling'],
+    featuredIds: ['featured-1'],
+  }]);
+  assert.deepEqual(result.queue.featuredSiblingMenusSynced, ['menu-sibling']);
+  assert.ok(auditCalls.some(call => call.eventType === 'send_notification'));
+  assert.ok(result.audit.loggedEvents.includes('send_notification'));
 });
 
 test('workflow preserves queue when notification delivery is partial', async () => {
+  const patchCalls = [];
   const { createMenuPublishWorkflow } = await importWorkflow();
   const workflow = createMenuPublishWorkflow({
     ports: createPorts({
+      menus: {
+        ...createPorts().menus,
+        async patchMeta(input) {
+          patchCalls.push(input);
+          return { downgradedFields: [] };
+        },
+      },
       notifications: {
         async deliver() {
           return {
@@ -206,6 +244,14 @@ test('workflow preserves queue when notification delivery is partial', async () 
   assert.equal(result.notification.partial, true);
   assert.equal(result.queue.baselineAdvanced, false);
   assert.ok(result.userOutcome.warnings.some(message => message.includes('failed')));
+  assert.deepEqual(patchCalls[0].patch, {
+    last_updated_ts: 1000,
+    draft_state: {},
+    draft_saved_ts: null,
+    draft_saved_by_user_id: null,
+    draft_saved_by_name: '',
+    draft_saved_source: '',
+  });
 });
 
 test('workflow rejects unsupported intent before mutating state', async () => {
@@ -256,4 +302,36 @@ test('workflow send without selected sections does not claim it sent notificatio
   assert.equal(result.ok, true);
   assert.equal(result.notification.attempted, false);
   assert.equal(result.userOutcome.successMessage, '✅ Main Menu send skipped.');
+});
+
+test('workflow logs clear-without-send when unchecked queue lines are dropped', async () => {
+  const auditCalls = [];
+  const { createMenuPublishWorkflow } = await importWorkflow();
+  const workflow = createMenuPublishWorkflow({
+    ports: createPorts({
+      preview: {
+        ...createPorts().preview,
+        resolveSelection() {
+          return {
+            selectedChangeIds: [],
+            selectedSections: [],
+            clearedChangeIds: ['beer::added::lager'],
+            clearedSections: [DEFAULT_SELECTED_SECTION],
+          };
+        },
+      },
+      audit: {
+        async append(input) {
+          auditCalls.push(input);
+          return { downgradedFields: [] };
+        },
+      },
+    }),
+  });
+
+  const result = await workflow.execute(createExecuteInput({ intent: 'send' }));
+
+  assert.equal(result.ok, true);
+  assert.ok(auditCalls.some(call => call.eventType === 'clear_without_send'));
+  assert.ok(result.audit.loggedEvents.includes('clear_without_send'));
 });

--- a/tests/boundaries/publish.boundary.test.cjs
+++ b/tests/boundaries/publish.boundary.test.cjs
@@ -3,6 +3,10 @@ const test = require('node:test');
 
 const { loadAppSandbox } = require('../helpers/runtime.cjs');
 
+function toPlainValue(value) {
+  return JSON.parse(JSON.stringify(value));
+}
+
 function createMenuSessionPorts(overrides = {}) {
   const diff = [
     {
@@ -71,36 +75,130 @@ function createMenuSessionPorts(overrides = {}) {
   };
 }
 
-test('menu publish service boundary saves drafts and publishes updates', async () => {
+test('menu publish facade prepares and commits through the workflow boundary', async () => {
   const sandbox = loadAppSandbox();
-  const saveCalls = [];
-  const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts({
-    publishMenuUpdate: async options => {
-      saveCalls.push(options);
-      if (options?.mode === 'save') {
-        return {
-          ok: true,
-          successMessage: 'quiet save',
-          snapshot: { source: 'saved-live' },
-        };
-      }
+  const prepareCalls = [];
+  const commitCalls = [];
+  const prepareOptions = {
+    pathname: '/elroyscantina',
+    search: '?menu=el-roys',
+    pageMode: 'manager',
+    requestedMenuId: 'menu-preview',
+    requestedMenuSlug: 'el-roys',
+    expectedLiveRevision: 10,
+    expectedDraftRevision: 11,
+    expectedNotificationRevision: 9,
+  };
+  const commitOptions = {
+    pathname: '/elroyscantina',
+    search: '?menu=elroys-cantina-drinks',
+    pageMode: 'manager',
+    requestedMenuId: 'menu-commit',
+    requestedMenuSlug: 'elroys-cantina-drinks',
+    selectedChangeIds: ['beer::added::lager'],
+    expectedLiveRevision: 10,
+    expectedDraftRevision: 11,
+    expectedNotificationRevision: 9,
+  };
+
+  sandbox.createMenuPublishWorkflow = ({ ports }) => ({
+    async preview(command) {
+      prepareCalls.push({ ports: !!ports, command });
       return {
         ok: true,
-        successMessage: '✅ Main Menu saved to the live menu.',
-        notificationStatus: null,
+        preview: {
+          hasChanges: true,
+          hasLocalDraft: true,
+          hasNotificationChanges: true,
+          notificationChanges: [{ id: 'beer::added::lager' }],
+          sections: [{ id: 'beer', changes: [] }],
+          mode: 'save-and-send',
+        },
+        revisions: {
+          liveRevision: 10,
+          draftRevision: 11,
+          notificationRevision: 9,
+        },
       };
     },
-  }));
+    async execute(command) {
+      commitCalls.push(command);
+      return {
+        ok: true,
+        preview: {
+          hasChanges: true,
+          hasLocalDraft: true,
+          hasNotificationChanges: true,
+          notificationChanges: [{ id: 'beer::added::lager' }],
+          sections: [{ id: 'beer', changes: [] }],
+          mode: 'save-and-send',
+        },
+        userOutcome: {
+          successMessage: 'published',
+          warningMessage: '',
+          warnings: [],
+        },
+        notification: {
+          attempted: true,
+          delivered: true,
+          partial: false,
+          summary: { okChannels: ['groupme'], skippedChannels: [], failedChannels: [] },
+          retryable: false,
+        },
+        queue: {
+          baselineAdvanced: true,
+          selectedChangeIds: ['beer::added::lager'],
+          clearedChangeIds: [],
+          featuredSiblingMenusSynced: [],
+        },
+        livePersistence: { attempted: true, persisted: true },
+      };
+    },
+  });
 
-  const draftResult = await lifecycle.saveDraft();
-  assert.equal(draftResult.ok, true);
-  assert.equal(draftResult.snapshot.source, 'saved-live');
-  assert.equal(saveCalls.length, 1);
-  assert.equal(saveCalls[0].mode, 'save');
-  assert.equal(saveCalls[0].notify, false);
-  assert.equal(saveCalls[0].preview.mode, 'update-only');
+  const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts());
+  const preview = await lifecycle.preparePublish(prepareOptions);
+  const result = await lifecycle.commitPublish(commitOptions);
 
-  const publishResult = await lifecycle.publishUpdate({ notify: false });
-  assert.equal(publishResult.ok, true);
-  assert.equal(publishResult.successMessage, '✅ Main Menu saved to the live menu.');
+  assert.equal(preview.ok, true);
+  assert.equal(result.ok, true);
+  assert.equal(prepareCalls.length, 1);
+  assert.equal(commitCalls.length, 1);
+  assert.equal(prepareCalls[0].ports, true);
+  assert.deepEqual(toPlainValue(prepareCalls[0].command.request), {
+    expectedLiveRevision: 10,
+    expectedDraftRevision: 11,
+    expectedNotificationRevision: 9,
+  });
+  assert.deepEqual(toPlainValue(prepareCalls[0].command.snapshot.request), {
+    pathname: '/elroyscantina',
+    search: '?menu=el-roys',
+    pageMode: 'manager',
+    actor: null,
+    siteRestaurantId: 'restaurant-main',
+    requestedMenuId: 'menu-preview',
+    requestedMenuSlug: 'el-roys',
+    expectedLiveRevision: 10,
+    expectedDraftRevision: 11,
+    expectedNotificationRevision: 9,
+  });
+  assert.deepEqual(toPlainValue(commitCalls[0].request), {
+    selectedChangeIds: ['beer::added::lager'],
+    expectedLiveRevision: 10,
+    expectedDraftRevision: 11,
+    expectedNotificationRevision: 9,
+  });
+  assert.deepEqual(toPlainValue(commitCalls[0].snapshot.request), {
+    pathname: '/elroyscantina',
+    search: '?menu=elroys-cantina-drinks',
+    pageMode: 'manager',
+    actor: null,
+    siteRestaurantId: 'restaurant-main',
+    requestedMenuId: 'menu-commit',
+    requestedMenuSlug: 'elroys-cantina-drinks',
+    selectedChangeIds: ['beer::added::lager'],
+    expectedLiveRevision: 10,
+    expectedDraftRevision: 11,
+    expectedNotificationRevision: 9,
+  });
 });

--- a/tests/helpers/runtime.cjs
+++ b/tests/helpers/runtime.cjs
@@ -20,6 +20,8 @@ const DEFAULT_RUNTIME_SCRIPTS = [
   'core/ui/admin/switcher.js',
   'core/ui/public/footer-actions.js',
   'core/ui/public/renderer-default.js',
+  'core/session/menu-publish-workflow.js',
+  'core/session/menu-publish-facade.js',
   'core/session/publish-service.js',
   'core/session/menu-session.js',
   'core/data/menu-state-loader.js',

--- a/tests/phase19-menu-preview-boundaries.test.cjs
+++ b/tests/phase19-menu-preview-boundaries.test.cjs
@@ -26,22 +26,51 @@ test('manager route supports server-owned preview and publish actions on one bou
   assert.match(publishRoute, /selected_group_ids/);
 });
 
-test('wave 4 publish command module exports canonical preview and selected-change publish contract', async () => {
-  const publishModuleSource = read('server/_menu-publish.js');
+test('wave 4 publish command module exports workflow-backed preview and publish helpers', async () => {
   const publishModule = await importApiModule('server/_menu-publish.js');
 
   assert.equal(typeof publishModule.previewMenuUpdateForMenu, 'function');
   assert.equal(typeof publishModule.publishMenuUpdateForMenu, 'function');
-  assert.match(publishModuleSource, /menu-publish-preview\.v2/);
-  assert.match(publishModuleSource, /serverOwned: true/);
-  assert.match(publishModuleSource, /Will Save Only/);
-  assert.match(publishModuleSource, /operation_id/);
-  assert.match(publishModuleSource, /eventType: 'send_failed'/);
-  assert.match(publishModuleSource, /__featured__/);
-  assert.match(publishModuleSource, /selected_change_ids/);
-  assert.match(publishModuleSource, /legacy_selected_change_ids/);
-  assert.match(publishModuleSource, /sections_by_outcome/);
-  assert.doesNotMatch(publishModuleSource, /previewDiff/);
+});
+
+test('wave 4 publish command module fails clearly when the ambient workflow factory is unavailable', async () => {
+  const publishModule = await importApiModule('server/_menu-publish.js');
+  const originalFactory = globalThis.createMenuPublishWorkflow;
+
+  try {
+    globalThis.createMenuPublishWorkflow = null;
+    await assert.rejects(
+      publishModule.previewMenuUpdateForMenu({
+        actor: { id: 'tester' },
+        menuId: 'leroys-drinks',
+        source: 'test',
+        snapshot: {},
+      }),
+      error => error instanceof Error
+        && error.status === 500
+        && error.message === 'createMenuPublishWorkflow is unavailable'
+        && error.code === 'menu_publish_workflow_unavailable',
+    );
+  } finally {
+    globalThis.createMenuPublishWorkflow = originalFactory;
+  }
+});
+
+test('wave 4 publish command module rejects unsupported menus with an Error instance', async () => {
+  const publishModule = await importApiModule('server/_menu-publish.js');
+
+  await assert.rejects(
+    publishModule.previewMenuUpdateForMenu({
+      actor: { id: 'tester' },
+      menuId: 'not-a-real-menu',
+      source: 'test',
+      snapshot: { cats: [] },
+    }),
+    error => error instanceof Error
+      && error.status === 400
+      && error.message === 'Unsupported menu_id'
+      && error.menuId === 'not-a-real-menu',
+  );
 });
 
 test('queue and publish preview boundaries preserve section display order metadata', async () => {
@@ -94,6 +123,7 @@ test('app runtime requests canonical preview and no longer posts legacy preview 
   assert.doesNotMatch(publishApiSource, /preview_diff/);
   assert.doesNotMatch(publishApiSource, /selected_sections/);
   assert.doesNotMatch(publishApiSource, /patch_message/);
-  assert.match(openPreviewSource, /requestPublishPreviewThroughApi/);
+  assert.match(openPreviewSource, /ensureCurrentMenuSession\(\)\.preparePublish\(/);
+  assert.doesNotMatch(openPreviewSource, /requestPublishPreviewThroughApi/);
   assert.doesNotMatch(openPreviewSource, /ensureCurrentMenuSession\(\)\.preview\(\)/);
 });


### PR DESCRIPTION
## What changed
Introduces a hybrid menu publish architecture with a dedicated workflow core plus a caller-facing facade.

- Added `core/session/menu-publish-workflow.js` as the deeper publish decision boundary
- Added `core/session/menu-publish-facade.js` so callers use `preparePublish` and `commitPublish`
- Rewired the shared session/runtime path in `app.js`, `core/session/menu-session.js`, and `core/session/publish-service.js`
- Moved the server publish path in `server/_menu-publish.js` onto the workflow-backed boundary
- Updated architecture, boundary, and phase-19 tests to exercise the new contract
- Saved the execution plan in `docs/superpowers/plans/2026-04-20-menu-publish-workflow-hybrid.md`

## Why it changed
The existing save/send flow was split across shallow wrappers, app globals, and server helpers. This made publish behavior hard to reason about and forced brittle boundary tests around delegation seams instead of one deeper workflow boundary.

## Impact
Manager/admin callers now go through a smaller publish interface while the real publish policy lives in one workflow boundary. That reduces orchestration in `app.js`, keeps the client/server contract clearer, and gives us tighter workflow-level tests.

## Root cause
Publish lifecycle logic had been spread across client session helpers, app runtime glue, and server export helpers, so understanding one save/send path required reconstructing behavior across multiple files.

## Validation
- `node --check app.js`
- `node --test tests/boundaries/menu-publish-workflow.boundary.test.cjs tests/boundaries/publish.boundary.test.cjs tests/phase19-menu-preview-boundaries.test.cjs tests/architecture-boundaries.test.cjs`