### PR TITLE
[codex] Refresh iOS redesign and ordering fixes

### DIFF
--- a/ElRoysManagerApp-redesign-clean.patch
+++ b/ElRoysManagerApp-redesign-clean.patch
@@ -1,0 +1,2165 @@
+diff --git a/ios/ElRoysManagerApp/App/ElRoysManagerApp.swift b/ios/ElRoysManagerApp/App/ElRoysManagerApp.swift
+index ad32a40..8a12d17 100644
+--- a/ios/ElRoysManagerApp/App/ElRoysManagerApp.swift
++++ b/ios/ElRoysManagerApp/App/ElRoysManagerApp.swift
+@@ -15,9 +15,7 @@ struct ElRoysManagerApp: App {
+   var body: some Scene {
+     WindowGroup {
+       RootView(model: model)
+-        .task {
+-          await model.start()
+-        }
++        .task { await model.start() }
+     }
+   }
+ }
+@@ -30,21 +28,8 @@ private struct RootView: View {
+       AppBackground()
+ 
+       if model.isLaunching {
+-        VStack(spacing: 18) {
+-          Text("El Roy's Manager")
+-            .font(.system(size: 34, weight: .bold, design: .rounded))
+-            .foregroundStyle(AppPalette.ink)
+-          Text("Native SwiftUI manager for Leroy's Lounge and El Roy's Cantina.")
+-            .font(.title3)
+-            .multilineTextAlignment(.center)
+-            .foregroundStyle(.secondary)
+-          ProgressView()
+-            .controlSize(.large)
+-          EnvironmentBadge(environment: model.environment)
+-        }
+-        .padding(28)
+-        .appGlassCard(tint: AppPalette.brand)
+-        .padding(24)
++        LaunchDeck(environment: model.environment)
++          .padding(24)
+       } else if model.isAuthenticated {
+         NavigationStack {
+           RestaurantChooserView(model: model)
+@@ -63,9 +48,61 @@ private struct RootView: View {
+               }
+             }
+         }
++        .tint(AppPalette.brand)
+       } else {
+         AuthGateView(model: model)
+       }
+     }
+   }
+ }
++
++private struct LaunchDeck: View {
++  let environment: AppEnvironment
++
++  var body: some View {
++    VStack(alignment: .leading, spacing: 22) {
++      HStack(alignment: .top) {
++        VStack(alignment: .leading, spacing: 12) {
++          AppEyebrow(title: "Native manager", tint: AppPalette.brass)
++          Text("El Roy's\nManager")
++            .font(AppTypography.display(42, weight: .bold))
++            .foregroundStyle(AppPalette.espresso)
++          Text("Editorial chrome, native performance, and the same live workspace pipeline used by the production manager.")
++            .font(AppTypography.body(16, weight: .medium))
++            .foregroundStyle(AppPalette.espresso.opacity(0.72))
++            .fixedSize(horizontal: false, vertical: true)
++        }
++        Spacer(minLength: 16)
++        VStack(alignment: .trailing, spacing: 10) {
++          EnvironmentBadge(environment: environment)
++          ProgressView()
++            .controlSize(.large)
++            .tint(AppPalette.brand)
++        }
++      }
++
++      HStack(spacing: 10) {
++        capsule(title: "Staff sign-in", tint: AppPalette.sage)
++        capsule(title: "Live menu tools", tint: AppPalette.cobalt)
++        capsule(title: "Preview routes", tint: AppPalette.brand)
++      }
++    }
++    .appGlassCard(tint: AppPalette.brand, cornerRadius: 38)
++    .frame(maxWidth: 620)
++    .appEntryReveal()
++  }
++
++  private func capsule(title: String, tint: Color) -> some View {
++    Text(title.uppercased())
++      .font(AppTypography.micro(9, weight: .bold))
++      .tracking(1.6)
++      .padding(.vertical, 8)
++      .padding(.horizontal, 10)
++      .background(tint.opacity(0.12), in: Capsule(style: .continuous))
++      .overlay {
++        Capsule(style: .continuous)
++          .stroke(tint.opacity(0.24), lineWidth: 0.7)
++      }
++      .foregroundStyle(tint)
++  }
++}
+diff --git a/ios/ElRoysManagerApp/Design/Glass.swift b/ios/ElRoysManagerApp/Design/Glass.swift
+index 4bed1db..d751f34 100644
+--- a/ios/ElRoysManagerApp/Design/Glass.swift
++++ b/ios/ElRoysManagerApp/Design/Glass.swift
+@@ -10,43 +10,78 @@ struct AppPalette {
+   static let warning = Color(red: 0.74, green: 0.50, blue: 0.18)
+   static let danger = Color(red: 0.71, green: 0.24, blue: 0.22)
+ 
+-  // Cinematic additions — consumed by the Home surface, safe to reuse elsewhere.
+-  static let brass      = Color(red: 0.757, green: 0.604, blue: 0.286)
+-  static let ember      = Color(red: 0.910, green: 0.381, blue: 0.164)
+-  static let oxblood    = Color(red: 0.478, green: 0.114, blue: 0.133)
+-  static let charcoal   = Color(red: 0.051, green: 0.043, blue: 0.043)
+-  static let ivory      = Color(red: 0.949, green: 0.913, blue: 0.847)
+-  static let cobalt     = Color(red: 0.118, green: 0.302, blue: 0.549)
+-  static let marigold   = Color(red: 0.910, green: 0.639, blue: 0.090)
+-  static let jade       = Color(red: 0.122, green: 0.373, blue: 0.227)
++  // Brand texture palette
++  static let brass = Color(red: 0.757, green: 0.604, blue: 0.286)
++  static let ember = Color(red: 0.910, green: 0.381, blue: 0.164)
++  static let oxblood = Color(red: 0.478, green: 0.114, blue: 0.133)
++  static let charcoal = Color(red: 0.051, green: 0.043, blue: 0.043)
++  static let ivory = Color(red: 0.949, green: 0.913, blue: 0.847)
++  static let cobalt = Color(red: 0.118, green: 0.302, blue: 0.549)
++  static let marigold = Color(red: 0.910, green: 0.639, blue: 0.090)
++  static let jade = Color(red: 0.122, green: 0.373, blue: 0.227)
+   static let terracotta = Color(red: 0.788, green: 0.416, blue: 0.231)
+   static let bloodOrange = Color(red: 0.780, green: 0.243, blue: 0.114)
++  static let sage = Color(red: 0.478, green: 0.545, blue: 0.431)
++  static let espresso = Color(red: 0.188, green: 0.137, blue: 0.110)
++  static let parchment = Color(red: 0.992, green: 0.972, blue: 0.936)
++  static let alabaster = Color(red: 0.978, green: 0.957, blue: 0.918)
++  static let linen = Color(red: 0.956, green: 0.921, blue: 0.862)
++}
++
++enum AppMotion {
++  static let reveal = Animation.timingCurve(0.32, 0.72, 0.0, 1.0, duration: 0.82)
++  static let settle = Animation.timingCurve(0.22, 0.86, 0.18, 1.0, duration: 0.62)
++  static let snap = Animation.timingCurve(0.32, 0.72, 0.0, 1.0, duration: 0.38)
++  static let press = Animation.interpolatingSpring(stiffness: 290, damping: 25)
++}
++
++enum AppTypography {
++  static func display(_ size: CGFloat, weight: Font.Weight = .bold) -> Font {
++    .system(size: size, weight: weight, design: .serif)
++  }
++
++  static func body(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {
++    .system(size: size, weight: weight, design: .rounded)
++  }
++
++  static func micro(_ size: CGFloat, weight: Font.Weight = .semibold) -> Font {
++    .system(size: size, weight: weight, design: .monospaced)
++  }
+ }
+ 
+ struct AppBackground: View {
+   var body: some View {
+-    LinearGradient(
+-      colors: [
+-        AppPalette.canvasTop,
+-        Color.white.opacity(0.95),
+-        AppPalette.canvasBottom,
+-      ],
+-      startPoint: .topLeading,
+-      endPoint: .bottomTrailing
+-    )
+-    .overlay(alignment: .topTrailing) {
++    ZStack {
++      LinearGradient(
++        colors: [
++          AppPalette.parchment,
++          AppPalette.alabaster,
++          AppPalette.canvasBottom,
++        ],
++        startPoint: .topLeading,
++        endPoint: .bottomTrailing
++      )
++
+       Circle()
+-        .fill(AppPalette.brand.opacity(0.10))
+-        .frame(width: 240, height: 240)
+-        .blur(radius: 8)
+-        .offset(x: 80, y: -60)
+-    }
+-    .overlay(alignment: .bottomLeading) {
++        .fill(AppPalette.brand.opacity(0.12))
++        .frame(width: 320, height: 320)
++        .blur(radius: 24)
++        .offset(x: 128, y: -180)
++
++      Circle()
++        .fill(AppPalette.sage.opacity(0.10))
++        .frame(width: 360, height: 360)
++        .blur(radius: 34)
++        .offset(x: -160, y: 190)
++
+       Circle()
+-        .fill(AppPalette.accent.opacity(0.10))
+-        .frame(width: 300, height: 300)
+-        .blur(radius: 12)
+-        .offset(x: -90, y: 100)
++        .fill(AppPalette.brass.opacity(0.10))
++        .frame(width: 260, height: 260)
++        .blur(radius: 22)
++        .offset(x: -120, y: -240)
++
++      FilmGrain(intensity: 0.055, seed: 117)
++        .opacity(0.26)
+     }
+     .ignoresSafeArea()
+   }
+@@ -57,77 +92,311 @@ struct GlassCardModifier: ViewModifier {
+   var cornerRadius: CGFloat
+ 
+   func body(content: Content) -> some View {
+-    if #available(iOS 26.0, *) {
+-      content
+-        .padding(18)
+-        .glassEffect(.regular.tint(tint.opacity(0.18)), in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+-        .overlay {
++    let innerRadius = max(18, cornerRadius - 7)
++
++    content
++      .padding(22)
++      .background {
++        ZStack {
+           RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+-            .stroke(tint.opacity(0.20), lineWidth: 1)
++            .fill(tint.opacity(0.07))
++
++          RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
++            .fill(.white.opacity(0.18))
++            .padding(0.75)
++
++          RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
++            .stroke(tint.opacity(0.18), lineWidth: 0.9)
++
++          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
++            .fill(
++              LinearGradient(
++                colors: [
++                  AppPalette.parchment.opacity(0.98),
++                  AppPalette.linen.opacity(0.94),
++                ],
++                startPoint: .topLeading,
++                endPoint: .bottomTrailing
++              )
++            )
++            .padding(6)
++
++          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
++            .stroke(.white.opacity(0.78), lineWidth: 0.75)
++            .padding(6)
++
++          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
++            .stroke(tint.opacity(0.14), lineWidth: 0.9)
++            .padding(6)
+         }
+-        .shadow(color: tint.opacity(0.14), radius: 18, y: 8)
+-    } else {
+-      content
+-        .padding(18)
+-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+-        .overlay {
++        .shadow(color: AppPalette.espresso.opacity(0.10), radius: 22, y: 14)
++        .shadow(color: tint.opacity(0.08), radius: 26, y: 16)
++      }
++  }
++}
++
++struct FieldChromeModifier: ViewModifier {
++  var tint: Color
++  var cornerRadius: CGFloat
++
++  func body(content: Content) -> some View {
++    let innerRadius = max(14, cornerRadius - 6)
++
++    content
++      .background {
++        ZStack {
++          RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
++            .fill(tint.opacity(0.08))
++
+           RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+-            .stroke(tint.opacity(0.18), lineWidth: 1)
++            .stroke(tint.opacity(0.18), lineWidth: 0.9)
++
++          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
++            .fill(
++              LinearGradient(
++                colors: [
++                  .white.opacity(0.88),
++                  AppPalette.parchment.opacity(0.92),
++                ],
++                startPoint: .topLeading,
++                endPoint: .bottomTrailing
++              )
++            )
++            .padding(5)
++
++          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
++            .stroke(.white.opacity(0.66), lineWidth: 0.7)
++            .padding(5)
+         }
+-        .shadow(color: Color.black.opacity(0.08), radius: 18, y: 8)
+-    }
++      }
++  }
++}
++
++struct AppPillChromeModifier: ViewModifier {
++  var accent: Color
++  var filled: Bool
++
++  func body(content: Content) -> some View {
++    content
++      .background {
++        let shell = Capsule()
++        let inner = Capsule()
++
++        ZStack {
++          shell
++            .fill(filled ? accent.opacity(0.16) : accent.opacity(0.08))
++          shell
++            .stroke(accent.opacity(filled ? 0.22 : 0.18), lineWidth: 0.9)
++          inner
++            .fill(
++              LinearGradient(
++                colors: filled
++                  ? [accent.opacity(0.72), accent.opacity(0.48)]
++                  : [.white.opacity(0.82), AppPalette.parchment.opacity(0.90)],
++                startPoint: .topLeading,
++                endPoint: .bottomTrailing
++              )
++            )
++            .padding(5)
++          inner
++            .stroke(filled ? .white.opacity(0.24) : .white.opacity(0.64), lineWidth: 0.7)
++            .padding(5)
++        }
++        .shadow(color: accent.opacity(filled ? 0.18 : 0.08), radius: 18, y: 10)
++      }
+   }
+ }
+ 
+ extension View {
+-  func appGlassCard(tint: Color = AppPalette.brand, cornerRadius: CGFloat = 28) -> some View {
++  func appGlassCard(tint: Color = AppPalette.brand, cornerRadius: CGFloat = 30) -> some View {
+     modifier(GlassCardModifier(tint: tint, cornerRadius: cornerRadius))
+   }
++
++  func appFieldChrome(tint: Color = AppPalette.brass, cornerRadius: CGFloat = 22) -> some View {
++    modifier(FieldChromeModifier(tint: tint, cornerRadius: cornerRadius))
++  }
++
++  func appPillChrome(accent: Color = AppPalette.brand, filled: Bool = false) -> some View {
++    modifier(AppPillChromeModifier(accent: accent, filled: filled))
++  }
+ }
+ 
+ struct PrimaryGlassButtonStyle: ButtonStyle {
++  var accent: Color = AppPalette.brand
++
+   func makeBody(configuration: Configuration) -> some View {
+-    if #available(iOS 26.0, *) {
+-      configuration.label
+-        .buttonStyle(.glassProminent)
+-        .scaleEffect(configuration.isPressed ? 0.97 : 1)
+-        .animation(.snappy(duration: 0.14), value: configuration.isPressed)
+-    } else {
+-      configuration.label
+-        .padding(.vertical, 12)
+-        .padding(.horizontal, 16)
+-        .frame(maxWidth: .infinity)
+-        .background(AppPalette.brand, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+-        .foregroundStyle(.white)
+-        .opacity(configuration.isPressed ? 0.84 : 1)
+-        .scaleEffect(configuration.isPressed ? 0.98 : 1)
+-        .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+-    }
++    configuration.label
++      .foregroundStyle(.white)
++      .scaleEffect(configuration.isPressed ? 0.985 : 1)
++      .opacity(configuration.isPressed ? 0.94 : 1)
++      .animation(AppMotion.press, value: configuration.isPressed)
++      .appPillChrome(accent: accent, filled: true)
+   }
+ }
+ 
+ struct SecondaryGlassButtonStyle: ButtonStyle {
++  var accent: Color = AppPalette.brass
++
+   func makeBody(configuration: Configuration) -> some View {
+-    if #available(iOS 26.0, *) {
+-      configuration.label
+-        .buttonStyle(.glass)
+-        .scaleEffect(configuration.isPressed ? 0.97 : 1)
+-        .animation(.snappy(duration: 0.14), value: configuration.isPressed)
+-    } else {
+-      configuration.label
+-        .padding(.vertical, 12)
+-        .padding(.horizontal, 16)
+-        .frame(maxWidth: .infinity)
+-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+-        .overlay {
+-          RoundedRectangle(cornerRadius: 18, style: .continuous)
+-            .stroke(AppPalette.ink.opacity(0.12), lineWidth: 1)
++    configuration.label
++      .foregroundStyle(AppPalette.ink)
++      .scaleEffect(configuration.isPressed ? 0.988 : 1)
++      .opacity(configuration.isPressed ? 0.9 : 1)
++      .animation(AppMotion.press, value: configuration.isPressed)
++      .appPillChrome(accent: accent, filled: false)
++  }
++}
++
++struct AppEyebrow: View {
++  let title: String
++  var tint: Color = AppPalette.brass
++
++  var body: some View {
++    Text(title.uppercased())
++      .font(AppTypography.micro(10, weight: .bold))
++      .tracking(2.2)
++      .padding(.vertical, 8)
++      .padding(.horizontal, 12)
++      .background(tint.opacity(0.12), in: Capsule())
++      .overlay {
++        Capsule()
++          .stroke(tint.opacity(0.24), lineWidth: 0.8)
++      }
++      .foregroundStyle(tint)
++  }
++}
++
++struct AppIslandButtonLabel: View {
++  let title: String
++  var subtitle: String? = nil
++  let systemImage: String
++
++  var body: some View {
++    HStack(spacing: 14) {
++      VStack(alignment: .leading, spacing: subtitle == nil ? 0 : 5) {
++        Text(title)
++          .font(AppTypography.body(16, weight: .bold))
++          .foregroundStyle(.white)
++        if let subtitle, !subtitle.isEmpty {
++          Text(subtitle)
++            .font(AppTypography.body(12, weight: .medium))
++            .foregroundStyle(.white.opacity(0.82))
++            .fixedSize(horizontal: false, vertical: true)
+         }
+-        .foregroundStyle(AppPalette.ink)
+-        .opacity(configuration.isPressed ? 0.84 : 1)
+-        .scaleEffect(configuration.isPressed ? 0.98 : 1)
+-        .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
++      }
++
++      Spacer(minLength: 12)
++
++      ZStack {
++        Circle()
++          .fill(.white.opacity(0.16))
++        Circle()
++          .stroke(.white.opacity(0.30), lineWidth: 0.8)
++        Image(systemName: systemImage)
++          .font(.system(size: 14, weight: .semibold))
++          .foregroundStyle(.white)
++      }
++      .frame(width: 36, height: 36)
+     }
++    .padding(.horizontal, 18)
++    .padding(.vertical, 15)
++    .frame(maxWidth: .infinity)
++  }
++}
++
++struct AppIslandActionButton: View {
++  let title: String
++  var subtitle: String? = nil
++  let systemImage: String
++  var accent: Color = AppPalette.brand
++  var isEnabled: Bool = true
++  let action: () -> Void
++
++  var body: some View {
++    Button(action: action) {
++      AppIslandButtonLabel(
++        title: title,
++        subtitle: subtitle,
++        systemImage: systemImage
++      )
++    }
++    .buttonStyle(.plain)
++    .appPillChrome(accent: accent, filled: true)
++    .disabled(!isEnabled)
++    .opacity(isEnabled ? 1 : 0.55)
++    .scaleEffect(isEnabled ? 1 : 0.992)
++    .animation(AppMotion.snap, value: isEnabled)
++  }
++}
++
++struct AppSegmentedControl<Selection: Hashable>: View {
++  let options: [Selection]
++  @Binding var selection: Selection
++  var accent: Color = AppPalette.brand
++  var title: (Selection) -> String
++  @Namespace private var namespace
++
++  var body: some View {
++    HStack(spacing: 8) {
++      ForEach(Array(options.enumerated()), id: \.offset) { _, option in
++        let isSelected = option == selection
++        Button {
++          withAnimation(AppMotion.settle) {
++            selection = option
++          }
++        } label: {
++          Text(title(option).uppercased())
++            .font(AppTypography.micro(10, weight: .bold))
++            .tracking(1.7)
++            .foregroundStyle(isSelected ? AppPalette.ink : AppPalette.espresso.opacity(0.72))
++            .frame(maxWidth: .infinity)
++            .padding(.vertical, 14)
++            .background {
++              if isSelected {
++                Capsule()
++                  .fill(.white.opacity(0.74))
++                  .matchedGeometryEffect(id: "app-segmented-selection", in: namespace)
++                  .padding(3)
++              }
++            }
++        }
++        .buttonStyle(.plain)
++      }
++    }
++    .padding(4)
++    .background {
++      Capsule()
++        .fill(accent.opacity(0.10))
++      Capsule()
++        .stroke(accent.opacity(0.18), lineWidth: 0.9)
++      Capsule()
++        .stroke(.white.opacity(0.52), lineWidth: 0.6)
++        .padding(3)
++    }
++  }
++}
++
++struct AppEntryRevealModifier: ViewModifier {
++  let delay: Double
++  @State private var isVisible = false
++
++  func body(content: Content) -> some View {
++    content
++      .opacity(isVisible ? 1 : 0)
++      .offset(y: isVisible ? 0 : 18)
++      .scaleEffect(isVisible ? 1 : 0.985)
++      .onAppear {
++        guard !isVisible else { return }
++        withAnimation(AppMotion.reveal.delay(delay)) {
++          isVisible = true
++        }
++      }
++  }
++}
++
++extension View {
++  func appEntryReveal(delay: Double = 0) -> some View {
++    modifier(AppEntryRevealModifier(delay: delay))
+   }
+ }
+ 
+@@ -135,13 +404,19 @@ struct EnvironmentBadge: View {
+   let environment: AppEnvironment
+ 
+   var body: some View {
+-    Text(environment.isProduction ? "PRODUCTION" : environment.displayName.uppercased())
+-      .font(.caption2.weight(.semibold))
+-      .tracking(0.8)
+-      .padding(.vertical, 6)
+-      .padding(.horizontal, 10)
+-      .background(environment.isProduction ? AppPalette.success.opacity(0.16) : AppPalette.warning.opacity(0.18), in: Capsule())
+-      .foregroundStyle(environment.isProduction ? AppPalette.success : AppPalette.warning)
++    let tint = environment.isProduction ? AppPalette.success : AppPalette.warning
++
++    return Text(environment.isProduction ? "PRODUCTION" : environment.displayName.uppercased())
++      .font(AppTypography.micro(10, weight: .bold))
++      .tracking(1.8)
++      .padding(.vertical, 8)
++      .padding(.horizontal, 12)
++      .background(tint.opacity(0.12), in: Capsule())
++      .overlay {
++        Capsule()
++          .stroke(tint.opacity(0.24), lineWidth: 0.8)
++      }
++      .foregroundStyle(tint)
+   }
+ }
+ 
+diff --git a/ios/ElRoysManagerApp/Features/Auth/AuthViews.swift b/ios/ElRoysManagerApp/Features/Auth/AuthViews.swift
+index d2b46c6..35e1007 100644
+--- a/ios/ElRoysManagerApp/Features/Auth/AuthViews.swift
++++ b/ios/ElRoysManagerApp/Features/Auth/AuthViews.swift
+@@ -4,67 +4,165 @@ struct AuthGateView: View {
+   @Bindable var model: AppModel
+ 
+   var body: some View {
+-    ScrollView {
+-      VStack(alignment: .leading, spacing: 20) {
+-        VStack(alignment: .leading, spacing: 10) {
+-          EnvironmentBadge(environment: model.environment)
+-          Text("Staff Manager")
+-            .font(.system(size: 36, weight: .bold, design: .rounded))
+-            .foregroundStyle(AppPalette.ink)
+-          Text("Sign in with the same Supabase-backed staff account used on the web manager. Sessions are stored in Keychain and can be re-opened with biometrics.")
+-            .font(.title3)
+-            .foregroundStyle(.secondary)
+-        }
++    ScrollView(showsIndicators: false) {
++      VStack(alignment: .leading, spacing: 22) {
++        heroCard
++          .appEntryReveal()
+ 
+-        Picker("Mode", selection: $model.authMode) {
+-          ForEach(AuthScreenMode.allCases) { mode in
+-            Text(mode.rawValue).tag(mode)
+-          }
+-        }
+-        .pickerStyle(.segmented)
+-
+-        VStack(spacing: 14) {
+-          TextField("Staff email", text: $model.email)
+-            .keyboardType(.emailAddress)
+-            .textInputAutocapitalization(.never)
+-            .autocorrectionDisabled()
+-            .textFieldStyle(.roundedBorder)
+-
+-          if model.authMode != .reset {
+-            SecureField("Password", text: $model.password)
+-              .textFieldStyle(.roundedBorder)
+-          }
+-
+-          if model.authMode == .signUp {
+-            TextField("Display name", text: $model.displayName)
+-              .textFieldStyle(.roundedBorder)
+-          }
+-        }
++        AppSegmentedControl(
++          options: AuthScreenMode.allCases,
++          selection: $model.authMode,
++          accent: AppPalette.brand,
++          title: { $0.rawValue }
++        )
++        .appEntryReveal(delay: 0.05)
++
++        credentialsCard
++          .appEntryReveal(delay: 0.10)
+ 
+         if let notice = model.notice {
+           StatusBanner(tone: notice.tone, title: notice.title, message: notice.message)
++            .appEntryReveal(delay: 0.14)
+         }
+ 
+-        Button(action: submit) {
+-          Label(primaryButtonTitle, systemImage: primaryButtonSymbol)
+-            .font(.headline)
+-            .frame(maxWidth: .infinity)
++        AppIslandActionButton(
++          title: primaryButtonTitle,
++          subtitle: primaryButtonSubtitle,
++          systemImage: primaryButtonSymbol,
++          accent: AppPalette.brand,
++          isEnabled: !model.isWorking,
++          action: submit
++        )
++        .appEntryReveal(delay: 0.18)
++
++        biometricCard
++          .appEntryReveal(delay: 0.22)
++
++        Color.clear.frame(height: 22)
++      }
++      .padding(.horizontal, 24)
++      .padding(.top, 34)
++      .padding(.bottom, 20)
++    }
++    .scrollBounceBehavior(.basedOnSize)
++  }
++
++  private var heroCard: some View {
++    VStack(alignment: .leading, spacing: 18) {
++      HStack {
++        EnvironmentBadge(environment: model.environment)
++        Spacer(minLength: 16)
++        AppEyebrow(title: model.authMode.rawValue, tint: AppPalette.sage)
++      }
++
++      VStack(alignment: .leading, spacing: 10) {
++        Text("Manager access\nwith floor-ready chrome.")
++          .font(AppTypography.display(40, weight: .bold))
++          .foregroundStyle(AppPalette.espresso)
++        Text("Sign in with the same Supabase-backed staff account used on the web manager. Sessions stay on device in Keychain and can be gated by Face ID or passcode.")
++          .font(AppTypography.body(16, weight: .medium))
++          .foregroundStyle(AppPalette.espresso.opacity(0.72))
++          .fixedSize(horizontal: false, vertical: true)
++      }
++
++      HStack(spacing: 10) {
++        detailPill(title: "Keychain session", tint: AppPalette.cobalt)
++        detailPill(title: "Native editor", tint: AppPalette.brass)
++        detailPill(title: "Live preview", tint: AppPalette.brand)
++      }
++    }
++    .appGlassCard(tint: AppPalette.brass, cornerRadius: 38)
++  }
++
++  private var credentialsCard: some View {
++    VStack(alignment: .leading, spacing: 16) {
++      AppEyebrow(title: "Credentials", tint: AppPalette.cobalt)
++
++      fieldGroup(title: "Staff email", systemImage: "envelope.open") {
++        TextField("manager@elroys.example", text: $model.email)
++          .keyboardType(.emailAddress)
++          .textInputAutocapitalization(.never)
++          .autocorrectionDisabled()
++          .font(AppTypography.body(16, weight: .medium))
++          .foregroundStyle(AppPalette.ink)
++          .padding(.horizontal, 16)
++          .padding(.vertical, 16)
++          .appFieldChrome(tint: AppPalette.cobalt)
++      }
++
++      if model.authMode != .reset {
++        fieldGroup(title: "Password", systemImage: "lock") {
++          SecureField("••••••••", text: $model.password)
++            .font(AppTypography.body(16, weight: .medium))
++            .foregroundStyle(AppPalette.ink)
++            .padding(.horizontal, 16)
++            .padding(.vertical, 16)
++            .appFieldChrome(tint: AppPalette.brand)
+         }
+-        .buttonStyle(PrimaryGlassButtonStyle())
+-        .disabled(model.isWorking)
++      }
+ 
+-        Toggle("Require Face ID / passcode before restoring the saved session", isOn: Binding(
++      if model.authMode == .signUp {
++        fieldGroup(title: "Display name", systemImage: "person.text.rectangle") {
++          TextField("Name used on edits and history", text: $model.displayName)
++            .font(AppTypography.body(16, weight: .medium))
++            .foregroundStyle(AppPalette.ink)
++            .padding(.horizontal, 16)
++            .padding(.vertical, 16)
++            .appFieldChrome(tint: AppPalette.sage)
++        }
++      }
++    }
++    .appGlassCard(tint: AppPalette.sage, cornerRadius: 34)
++  }
++
++  private var biometricCard: some View {
++    VStack(alignment: .leading, spacing: 14) {
++      AppEyebrow(title: "Device protection", tint: AppPalette.warning)
++      Text("Require Face ID or passcode before restoring the saved session.")
++        .font(AppTypography.body(15, weight: .medium))
++        .foregroundStyle(AppPalette.espresso)
++      Toggle(
++        "Biometric unlock",
++        isOn: Binding(
+           get: { SessionStore().biometricUnlockEnabled },
+           set: { SessionStore().biometricUnlockEnabled = $0 }
+-        ))
+-        .font(.footnote)
+-        .toggleStyle(.switch)
++        )
++      )
++      .tint(AppPalette.brand)
++      .font(AppTypography.body(15, weight: .semibold))
++      .foregroundStyle(AppPalette.ink)
++    }
++    .appGlassCard(tint: AppPalette.warning, cornerRadius: 30)
++  }
++
++  @ViewBuilder
++  private func fieldGroup<Content: View>(title: String, systemImage: String, @ViewBuilder content: () -> Content) -> some View {
++    VStack(alignment: .leading, spacing: 10) {
++      HStack(spacing: 8) {
++        Image(systemName: systemImage)
++          .font(.system(size: 12, weight: .semibold))
++          .foregroundStyle(AppPalette.brand)
++        Text(title.uppercased())
++          .font(AppTypography.micro(10, weight: .bold))
++          .tracking(1.8)
++          .foregroundStyle(AppPalette.espresso.opacity(0.76))
+       }
+-      .padding(24)
+-      .appGlassCard(tint: AppPalette.brand, cornerRadius: 30)
+-      .padding(24)
++      content()
+     }
+-    .scrollBounceBehavior(.basedOnSize)
++  }
++
++  private func detailPill(title: String, tint: Color) -> some View {
++    Text(title.uppercased())
++      .font(AppTypography.micro(9, weight: .bold))
++      .tracking(1.6)
++      .padding(.vertical, 8)
++      .padding(.horizontal, 10)
++      .background(tint.opacity(0.12), in: Capsule(style: .continuous))
++      .overlay {
++        Capsule(style: .continuous)
++          .stroke(tint.opacity(0.22), lineWidth: 0.7)
++      }
++      .foregroundStyle(tint)
+   }
+ 
+   private var primaryButtonTitle: String {
+@@ -78,14 +176,25 @@ struct AuthGateView: View {
+     }
+   }
+ 
++  private var primaryButtonSubtitle: String {
++    switch model.authMode {
++    case .signIn:
++      return "Restore the saved manager session and load the live workspace."
++    case .signUp:
++      return "Create a staff account and move straight into the native manager."
++    case .reset:
++      return "Send the recovery link to the staff email on file."
++    }
++  }
++
+   private var primaryButtonSymbol: String {
+     switch model.authMode {
+     case .signIn:
+-      return "person.crop.circle.badge.checkmark"
++      return "arrow.up.right"
+     case .signUp:
+-      return "person.crop.circle.badge.plus"
++      return "plus"
+     case .reset:
+-      return "envelope.badge"
++      return "paperplane"
+     }
+   }
+ 
+diff --git a/ios/ElRoysManagerApp/Features/Home/HomeViews.swift b/ios/ElRoysManagerApp/Features/Home/HomeViews.swift
+index e0d5a06..27fd13f 100644
+--- a/ios/ElRoysManagerApp/Features/Home/HomeViews.swift
++++ b/ios/ElRoysManagerApp/Features/Home/HomeViews.swift
+@@ -59,7 +59,7 @@ struct RestaurantChooserView: View {
+             theme: theme,
+             namespace: switcherNamespace,
+             onSelect: { slug in
+-              withAnimation(.easeInOut(duration: 0.35)) {
++              withAnimation(AppMotion.settle) {
+                 selectedRestaurantSlug = slug
+                 expandedUpdateID = nil
+               }
+@@ -125,7 +125,7 @@ struct RestaurantChooserView: View {
+     .navigationTitle("Home")
+     .navigationBarTitleDisplayMode(.inline)
+     .toolbar(.hidden, for: .navigationBar)
+-    .animation(.easeInOut(duration: 0.30), value: selectedRestaurantSlug)
++    .animation(AppMotion.settle, value: selectedRestaurantSlug)
+     .task(id: selectedRestaurantSlug) {
+       guard let restaurant = selectedRestaurant else { return }
+       await model.loadRestaurantTools(for: restaurant.id)
+@@ -526,7 +526,7 @@ private struct HomeRecentUpdatesCard: View {
+               isExpanded: expandedUpdateID == update.id,
+               theme: theme,
+               onToggle: {
+-                withAnimation(.easeInOut(duration: 0.22)) {
++                withAnimation(AppMotion.snap) {
+                   expandedUpdateID = expandedUpdateID == update.id ? nil : update.id
+                 }
+               }
+@@ -1435,31 +1435,34 @@ private struct HomeBottomBarClusterModifier: ViewModifier {
+   let theme: HomeTheme
+ 
+   func body(content: Content) -> some View {
+-    if #available(iOS 26.0, *) {
+-      content
+-        .glassEffect(.regular.tint(theme.bottomNavGlassTint.opacity(0.34)), in: .capsule)
+-        .overlay {
++    content
++      .background {
++        ZStack {
+           Capsule()
+-            .stroke(theme.bottomNavSelectedBorder.opacity(0.56), lineWidth: 1)
+-        }
+-    } else {
+-      content
+-        .background(
+-          LinearGradient(
+-            colors: [
+-              theme.bottomNavGlassTint.opacity(0.96),
+-              theme.bottomNavGlassTint.opacity(0.84),
+-            ],
+-            startPoint: .topLeading,
+-            endPoint: .bottomTrailing
+-          ),
+-          in: Capsule()
+-        )
+-        .overlay {
++            .fill(theme.bottomNavGlassTint.opacity(0.16))
++
++          Capsule()
++            .stroke(theme.bottomNavSelectedBorder.opacity(0.22), lineWidth: 0.9)
++
++          Capsule()
++            .fill(
++              LinearGradient(
++                colors: [
++                  .white.opacity(0.82),
++                  theme.bottomNavGlassTint.opacity(0.86),
++                ],
++                startPoint: .topLeading,
++                endPoint: .bottomTrailing
++              )
++            )
++            .padding(5)
++
+           Capsule()
+-            .stroke(theme.bottomNavSelectedBorder.opacity(0.56), lineWidth: 1)
++            .stroke(.white.opacity(0.66), lineWidth: 0.7)
++            .padding(5)
+         }
+-    }
++        .shadow(color: theme.shadowTint.opacity(0.10), radius: 20, y: 12)
++      }
+   }
+ }
+ 
+@@ -1467,13 +1470,31 @@ private struct HomeDetachedQRButtonModifier: ViewModifier {
+   let theme: HomeTheme
+ 
+   func body(content: Content) -> some View {
+-    if #available(iOS 26.0, *) {
+-      content
+-        .glassEffect(.regular.tint(theme.bottomNavGlassTint.opacity(0.34)).interactive(), in: .circle)
+-    } else {
+-      content
+-        .background(theme.bottomNavGlassTint.opacity(0.94), in: Circle())
+-    }
++    content
++      .background {
++        ZStack {
++          Circle()
++            .fill(theme.bottomNavGlassTint.opacity(0.18))
++          Circle()
++            .stroke(theme.bottomNavSelectedBorder.opacity(0.22), lineWidth: 0.9)
++          Circle()
++            .fill(
++              LinearGradient(
++                colors: [
++                  .white.opacity(0.88),
++                  theme.bottomNavGlassTint.opacity(0.92),
++                ],
++                startPoint: .topLeading,
++                endPoint: .bottomTrailing
++              )
++            )
++            .padding(5)
++          Circle()
++            .stroke(.white.opacity(0.64), lineWidth: 0.7)
++            .padding(5)
++        }
++        .shadow(color: theme.shadowTint.opacity(0.10), radius: 18, y: 10)
++      }
+   }
+ }
+ 
+@@ -1482,21 +1503,41 @@ private struct HomeGlassChromeModifier: ViewModifier {
+   let cornerRadius: CGFloat
+ 
+   func body(content: Content) -> some View {
+-    if #available(iOS 26.0, *) {
+-      content
+-        .glassEffect(.regular.tint(tint.opacity(0.20)), in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+-        .overlay {
++    let innerRadius = max(18, cornerRadius - 7)
++
++    content
++      .background {
++        ZStack {
+           RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+-            .stroke(tint.opacity(0.24), lineWidth: 1)
+-        }
+-    } else {
+-      content
+-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
+-        .overlay {
++            .fill(tint.opacity(0.08))
++
+           RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+-            .stroke(tint.opacity(0.20), lineWidth: 1)
++            .stroke(tint.opacity(0.20), lineWidth: 0.9)
++
++          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
++            .fill(
++              LinearGradient(
++                colors: [
++                  .white.opacity(0.82),
++                  tint.opacity(0.14),
++                ],
++                startPoint: .topLeading,
++                endPoint: .bottomTrailing
++              )
++            )
++            .padding(6)
++
++          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
++            .stroke(.white.opacity(0.66), lineWidth: 0.7)
++            .padding(6)
+         }
+-    }
++        .shadow(color: tint.opacity(0.10), radius: 22, y: 12)
++        .shadow(color: themeShadow(tint: tint), radius: 20, y: 12)
++      }
++  }
++
++  private func themeShadow(tint: Color) -> Color {
++    tint.opacity(0.06)
+   }
+ }
+ 
+diff --git a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+index 7b0641b..e7a365d 100644
+--- a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
++++ b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+@@ -570,7 +570,7 @@ private struct PublishPreviewActionButton: View {
+     .disabled(!enabled)
+     .opacity(enabled ? 1 : 0.5)
+     .scaleEffect(enabled ? 1 : 0.98)
+-    .animation(.easeOut(duration: 0.16), value: enabled)
++    .animation(AppMotion.snap, value: enabled)
+   }
+ }
+ 
+@@ -1210,32 +1210,23 @@ private enum EditorTypography {
+     case medium
+     case semibold
+     case bold
++
++    var fontWeight: Font.Weight {
++      switch self {
++      case .regular: return .regular
++      case .medium: return .medium
++      case .semibold: return .semibold
++      case .bold: return .bold
++      }
++    }
+   }
+ 
+   static func display(_ size: CGFloat, weight: Weight = .semibold) -> Font {
+-    switch weight {
+-    case .regular:
+-      return .custom("AvenirNextCondensed-Regular", size: size)
+-    case .medium:
+-      return .custom("AvenirNextCondensed-Medium", size: size)
+-    case .semibold:
+-      return .custom("AvenirNextCondensed-DemiBold", size: size)
+-    case .bold:
+-      return .custom("AvenirNextCondensed-Bold", size: size)
+-    }
++    AppTypography.display(size, weight: weight.fontWeight)
+   }
+ 
+   static func body(_ size: CGFloat, weight: Weight = .regular) -> Font {
+-    switch weight {
+-    case .regular:
+-      return .custom("AvenirNext-Regular", size: size)
+-    case .medium:
+-      return .custom("AvenirNext-Medium", size: size)
+-    case .semibold:
+-      return .custom("AvenirNext-DemiBold", size: size)
+-    case .bold:
+-      return .custom("AvenirNext-Bold", size: size)
+-    }
++    AppTypography.body(size, weight: weight.fontWeight)
+   }
+ }
+ 
+@@ -1245,17 +1236,30 @@ private struct MenuEditorSurfaceModifier: ViewModifier {
+   let radius: CGFloat
+ 
+   func body(content: Content) -> some View {
++    let innerRadius = max(18, radius - 7)
++
+     content
+       .padding(18)
+-      .background(
+-        LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing),
+-        in: RoundedRectangle(cornerRadius: radius, style: .continuous)
+-      )
+-      .overlay {
+-        RoundedRectangle(cornerRadius: radius, style: .continuous)
+-          .stroke(border, lineWidth: 1)
++      .background {
++        ZStack {
++          RoundedRectangle(cornerRadius: radius, style: .continuous)
++            .fill(border.opacity(0.08))
++
++          RoundedRectangle(cornerRadius: radius, style: .continuous)
++            .stroke(border.opacity(0.20), lineWidth: 0.9)
++
++          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
++            .fill(
++              LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
++            )
++            .padding(6)
++
++          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
++            .stroke(.white.opacity(0.64), lineWidth: 0.7)
++            .padding(6)
++        }
++        .shadow(color: border.opacity(0.12), radius: 22, y: 14)
+       }
+-      .shadow(color: border.opacity(0.16), radius: 18, y: 8)
+   }
+ }
+ 
+diff --git a/ios/ElRoysManagerApp/Features/Preview/RoutePreviewView.swift b/ios/ElRoysManagerApp/Features/Preview/RoutePreviewView.swift
+index 357106b..c072629 100644
+--- a/ios/ElRoysManagerApp/Features/Preview/RoutePreviewView.swift
++++ b/ios/ElRoysManagerApp/Features/Preview/RoutePreviewView.swift
+@@ -6,26 +6,58 @@ struct RoutePreviewScreen: View {
+   let menu: MenuRecord
+ 
+   var body: some View {
+-    VStack(spacing: 0) {
+-      HStack {
+-        VStack(alignment: .leading, spacing: 4) {
+-          Text("Exact Route Preview")
+-            .font(.headline)
+-          Text(model.exactRoutePreviewURL(for: menu).absoluteString)
+-            .font(.caption)
+-            .foregroundStyle(.secondary)
+-            .lineLimit(2)
+-        }
+-        Spacer()
+-      }
+-      .padding(16)
+-      .background(.thinMaterial)
++    VStack(spacing: 18) {
++      headerCard
++        .padding(.horizontal, 20)
++        .padding(.top, 16)
++        .appEntryReveal()
+ 
+-      WebPreview(url: model.exactRoutePreviewURL(for: menu))
++      ZStack {
++        RoundedRectangle(cornerRadius: 34, style: .continuous)
++          .fill(AppPalette.parchment.opacity(0.24))
++        RoundedRectangle(cornerRadius: 34, style: .continuous)
++          .stroke(AppPalette.cobalt.opacity(0.16), lineWidth: 0.9)
++        RoundedRectangle(cornerRadius: 28, style: .continuous)
++          .fill(.white.opacity(0.55))
++          .padding(6)
++        WebPreview(url: model.exactRoutePreviewURL(for: menu))
++          .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
++          .padding(6)
++      }
++      .padding(.horizontal, 20)
++      .padding(.bottom, 18)
++      .appEntryReveal(delay: 0.08)
++    }
++    .background {
++      AppBackground()
++        .ignoresSafeArea()
+     }
+     .navigationTitle(menu.displayTypeLabel)
+     .navigationBarTitleDisplayMode(.inline)
+   }
++
++  private var headerCard: some View {
++    VStack(alignment: .leading, spacing: 14) {
++      HStack {
++        AppEyebrow(title: "Exact route preview", tint: AppPalette.cobalt)
++        Spacer(minLength: 12)
++        Text(menu.displayTypeLabel.uppercased())
++          .font(AppTypography.micro(9, weight: .bold))
++          .tracking(1.6)
++          .foregroundStyle(AppPalette.espresso.opacity(0.62))
++      }
++
++      Text("Deployed guest-facing route")
++        .font(AppTypography.display(30, weight: .bold))
++        .foregroundStyle(AppPalette.espresso)
++
++      Text(model.exactRoutePreviewURL(for: menu).absoluteString)
++        .font(AppTypography.body(13, weight: .medium))
++        .foregroundStyle(AppPalette.espresso.opacity(0.70))
++        .textSelection(.enabled)
++    }
++    .appGlassCard(tint: AppPalette.cobalt, cornerRadius: 34)
++  }
+ }
+ 
+ private struct WebPreview: UIViewRepresentable {
+@@ -36,6 +68,9 @@ private struct WebPreview: UIViewRepresentable {
+     configuration.defaultWebpagePreferences.allowsContentJavaScript = true
+     let webView = WKWebView(frame: .zero, configuration: configuration)
+     webView.scrollView.contentInsetAdjustmentBehavior = .never
++    webView.isOpaque = false
++    webView.backgroundColor = .clear
++    webView.scrollView.backgroundColor = .clear
+     webView.load(URLRequest(url: url))
+     return webView
+   }
+diff --git a/ios/ElRoysManagerApp/Features/Public/PublicMenuViews.swift b/ios/ElRoysManagerApp/Features/Public/PublicMenuViews.swift
+index 12740d5..dcc2778 100644
+--- a/ios/ElRoysManagerApp/Features/Public/PublicMenuViews.swift
++++ b/ios/ElRoysManagerApp/Features/Public/PublicMenuViews.swift
+@@ -12,41 +12,39 @@ struct PublicMenuScreen: View {
+   }
+ 
+   var body: some View {
+-    ScrollView {
+-      VStack(alignment: .leading, spacing: 18) {
+-        header
++    ScrollView(showsIndicators: false) {
++      VStack(alignment: .leading, spacing: 22) {
++        heroCard
++          .appEntryReveal()
+ 
+         if let notice = model.notice {
+           StatusBanner(tone: notice.tone, title: notice.title, message: notice.message)
++            .appEntryReveal(delay: 0.05)
+         }
+ 
+         if let payload = model.currentPublicMenu {
++          summaryStrip(payload: payload)
++            .appEntryReveal(delay: 0.08)
++
+           if !payload.featuredGroups.isEmpty {
+-            FeaturedGroupsSection(groups: payload.featuredGroups)
++            FeaturedGroupsSection(groups: payload.featuredGroups, accent: accent)
++              .appEntryReveal(delay: 0.12)
+           }
+ 
+-          ForEach(payload.cats) { category in
+-            VStack(alignment: .leading, spacing: 10) {
+-              Text(category.label)
+-                .font(.title3.weight(.bold))
+-              if !category.sub.isEmpty {
+-                Text(category.sub)
+-                  .font(.subheadline)
+-                  .foregroundStyle(.secondary)
+-              }
+-              ForEach(category.items) { item in
+-                PublicMenuItemRow(item: item)
+-              }
+-            }
+-            .appGlassCard(tint: AppPalette.accent)
++          ForEach(Array(payload.cats.enumerated()), id: \.element.id) { index, category in
++            PublicMenuCategoryCard(category: category, accent: accent)
++              .appEntryReveal(delay: 0.16 + (Double(index) * 0.04))
+           }
+         } else {
+-          ProgressView("Loading menu...")
+-            .frame(maxWidth: .infinity)
+-            .padding()
++          loadingCard
++            .appEntryReveal(delay: 0.10)
+         }
++
++        Color.clear.frame(height: 28)
+       }
+-      .padding(24)
++      .padding(.horizontal, 24)
++      .padding(.top, 24)
++      .padding(.bottom, 24)
+     }
+     .navigationTitle(restaurant.name)
+     .navigationBarTitleDisplayMode(.inline)
+@@ -58,26 +56,89 @@ struct PublicMenuScreen: View {
+     }
+   }
+ 
+-  private var header: some View {
+-    VStack(alignment: .leading, spacing: 12) {
+-      Text("Public Menu")
+-        .font(.system(size: 30, weight: .bold, design: .rounded))
+-      Picker("Menu", selection: $selectedType) {
+-        Text("Drinks").tag("drinks")
+-        Text("Food").tag("food")
++  private var accent: Color {
++    selectedType == "food" ? AppPalette.jade : AppPalette.bloodOrange
++  }
++
++  private var heroCard: some View {
++    VStack(alignment: .leading, spacing: 18) {
++      HStack(alignment: .top) {
++        VStack(alignment: .leading, spacing: 12) {
++          AppEyebrow(title: "Public menu preview", tint: accent)
++          Text(restaurant.name)
++            .font(AppTypography.display(36, weight: .bold))
++            .foregroundStyle(AppPalette.espresso)
++          Text(selectedType == "food"
++            ? "Review the guest-facing food presentation with the same editorial spacing and hierarchy customers will see."
++            : "Review the guest-facing drinks presentation with premium card rhythm, featured highlights, and live menu structure.")
++            .font(AppTypography.body(15, weight: .medium))
++            .foregroundStyle(AppPalette.espresso.opacity(0.72))
++            .fixedSize(horizontal: false, vertical: true)
++        }
++        Spacer(minLength: 16)
+       }
+-      .pickerStyle(.segmented)
++
++      AppSegmentedControl(
++        options: ["drinks", "food"],
++        selection: $selectedType,
++        accent: accent,
++        title: { $0.capitalized }
++      )
+ 
+       if let menu = selectedMenu {
+         NavigationLink(value: AppDestination.routePreview(menu)) {
+-          Label("Open Exact Route Preview", systemImage: "safari")
+-            .font(.headline)
+-            .frame(maxWidth: .infinity)
++          AppIslandButtonLabel(
++            title: "Open exact route preview",
++            subtitle: "Verify the deployed path before publishing or sharing.",
++            systemImage: "arrow.up.right"
++          )
+         }
+-        .buttonStyle(SecondaryGlassButtonStyle())
++        .buttonStyle(.plain)
++        .appPillChrome(accent: accent, filled: true)
+       }
+     }
+-    .appGlassCard(tint: AppPalette.brand)
++    .appGlassCard(tint: accent, cornerRadius: 38)
++  }
++
++  private func summaryStrip(payload: PublicMenuPayload) -> some View {
++    let itemCount = payload.cats.reduce(into: 0) { partialResult, category in
++      partialResult += category.items.filter(\.onMenu).count
++    }
++
++    return HStack(spacing: 10) {
++      metricPill(title: "sections", value: "\(payload.cats.count)")
++      metricPill(title: "items", value: "\(itemCount)")
++      metricPill(title: "featured", value: "\(payload.featuredGroups.reduce(0) { $0 + $1.slots.count })")
++    }
++  }
++
++  private func metricPill(title: String, value: String) -> some View {
++    VStack(alignment: .leading, spacing: 5) {
++      Text(title.uppercased())
++        .font(AppTypography.micro(9, weight: .bold))
++        .tracking(1.6)
++        .foregroundStyle(accent)
++      Text(value)
++        .font(AppTypography.display(18, weight: .bold))
++        .foregroundStyle(AppPalette.espresso)
++    }
++    .padding(.horizontal, 14)
++    .padding(.vertical, 12)
++    .frame(maxWidth: .infinity, alignment: .leading)
++    .appFieldChrome(tint: accent, cornerRadius: 20)
++  }
++
++  private var loadingCard: some View {
++    VStack(spacing: 12) {
++      ProgressView()
++        .tint(accent)
++      Text("Loading public menu…")
++        .font(AppTypography.body(15, weight: .medium))
++        .foregroundStyle(AppPalette.espresso.opacity(0.72))
++    }
++    .frame(maxWidth: .infinity)
++    .padding(.vertical, 36)
++    .appGlassCard(tint: accent, cornerRadius: 34)
+   }
+ 
+   private var selectedMenu: MenuRecord? {
+@@ -93,74 +154,139 @@ struct PublicMenuScreen: View {
+ 
+ private struct FeaturedGroupsSection: View {
+   let groups: [FeaturedGroup]
++  let accent: Color
+ 
+   var body: some View {
+     VStack(alignment: .leading, spacing: 14) {
+-      Text("Featured")
+-        .font(.title3.weight(.bold))
++      HStack {
++        VStack(alignment: .leading, spacing: 6) {
++          AppEyebrow(title: "Featured", tint: accent)
++          Text("Spotlight groups")
++            .font(AppTypography.display(26, weight: .bold))
++            .foregroundStyle(AppPalette.espresso)
++        }
++        Spacer(minLength: 16)
++      }
++
+       ForEach(groups) { group in
+-        VStack(alignment: .leading, spacing: 10) {
+-          Text(group.name)
+-            .font(.headline)
++        VStack(alignment: .leading, spacing: 12) {
++          HStack {
++            Text(group.name)
++              .font(AppTypography.body(18, weight: .bold))
++              .foregroundStyle(AppPalette.espresso)
++            Spacer()
++            Text("\(group.slots.count) items")
++              .font(AppTypography.micro(9, weight: .bold))
++              .tracking(1.4)
++              .padding(.vertical, 7)
++              .padding(.horizontal, 10)
++              .background(accent.opacity(0.10), in: Capsule(style: .continuous))
++              .foregroundStyle(accent)
++          }
++
+           ForEach(group.slots) { slot in
+             HStack(alignment: .top, spacing: 12) {
+-              VStack(alignment: .leading, spacing: 4) {
++              VStack(alignment: .leading, spacing: 5) {
+                 Text(slot.item?.name ?? "Featured Item")
+-                  .font(.subheadline.weight(.semibold))
++                  .font(AppTypography.body(16, weight: .bold))
++                  .foregroundStyle(AppPalette.ink)
+                 if !slot.sellNote.isEmpty {
+                   Text(slot.sellNote)
+-                    .font(.footnote)
+-                    .foregroundStyle(.secondary)
++                    .font(AppTypography.body(13, weight: .medium))
++                    .foregroundStyle(AppPalette.espresso.opacity(0.70))
++                    .fixedSize(horizontal: false, vertical: true)
+                 }
+               }
+-              Spacer()
+-              Text(slot.item?.price ?? "")
+-                .font(.subheadline.monospacedDigit())
++              Spacer(minLength: 12)
++              if let price = slot.item?.price.nilIfBlank {
++                Text(price)
++                  .font(AppTypography.body(13, weight: .bold))
++                  .foregroundStyle(accent)
++                  .padding(.vertical, 7)
++                  .padding(.horizontal, 10)
++                  .background(accent.opacity(0.10), in: Capsule(style: .continuous))
++              }
+             }
++            .padding(14)
++            .appFieldChrome(tint: accent, cornerRadius: 20)
+           }
+         }
++        .appGlassCard(tint: accent, cornerRadius: 30)
+       }
+     }
+-    .appGlassCard(tint: AppPalette.warning)
++  }
++}
++
++private struct PublicMenuCategoryCard: View {
++  let category: MenuCategoryPayload
++  let accent: Color
++
++  var body: some View {
++    VStack(alignment: .leading, spacing: 16) {
++      VStack(alignment: .leading, spacing: 6) {
++        AppEyebrow(title: category.label, tint: accent)
++        if !category.sub.isEmpty {
++          Text(category.sub)
++            .font(AppTypography.body(14, weight: .medium))
++            .foregroundStyle(AppPalette.espresso.opacity(0.72))
++            .fixedSize(horizontal: false, vertical: true)
++        }
++      }
++
++      ForEach(category.items.filter(\.onMenu)) { item in
++        PublicMenuItemRow(item: item, accent: accent)
++      }
++    }
++    .appGlassCard(tint: accent, cornerRadius: 34)
+   }
+ }
+ 
+ private struct PublicMenuItemRow: View {
+   let item: MenuItemPayload
++  let accent: Color
+ 
+   var body: some View {
+-    VStack(alignment: .leading, spacing: 6) {
+-      HStack(alignment: .top) {
+-        VStack(alignment: .leading, spacing: 4) {
+-          Text(item.name)
+-            .font(.headline)
+-            .strikethrough(item.isEightySixed)
++    VStack(alignment: .leading, spacing: 10) {
++      HStack(alignment: .top, spacing: 12) {
++        VStack(alignment: .leading, spacing: 5) {
++          HStack(spacing: 8) {
++            Text(item.name)
++              .font(AppTypography.body(16, weight: .bold))
++              .foregroundStyle(AppPalette.ink)
++              .strikethrough(item.isEightySixed)
++            if item.isEightySixed {
++              Text("86'D")
++                .font(AppTypography.micro(9, weight: .bold))
++                .tracking(1.4)
++                .padding(.vertical, 5)
++                .padding(.horizontal, 8)
++                .background(AppPalette.danger.opacity(0.10), in: Capsule(style: .continuous))
++                .foregroundStyle(AppPalette.danger)
++            }
++          }
+           if item.showDescription, !item.desc.isEmpty {
+             Text(item.desc)
+-              .font(.subheadline)
+-              .foregroundStyle(.secondary)
++              .font(AppTypography.body(13, weight: .medium))
++              .foregroundStyle(AppPalette.espresso.opacity(0.70))
++              .fixedSize(horizontal: false, vertical: true)
+           }
+         }
+-        Spacer()
+-        Text(item.price)
+-          .font(.headline.monospacedDigit())
++        Spacer(minLength: 12)
++        Text(item.price.isEmpty ? "—" : item.price)
++          .font(AppTypography.body(13, weight: .bold))
++          .foregroundStyle(accent)
++          .padding(.vertical, 7)
++          .padding(.horizontal, 10)
++          .background(accent.opacity(0.10), in: Capsule(style: .continuous))
+       }
+ 
+       if item.showRecipe, !item.recipe.isEmpty {
+         Text(item.recipe.joined(separator: " • "))
+-          .font(.footnote)
+-          .foregroundStyle(.secondary)
+-      }
+-
+-      if item.isEightySixed {
+-        Text("86'D")
+-          .font(.caption2.weight(.bold))
+-          .padding(.vertical, 4)
+-          .padding(.horizontal, 8)
+-          .background(AppPalette.danger.opacity(0.16), in: Capsule())
+-          .foregroundStyle(AppPalette.danger)
++          .font(AppTypography.body(12, weight: .semibold))
++          .foregroundStyle(accent.opacity(0.86))
+       }
+     }
+-    .padding(.vertical, 6)
++    .padding(15)
++    .appFieldChrome(tint: accent, cornerRadius: 22)
+   }
+ }
+diff --git a/ios/ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift b/ios/ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift
+index 663ffa2..7307ce1 100644
+--- a/ios/ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift
++++ b/ios/ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift
+@@ -9,108 +9,34 @@ struct RestaurantToolsScreen: View {
+   @State private var noteText = ""
+ 
+   var body: some View {
+-    ScrollView {
+-      VStack(alignment: .leading, spacing: 18) {
+-        VStack(alignment: .leading, spacing: 12) {
+-          Text("Restaurant Tools")
+-            .font(.system(size: 30, weight: .bold, design: .rounded))
+-          Picker("Menu", selection: $selectedType) {
+-            Text("Drinks").tag("drinks")
+-            Text("Food").tag("food")
+-          }
+-          .pickerStyle(.segmented)
+-        }
+-        .appGlassCard(tint: AppPalette.brand)
++    ScrollView(showsIndicators: false) {
++      VStack(alignment: .leading, spacing: 22) {
++        headerCard
++          .appEntryReveal()
+ 
+         if let notice = model.notice {
+           StatusBanner(tone: notice.tone, title: notice.title, message: notice.message)
++            .appEntryReveal(delay: 0.05)
+         }
+ 
+         if let workspace = currentWorkspace {
+-          VStack(alignment: .leading, spacing: 12) {
+-            HStack {
+-              Text("Featured")
+-                .font(.headline)
+-              Spacer()
+-              Button("Add From Catalog") {
+-                showingCatalog = true
+-              }
+-              .buttonStyle(SecondaryGlassButtonStyle())
+-              .frame(maxWidth: 170)
+-            }
+-
+-            ForEach(workspace.restaurantTools?.featuredGroups ?? []) { group in
+-              ForEach(group.slots) { slot in
+-                VStack(alignment: .leading, spacing: 8) {
+-                  HStack {
+-                    VStack(alignment: .leading, spacing: 4) {
+-                      Text(slot.item?.name ?? "Featured Item")
+-                        .font(.subheadline.weight(.semibold))
+-                      if !slot.sellNote.isEmpty {
+-                        Text(slot.sellNote)
+-                          .font(.footnote)
+-                          .foregroundStyle(.secondary)
+-                      }
+-                    }
+-                    Spacer()
+-                    Text(slot.item?.price ?? "")
+-                      .font(.subheadline.monospacedDigit())
+-                  }
+-
+-                  HStack {
+-                    Button("Up") {
+-                      Task { await model.saveFeaturedAction(action: "move", restaurantId: restaurant.id, slotId: slot.id, direction: -1) }
+-                    }
+-                    .buttonStyle(SecondaryGlassButtonStyle())
+-                    Button("Down") {
+-                      Task { await model.saveFeaturedAction(action: "move", restaurantId: restaurant.id, slotId: slot.id, direction: 1) }
+-                    }
+-                    .buttonStyle(SecondaryGlassButtonStyle())
+-                    Button("Note") {
+-                      noteEditingSlot = slot
+-                      noteText = slot.sellNote
+-                    }
+-                    .buttonStyle(SecondaryGlassButtonStyle())
+-                    Button("Remove") {
+-                      Task { await model.saveFeaturedAction(action: "remove", restaurantId: restaurant.id, slotId: slot.id) }
+-                    }
+-                    .buttonStyle(SecondaryGlassButtonStyle())
+-                  }
+-                }
+-                .padding(.vertical, 6)
+-              }
+-            }
+-
+-            Button("Confirm Featured Lineup") {
+-              Task { await model.saveFeaturedAction(action: "confirm", restaurantId: restaurant.id) }
+-            }
+-            .buttonStyle(PrimaryGlassButtonStyle())
+-          }
+-          .appGlassCard(tint: AppPalette.warning)
++          featuredLineupCard(workspace: workspace)
++            .appEntryReveal(delay: 0.08)
++        } else {
++          loadingCard
++            .appEntryReveal(delay: 0.08)
+         }
+ 
+-        if let history = currentHistory {
+-          VStack(alignment: .leading, spacing: 12) {
+-            Text("Recent Changes")
+-              .font(.headline)
+-            ForEach(history.logs) { entry in
+-              VStack(alignment: .leading, spacing: 6) {
+-                Text(entry.userName)
+-                  .font(.subheadline.weight(.semibold))
+-                Text(entry.message.isEmpty ? "No message provided." : entry.message)
+-                  .font(.footnote)
+-                  .foregroundStyle(.secondary)
+-                Text(entry.createdAt)
+-                  .font(.caption)
+-                  .foregroundStyle(.secondary)
+-              }
+-              .padding(.vertical, 4)
+-            }
+-          }
+-          .appGlassCard(tint: AppPalette.accent)
++        if let history = currentHistory, !history.logs.isEmpty {
++          historyCard(history)
++            .appEntryReveal(delay: 0.12)
+         }
++
++        Color.clear.frame(height: 24)
+       }
+-      .padding(24)
++      .padding(.horizontal, 24)
++      .padding(.top, 24)
++      .padding(.bottom, 24)
+     }
+     .navigationTitle(restaurant.name)
+     .navigationBarTitleDisplayMode(.inline)
+@@ -118,29 +44,16 @@ struct RestaurantToolsScreen: View {
+       await model.loadRestaurantTools(for: restaurant.id)
+     }
+     .sheet(isPresented: $showingCatalog) {
+-      NavigationStack {
+-        List(currentWorkspace?.restaurantTools?.siblingCatalog ?? []) { item in
+-          Button {
+-            Task {
+-              await model.saveFeaturedAction(action: "add", restaurantId: restaurant.id, itemId: item.id)
+-              showingCatalog = false
+-            }
+-          } label: {
+-            VStack(alignment: .leading, spacing: 4) {
+-              Text(item.name)
+-              Text("\(item.menuLabel) • \(item.cat)")
+-                .font(.caption)
+-                .foregroundStyle(.secondary)
+-            }
++      FeaturedCatalogSheet(
++        items: currentWorkspace?.restaurantTools?.siblingCatalog ?? [],
++        accent: accent,
++        onSelect: { item in
++          Task {
++            await model.saveFeaturedAction(action: "add", restaurantId: restaurant.id, itemId: item.id)
++            showingCatalog = false
+           }
+         }
+-        .navigationTitle("Add Featured Item")
+-        .toolbar {
+-          ToolbarItem(placement: .cancellationAction) {
+-            Button("Close") { showingCatalog = false }
+-          }
+-        }
+-      }
++      )
+     }
+     .alert("Edit Sell Note", isPresented: Binding(
+       get: { noteEditingSlot != nil },
+@@ -156,6 +69,167 @@ struct RestaurantToolsScreen: View {
+     }
+   }
+ 
++  private var accent: Color {
++    selectedType == "food" ? AppPalette.jade : AppPalette.bloodOrange
++  }
++
++  private var headerCard: some View {
++    VStack(alignment: .leading, spacing: 18) {
++      HStack(alignment: .top) {
++        VStack(alignment: .leading, spacing: 12) {
++          AppEyebrow(title: "Restaurant tools", tint: accent)
++          Text("Featured lineup control")
++            .font(AppTypography.display(34, weight: .bold))
++            .foregroundStyle(AppPalette.espresso)
++          Text("Curate the floor-facing spotlight list, manage sell notes, and confirm the final sequence before service.")
++            .font(AppTypography.body(15, weight: .medium))
++            .foregroundStyle(AppPalette.espresso.opacity(0.72))
++            .fixedSize(horizontal: false, vertical: true)
++        }
++        Spacer(minLength: 16)
++      }
++
++      AppSegmentedControl(
++        options: ["drinks", "food"],
++        selection: $selectedType,
++        accent: accent,
++        title: { $0.capitalized }
++      )
++
++      Button {
++        showingCatalog = true
++      } label: {
++        AppIslandButtonLabel(
++          title: "Add from catalog",
++          subtitle: "Pull an item from the sibling catalog into the featured sequence.",
++          systemImage: "plus"
++        )
++      }
++      .buttonStyle(.plain)
++      .appPillChrome(accent: accent, filled: true)
++      .disabled(currentWorkspace == nil)
++      .opacity(currentWorkspace == nil ? 0.55 : 1)
++    }
++    .appGlassCard(tint: accent, cornerRadius: 38)
++  }
++
++  private func featuredLineupCard(workspace: MenuWorkspacePayload) -> some View {
++    VStack(alignment: .leading, spacing: 16) {
++      HStack(alignment: .center) {
++        VStack(alignment: .leading, spacing: 6) {
++          AppEyebrow(title: "Featured", tint: accent)
++          Text("Current lineup")
++            .font(AppTypography.display(28, weight: .bold))
++            .foregroundStyle(AppPalette.espresso)
++        }
++        Spacer(minLength: 16)
++        Text("\(workspace.restaurantTools?.featuredGroups.reduce(0) { $0 + $1.slots.count } ?? 0) live slots")
++          .font(AppTypography.micro(9, weight: .bold))
++          .tracking(1.6)
++          .padding(.vertical, 8)
++          .padding(.horizontal, 10)
++          .background(accent.opacity(0.10), in: Capsule(style: .continuous))
++          .foregroundStyle(accent)
++      }
++
++      ForEach(workspace.restaurantTools?.featuredGroups ?? []) { group in
++        VStack(alignment: .leading, spacing: 12) {
++          HStack {
++            Text(group.name)
++              .font(AppTypography.body(18, weight: .bold))
++              .foregroundStyle(AppPalette.ink)
++            Spacer(minLength: 12)
++            Text("\(group.slots.count) items")
++              .font(AppTypography.micro(9, weight: .bold))
++              .tracking(1.4)
++              .foregroundStyle(AppPalette.espresso.opacity(0.68))
++          }
++
++          ForEach(group.slots) { slot in
++            FeaturedSlotCard(
++              slot: slot,
++              accent: accent,
++              onMoveUp: {
++                Task { await model.saveFeaturedAction(action: "move", restaurantId: restaurant.id, slotId: slot.id, direction: -1) }
++              },
++              onMoveDown: {
++                Task { await model.saveFeaturedAction(action: "move", restaurantId: restaurant.id, slotId: slot.id, direction: 1) }
++              },
++              onEditNote: {
++                noteEditingSlot = slot
++                noteText = slot.sellNote
++              },
++              onRemove: {
++                Task { await model.saveFeaturedAction(action: "remove", restaurantId: restaurant.id, slotId: slot.id) }
++              }
++            )
++          }
++        }
++        .appGlassCard(tint: accent, cornerRadius: 30)
++      }
++
++      AppIslandActionButton(
++        title: "Confirm featured lineup",
++        subtitle: "Lock the final sell sequence for service.",
++        systemImage: "checkmark",
++        accent: accent,
++        action: {
++          Task { await model.saveFeaturedAction(action: "confirm", restaurantId: restaurant.id) }
++        }
++      )
++    }
++    .appGlassCard(tint: AppPalette.brass, cornerRadius: 36)
++  }
++
++  private func historyCard(_ history: HistoryPayload) -> some View {
++    VStack(alignment: .leading, spacing: 14) {
++      AppEyebrow(title: "History", tint: AppPalette.cobalt)
++      Text("Recent changes")
++        .font(AppTypography.display(26, weight: .bold))
++        .foregroundStyle(AppPalette.espresso)
++
++      ForEach(Array(history.logs.prefix(6).enumerated()), id: \.element.id) { index, entry in
++        VStack(alignment: .leading, spacing: 6) {
++          HStack(spacing: 8) {
++            Text(entry.userName.nilIfBlank ?? "Unknown")
++              .font(AppTypography.body(15, weight: .bold))
++              .foregroundStyle(AppPalette.ink)
++            Text(entry.createdAt)
++              .font(AppTypography.micro(9, weight: .bold))
++              .tracking(1.3)
++              .foregroundStyle(AppPalette.espresso.opacity(0.58))
++          }
++          Text(entry.message.isEmpty ? "No message provided." : entry.message)
++            .font(AppTypography.body(13, weight: .medium))
++            .foregroundStyle(AppPalette.espresso.opacity(0.72))
++            .fixedSize(horizontal: false, vertical: true)
++        }
++        .padding(14)
++        .appFieldChrome(tint: AppPalette.cobalt, cornerRadius: 22)
++
++        if index < min(history.logs.count, 6) - 1 {
++          Rectangle()
++            .fill(AppPalette.cobalt.opacity(0.14))
++            .frame(height: 1)
++        }
++      }
++    }
++    .appGlassCard(tint: AppPalette.cobalt, cornerRadius: 34)
++  }
++
++  private var loadingCard: some View {
++    VStack(spacing: 12) {
++      ProgressView()
++        .tint(accent)
++      Text("Loading restaurant tools…")
++        .font(AppTypography.body(15, weight: .medium))
++        .foregroundStyle(AppPalette.espresso.opacity(0.72))
++    }
++    .frame(maxWidth: .infinity)
++    .padding(.vertical, 34)
++    .appGlassCard(tint: accent, cornerRadius: 34)
++  }
++
+   private var currentWorkspace: MenuWorkspacePayload? {
+     if let menu = model.menu(for: restaurant.id, type: selectedType) {
+       return model.currentToolsMenus[menu.id]
+@@ -170,3 +244,131 @@ struct RestaurantToolsScreen: View {
+     return nil
+   }
+ }
++
++private struct FeaturedSlotCard: View {
++  let slot: FeaturedSlot
++  let accent: Color
++  let onMoveUp: () -> Void
++  let onMoveDown: () -> Void
++  let onEditNote: () -> Void
++  let onRemove: () -> Void
++
++  var body: some View {
++    VStack(alignment: .leading, spacing: 12) {
++      HStack(alignment: .top, spacing: 12) {
++        VStack(alignment: .leading, spacing: 6) {
++          HStack(spacing: 8) {
++            Text(slot.item?.name ?? "Featured item")
++              .font(AppTypography.body(16, weight: .bold))
++              .foregroundStyle(AppPalette.ink)
++            if let confirmedAt = slot.confirmedAt.nilIfBlank {
++              Text("CONFIRMED")
++                .font(AppTypography.micro(8, weight: .bold))
++                .tracking(1.4)
++                .padding(.vertical, 5)
++                .padding(.horizontal, 8)
++                .background(AppPalette.success.opacity(0.10), in: Capsule(style: .continuous))
++                .foregroundStyle(AppPalette.success)
++                .help(confirmedAt)
++            }
++          }
++          if !slot.sellNote.isEmpty {
++            Text(slot.sellNote)
++              .font(AppTypography.body(13, weight: .medium))
++              .foregroundStyle(AppPalette.espresso.opacity(0.72))
++              .fixedSize(horizontal: false, vertical: true)
++          }
++        }
++        Spacer(minLength: 12)
++        if let price = slot.item?.price.nilIfBlank {
++          Text(price)
++            .font(AppTypography.body(13, weight: .bold))
++            .foregroundStyle(accent)
++            .padding(.vertical, 7)
++            .padding(.horizontal, 10)
++            .background(accent.opacity(0.10), in: Capsule(style: .continuous))
++        }
++      }
++
++      HStack(spacing: 8) {
++        toolButton(title: "Up", icon: "arrow.up", accent: accent, action: onMoveUp)
++        toolButton(title: "Down", icon: "arrow.down", accent: accent, action: onMoveDown)
++        toolButton(title: "Note", icon: "pencil", accent: AppPalette.brass, action: onEditNote)
++        toolButton(title: "Remove", icon: "trash", accent: AppPalette.danger, action: onRemove)
++      }
++    }
++    .padding(15)
++    .appFieldChrome(tint: accent, cornerRadius: 22)
++  }
++
++  private func toolButton(title: String, icon: String, accent: Color, action: @escaping () -> Void) -> some View {
++    Button(action: action) {
++      Label(title, systemImage: icon)
++        .font(AppTypography.micro(9, weight: .bold))
++        .tracking(1.2)
++        .padding(.horizontal, 11)
++        .padding(.vertical, 10)
++        .frame(maxWidth: .infinity)
++    }
++    .buttonStyle(.plain)
++    .foregroundStyle(accent)
++    .appPillChrome(accent: accent, filled: false)
++  }
++}
++
++private struct FeaturedCatalogSheet: View {
++  @Environment(\.dismiss) private var dismiss
++  let items: [SiblingCatalogItem]
++  let accent: Color
++  let onSelect: (SiblingCatalogItem) -> Void
++
++  var body: some View {
++    NavigationStack {
++      ScrollView(showsIndicators: false) {
++        VStack(alignment: .leading, spacing: 14) {
++          ForEach(items) { item in
++            Button {
++              onSelect(item)
++            } label: {
++              HStack(alignment: .top, spacing: 12) {
++                VStack(alignment: .leading, spacing: 6) {
++                  Text(item.name)
++                    .font(AppTypography.body(16, weight: .bold))
++                    .foregroundStyle(AppPalette.ink)
++                  Text("\(item.menuLabel) • \(item.cat)")
++                    .font(AppTypography.body(13, weight: .medium))
++                    .foregroundStyle(AppPalette.espresso.opacity(0.68))
++                  if !item.onMenu {
++                    Text("Off menu")
++                      .font(AppTypography.micro(8, weight: .bold))
++                      .tracking(1.4)
++                      .foregroundStyle(AppPalette.warning)
++                  }
++                }
++                Spacer(minLength: 12)
++                Image(systemName: "arrow.up.right")
++                  .font(.system(size: 14, weight: .semibold))
++                  .foregroundStyle(accent)
++              }
++              .padding(15)
++            }
++            .buttonStyle(.plain)
++            .appFieldChrome(tint: accent, cornerRadius: 22)
++          }
++        }
++        .padding(24)
++      }
++      .background {
++        AppBackground()
++          .ignoresSafeArea()
++      }
++      .navigationTitle("Add Featured Item")
++      .navigationBarTitleDisplayMode(.inline)
++      .toolbar {
++        ToolbarItem(placement: .cancellationAction) {
++          Button("Close") { dismiss() }
++        }
++      }
++    }
++  }
++}
+diff --git a/ios/ElRoysManagerApp/Features/Scanner/BarcodeScannerView.swift b/ios/ElRoysManagerApp/Features/Scanner/BarcodeScannerView.swift
+index b55cd89..0b757a1 100644
+--- a/ios/ElRoysManagerApp/Features/Scanner/BarcodeScannerView.swift
++++ b/ios/ElRoysManagerApp/Features/Scanner/BarcodeScannerView.swift
+@@ -8,26 +8,73 @@ struct BarcodeScannerSheet: View {
+ 
+   var body: some View {
+     NavigationStack {
+-      VStack(spacing: 18) {
+-        BarcodeScannerCaptureView { code in
+-          scannedCode = code
++      ScrollView(showsIndicators: false) {
++        VStack(alignment: .leading, spacing: 20) {
++          VStack(alignment: .leading, spacing: 14) {
++            AppEyebrow(title: "Barcode capture", tint: AppPalette.cobalt)
++            Text("Scan or paste a UPC")
++              .font(AppTypography.display(32, weight: .bold))
++              .foregroundStyle(AppPalette.espresso)
++            Text("Use the live camera feed for speed, then fall back to manual entry when a label is damaged or hard to frame.")
++              .font(AppTypography.body(15, weight: .medium))
++              .foregroundStyle(AppPalette.espresso.opacity(0.72))
++              .fixedSize(horizontal: false, vertical: true)
++          }
++          .appGlassCard(tint: AppPalette.cobalt, cornerRadius: 36)
++          .appEntryReveal()
++
++          ZStack {
++            BarcodeScannerCaptureView { code in
++              scannedCode = code
++            }
++            scannerOverlay
++          }
++          .frame(height: 320)
++          .clipShape(RoundedRectangle(cornerRadius: 32, style: .continuous))
++          .overlay {
++            RoundedRectangle(cornerRadius: 32, style: .continuous)
++              .stroke(AppPalette.cobalt.opacity(0.24), lineWidth: 1)
++          }
++          .appEntryReveal(delay: 0.06)
++
++          VStack(alignment: .leading, spacing: 12) {
++            Text("Manual fallback")
++              .font(AppTypography.micro(10, weight: .bold))
++              .tracking(1.8)
++              .foregroundStyle(AppPalette.cobalt)
++            TextField("Enter UPC", text: $scannedCode)
++              .keyboardType(.numberPad)
++              .font(AppTypography.body(16, weight: .medium))
++              .padding(.horizontal, 16)
++              .padding(.vertical, 16)
++              .appFieldChrome(tint: AppPalette.cobalt)
++          }
++          .appGlassCard(tint: AppPalette.brass, cornerRadius: 30)
++          .appEntryReveal(delay: 0.10)
++
++          AppIslandActionButton(
++            title: "Use this barcode",
++            subtitle: "Insert the captured value into the item editor.",
++            systemImage: "arrow.up.right",
++            accent: AppPalette.brand,
++            isEnabled: !scannedCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
++            action: {
++              onFound(scannedCode)
++              dismiss()
++            }
++          )
++          .appEntryReveal(delay: 0.14)
+         }
+-        .frame(height: 320)
+-        .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
+-
+-        TextField("Manual UPC fallback", text: $scannedCode)
+-          .keyboardType(.numberPad)
+-          .textFieldStyle(.roundedBorder)
+-
+-        Button("Use This Barcode") {
+-          onFound(scannedCode)
+-          dismiss()
+-        }
+-        .buttonStyle(PrimaryGlassButtonStyle())
+-        .disabled(scannedCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
++        .padding(.horizontal, 24)
++        .padding(.top, 24)
++        .padding(.bottom, 24)
++      }
++      .background {
++        AppBackground()
++          .ignoresSafeArea()
+       }
+-      .padding(24)
+       .navigationTitle("Scan Barcode")
++      .navigationBarTitleDisplayMode(.inline)
+       .toolbar {
+         ToolbarItem(placement: .cancellationAction) {
+           Button("Close") { dismiss() }
+@@ -35,6 +82,40 @@ struct BarcodeScannerSheet: View {
+       }
+     }
+   }
++
++  private var scannerOverlay: some View {
++    GeometryReader { proxy in
++      let size = min(proxy.size.width, proxy.size.height) * 0.58
++      let line: CGFloat = 26
++      let stroke = AppPalette.ivory.opacity(0.92)
++      let frameRect = CGRect(
++        x: (proxy.size.width - size) / 2,
++        y: (proxy.size.height - size) / 2,
++        width: size,
++        height: size
++      )
++
++      Path { path in
++        path.move(to: CGPoint(x: frameRect.minX, y: frameRect.minY + line))
++        path.addLine(to: CGPoint(x: frameRect.minX, y: frameRect.minY))
++        path.addLine(to: CGPoint(x: frameRect.minX + line, y: frameRect.minY))
++
++        path.move(to: CGPoint(x: frameRect.maxX - line, y: frameRect.minY))
++        path.addLine(to: CGPoint(x: frameRect.maxX, y: frameRect.minY))
++        path.addLine(to: CGPoint(x: frameRect.maxX, y: frameRect.minY + line))
++
++        path.move(to: CGPoint(x: frameRect.minX, y: frameRect.maxY - line))
++        path.addLine(to: CGPoint(x: frameRect.minX, y: frameRect.maxY))
++        path.addLine(to: CGPoint(x: frameRect.minX + line, y: frameRect.maxY))
++
++        path.move(to: CGPoint(x: frameRect.maxX - line, y: frameRect.maxY))
++        path.addLine(to: CGPoint(x: frameRect.maxX, y: frameRect.maxY))
++        path.addLine(to: CGPoint(x: frameRect.maxX, y: frameRect.maxY - line))
++      }
++      .stroke(stroke, style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
++    }
++    .allowsHitTesting(false)
++  }
+ }
+ 
+ private struct BarcodeScannerCaptureView: UIViewControllerRepresentable {

--- a/app.js
+++ b/app.js
@@ -5947,9 +5947,53 @@ function isItemRecipePublic(item) {
   return !!item?.showRecipe;
 }
 
+function canonicalNumericDisplayOrder(value, fallback = Number.MAX_SAFE_INTEGER) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function canonicalCompareText(left = '', right = '') {
+  return String(left || '').localeCompare(String(right || ''));
+}
+
+function compareCanonicalCategoryOrder(left = {}, right = {}) {
+  const leftIsUncategorized = left?.key === UNCATEGORIZED_ID;
+  const rightIsUncategorized = right?.key === UNCATEGORIZED_ID;
+  if (leftIsUncategorized !== rightIsUncategorized) {
+    return leftIsUncategorized ? 1 : -1;
+  }
+
+  const displayDelta = canonicalNumericDisplayOrder(left?.display_order) - canonicalNumericDisplayOrder(right?.display_order);
+  if (displayDelta !== 0) return displayDelta;
+
+  const keyDelta = canonicalCompareText(left?.key, right?.key);
+  if (keyDelta !== 0) return keyDelta;
+
+  return canonicalCompareText(left?.id, right?.id);
+}
+
+function compareCanonicalItemOrder(left = {}, right = {}) {
+  const displayDelta = canonicalNumericDisplayOrder(left?.display_order) - canonicalNumericDisplayOrder(right?.display_order);
+  if (displayDelta !== 0) return displayDelta;
+
+  const idDelta = canonicalCompareText(left?.id, right?.id);
+  if (idDelta !== 0) return idDelta;
+
+  return canonicalCompareText(left?.name, right?.name);
+}
+
+function sortCanonicalCategories(categories = []) {
+  return (Array.isArray(categories) ? categories : []).slice().sort(compareCanonicalCategoryOrder);
+}
+
+function sortCanonicalItems(items = []) {
+  return (Array.isArray(items) ? items : []).slice().sort(compareCanonicalItemOrder);
+}
+
 function hydrateState({ cats, meta, restaurant }) {
-  const realCats = (cats || []).filter(c => c.key !== UNCATEGORIZED_ID);
-  const uncatCat = (cats || []).find(c => c.key === UNCATEGORIZED_ID);
+  const orderedCats = sortCanonicalCategories(cats);
+  const realCats = orderedCats.filter(c => c.key !== UNCATEGORIZED_ID);
+  const uncatCat = orderedCats.find(c => c.key === UNCATEGORIZED_ID);
 
   if (uncatCat) _uncatCategoryUuid = uncatCat.id;
 
@@ -5972,8 +6016,7 @@ function hydrateState({ cats, meta, restaurant }) {
   const hasLastSentTs = !!meta?.last_sent_ts;
   menuState = {};
   realCats.forEach(c => {
-    const items = (c.items || [])
-      .sort((a, b) => a.display_order - b.display_order)
+    const items = sortCanonicalItems(c.items)
       .map(i => hydrateMenuItem(i));
     const hasStoredLastSent = Object.prototype.hasOwnProperty.call(lastSentState, c.key);
     menuState[c.key] = {
@@ -5986,7 +6029,7 @@ function hydrateState({ cats, meta, restaurant }) {
 
   if (uncatCat) {
     menuState[UNCATEGORIZED_ID] = {
-      items: (uncatCat.items || []).map(i => hydrateMenuItem(i, { onMenu: false })),
+      items: sortCanonicalItems(uncatCat.items).map(i => hydrateMenuItem(i, { onMenu: false })),
       lastSent: [],
     };
   }
@@ -6025,8 +6068,9 @@ function applyPersistedDraftState(draftState = {}) {
     liveLastSentState[cat.id] = (menuState[cat.id]?.lastSent || []).map(cloneMenuItemState);
   });
 
-  const realCats = cats.filter(cat => cat.key !== UNCATEGORIZED_ID);
-  const uncatCat = cats.find(cat => cat.key === UNCATEGORIZED_ID) || null;
+  const orderedCats = sortCanonicalCategories(cats);
+  const realCats = orderedCats.filter(cat => cat.key !== UNCATEGORIZED_ID);
+  const uncatCat = orderedCats.find(cat => cat.key === UNCATEGORIZED_ID) || null;
 
   CATEGORY_DEFS = realCats.map(cat => ({
     id: cat.key,
@@ -6042,8 +6086,7 @@ function applyPersistedDraftState(draftState = {}) {
   menuState = {};
   realCats.forEach(cat => {
     menuState[cat.key] = {
-      items: (cat.items || [])
-        .sort((a, b) => (a.display_order || 0) - (b.display_order || 0))
+      items: sortCanonicalItems(cat.items)
         .map(item => hydrateMenuItem(item)),
       lastSent: liveLastSentState[cat.key] || [],
     };
@@ -6052,8 +6095,7 @@ function applyPersistedDraftState(draftState = {}) {
   _uncatCategoryUuid = normalizeDraftCategoryUuid(uncatCat?.id || '', UNCATEGORIZED_ID);
   if (uncatCat) {
     menuState[UNCATEGORIZED_ID] = {
-      items: (uncatCat.items || [])
-        .sort((a, b) => (a.display_order || 0) - (b.display_order || 0))
+      items: sortCanonicalItems(uncatCat.items)
         .map(item => hydrateMenuItem(item, { onMenu: false })),
       lastSent: [],
     };
@@ -6661,7 +6703,7 @@ function normalizeDraftDocumentSnapshot(snapshot = {}) {
   const normalized = snapshot && typeof snapshot === 'object' && !Array.isArray(snapshot)
     ? cloneJsonCompatible(snapshot, {})
     : {};
-  return {
+  return sortDraftDocumentInPlace({
     context: normalized.context && typeof normalized.context === 'object' ? normalized.context : null,
     cats: Array.isArray(normalized.cats) ? normalized.cats : [],
     meta: normalized.meta && typeof normalized.meta === 'object' ? normalized.meta : {},
@@ -6670,7 +6712,7 @@ function normalizeDraftDocumentSnapshot(snapshot = {}) {
     save_only_changes: Array.isArray(normalized.save_only_changes)
       ? normalized.save_only_changes
       : (Array.isArray(normalized.saveOnlyChanges) ? normalized.saveOnlyChanges : []),
-  };
+  });
 }
 
 function stripDraftDocumentForComparison(snapshot = {}) {
@@ -6792,17 +6834,26 @@ function buildLocalDraftOverlapSummary(baseSnapshot = null, localSnapshot = null
 }
 
 function sortDraftDocumentInPlace(snapshot = {}) {
-  snapshot.cats = (Array.isArray(snapshot.cats) ? snapshot.cats : []).sort((left, right) => (
-    Number(left?.display_order || 0) - Number(right?.display_order || 0)
-  ));
-  snapshot.cats.forEach(category => {
-    category.items = (Array.isArray(category.items) ? category.items : []).sort((left, right) => (
-      Number(left?.display_order || 0) - Number(right?.display_order || 0)
-    ));
-  });
+  snapshot.cats = sortCanonicalCategories(snapshot.cats).map((category, categoryIndex) => ({
+    ...category,
+    display_order: category.key === UNCATEGORIZED_ID ? 9999 : categoryIndex,
+    items: sortCanonicalItems(category.items).map((item, itemIndex) => ({
+      ...item,
+      display_order: itemIndex,
+    })),
+  }));
   snapshot.featured_groups = (Array.isArray(snapshot.featured_groups) ? snapshot.featured_groups : []).sort((left, right) => (
     Number(left?.display_order || 0) - Number(right?.display_order || 0)
-  ));
+  )).map((group, groupIndex) => ({
+    ...group,
+    display_order: groupIndex,
+    slots: (Array.isArray(group?.slots) ? group.slots : []).sort((left, right) => (
+      Number(left?.display_order || 0) - Number(right?.display_order || 0)
+    )).map((slot, slotIndex) => ({
+      ...slot,
+      display_order: slotIndex,
+    })),
+  }));
   return snapshot;
 }
 
@@ -6849,8 +6900,9 @@ function mergeLocalDraftSnapshots({
   const remoteCategoryKeys = new Set(remoteDelta.categoryChanges.keys());
 
   Array.from(localDelta.categoryChanges.entries())
-    .sort((left, right) => (
-      Number(left[1]?.display_order || Number.MAX_SAFE_INTEGER) - Number(right[1]?.display_order || Number.MAX_SAFE_INTEGER)
+    .sort((left, right) => compareCanonicalCategoryOrder(
+      left[1] || { key: left[0] },
+      right[1] || { key: right[0] },
     ))
     .forEach(([key, categoryState]) => {
       if (strategy === 'update-local' && remoteCategoryKeys.has(key)) return;

--- a/docs/superpowers/plans/2026-04-20-ios-category-tools-and-reorder-controls.md
+++ b/docs/superpowers/plans/2026-04-20-ios-category-tools-and-reorder-controls.md
@@ -1,0 +1,752 @@
+# iOS Category Tools And Reorder Controls Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move category add/rename/delete/reorder work out of the main menu editor and into restaurant tools, while making the item-level `Reorder` / `Done Reordering` control directly visible on each menu category card.
+
+**Architecture:** Keep all category mutations on the existing editor draft/save/send pipeline instead of inventing a second persistence flow. Add a dedicated category-management screen that is launched from restaurant tools for the currently selected drinks or food menu, then simplify the standard menu editor so it focuses on item editing and exposes item reordering with a visible button instead of an overflow menu.
+
+**Tech Stack:** SwiftUI, Observation (`@Observable`, `@Bindable`), XCTest, `xcodebuild`.
+
+---
+
+## File Map
+
+- Modify: `ios/ElRoysManagerApp/App/ElRoysManagerApp.swift`
+  - Add a new navigation destination for category management under restaurant tools.
+- Modify: `ios/ElRoysManagerApp/App/AppModel.swift`
+  - Expose a public wrapper for visible category reordering so the new screen can reuse the existing editable document mutations.
+- Create: `ios/ElRoysManagerApp/Features/Menu/RestaurantCategoryManagementView.swift`
+  - Add a dedicated category-management screen that loads the selected menu into the existing editor pipeline and provides add/rename/delete/reorder plus save/send/discard actions.
+- Modify: `ios/ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift`
+  - Add the visible entry point that launches category management for the segmented drinks/food menu.
+- Modify: `ios/ElRoysManagerApp/Features/Menu/MenuViews.swift`
+  - Remove category-management affordances from the standard editor and replace the overflow-only reorder action with a visible button.
+- Modify: `ios/ElRoysManagerAppTests/MenuDocumentTests.swift`
+  - Lock the new route entry point, category reorder mutation, and visible reorder affordance with focused tests and source assertions.
+- Create: `docs/superpowers/plans/2026-04-20-ios-category-tools-and-reorder-controls.md`
+  - This implementation plan.
+
+## Task 1: Lock The New UX Contract With Failing Tests
+
+**Files:**
+- Modify: `ios/ElRoysManagerAppTests/MenuDocumentTests.swift`
+- Test: `ios/ElRoysManagerApp/App/ElRoysManagerApp.swift`
+- Test: `ios/ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift`
+- Test: `ios/ElRoysManagerApp/Features/Menu/MenuViews.swift`
+
+- [ ] **Step 1: Add the focused tests and helper source URLs**
+
+Add these tests near the existing menu-editor source assertions, then add the two helper URL functions alongside the other `*SourceURL()` helpers at the bottom of the file.
+
+```swift
+  func testEditableDocumentMovesVisibleCategoriesAndKeepsRecoveryBucketLast() {
+    let workspace = makeWorkspace(categories: [
+      MenuCategoryPayload(
+        id: "beer",
+        menuId: "menu",
+        key: "beer",
+        label: "Beer",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 0,
+        items: [makeItem(id: "item-1", name: "Pilsner")]
+      ),
+      MenuCategoryPayload(
+        id: "wine",
+        menuId: "menu",
+        key: "wine",
+        label: "Wine",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 1,
+        items: [makeItem(id: "item-2", name: "Orange Wine")]
+      ),
+      MenuCategoryPayload(
+        id: "uncategorized",
+        menuId: "menu",
+        key: EditableMenuDocument.uncategorizedKey,
+        label: "Uncategorized",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 2,
+        items: []
+      )
+    ])
+
+    var document = EditableMenuDocument(workspace: workspace)
+    document.moveVisibleCategories(from: IndexSet(integer: 0), to: 2)
+
+    XCTAssertEqual(document.visibleCategories.map(\.key), ["wine", "beer"])
+    XCTAssertEqual(document.visibleCategories.map(\.displayOrder), [0, 1])
+    XCTAssertEqual(document.cats.last?.key, EditableMenuDocument.uncategorizedKey)
+  }
+
+  func testRestaurantToolsProvidesCategoryManagementEntryPoint() throws {
+    let toolsSource = try String(contentsOf: restaurantToolsSourceURL(), encoding: .utf8)
+    let appSource = try String(contentsOf: appEntrySourceURL(), encoding: .utf8)
+
+    XCTAssertTrue(toolsSource.contains("Manage Categories"))
+    XCTAssertTrue(appSource.contains("case categoryTools(MenuRecord)"))
+    XCTAssertTrue(appSource.contains("RestaurantCategoryManagementScreen"))
+  }
+
+  func testMenuEditorCategoryCardUsesVisibleReorderButtonInsteadOfOverflowMenu() throws {
+    let source = try String(contentsOf: menuViewsSourceURL(), encoding: .utf8)
+    let cardRange = try XCTUnwrap(source.range(of: "private struct MenuEditorCategoryCard"))
+    let swipeRange = try XCTUnwrap(source.range(of: "private struct MenuEditorSwipeList"))
+    let cardSource = String(source[cardRange.lowerBound..<swipeRange.lowerBound])
+
+    XCTAssertTrue(cardSource.contains("Button(action: onToggleReorder)"))
+    XCTAssertTrue(cardSource.contains("Done Reordering"))
+    XCTAssertFalse(cardSource.contains("Menu {"))
+    XCTAssertFalse(cardSource.contains("ellipsis.circle.fill"))
+  }
+```
+
+```swift
+private func restaurantToolsSourceURL(filePath: StaticString = #filePath) -> URL {
+  URL(fileURLWithPath: "\(filePath)")
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .appendingPathComponent("ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift")
+}
+
+private func appEntrySourceURL(filePath: StaticString = #filePath) -> URL {
+  URL(fileURLWithPath: "\(filePath)")
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .appendingPathComponent("ElRoysManagerApp/App/ElRoysManagerApp.swift")
+}
+```
+
+- [ ] **Step 2: Run the focused tests to confirm the new source assertions fail**
+
+Run:
+
+```bash
+xcodebuild test -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testEditableDocumentMovesVisibleCategoriesAndKeepsRecoveryBucketLast -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testRestaurantToolsProvidesCategoryManagementEntryPoint -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testMenuEditorCategoryCardUsesVisibleReorderButtonInsteadOfOverflowMenu
+```
+
+Expected:
+
+```text
+testEditableDocumentMovesVisibleCategoriesAndKeepsRecoveryBucketLast ... passed
+testRestaurantToolsProvidesCategoryManagementEntryPoint ... failed
+testMenuEditorCategoryCardUsesVisibleReorderButtonInsteadOfOverflowMenu ... failed
+```
+
+- [ ] **Step 3: Commit the failing contract tests**
+
+```bash
+git add ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+git commit -m "test: lock iOS category tools UX contract"
+```
+
+## Task 2: Add The Category-Tools Route And Category Reorder Hook
+
+**Files:**
+- Modify: `ios/ElRoysManagerApp/App/ElRoysManagerApp.swift`
+- Modify: `ios/ElRoysManagerApp/App/AppModel.swift`
+- Create: `ios/ElRoysManagerApp/Features/Menu/RestaurantCategoryManagementView.swift`
+- Test: `ios/ElRoysManagerAppTests/MenuDocumentTests.swift`
+
+- [ ] **Step 1: Create a compileable category-management screen stub**
+
+Start with a minimal screen so the new destination can compile before the UI is fleshed out.
+
+```swift
+import SwiftUI
+
+struct RestaurantCategoryManagementScreen: View {
+  @Bindable var model: AppModel
+  let menu: MenuRecord
+
+  var body: some View {
+    Text("\(menu.displayTypeLabel) Categories")
+      .font(.title.weight(.bold))
+      .padding()
+  }
+}
+```
+
+- [ ] **Step 2: Add the new app destination and route it to the screen**
+
+Update the destination enum and navigation switch.
+
+```swift
+enum AppDestination: Hashable {
+  case restaurantHub(RestaurantRecord)
+  case publicMenu(RestaurantRecord, initialType: String)
+  case editor(MenuRecord)
+  case restaurantTools(RestaurantRecord)
+  case categoryTools(MenuRecord)
+  case routePreview(MenuRecord)
+}
+```
+
+```swift
+              case .categoryTools(let menu):
+                RestaurantCategoryManagementScreen(model: model, menu: menu)
+```
+
+- [ ] **Step 3: Expose the visible-category reorder mutation through `AppModel`**
+
+Add the public wrapper next to the existing item-reorder method so the new screen does not reach into `EditableMenuDocument` directly.
+
+```swift
+  func moveVisibleCategories(from source: IndexSet, to destination: Int) {
+    guard canEditCategories else { return }
+    mutateEditorDocument { $0.moveVisibleCategories(from: source, to: destination) }
+  }
+```
+
+- [ ] **Step 4: Build to verify the new route and stub compile**
+
+Run:
+
+```bash
+xcodebuild -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'generic/platform=iOS Simulator' build
+```
+
+Expected:
+
+```text
+** BUILD SUCCEEDED **
+```
+
+- [ ] **Step 5: Commit the route and model plumbing**
+
+```bash
+git add ios/ElRoysManagerApp/App/ElRoysManagerApp.swift ios/ElRoysManagerApp/App/AppModel.swift ios/ElRoysManagerApp/Features/Menu/RestaurantCategoryManagementView.swift
+git commit -m "feat: add iOS category tools route"
+```
+
+## Task 3: Build The Dedicated Category-Management Screen
+
+**Files:**
+- Modify: `ios/ElRoysManagerApp/Features/Menu/RestaurantCategoryManagementView.swift`
+- Test: `ios/ElRoysManagerApp/App/AppModel.swift`
+
+- [ ] **Step 1: Replace the stub with the real screen shell and editor loading**
+
+Use the existing editor pipeline so category edits retain draft persistence, save quietly, and send-preview behavior.
+
+```swift
+import SwiftUI
+
+struct RestaurantCategoryManagementScreen: View {
+  @Bindable var model: AppModel
+  let menu: MenuRecord
+
+  @State private var addCategoryName = ""
+  @State private var renameTarget: MenuCategoryPayload?
+  @State private var renameText = ""
+  @State private var isReordering = false
+  @State private var showingAddCategory = false
+  @State private var showingDiscardDraftConfirm = false
+  @State private var showingPreview = false
+
+  private var accent: Color {
+    menu.isFoodMenu ? AppPalette.jade : AppPalette.bloodOrange
+  }
+
+  var body: some View {
+    ScrollView(showsIndicators: false) {
+      VStack(alignment: .leading, spacing: 18) {
+        AppSectionHeader(
+          eyebrow: "Restaurant tools",
+          title: "\(menu.displayTypeLabel) categories",
+          subtitle: "Add, rename, delete, and reorder categories without leaving the staff tools flow.",
+          tint: accent
+        )
+
+        if let notice = model.notice {
+          StatusBanner(tone: notice.tone, title: notice.title, message: notice.message)
+        }
+
+        categoryActions
+
+        if let document = model.currentEditorDocument {
+          categoryList(document.visibleCategories)
+        } else {
+          AppLoadingCard(
+            title: "Loading categories",
+            subtitle: "Preparing the live workspace, local draft state, and category structure.",
+            tint: accent
+          )
+        }
+      }
+      .padding(24)
+    }
+    .navigationTitle("\(menu.displayTypeLabel) Categories")
+    .navigationBarTitleDisplayMode(.inline)
+    .task(id: menu.id) {
+      await model.loadEditor(menuId: menu.id)
+    }
+```
+
+- [ ] **Step 2: Add the category action row, alerts, and preview sheet**
+
+Use the same `AppModel` methods the standard editor already trusts.
+
+```swift
+    .sheet(isPresented: $showingPreview) {
+      if let preview = model.currentEditorPreview {
+        RestaurantCategoryPublishPreviewSheet(
+          model: model,
+          preview: preview,
+          accent: accent,
+          onPublish: {
+            Task {
+              await model.publishSelectedChanges()
+              showingPreview = false
+            }
+          }
+        )
+      } else {
+        ProgressView("Loading preview…")
+          .presentationDetents([.medium])
+      }
+    }
+    .alert("Add Category", isPresented: $showingAddCategory) {
+      TextField("Category name", text: $addCategoryName)
+      Button("Add") {
+        model.addCategory(label: addCategoryName)
+        addCategoryName = ""
+      }
+      Button("Cancel", role: .cancel) {
+        addCategoryName = ""
+      }
+    }
+    .alert("Rename Category", isPresented: Binding(
+      get: { renameTarget != nil },
+      set: { if !$0 { renameTarget = nil } }
+    )) {
+      TextField("Category name", text: $renameText)
+      Button("Save") {
+        if let target = renameTarget {
+          model.renameCategory(key: target.key, label: renameText)
+        }
+      }
+      Button("Cancel", role: .cancel) {}
+    }
+    .alert("Discard Local Draft?", isPresented: $showingDiscardDraftConfirm) {
+      Button("Discard Draft", role: .destructive) {
+        model.discardLocalDraft()
+      }
+      Button("Keep Editing", role: .cancel) {}
+    } message: {
+      Text("This only removes unsaved edits from this device and does not modify the shared server queue.")
+    }
+  }
+
+  private var categoryActions: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Button("Add Category") { showingAddCategory = true }
+        .buttonStyle(PrimaryGlassButtonStyle())
+
+      HStack(spacing: 12) {
+        Button("Save Quietly") {
+          Task { await model.saveLiveMenu() }
+        }
+        .buttonStyle(SecondaryGlassButtonStyle())
+        .disabled(!model.canSaveQuietlyRemotely)
+
+        Button(model.hasLocalDraftChanges ? "Save & Send" : "Send Update") {
+          Task {
+            await model.loadPublishPreview()
+            showingPreview = model.currentEditorPreview != nil
+          }
+        }
+        .buttonStyle(SecondaryGlassButtonStyle())
+        .disabled(!model.canLoadPublishPreview)
+
+        Button("Discard Draft") {
+          showingDiscardDraftConfirm = true
+        }
+        .buttonStyle(SecondaryGlassButtonStyle())
+        .disabled(!model.canDiscardLocalDraft)
+      }
+    }
+    .appGlassCard(tint: accent, cornerRadius: 28)
+  }
+```
+
+- [ ] **Step 3: Add the category list, direct reorder toggle, and preview sheet view**
+
+Keep category reorder visible on this screen too, and wire it through the new `AppModel.moveVisibleCategories(from:to:)` wrapper.
+
+```swift
+  @ViewBuilder
+  private func categoryList(_ categories: [MenuCategoryPayload]) -> some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack {
+        Text("Categories")
+          .font(AppTypography.display(24, weight: .bold))
+          .foregroundStyle(AppPalette.ink)
+
+        Spacer()
+
+        if categories.count > 1 || isReordering {
+          Button(isReordering ? "Done Reordering" : "Reorder Categories") {
+            isReordering.toggle()
+          }
+          .buttonStyle(SecondaryGlassButtonStyle())
+          .tint(accent)
+        }
+      }
+
+      List {
+        ForEach(categories) { category in
+          HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text(category.label)
+                .font(AppTypography.body(16, weight: .bold))
+              Text("\(category.items.filter(\\.onMenu).count) live items")
+                .font(AppTypography.body(12, weight: .medium))
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if !isReordering {
+              Button("Rename") {
+                renameTarget = category
+                renameText = category.label
+              }
+              .buttonStyle(SecondaryGlassButtonStyle())
+
+              Button("Delete", role: .destructive) {
+                model.deleteCategory(key: category.key)
+              }
+              .buttonStyle(SecondaryGlassButtonStyle())
+            }
+          }
+          .listRowSeparator(.hidden)
+          .listRowBackground(Color.clear)
+          .moveDisabled(!isReordering)
+        }
+        .onMove(perform: model.moveVisibleCategories)
+      }
+      .environment(\\.editMode, .constant(isReordering ? .active : .inactive))
+      .listStyle(.plain)
+      .frame(height: max(CGFloat(categories.count) * 72, 88))
+    }
+    .appGlassCard(tint: accent, cornerRadius: 30)
+  }
+}
+
+private struct RestaurantCategoryPublishPreviewSheet: View {
+  @Bindable var model: AppModel
+  let preview: MenuPreviewPayload
+  let accent: Color
+  let onPublish: () -> Void
+  @Environment(\\.dismiss) private var dismiss
+
+  var body: some View {
+    NavigationStack {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 16) {
+          Text(preview.patchMessage.isEmpty ? "Review the queued category changes before sending." : preview.patchMessage)
+            .font(AppTypography.body(14, weight: .medium))
+
+          ForEach(preview.sections) { section in
+            VStack(alignment: .leading, spacing: 10) {
+              Text(section.label)
+                .font(AppTypography.body(16, weight: .bold))
+              ForEach(section.changes) { change in
+                Toggle(
+                  isOn: Binding(
+                    get: { model.selectedPreviewChangeIDs.contains(change.id) },
+                    set: { model.updatePreviewSelection(change.id, selected: $0) }
+                  )
+                ) {
+                  Text(change.text)
+                }
+                .tint(accent)
+              }
+            }
+            .appFieldChrome(tint: accent, cornerRadius: 20)
+          }
+        }
+        .padding(24)
+      }
+      .navigationTitle("Send Preview")
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Close") { dismiss() }
+        }
+        ToolbarItem(placement: .confirmationAction) {
+          Button(preview.hasNotificationChanges ? "Send Update" : "Save Changes", action: onPublish)
+        }
+      }
+    }
+  }
+}
+```
+
+- [ ] **Step 4: Run the focused tests again**
+
+Run:
+
+```bash
+xcodebuild test -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testEditableDocumentMovesVisibleCategoriesAndKeepsRecoveryBucketLast -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testRestaurantToolsProvidesCategoryManagementEntryPoint
+```
+
+Expected:
+
+```text
+Both tests pass, but the visible reorder-button test still fails until the standard menu editor is updated.
+```
+
+- [ ] **Step 5: Commit the dedicated category-management screen**
+
+```bash
+git add ios/ElRoysManagerApp/Features/Menu/RestaurantCategoryManagementView.swift ios/ElRoysManagerApp/App/AppModel.swift ios/ElRoysManagerApp/App/ElRoysManagerApp.swift
+git commit -m "feat: add iOS category management screen"
+```
+
+## Task 4: Launch Category Management From Restaurant Tools And Remove It From The Standard Editor
+
+**Files:**
+- Modify: `ios/ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift`
+- Modify: `ios/ElRoysManagerApp/Features/Menu/MenuViews.swift`
+- Test: `ios/ElRoysManagerAppTests/MenuDocumentTests.swift`
+
+- [ ] **Step 1: Add the visible restaurant-tools entry point for the selected menu**
+
+Place this directly below the drinks/food segmented control so staff can reach category management without opening a menu editor first.
+
+```swift
+      if let menu = model.menu(for: restaurant.id, type: selectedType) {
+        NavigationLink(value: AppDestination.categoryTools(menu)) {
+          AppIslandButtonLabel(
+            title: "Manage Categories",
+            subtitle: "Add, rename, delete, and reorder \(menu.displayTypeLabel.lowercased()) categories.",
+            systemImage: "square.split.1x2.fill"
+          )
+        }
+        .buttonStyle(.plain)
+        .appPillChrome(accent: accent)
+      }
+```
+
+- [ ] **Step 2: Remove category add/rename/delete controls from the standard menu editor**
+
+Strip the category-management state and alerts from `MenuEditorScreen`, then turn the categories header into a read-only note.
+
+```swift
+private struct MenuEditorCategoriesHeader: View {
+  let theme: MenuEditorTheme
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Text("Menu Items")
+        .font(EditorTypography.display(20, weight: .bold))
+        .foregroundStyle(theme.titleText)
+      Text("Categories are managed from Restaurant Tools.")
+        .font(EditorTypography.body(12, weight: .medium))
+        .foregroundStyle(theme.subtleText)
+    }
+  }
+}
+```
+
+Remove these state properties and the related alert blocks from `MenuEditorScreen`:
+
+```swift
+  @State private var addCategoryName = ""
+  @State private var showingAddCategory = false
+  @State private var renameTarget: MenuCategoryPayload?
+  @State private var renameText = ""
+```
+
+Update the category-card initializer usage so the standard editor no longer passes rename/delete closures:
+
+```swift
+              MenuEditorCategoryCard(
+                menu: menu,
+                category: category,
+                theme: theme,
+                menuAccent: menuAccent,
+                onSelectItem: { item in
+                  reorderingCategoryKey = nil
+                  editingDraft = EditableItemDraft(item: item, categoryKey: category.key, isFoodMenu: menu.isFoodMenu)
+                  activeSheet = .itemEditor
+                },
+                onToggleEightySix: { item in
+                  model.setItemEightySixed(
+                    itemID: item.id,
+                    categoryKey: category.key,
+                    isEightySixed: !item.isEightySixed
+                  )
+                },
+                isReordering: reorderingCategoryKey == category.key,
+                onToggleReorder: {
+                  reorderingCategoryKey = reorderingCategoryKey == category.key ? nil : category.key
+                },
+                onMoveVisibleItems: { source, destination in
+                  model.moveVisibleItems(in: category.key, from: source, to: destination)
+                }
+              )
+```
+
+- [ ] **Step 3: Update the no-category warning so it points staff to restaurant tools**
+
+Keep the guard, but change the notice copy so the new workflow is discoverable.
+
+```swift
+      model.notice = AppNotice(
+        tone: .warning,
+        title: "Add A Category First",
+        message: "Create at least one category in Restaurant Tools before adding menu items."
+      )
+```
+
+- [ ] **Step 4: Run the category-entry test to confirm the restaurant-tools route is now discoverable**
+
+Run:
+
+```bash
+xcodebuild test -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testRestaurantToolsProvidesCategoryManagementEntryPoint
+```
+
+Expected:
+
+```text
+testRestaurantToolsProvidesCategoryManagementEntryPoint ... passed
+```
+
+- [ ] **Step 5: Commit the workflow relocation**
+
+```bash
+git add ios/ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+git commit -m "feat: move iOS category management into restaurant tools"
+```
+
+## Task 5: Make Reorder Controls Visible In The Standard Menu Editor And Verify The Feature End To End
+
+**Files:**
+- Modify: `ios/ElRoysManagerApp/Features/Menu/MenuViews.swift`
+- Modify: `ios/ElRoysManagerAppTests/MenuDocumentTests.swift`
+- Test: `ios/ElRoysManagerApp.xcodeproj`
+
+- [ ] **Step 1: Replace the overflow-only reorder action with a visible button**
+
+Update the category-card header so the reorder control is always visible when it can be used. Remove the overflow menu entirely.
+
+```swift
+private struct MenuEditorCategoryCard: View {
+  let menu: MenuRecord
+  let category: MenuCategoryPayload
+  let theme: MenuEditorTheme
+  let menuAccent: Color
+  let onSelectItem: (MenuItemPayload) -> Void
+  let onToggleEightySix: (MenuItemPayload) -> Void
+  let isReordering: Bool
+  let onToggleReorder: () -> Void
+  let onMoveVisibleItems: (IndexSet, Int) -> Void
+
+  private var visibleItems: [MenuItemPayload] {
+    category.items.filter(\\.onMenu)
+  }
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 4) {
+          Text(category.label)
+            .font(EditorTypography.display(22, weight: .bold))
+            .foregroundStyle(theme.titleText)
+          if !category.sub.isEmpty {
+            Text(category.sub)
+              .font(EditorTypography.body(13))
+              .foregroundStyle(theme.subtleText)
+          }
+        }
+
+        Spacer()
+
+        Text("\(visibleItems.count)")
+          .font(EditorTypography.body(12, weight: .bold))
+          .padding(.vertical, 6)
+          .padding(.horizontal, 8)
+          .background(menuAccent.opacity(0.15), in: Capsule())
+          .foregroundStyle(menuAccent)
+
+        if visibleItems.count > 1 || isReordering {
+          Button(action: onToggleReorder) {
+            Label(
+              isReordering ? "Done Reordering" : "Reorder",
+              systemImage: isReordering ? "checkmark.circle.fill" : "arrow.up.arrow.down.circle.fill"
+            )
+          }
+          .buttonStyle(SecondaryGlassButtonStyle())
+          .tint(menuAccent)
+        }
+      }
+```
+
+- [ ] **Step 2: Update the source assertion to match the visible-button contract**
+
+Replace the older category-card source assertion with the final expectation.
+
+```swift
+  func testMenuEditorCategoryCardUsesVisibleReorderButtonInsteadOfOverflowMenu() throws {
+    let source = try String(contentsOf: menuViewsSourceURL(), encoding: .utf8)
+    let cardRange = try XCTUnwrap(source.range(of: "private struct MenuEditorCategoryCard"))
+    let swipeRange = try XCTUnwrap(source.range(of: "private struct MenuEditorSwipeList"))
+    let cardSource = String(source[cardRange.lowerBound..<swipeRange.lowerBound])
+
+    XCTAssertTrue(cardSource.contains("Button(action: onToggleReorder)"))
+    XCTAssertTrue(cardSource.contains("Done Reordering"))
+    XCTAssertFalse(cardSource.contains("Menu {"))
+    XCTAssertFalse(cardSource.contains("ellipsis.circle.fill"))
+  }
+```
+
+- [ ] **Step 3: Run the focused tests and the full native build**
+
+Run:
+
+```bash
+xcodebuild test -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testEditableDocumentMovesVisibleCategoriesAndKeepsRecoveryBucketLast -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testRestaurantToolsProvidesCategoryManagementEntryPoint -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testMenuEditorCategoryCardUsesVisibleReorderButtonInsteadOfOverflowMenu
+```
+
+Expected:
+
+```text
+All three focused tests pass.
+```
+
+Run:
+
+```bash
+xcodebuild -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'generic/platform=iOS Simulator' build
+```
+
+Expected:
+
+```text
+** BUILD SUCCEEDED **
+```
+
+- [ ] **Step 4: Commit the visible reorder-control update**
+
+```bash
+git add ios/ElRoysManagerApp/Features/Menu/MenuViews.swift ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+git commit -m "feat: expose iOS reorder controls in menu editor"
+```
+
+## Self-Review
+
+- Spec coverage: category management relocation is handled by Tasks 2 through 4; visible `Reorder` / `Done Reordering` controls are handled by Task 5; no requested behavior is uncovered.
+- Placeholder scan: no `TODO`, `TBD`, or “similar to” references remain.
+- Type consistency: the plan consistently uses `AppDestination.categoryTools(MenuRecord)`, `RestaurantCategoryManagementScreen`, and `moveVisibleCategories(from:to:)`.

--- a/docs/superpowers/plans/2026-04-20-ordering-consistency-server-and-clients.md
+++ b/docs/superpowers/plans/2026-04-20-ordering-consistency-server-and-clients.md
@@ -1,0 +1,583 @@
+# Ordering Consistency Server And Clients Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make menu category and item ordering deterministic across all clients by having the server always emit a canonical order and both web and iOS consume that canonical order consistently.
+
+**Architecture:** First, normalize ordering on the server read boundary so every payload leaves the server with explicitly sorted categories and items, including stable tie-breakers when `display_order` values collide. Next, update the web and iOS clients to hydrate from that canonical ordering instead of trusting incidental wire order or preserving stale array order. Keep the fix narrow: do not redesign drafts, persistence, or menu CRUD; only harden read ordering and client hydration around the existing menu model.
+
+**Tech Stack:** Zero-dependency web app, Node/Vercel serverless handlers, CommonJS tests with `node:test`, Swift/iOS app models with XCTest.
+
+---
+
+## File Structure
+
+- Modify: `server/_menu-read.js`
+  Responsibility: Canonicalize category/item ordering for workspace and public payloads before any client sees the data.
+- Modify: `tests/phase7-server-read-boundaries.test.cjs`
+  Responsibility: Lock server payload ordering so regressions are caught in JS tests.
+- Modify: `app.js`
+  Responsibility: Make web hydration paths consume server-canonical ordering with a shared deterministic comparator instead of ad hoc sorts.
+- Modify: `ios/ElRoysManagerApp/Models/AppModels.swift`
+  Responsibility: Normalize decoded workspace/public categories and items into canonical display order on iOS.
+- Modify: `ios/ElRoysManagerAppTests/MenuDocumentTests.swift`
+  Responsibility: Prove iOS applies canonical ordering from payloads, including stable tie-break behavior.
+
+## Ordering Rules To Implement
+
+- Categories sort by `display_order` ascending.
+- Regular categories sort ahead of `__uncategorized__`.
+- Item arrays sort by `display_order` ascending.
+- When `display_order` ties, use a stable secondary key:
+  - categories: `key`, then `id`
+  - items: `id`, then `name`
+- Server-side read models are the source of truth for this ordering.
+- Web and iOS should still normalize payloads defensively using the same ordering rules so stale or partially ordered payloads cannot reintroduce divergence.
+
+### Task 1: Canonicalize Server Ordering At The Read Boundary
+
+**Files:**
+- Modify: `server/_menu-read.js`
+- Test: `tests/phase7-server-read-boundaries.test.cjs`
+
+- [ ] **Step 1: Write the failing server boundary test**
+
+Add this test near the existing `createPublicMenuPayload` assertions in `tests/phase7-server-read-boundaries.test.cjs`:
+
+```js
+test('createPublicMenuPayload canonicalizes category and item ordering', () => {
+  const payload = helper.createPublicMenuPayload({
+    menu: {
+      id: 'menu-1',
+      slug: 'drinks',
+      name: 'Drinks',
+      type: 'drinks',
+      restaurantId: 'rest-1',
+    },
+    cats: [
+      {
+        id: 'cat-z',
+        menu_id: 'menu-1',
+        key: 'wine',
+        label: 'Wine',
+        display_order: 2,
+        items: [
+          { id: 'item-b', name: 'Bordeaux', display_order: 1, on_menu: true, visibility: 'public' },
+          { id: 'item-a', name: 'Albarino', display_order: 1, on_menu: true, visibility: 'public' },
+          { id: 'item-c', name: 'Chianti', display_order: 0, on_menu: true, visibility: 'public' },
+        ],
+      },
+      {
+        id: 'cat-u',
+        menu_id: 'menu-1',
+        key: '__uncategorized__',
+        label: 'Uncategorized',
+        display_order: 0,
+        items: [
+          { id: 'hidden-1', name: 'Hidden', display_order: 0, on_menu: false, visibility: 'off_menu' },
+        ],
+      },
+      {
+        id: 'cat-a',
+        menu_id: 'menu-1',
+        key: 'beer',
+        label: 'Beer',
+        display_order: 0,
+        items: [
+          { id: 'beer-2', name: 'Z Lager', display_order: 1, on_menu: true, visibility: 'public' },
+          { id: 'beer-1', name: 'A Lager', display_order: 1, on_menu: true, visibility: 'public' },
+        ],
+      },
+    ],
+    meta: {},
+    restaurant: null,
+  });
+
+  assert.deepEqual(payload.cats.map(category => category.key), ['beer', 'wine']);
+  assert.deepEqual(payload.cats[0].items.map(item => item.id), ['beer-1', 'beer-2']);
+  assert.deepEqual(payload.cats[1].items.map(item => item.id), ['item-c', 'item-a', 'item-b']);
+});
+```
+
+- [ ] **Step 2: Run the server test to verify it fails**
+
+Run: `node --test tests/phase7-server-read-boundaries.test.cjs`
+Expected: FAIL on category and/or item ordering because `createPublicMenuPayload()` currently forwards nested item arrays without canonical sorting.
+
+- [ ] **Step 3: Write the minimal server implementation**
+
+Update `server/_menu-read.js` by adding shared comparators and applying them inside `sanitizePublicCategory()` and `readMenuStateBundle()` normalization:
+
+```js
+function numericDisplayOrder(value, fallback = Number.MAX_SAFE_INTEGER) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function compareText(left = '', right = '') {
+  return String(left || '').localeCompare(String(right || ''));
+}
+
+function compareCategoryOrder(left = {}, right = {}) {
+  const leftIsUncategorized = left?.key === '__uncategorized__';
+  const rightIsUncategorized = right?.key === '__uncategorized__';
+  if (leftIsUncategorized !== rightIsUncategorized) return leftIsUncategorized ? 1 : -1;
+
+  const displayDelta = numericDisplayOrder(left?.display_order) - numericDisplayOrder(right?.display_order);
+  if (displayDelta !== 0) return displayDelta;
+
+  const keyDelta = compareText(left?.key, right?.key);
+  if (keyDelta !== 0) return keyDelta;
+
+  return compareText(left?.id, right?.id);
+}
+
+function compareItemOrder(left = {}, right = {}) {
+  const displayDelta = numericDisplayOrder(left?.display_order) - numericDisplayOrder(right?.display_order);
+  if (displayDelta !== 0) return displayDelta;
+
+  const idDelta = compareText(left?.id, right?.id);
+  if (idDelta !== 0) return idDelta;
+
+  return compareText(left?.name, right?.name);
+}
+
+function sortCategoryItems(items = []) {
+  return (Array.isArray(items) ? items : []).slice().sort(compareItemOrder);
+}
+
+function sortCategories(categories = []) {
+  return (Array.isArray(categories) ? categories : []).slice().sort(compareCategoryOrder);
+}
+
+function sanitizePublicCategory(category = {}) {
+  return {
+    id: category.id || '',
+    menu_id: category.menu_id || '',
+    key: category.key || '',
+    label: category.label || '',
+    icon: category.icon || '',
+    color: category.color || '',
+    sub: category.sub || '',
+    placeholder: category.placeholder || '',
+    display_order: Number.isFinite(Number(category.display_order)) ? Number(category.display_order) : 0,
+    items: sortCategoryItems(category.items)
+      .filter(isGuestVisibleItem)
+      .map(sanitizePublicItem),
+  };
+}
+
+export async function readMenuStateBundle(menuId) {
+  // existing fetches...
+
+  return {
+    menu: {
+      id: menuRow.id,
+      slug: menuRow.slug || '',
+      name: menuRow.name || '',
+      type: menuRow.type || 'drinks',
+      restaurantId: menuRow.restaurant_id || '',
+    },
+    cats: sortCategories(cats).map(category => ({
+      ...category,
+      items: sortCategoryItems(category?.items),
+    })),
+    meta: metaRows?.[0] || {},
+    restaurant: restaurantRows?.[0] || null,
+    featuredCurrentIds,
+  };
+}
+```
+
+- [ ] **Step 4: Run the server test to verify it passes**
+
+Run: `node --test tests/phase7-server-read-boundaries.test.cjs`
+Expected: PASS, including the new canonical ordering assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add server/_menu-read.js tests/phase7-server-read-boundaries.test.cjs
+git commit -m "fix: canonicalize menu ordering on server reads"
+```
+
+### Task 2: Make Web Hydration Follow Canonical Server Ordering
+
+**Files:**
+- Modify: `app.js`
+- Test: `tests/manager-item-reorder-draft-state.test.cjs`
+
+- [ ] **Step 1: Write the failing web hydration test**
+
+Add this test to `tests/manager-item-reorder-draft-state.test.cjs`:
+
+```js
+test('hydrateState canonicalizes item ties by id after display order', () => {
+  const sandbox = loadAppSandbox();
+
+  setState(sandbox, {
+    CATEGORY_DEFS: [],
+    menuState: {},
+  });
+
+  getState(sandbox, `
+    hydrateState({
+      cats: [{
+        id: 'cat-1',
+        key: 'beer',
+        label: 'Beer',
+        display_order: 0,
+        items: [
+          { id: 'beer-b', name: 'Beta', display_order: 1, on_menu: true, visibility: 'public' },
+          { id: 'beer-a', name: 'Alpha', display_order: 1, on_menu: true, visibility: 'public' },
+          { id: 'beer-c', name: 'Gamma', display_order: 0, on_menu: true, visibility: 'public' }
+        ]
+      }],
+      meta: {},
+      restaurant: null
+    });
+  `);
+
+  assert.deepEqual(
+    getState(sandbox, 'JSON.parse(JSON.stringify(menuState.beer.items.map(item => item.id)))'),
+    ['beer-c', 'beer-a', 'beer-b'],
+  );
+});
+```
+
+- [ ] **Step 2: Run the web test to verify it fails**
+
+Run: `node --test tests/manager-item-reorder-draft-state.test.cjs`
+Expected: FAIL because the existing sort only compares `display_order`.
+
+- [ ] **Step 3: Write the minimal web implementation**
+
+Add a shared canonical comparator in `app.js` near the existing menu-state helpers, then use it in both `hydrateState()` and `applyPersistedDraftState()`:
+
+```js
+function compareCanonicalText(left = '', right = '') {
+  return String(left || '').localeCompare(String(right || ''));
+}
+
+function compareCanonicalDisplayOrder(left = {}, right = {}, { keyField = 'id', fallbackField = 'name' } = {}) {
+  const displayDelta = Number(left?.display_order || 0) - Number(right?.display_order || 0);
+  if (displayDelta !== 0) return displayDelta;
+
+  const keyDelta = compareCanonicalText(left?.[keyField], right?.[keyField]);
+  if (keyDelta !== 0) return keyDelta;
+
+  return compareCanonicalText(left?.[fallbackField], right?.[fallbackField]);
+}
+
+function sortCanonicalWorkspaceItems(items = []) {
+  return (Array.isArray(items) ? items : []).slice().sort((left, right) => (
+    compareCanonicalDisplayOrder(left, right, { keyField: 'id', fallbackField: 'name' })
+  ));
+}
+
+function sortCanonicalWorkspaceCategories(categories = []) {
+  return (Array.isArray(categories) ? categories : []).slice().sort((left, right) => {
+    const leftIsUncategorized = left?.key === UNCATEGORIZED_ID;
+    const rightIsUncategorized = right?.key === UNCATEGORIZED_ID;
+    if (leftIsUncategorized !== rightIsUncategorized) return leftIsUncategorized ? 1 : -1;
+
+    return compareCanonicalDisplayOrder(left, right, { keyField: 'key', fallbackField: 'id' });
+  });
+}
+
+function hydrateState({ cats, meta, restaurant }) {
+  const orderedCats = sortCanonicalWorkspaceCategories(cats || []);
+  const realCats = orderedCats.filter(c => c.key !== UNCATEGORIZED_ID);
+  const uncatCat = orderedCats.find(c => c.key === UNCATEGORIZED_ID);
+
+  // existing category setup...
+
+  realCats.forEach(c => {
+    const items = sortCanonicalWorkspaceItems(c.items || [])
+      .map(i => hydrateMenuItem(i));
+    // existing assignment...
+  });
+
+  if (uncatCat) {
+    menuState[UNCATEGORIZED_ID] = {
+      items: sortCanonicalWorkspaceItems(uncatCat.items || []).map(i => hydrateMenuItem(i, { onMenu: false })),
+      lastSent: [],
+    };
+  }
+}
+
+function applyPersistedDraftState(draftState = {}) {
+  const cats = sortCanonicalWorkspaceCategories(Array.isArray(draftState?.cats) ? draftState.cats : []);
+  if (!cats.length) return false;
+
+  // existing category setup...
+
+  realCats.forEach(cat => {
+    menuState[cat.key] = {
+      items: sortCanonicalWorkspaceItems(cat.items || []).map(item => hydrateMenuItem(item)),
+      lastSent: liveLastSentState[cat.key] || [],
+    };
+  });
+
+  if (uncatCat) {
+    menuState[UNCATEGORIZED_ID] = {
+      items: sortCanonicalWorkspaceItems(uncatCat.items || []).map(item => hydrateMenuItem(item, { onMenu: false })),
+      lastSent: [],
+    };
+  }
+
+  return true;
+}
+```
+
+- [ ] **Step 4: Run the web test to verify it passes**
+
+Run: `node --test tests/manager-item-reorder-draft-state.test.cjs`
+Expected: PASS, including the new hydrate canonicalization assertion.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add app.js tests/manager-item-reorder-draft-state.test.cjs
+git commit -m "fix: normalize web menu hydration ordering"
+```
+
+### Task 3: Make iOS Normalize Server Ordering For Workspace And Public Payloads
+
+**Files:**
+- Modify: `ios/ElRoysManagerApp/Models/AppModels.swift`
+- Test: `ios/ElRoysManagerAppTests/MenuDocumentTests.swift`
+
+- [ ] **Step 1: Write the failing iOS tests**
+
+Add these tests to `ios/ElRoysManagerAppTests/MenuDocumentTests.swift`:
+
+```swift
+func testEditableMenuDocumentNormalizesItemOrderFromWorkspacePayload() throws {
+  let workspace = MenuWorkspacePayload(
+    cats: [
+      MenuCategoryPayload(
+        id: "cat-1",
+        menuId: "menu-1",
+        key: "beer",
+        label: "Beer",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 0,
+        items: [
+          MenuItemPayload(id: "beer-b", name: "Beta", desc: "", recipe: [], price: "", isEightySixed: false, onMenu: true, visibility: "public", displayOrder: 1, upcharges: [], showDescription: true, showRecipe: false),
+          MenuItemPayload(id: "beer-a", name: "Alpha", desc: "", recipe: [], price: "", isEightySixed: false, onMenu: true, visibility: "public", displayOrder: 1, upcharges: [], showDescription: true, showRecipe: false),
+          MenuItemPayload(id: "beer-c", name: "Gamma", desc: "", recipe: [], price: "", isEightySixed: false, onMenu: true, visibility: "public", displayOrder: 0, upcharges: [], showDescription: true, showRecipe: false),
+        ]
+      )
+    ],
+    meta: MenuMetaPayload(),
+    restaurant: nil,
+    context: MenuContext(kind: "menu-workspace", menu: MenuRecord(id: "menu-1", slug: "drinks", name: "Drinks", type: "drinks", restaurantId: "rest-1")),
+    workspace: MenuWorkspace(),
+    capabilities: WorkspaceCapabilities(),
+    compatibility: nil,
+    restaurantTools: nil
+  )
+
+  let document = EditableMenuDocument(workspace: workspace)
+
+  XCTAssertEqual(document.category(for: "beer")?.items.map(\.id), ["beer-c", "beer-a", "beer-b"])
+}
+
+func testPublicMenuPayloadDecodingPreservesCanonicalServerOrderAfterNormalization() throws {
+  let json = """
+  {
+    "cats": [
+      {
+        "id": "cat-1",
+        "menuId": "menu-1",
+        "key": "beer",
+        "label": "Beer",
+        "displayOrder": 0,
+        "items": [
+          { "id": "beer-b", "name": "Beta", "displayOrder": 1, "onMenu": true, "visibility": "public" },
+          { "id": "beer-a", "name": "Alpha", "displayOrder": 1, "onMenu": true, "visibility": "public" },
+          { "id": "beer-c", "name": "Gamma", "displayOrder": 0, "onMenu": true, "visibility": "public" }
+        ]
+      }
+    ],
+    "meta": {},
+    "restaurant": null,
+    "featuredGroups": [],
+    "context": { "kind": "menu-public", "menu": { "id": "menu-1", "slug": "drinks", "name": "Drinks", "type": "drinks", "restaurantId": "rest-1" } },
+    "capabilities": { "guestReadable": true, "requiresAuth": false, "includesDraftState": false, "includesNotificationConfig": false }
+  }
+  """.data(using: .utf8)!
+
+  let decoder = JSONDecoder()
+  decoder.keyDecodingStrategy = .convertFromSnakeCase
+  let payload = try decoder.decode(PublicMenuPayload.self, from: json)
+
+  XCTAssertEqual(payload.cats.first?.items.map(\.id), ["beer-c", "beer-a", "beer-b"])
+}
+```
+
+- [ ] **Step 2: Run the iOS tests to verify they fail**
+
+Run: `xcodebuild test -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:ElRoysManagerAppTests/MenuDocumentTests`
+Expected: FAIL because decoded item arrays preserve payload order instead of canonical sorting.
+
+- [ ] **Step 3: Write the minimal iOS implementation**
+
+Add canonical ordering helpers to `ios/ElRoysManagerApp/Models/AppModels.swift` and apply them in both `EditableMenuDocument` initialization and payload decoding:
+
+```swift
+private func canonicalTextCompare(_ left: String, _ right: String) -> Bool {
+  left.localizedCaseInsensitiveCompare(right) == .orderedAscending
+}
+
+private func canonicalSortedItems(_ items: [MenuItemPayload]) -> [MenuItemPayload] {
+  items.sorted { lhs, rhs in
+    if lhs.displayOrder != rhs.displayOrder {
+      return lhs.displayOrder < rhs.displayOrder
+    }
+    if lhs.id != rhs.id {
+      return canonicalTextCompare(lhs.id, rhs.id)
+    }
+    return canonicalTextCompare(lhs.name, rhs.name)
+  }
+}
+
+private func canonicalSortedCategories(_ categories: [MenuCategoryPayload]) -> [MenuCategoryPayload] {
+  categories.sorted { lhs, rhs in
+    let lhsIsUncategorized = lhs.key == EditableMenuDocument.uncategorizedKey
+    let rhsIsUncategorized = rhs.key == EditableMenuDocument.uncategorizedKey
+    if lhsIsUncategorized != rhsIsUncategorized {
+      return rhsIsUncategorized
+    }
+    if lhs.displayOrder != rhs.displayOrder {
+      return lhs.displayOrder < rhs.displayOrder
+    }
+    if lhs.key != rhs.key {
+      return canonicalTextCompare(lhs.key, rhs.key)
+    }
+    return canonicalTextCompare(lhs.id, rhs.id)
+  }
+}
+
+extension MenuCategoryPayload {
+  func canonicalized() -> MenuCategoryPayload {
+    var next = self
+    next.items = canonicalSortedItems(items)
+    return next
+  }
+}
+
+extension PublicMenuPayload {
+  mutating func normalizeCanonicalOrdering() {
+    cats = canonicalSortedCategories(cats).map { $0.canonicalized() }
+  }
+}
+
+struct PublicMenuPayload: Codable, Equatable {
+  var cats: [MenuCategoryPayload]
+  var meta: MenuMetaPayload
+  var restaurant: RestaurantRecord?
+  var featuredGroups: [FeaturedGroup]
+  var context: MenuContext
+  var capabilities: PublicMenuCapabilities
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.cats = try container.decodeArray([MenuCategoryPayload].self, forKey: .cats)
+    self.meta = try container.decodeIfPresent(MenuMetaPayload.self, forKey: .meta) ?? MenuMetaPayload()
+    self.restaurant = try container.decodeIfPresent(RestaurantRecord.self, forKey: .restaurant)
+    self.featuredGroups = try container.decodeArray([FeaturedGroup].self, forKey: .featuredGroups)
+    self.context = try container.decode(MenuContext.self, forKey: .context)
+    self.capabilities = try container.decode(PublicMenuCapabilities.self, forKey: .capabilities)
+    normalizeCanonicalOrdering()
+  }
+}
+
+init(workspace: MenuWorkspacePayload) {
+  context = MenuSnapshotContext(
+    menuId: workspace.context.menu?.id ?? "",
+    restaurantId: workspace.context.menu?.restaurantId ?? "",
+    menuType: workspace.context.menu?.type ?? "drinks"
+  )
+  cats = Self.normalizeIdentifiers(
+    in: canonicalSortedCategories(workspace.cats).map { $0.canonicalized() },
+    menuId: workspace.context.menu?.id ?? ""
+  )
+  meta = workspace.meta
+  restaurant = workspace.restaurant
+  featuredGroups = workspace.restaurantTools?.featuredGroups ?? []
+}
+```
+
+- [ ] **Step 4: Run the iOS tests to verify they pass**
+
+Run: `xcodebuild test -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:ElRoysManagerAppTests/MenuDocumentTests`
+Expected: PASS, including both new canonical ordering tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add ios/ElRoysManagerApp/Models/AppModels.swift ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+git commit -m "fix: normalize ios menu ordering from server payloads"
+```
+
+### Task 4: Run Cross-Surface Regression Verification
+
+**Files:**
+- Modify: `tests/phase7-server-read-boundaries.test.cjs`
+- Modify: `tests/manager-item-reorder-draft-state.test.cjs`
+- Modify: `ios/ElRoysManagerAppTests/MenuDocumentTests.swift`
+
+- [ ] **Step 1: Run the JS regression suite**
+
+Run:
+
+```bash
+node --test tests/phase7-server-read-boundaries.test.cjs tests/manager-item-reorder-draft-state.test.cjs
+```
+
+Expected: PASS for both files, proving server and web ordering are deterministic.
+
+- [ ] **Step 2: Run the iOS regression suite**
+
+Run:
+
+```bash
+xcodebuild test -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:ElRoysManagerAppTests/MenuDocumentTests
+```
+
+Expected: PASS, proving iOS document/workspace/public payload normalization matches the server ordering contract.
+
+- [ ] **Step 3: Run one manual verification pass**
+
+Run:
+
+```bash
+open http://localhost:3000/manager
+```
+
+Expected: In two separate browser profiles on the same menu, after a save and reload, the visible order matches exactly; ties do not flip between reloads. If a second local draft is active, it may still intentionally overlay live order, but once discarded both clients should converge to the same live ordering.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/phase7-server-read-boundaries.test.cjs tests/manager-item-reorder-draft-state.test.cjs ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+git commit -m "test: lock ordering consistency across server and clients"
+```
+
+## Self-Review
+
+- Spec coverage:
+  - Server-side deterministic ordering: covered by Task 1.
+  - Web client reading canonical server order correctly: covered by Task 2.
+  - iOS client reading canonical server order correctly: covered by Task 3.
+  - End-to-end regression verification: covered by Task 4.
+- Placeholder scan:
+  - Removed vague language and included exact files, commands, and code for each task.
+- Type consistency:
+  - The plan uses `display_order` on JS/server surfaces and `displayOrder` on Swift surfaces consistently.
+  - The same canonical ordering rules are applied in every task: display order first, stable tie-break second, uncategorized last.

--- a/ios/ElRoysManagerApp.xcodeproj/project.pbxproj
+++ b/ios/ElRoysManagerApp.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		4EF9C5DA4C838D7C2F7EDCCD /* RoutePreviewView.swift in Sources */ = {isa = PBXBuildFile; fileRef = AA1F85E2F0DEF0F6E95E021D /* RoutePreviewView.swift */; };
 		504ADBCDE4287D896A097C9E /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 984625EC61B70E28EBE29AA7 /* Foundation.framework */; };
 		51938CF52E3035B8FD40D98C /* OfflineDraftStore.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1FF3EEDF738DA7824619341B /* OfflineDraftStore.swift */; };
+		98B4C1D22A2F4E0BA1C9D301 /* RestaurantCategoryManagementView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 98B4C1D32A2F4E0BA1C9D301 /* RestaurantCategoryManagementView.swift */; };
 		77FA0AAB51126DD1E3349379 /* MenuViews.swift in Sources */ = {isa = PBXBuildFile; fileRef = E4D3CFF2A8BA4E1EF4B02B03 /* MenuViews.swift */; };
 		B658E6A6DD31C472D6BDE8EA /* ElRoysManagerApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34EB2A5A1E80AEC9A6C5F892 /* ElRoysManagerApp.swift */; };
 		B74AD36AC43DEA6771F8A50B /* BarcodeScannerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 4960978B1EB557BC4FD6A6DC /* BarcodeScannerView.swift */; };
@@ -62,6 +63,7 @@
 		8EA9EC632EBEE43B8E14234E /* ElRoysManagerApp.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ElRoysManagerApp.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		95254918D5739FE7B2D38658 /* SessionStore.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = SessionStore.swift; sourceTree = "<group>"; };
 		984625EC61B70E28EBE29AA7 /* Foundation.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Foundation.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS18.0.sdk/System/Library/Frameworks/Foundation.framework; sourceTree = DEVELOPER_DIR; };
+		98B4C1D32A2F4E0BA1C9D301 /* RestaurantCategoryManagementView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RestaurantCategoryManagementView.swift; sourceTree = "<group>"; };
 		AA1F85E2F0DEF0F6E95E021D /* RoutePreviewView.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = RoutePreviewView.swift; sourceTree = "<group>"; };
 		BACAEC402B9AB79F23A25C53 /* AppModels.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = AppModels.swift; sourceTree = "<group>"; };
 		D6643FCD672AA78BFDDC9BB0 /* ElRoysManagerAppUITests.swift */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = sourcecode.swift; path = ElRoysManagerAppUITests.swift; sourceTree = "<group>"; };
@@ -111,6 +113,7 @@
 			isa = PBXGroup;
 			children = (
 				E4D3CFF2A8BA4E1EF4B02B03 /* MenuViews.swift */,
+				98B4C1D32A2F4E0BA1C9D301 /* RestaurantCategoryManagementView.swift */,
 			);
 			path = Menu;
 			sourceTree = "<group>";
@@ -447,6 +450,7 @@
 				FB1FE66B120AC8EE6E3B36D4 /* AuthViews.swift in Sources */,
 				0DF17767BB6EF4F7AF0E8E4F /* HomeViews.swift in Sources */,
 				77FA0AAB51126DD1E3349379 /* MenuViews.swift in Sources */,
+				98B4C1D22A2F4E0BA1C9D301 /* RestaurantCategoryManagementView.swift in Sources */,
 				4EF9C5DA4C838D7C2F7EDCCD /* RoutePreviewView.swift in Sources */,
 				075F36D0B1BF2C903520C45F /* PublicMenuViews.swift in Sources */,
 				2A514DBF47B17B337CB32D46 /* RestaurantToolsView.swift in Sources */,

--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -295,7 +295,9 @@ final class AppModel {
     guard bootstrap?.menus.contains(where: { $0.id == menuId }) == true else { return }
     currentMenuId = menuId
     await run("Loading Public Menu") { model in
-      model.currentPublicMenu = try await model.services.publicMenu.fetch(menuId: menuId, accessToken: model.authSession?.accessToken)
+      let payload = try await model.services.publicMenu.fetch(menuId: menuId, accessToken: model.authSession?.accessToken)
+      guard model.currentMenuId == menuId else { return }
+      model.currentPublicMenu = payload
     }
   }
 
@@ -411,10 +413,16 @@ final class AppModel {
           }
         }
       }
-      model.currentToolsMenus = menus
-      model.currentToolsHistories = histories
+      for (menuId, workspace) in menus {
+        model.currentToolsMenus[menuId] = workspace
+      }
+      for (menuId, history) in histories {
+        model.currentToolsHistories[menuId] = history
+      }
       model.homeDataVersion += 1
-      model.currentMenuId = menuIds.first
+      if model.currentMenuId == nil || !menuIds.contains(model.currentMenuId ?? "") {
+        model.currentMenuId = menuIds.first
+      }
     }
   }
 
@@ -603,6 +611,11 @@ final class AppModel {
 
   func restoreItemFromOffMenu(itemID: String, to categoryKey: String) {
     mutateEditorDocument { $0.restoreItemFromOffMenu(itemID: itemID, to: categoryKey) }
+  }
+
+  func moveVisibleCategories(from source: IndexSet, to destination: Int) {
+    guard canEditCategories else { return }
+    mutateEditorDocument { $0.moveVisibleCategories(from: source, to: destination) }
   }
 
   func moveVisibleItems(in categoryKey: String, from source: IndexSet, to destination: Int) {
@@ -1180,8 +1193,13 @@ final class AppModel {
   }
 
   private func updateEditorStateFlags(for document: EditableMenuDocument) {
-    editorDirty = isDocumentDirty(document)
-    editorHasLiveChanges = isDocumentDifferentFromLive(document)
+    guard let currentData = try? documentData(for: document) else {
+      editorDirty = true
+      editorHasLiveChanges = true
+      return
+    }
+    editorDirty = draftBaselineDocumentData.map { currentData != $0 } ?? true
+    editorHasLiveChanges = liveBaselineDocumentData.map { currentData != $0 } ?? true
   }
 
   private func run(_ label: String, operation: @escaping @MainActor (AppModel) async throws -> Void) async {

--- a/ios/ElRoysManagerApp/App/ElRoysManagerApp.swift
+++ b/ios/ElRoysManagerApp/App/ElRoysManagerApp.swift
@@ -5,6 +5,7 @@ enum AppDestination: Hashable {
   case publicMenu(RestaurantRecord, initialType: String)
   case editor(MenuRecord)
   case restaurantTools(RestaurantRecord)
+  case categoryTools(MenuRecord)
   case routePreview(MenuRecord)
 }
 
@@ -15,9 +16,7 @@ struct ElRoysManagerApp: App {
   var body: some Scene {
     WindowGroup {
       RootView(model: model)
-        .task {
-          await model.start()
-        }
+        .task { await model.start() }
     }
   }
 }
@@ -30,21 +29,8 @@ private struct RootView: View {
       AppBackground()
 
       if model.isLaunching {
-        VStack(spacing: 18) {
-          Text("El Roy's Manager")
-            .font(.system(size: 34, weight: .bold, design: .rounded))
-            .foregroundStyle(AppPalette.ink)
-          Text("Native SwiftUI manager for Leroy's Lounge and El Roy's Cantina.")
-            .font(.title3)
-            .multilineTextAlignment(.center)
-            .foregroundStyle(.secondary)
-          ProgressView()
-            .controlSize(.large)
-          EnvironmentBadge(environment: model.environment)
-        }
-        .padding(28)
-        .appGlassCard(tint: AppPalette.brand)
-        .padding(24)
+        LaunchDeck(environment: model.environment)
+          .padding(24)
       } else if model.isAuthenticated {
         NavigationStack {
           RestaurantChooserView(model: model)
@@ -58,14 +44,76 @@ private struct RootView: View {
                 MenuEditorScreen(model: model, menu: menu)
               case .restaurantTools(let restaurant):
                 RestaurantToolsScreen(model: model, restaurant: restaurant)
+              case .categoryTools(let menu):
+                RestaurantCategoryManagementScreen(model: model, menu: menu)
               case .routePreview(let menu):
-                RoutePreviewScreen(model: model, menu: menu)
+                RoutePreviewScreen(menu: menu, url: model.exactRoutePreviewURL(for: menu))
               }
             }
         }
+        .tint(AppPalette.brand)
       } else {
         AuthGateView(model: model)
       }
     }
+  }
+}
+
+private struct LaunchDeck: View {
+  let environment: AppEnvironment
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 22) {
+      HStack(alignment: .top) {
+        AppSectionHeader(
+          eyebrow: "Native manager",
+          title: "El Roy's\nManager",
+          subtitle: "Editorial chrome, native performance, and the same live workspace pipeline used by the production manager.",
+          tint: AppPalette.brass
+        )
+        Spacer(minLength: 16)
+        VStack(alignment: .trailing, spacing: 10) {
+          EnvironmentBadge(environment: environment)
+          ProgressView()
+            .controlSize(.large)
+            .tint(AppPalette.brand)
+        }
+      }
+
+      Group {
+        if #available(iOS 26.0, *) {
+          GlassEffectContainer(spacing: 10) {
+            HStack(spacing: 10) {
+              capsule(title: "Staff sign-in", tint: AppPalette.sage)
+              capsule(title: "Live menu tools", tint: AppPalette.cobalt)
+              capsule(title: "Preview routes", tint: AppPalette.brand)
+            }
+          }
+        } else {
+          HStack(spacing: 10) {
+            capsule(title: "Staff sign-in", tint: AppPalette.sage)
+            capsule(title: "Live menu tools", tint: AppPalette.cobalt)
+            capsule(title: "Preview routes", tint: AppPalette.brand)
+          }
+        }
+      }
+    }
+    .appGlassCard(tint: AppPalette.brand, cornerRadius: 38)
+    .frame(maxWidth: 620)
+    .appEntryReveal()
+  }
+
+  private func capsule(title: String, tint: Color) -> some View {
+    Text(title.uppercased())
+      .font(AppTypography.micro(9, weight: .bold))
+      .tracking(1.6)
+      .padding(.vertical, 8)
+      .padding(.horizontal, 10)
+      .background(tint.opacity(0.12), in: Capsule(style: .continuous))
+      .overlay {
+        Capsule(style: .continuous)
+          .stroke(tint.opacity(0.24), lineWidth: 0.7)
+      }
+      .foregroundStyle(tint)
   }
 }

--- a/ios/ElRoysManagerApp/Design/Glass.swift
+++ b/ios/ElRoysManagerApp/Design/Glass.swift
@@ -10,43 +10,78 @@ struct AppPalette {
   static let warning = Color(red: 0.74, green: 0.50, blue: 0.18)
   static let danger = Color(red: 0.71, green: 0.24, blue: 0.22)
 
-  // Cinematic additions — consumed by the Home surface, safe to reuse elsewhere.
-  static let brass      = Color(red: 0.757, green: 0.604, blue: 0.286)
-  static let ember      = Color(red: 0.910, green: 0.381, blue: 0.164)
-  static let oxblood    = Color(red: 0.478, green: 0.114, blue: 0.133)
-  static let charcoal   = Color(red: 0.051, green: 0.043, blue: 0.043)
-  static let ivory      = Color(red: 0.949, green: 0.913, blue: 0.847)
-  static let cobalt     = Color(red: 0.118, green: 0.302, blue: 0.549)
-  static let marigold   = Color(red: 0.910, green: 0.639, blue: 0.090)
-  static let jade       = Color(red: 0.122, green: 0.373, blue: 0.227)
+  // Brand texture palette
+  static let brass = Color(red: 0.757, green: 0.604, blue: 0.286)
+  static let ember = Color(red: 0.910, green: 0.381, blue: 0.164)
+  static let oxblood = Color(red: 0.478, green: 0.114, blue: 0.133)
+  static let charcoal = Color(red: 0.051, green: 0.043, blue: 0.043)
+  static let ivory = Color(red: 0.949, green: 0.913, blue: 0.847)
+  static let cobalt = Color(red: 0.118, green: 0.302, blue: 0.549)
+  static let marigold = Color(red: 0.910, green: 0.639, blue: 0.090)
+  static let jade = Color(red: 0.122, green: 0.373, blue: 0.227)
   static let terracotta = Color(red: 0.788, green: 0.416, blue: 0.231)
   static let bloodOrange = Color(red: 0.780, green: 0.243, blue: 0.114)
+  static let sage = Color(red: 0.478, green: 0.545, blue: 0.431)
+  static let espresso = Color(red: 0.188, green: 0.137, blue: 0.110)
+  static let parchment = Color(red: 0.992, green: 0.972, blue: 0.936)
+  static let alabaster = Color(red: 0.978, green: 0.957, blue: 0.918)
+  static let linen = Color(red: 0.956, green: 0.921, blue: 0.862)
+}
+
+enum AppMotion {
+  static let reveal = Animation.timingCurve(0.32, 0.72, 0.0, 1.0, duration: 0.82)
+  static let settle = Animation.timingCurve(0.22, 0.86, 0.18, 1.0, duration: 0.62)
+  static let snap = Animation.timingCurve(0.32, 0.72, 0.0, 1.0, duration: 0.38)
+  static let press = Animation.interpolatingSpring(stiffness: 290, damping: 25)
+}
+
+enum AppTypography {
+  static func display(_ size: CGFloat, weight: Font.Weight = .bold) -> Font {
+    .system(size: size, weight: weight, design: .rounded)
+  }
+
+  static func body(_ size: CGFloat, weight: Font.Weight = .regular) -> Font {
+    .system(size: size, weight: weight, design: .rounded)
+  }
+
+  static func micro(_ size: CGFloat, weight: Font.Weight = .semibold) -> Font {
+    .system(size: size, weight: weight, design: .monospaced)
+  }
 }
 
 struct AppBackground: View {
   var body: some View {
-    LinearGradient(
-      colors: [
-        AppPalette.canvasTop,
-        Color.white.opacity(0.95),
-        AppPalette.canvasBottom,
-      ],
-      startPoint: .topLeading,
-      endPoint: .bottomTrailing
-    )
-    .overlay(alignment: .topTrailing) {
+    ZStack {
+      LinearGradient(
+        colors: [
+          AppPalette.parchment,
+          AppPalette.alabaster,
+          AppPalette.canvasBottom,
+        ],
+        startPoint: .topLeading,
+        endPoint: .bottomTrailing
+      )
+
       Circle()
-        .fill(AppPalette.brand.opacity(0.10))
-        .frame(width: 240, height: 240)
-        .blur(radius: 8)
-        .offset(x: 80, y: -60)
-    }
-    .overlay(alignment: .bottomLeading) {
+        .fill(AppPalette.brand.opacity(0.12))
+        .frame(width: 320, height: 320)
+        .blur(radius: 24)
+        .offset(x: 128, y: -180)
+
       Circle()
-        .fill(AppPalette.accent.opacity(0.10))
-        .frame(width: 300, height: 300)
-        .blur(radius: 12)
-        .offset(x: -90, y: 100)
+        .fill(AppPalette.sage.opacity(0.10))
+        .frame(width: 360, height: 360)
+        .blur(radius: 34)
+        .offset(x: -160, y: 190)
+
+      Circle()
+        .fill(AppPalette.brass.opacity(0.10))
+        .frame(width: 260, height: 260)
+        .blur(radius: 22)
+        .offset(x: -120, y: -240)
+
+      FilmGrain(intensity: 0.055, seed: 117)
+        .opacity(0.26)
     }
     .ignoresSafeArea()
   }
@@ -57,77 +92,448 @@ struct GlassCardModifier: ViewModifier {
   var cornerRadius: CGFloat
 
   func body(content: Content) -> some View {
-    if #available(iOS 26.0, *) {
-      content
-        .padding(18)
-        .glassEffect(.regular.tint(tint.opacity(0.18)), in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-        .overlay {
+    let innerRadius = max(18, cornerRadius - 7)
+
+    content
+      .padding(22)
+      .background {
+        ZStack {
+          if #available(iOS 26.0, *) {
+            Color.clear
+              .glassEffect(
+                .regular.tint(tint.opacity(0.12)),
+                in: .rect(cornerRadius: cornerRadius)
+              )
+          }
+
           RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-            .stroke(tint.opacity(0.20), lineWidth: 1)
-        }
-        .shadow(color: tint.opacity(0.14), radius: 18, y: 8)
-    } else {
-      content
-        .padding(18)
-        .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-        .overlay {
+            .fill(tint.opacity(0.07))
+
           RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-            .stroke(tint.opacity(0.18), lineWidth: 1)
+            .fill(.white.opacity(0.18))
+            .padding(0.75)
+
+          RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .stroke(tint.opacity(0.18), lineWidth: 0.9)
+
+          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
+            .fill(
+              LinearGradient(
+                colors: [
+                  AppPalette.parchment.opacity(0.98),
+                  AppPalette.linen.opacity(0.94),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+              )
+            )
+            .padding(6)
+
+          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
+            .stroke(.white.opacity(0.78), lineWidth: 0.75)
+            .padding(6)
+
+          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
+            .stroke(tint.opacity(0.14), lineWidth: 0.9)
+            .padding(6)
         }
-        .shadow(color: Color.black.opacity(0.08), radius: 18, y: 8)
-    }
+        .shadow(color: AppPalette.espresso.opacity(0.10), radius: 22, y: 14)
+        .shadow(color: tint.opacity(0.08), radius: 26, y: 16)
+      }
+  }
+}
+
+struct FieldChromeModifier: ViewModifier {
+  var tint: Color
+  var cornerRadius: CGFloat
+
+  func body(content: Content) -> some View {
+    let innerRadius = max(14, cornerRadius - 6)
+
+    content
+      .background {
+        ZStack {
+          if #available(iOS 26.0, *) {
+            Color.clear
+              .glassEffect(
+                .regular.tint(tint.opacity(0.08)),
+                in: .rect(cornerRadius: cornerRadius)
+              )
+          }
+
+          RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .fill(tint.opacity(0.08))
+
+          RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+            .stroke(tint.opacity(0.18), lineWidth: 0.9)
+
+          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
+            .fill(
+              LinearGradient(
+                colors: [
+                  .white.opacity(0.88),
+                  AppPalette.parchment.opacity(0.92),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+              )
+            )
+            .padding(5)
+
+          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
+            .stroke(.white.opacity(0.66), lineWidth: 0.7)
+            .padding(5)
+        }
+      }
+  }
+}
+
+struct AppPillChromeModifier: ViewModifier {
+  var accent: Color
+  var filled: Bool
+
+  func body(content: Content) -> some View {
+    content
+      .background {
+        let shell = Capsule()
+        let inner = Capsule()
+
+        ZStack {
+          shell
+            .fill(filled ? accent.opacity(0.16) : accent.opacity(0.08))
+          shell
+            .stroke(accent.opacity(filled ? 0.22 : 0.18), lineWidth: 0.9)
+          inner
+            .fill(
+              LinearGradient(
+                colors: filled
+                  ? [accent.opacity(0.72), accent.opacity(0.48)]
+                  : [.white.opacity(0.82), AppPalette.parchment.opacity(0.90)],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+              )
+            )
+            .padding(5)
+          inner
+            .stroke(filled ? .white.opacity(0.24) : .white.opacity(0.64), lineWidth: 0.7)
+            .padding(5)
+        }
+        .shadow(color: accent.opacity(filled ? 0.18 : 0.08), radius: 18, y: 10)
+      }
   }
 }
 
 extension View {
-  func appGlassCard(tint: Color = AppPalette.brand, cornerRadius: CGFloat = 28) -> some View {
+  func appGlassCard(tint: Color = AppPalette.brand, cornerRadius: CGFloat = 30) -> some View {
     modifier(GlassCardModifier(tint: tint, cornerRadius: cornerRadius))
+  }
+
+  func appFieldChrome(tint: Color = AppPalette.brass, cornerRadius: CGFloat = 22) -> some View {
+    modifier(FieldChromeModifier(tint: tint, cornerRadius: cornerRadius))
+  }
+
+  func appPillChrome(accent: Color = AppPalette.brand, filled: Bool = false) -> some View {
+    modifier(AppPillChromeModifier(accent: accent, filled: filled))
   }
 }
 
 struct PrimaryGlassButtonStyle: ButtonStyle {
+  var accent: Color = AppPalette.brand
+
   func makeBody(configuration: Configuration) -> some View {
-    if #available(iOS 26.0, *) {
-      configuration.label
-        .buttonStyle(.glassProminent)
-        .scaleEffect(configuration.isPressed ? 0.97 : 1)
-        .animation(.snappy(duration: 0.14), value: configuration.isPressed)
-    } else {
-      configuration.label
-        .padding(.vertical, 12)
-        .padding(.horizontal, 16)
-        .frame(maxWidth: .infinity)
-        .background(AppPalette.brand, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-        .foregroundStyle(.white)
-        .opacity(configuration.isPressed ? 0.84 : 1)
-        .scaleEffect(configuration.isPressed ? 0.98 : 1)
-        .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
-    }
+    configuration.label
+      .foregroundStyle(.white)
+      .scaleEffect(configuration.isPressed ? 0.985 : 1)
+      .opacity(configuration.isPressed ? 0.94 : 1)
+      .animation(AppMotion.press, value: configuration.isPressed)
+      .appPillChrome(accent: accent, filled: true)
   }
 }
 
 struct SecondaryGlassButtonStyle: ButtonStyle {
+  var accent: Color = AppPalette.brass
+
   func makeBody(configuration: Configuration) -> some View {
-    if #available(iOS 26.0, *) {
-      configuration.label
-        .buttonStyle(.glass)
-        .scaleEffect(configuration.isPressed ? 0.97 : 1)
-        .animation(.snappy(duration: 0.14), value: configuration.isPressed)
-    } else {
-      configuration.label
-        .padding(.vertical, 12)
-        .padding(.horizontal, 16)
-        .frame(maxWidth: .infinity)
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
-        .overlay {
-          RoundedRectangle(cornerRadius: 18, style: .continuous)
-            .stroke(AppPalette.ink.opacity(0.12), lineWidth: 1)
+    configuration.label
+      .foregroundStyle(AppPalette.ink)
+      .scaleEffect(configuration.isPressed ? 0.988 : 1)
+      .opacity(configuration.isPressed ? 0.9 : 1)
+      .animation(AppMotion.press, value: configuration.isPressed)
+      .appPillChrome(accent: accent, filled: false)
+  }
+}
+
+struct AppEyebrow: View {
+  let title: String
+  var tint: Color = AppPalette.brass
+
+  var body: some View {
+    Text(title.uppercased())
+      .font(AppTypography.micro(10, weight: .bold))
+      .tracking(2.2)
+      .padding(.vertical, 8)
+      .padding(.horizontal, 12)
+      .background(tint.opacity(0.12), in: Capsule())
+      .overlay {
+        Capsule()
+          .stroke(tint.opacity(0.24), lineWidth: 0.8)
+      }
+      .foregroundStyle(tint)
+  }
+}
+
+struct AppIslandButtonLabel: View {
+  let title: String
+  var subtitle: String? = nil
+  let systemImage: String
+
+  var body: some View {
+    HStack(spacing: 14) {
+      VStack(alignment: .leading, spacing: subtitle == nil ? 0 : 5) {
+        Text(title)
+          .font(AppTypography.body(16, weight: .bold))
+          .foregroundStyle(.white)
+        if let subtitle, !subtitle.isEmpty {
+          Text(subtitle)
+            .font(AppTypography.body(12, weight: .medium))
+            .foregroundStyle(.white.opacity(0.82))
+            .fixedSize(horizontal: false, vertical: true)
         }
-        .foregroundStyle(AppPalette.ink)
-        .opacity(configuration.isPressed ? 0.84 : 1)
-        .scaleEffect(configuration.isPressed ? 0.98 : 1)
-        .animation(.easeOut(duration: 0.12), value: configuration.isPressed)
+      }
+
+      Spacer(minLength: 12)
+
+      ZStack {
+        Circle()
+          .fill(.white.opacity(0.16))
+        Circle()
+          .stroke(.white.opacity(0.30), lineWidth: 0.8)
+        Image(systemName: systemImage)
+          .font(.system(size: 14, weight: .semibold))
+          .foregroundStyle(.white)
+      }
+      .frame(width: 36, height: 36)
     }
+    .padding(.horizontal, 18)
+    .padding(.vertical, 15)
+    .frame(maxWidth: .infinity)
+  }
+}
+
+struct AppIslandActionButton: View {
+  let title: String
+  var subtitle: String? = nil
+  let systemImage: String
+  var accent: Color = AppPalette.brand
+  var isEnabled: Bool = true
+  let action: () -> Void
+
+  var body: some View {
+    Group {
+      if #available(iOS 26.0, *) {
+        Button(action: action) {
+          AppIslandButtonLabel(
+            title: title,
+            subtitle: subtitle,
+            systemImage: systemImage
+          )
+        }
+        .buttonStyle(.glassProminent)
+        .tint(accent)
+      } else {
+        Button(action: action) {
+          AppIslandButtonLabel(
+            title: title,
+            subtitle: subtitle,
+            systemImage: systemImage
+          )
+        }
+        .buttonStyle(.plain)
+        .appPillChrome(accent: accent, filled: true)
+      }
+    }
+    .disabled(!isEnabled)
+    .opacity(isEnabled ? 1 : 0.55)
+    .scaleEffect(isEnabled ? 1 : 0.992)
+    .animation(AppMotion.snap, value: isEnabled)
+  }
+}
+
+struct AppSectionHeader: View {
+  let eyebrow: String
+  let title: String
+  var subtitle: String? = nil
+  var tint: Color = AppPalette.brand
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 8) {
+      AppEyebrow(title: eyebrow, tint: tint)
+      Text(title)
+        .font(AppTypography.display(28, weight: .bold))
+        .foregroundStyle(AppPalette.espresso)
+      if let subtitle, !subtitle.isEmpty {
+        Text(subtitle)
+          .font(AppTypography.body(15, weight: .medium))
+          .foregroundStyle(AppPalette.espresso.opacity(0.72))
+          .fixedSize(horizontal: false, vertical: true)
+      }
+    }
+  }
+}
+
+struct AppMetricPill: View {
+  let title: String
+  let value: String
+  var accent: Color = AppPalette.brand
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 5) {
+      Text(title.uppercased())
+        .font(AppTypography.micro(9, weight: .bold))
+        .tracking(1.6)
+        .foregroundStyle(accent)
+      Text(value)
+        .font(AppTypography.display(18, weight: .bold))
+        .foregroundStyle(AppPalette.espresso)
+    }
+    .padding(.horizontal, 14)
+    .padding(.vertical, 12)
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .appFieldChrome(tint: accent, cornerRadius: 20)
+  }
+}
+
+struct AppLoadingCard: View {
+  let title: String
+  var subtitle: String? = nil
+  var tint: Color = AppPalette.brand
+  var titleColor: Color = AppPalette.espresso
+  var subtitleColor: Color = AppPalette.espresso.opacity(0.68)
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      HStack(spacing: 12) {
+        AppSkeletonBlock(width: 42, height: 42, cornerRadius: 14, tint: tint)
+        VStack(alignment: .leading, spacing: 8) {
+          Text(title)
+            .font(AppTypography.body(16, weight: .bold))
+            .foregroundStyle(titleColor)
+          if let subtitle, !subtitle.isEmpty {
+            Text(subtitle)
+              .font(AppTypography.body(13, weight: .medium))
+              .foregroundStyle(subtitleColor)
+          }
+        }
+      }
+
+      VStack(alignment: .leading, spacing: 10) {
+        AppSkeletonBlock(width: nil, height: 14, cornerRadius: 8, tint: tint.opacity(0.7))
+        AppSkeletonBlock(width: nil, height: 14, cornerRadius: 8, tint: tint.opacity(0.52))
+        AppSkeletonBlock(width: 180, height: 14, cornerRadius: 8, tint: tint.opacity(0.40))
+      }
+    }
+    .frame(maxWidth: .infinity, alignment: .leading)
+    .appGlassCard(tint: tint, cornerRadius: 32)
+  }
+}
+
+struct AppSkeletonBlock: View {
+  @Environment(\.accessibilityReduceMotion) private var reduceMotion
+  var width: CGFloat?
+  var height: CGFloat
+  var cornerRadius: CGFloat
+  var tint: Color
+
+  var body: some View {
+    RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+      .fill(
+        LinearGradient(
+          colors: [
+            tint.opacity(0.20),
+            .white.opacity(0.82),
+            tint.opacity(0.16),
+          ],
+          startPoint: .leading,
+          endPoint: .trailing
+        )
+      )
+      .frame(maxWidth: width == nil ? .infinity : width, minHeight: height, maxHeight: height)
+      .opacity(reduceMotion ? 0.82 : 1)
+      .overlay {
+        RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
+          .stroke(.white.opacity(0.45), lineWidth: 0.7)
+      }
+  }
+}
+
+struct AppSegmentedControl<Selection: Hashable>: View {
+  let options: [Selection]
+  @Binding var selection: Selection
+  var accent: Color = AppPalette.brand
+  var title: (Selection) -> String
+  @Namespace private var namespace
+
+  var body: some View {
+    HStack(spacing: 8) {
+      ForEach(options, id: \.self) { option in
+        let isSelected = option == selection
+        Button {
+          withAnimation(AppMotion.settle) {
+            selection = option
+          }
+        } label: {
+          Text(title(option).uppercased())
+            .font(AppTypography.micro(10, weight: .bold))
+            .tracking(1.7)
+            .foregroundStyle(isSelected ? AppPalette.ink : AppPalette.espresso.opacity(0.72))
+            .frame(maxWidth: .infinity)
+            .padding(.vertical, 14)
+            .background {
+              if isSelected {
+                Capsule()
+                  .fill(.white.opacity(0.74))
+                  .matchedGeometryEffect(id: "app-segmented-selection", in: namespace)
+                  .padding(3)
+              }
+            }
+        }
+        .buttonStyle(.plain)
+      }
+    }
+    .padding(4)
+    .background {
+      Capsule()
+        .fill(accent.opacity(0.10))
+      Capsule()
+        .stroke(accent.opacity(0.18), lineWidth: 0.9)
+      Capsule()
+        .stroke(.white.opacity(0.52), lineWidth: 0.6)
+        .padding(3)
+    }
+  }
+}
+
+struct AppEntryRevealModifier: ViewModifier {
+  let delay: Double
+  @State private var isVisible = false
+
+  func body(content: Content) -> some View {
+    content
+      .opacity(isVisible ? 1 : 0)
+      .offset(y: isVisible ? 0 : 18)
+      .scaleEffect(isVisible ? 1 : 0.985)
+      .onAppear {
+        guard !isVisible else { return }
+        withAnimation(AppMotion.reveal.delay(delay)) {
+          isVisible = true
+        }
+      }
+  }
+}
+
+extension View {
+  func appEntryReveal(delay: Double = 0) -> some View {
+    modifier(AppEntryRevealModifier(delay: delay))
   }
 }
 
@@ -135,13 +541,19 @@ struct EnvironmentBadge: View {
   let environment: AppEnvironment
 
   var body: some View {
-    Text(environment.isProduction ? "PRODUCTION" : environment.displayName.uppercased())
-      .font(.caption2.weight(.semibold))
-      .tracking(0.8)
-      .padding(.vertical, 6)
-      .padding(.horizontal, 10)
-      .background(environment.isProduction ? AppPalette.success.opacity(0.16) : AppPalette.warning.opacity(0.18), in: Capsule())
-      .foregroundStyle(environment.isProduction ? AppPalette.success : AppPalette.warning)
+    let tint = environment.isProduction ? AppPalette.success : AppPalette.warning
+
+    return Text(environment.isProduction ? "PRODUCTION" : environment.displayName.uppercased())
+      .font(AppTypography.micro(10, weight: .bold))
+      .tracking(1.8)
+      .padding(.vertical, 8)
+      .padding(.horizontal, 12)
+      .background(tint.opacity(0.12), in: Capsule())
+      .overlay {
+        Capsule()
+          .stroke(tint.opacity(0.24), lineWidth: 0.8)
+      }
+      .foregroundStyle(tint)
   }
 }
 
@@ -360,6 +772,19 @@ struct StatusBanner: View {
         return AppPalette.danger
       }
     }
+
+    var symbol: String {
+      switch self {
+      case .neutral:
+        return "bell.badge"
+      case .success:
+        return "checkmark.circle.fill"
+      case .warning:
+        return "exclamationmark.triangle.fill"
+      case .danger:
+        return "xmark.octagon.fill"
+      }
+    }
   }
 
   let tone: Tone
@@ -367,12 +792,22 @@ struct StatusBanner: View {
   let message: String
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      Text(title)
-        .font(.headline)
-      Text(message)
-        .font(.subheadline)
-        .foregroundStyle(.secondary)
+    HStack(alignment: .top, spacing: 12) {
+      Image(systemName: tone.symbol)
+        .font(.system(size: 15, weight: .bold))
+        .foregroundStyle(tone.color)
+        .frame(width: 34, height: 34)
+        .background(tone.color.opacity(0.12), in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+
+      VStack(alignment: .leading, spacing: 5) {
+        Text(title)
+          .font(AppTypography.body(15, weight: .bold))
+          .foregroundStyle(AppPalette.espresso)
+        Text(message)
+          .font(AppTypography.body(13, weight: .medium))
+          .foregroundStyle(AppPalette.espresso.opacity(0.72))
+          .fixedSize(horizontal: false, vertical: true)
+      }
     }
     .frame(maxWidth: .infinity, alignment: .leading)
     .appGlassCard(tint: tone.color, cornerRadius: 24)

--- a/ios/ElRoysManagerApp/Features/Auth/AuthViews.swift
+++ b/ios/ElRoysManagerApp/Features/Auth/AuthViews.swift
@@ -4,67 +4,174 @@ struct AuthGateView: View {
   @Bindable var model: AppModel
 
   var body: some View {
-    ScrollView {
-      VStack(alignment: .leading, spacing: 20) {
-        VStack(alignment: .leading, spacing: 10) {
-          EnvironmentBadge(environment: model.environment)
-          Text("Staff Manager")
-            .font(.system(size: 36, weight: .bold, design: .rounded))
-            .foregroundStyle(AppPalette.ink)
-          Text("Sign in with the same Supabase-backed staff account used on the web manager. Sessions are stored in Keychain and can be re-opened with biometrics.")
-            .font(.title3)
-            .foregroundStyle(.secondary)
-        }
+    ScrollView(showsIndicators: false) {
+      VStack(alignment: .leading, spacing: 22) {
+        heroCard
+          .appEntryReveal()
 
-        Picker("Mode", selection: $model.authMode) {
-          ForEach(AuthScreenMode.allCases) { mode in
-            Text(mode.rawValue).tag(mode)
-          }
-        }
-        .pickerStyle(.segmented)
+        AppSegmentedControl(
+          options: AuthScreenMode.allCases,
+          selection: $model.authMode,
+          accent: AppPalette.brand,
+          title: { $0.rawValue }
+        )
+        .appEntryReveal(delay: 0.05)
 
-        VStack(spacing: 14) {
-          TextField("Staff email", text: $model.email)
-            .keyboardType(.emailAddress)
-            .textInputAutocapitalization(.never)
-            .autocorrectionDisabled()
-            .textFieldStyle(.roundedBorder)
-
-          if model.authMode != .reset {
-            SecureField("Password", text: $model.password)
-              .textFieldStyle(.roundedBorder)
-          }
-
-          if model.authMode == .signUp {
-            TextField("Display name", text: $model.displayName)
-              .textFieldStyle(.roundedBorder)
-          }
-        }
+        credentialsCard
+          .appEntryReveal(delay: 0.10)
 
         if let notice = model.notice {
           StatusBanner(tone: notice.tone, title: notice.title, message: notice.message)
+            .appEntryReveal(delay: 0.14)
         }
 
-        Button(action: submit) {
-          Label(primaryButtonTitle, systemImage: primaryButtonSymbol)
-            .font(.headline)
-            .frame(maxWidth: .infinity)
-        }
-        .buttonStyle(PrimaryGlassButtonStyle())
-        .disabled(model.isWorking)
+        AppIslandActionButton(
+          title: primaryButtonTitle,
+          subtitle: primaryButtonSubtitle,
+          systemImage: primaryButtonSymbol,
+          accent: AppPalette.brand,
+          isEnabled: !model.isWorking,
+          action: submit
+        )
+        .appEntryReveal(delay: 0.18)
 
-        Toggle("Require Face ID / passcode before restoring the saved session", isOn: Binding(
-          get: { SessionStore().biometricUnlockEnabled },
-          set: { SessionStore().biometricUnlockEnabled = $0 }
-        ))
-        .font(.footnote)
-        .toggleStyle(.switch)
+        biometricCard
+          .appEntryReveal(delay: 0.22)
+
+        Color.clear.frame(height: 22)
       }
-      .padding(24)
-      .appGlassCard(tint: AppPalette.brand, cornerRadius: 30)
-      .padding(24)
+      .padding(.horizontal, 24)
+      .padding(.top, 34)
+      .padding(.bottom, 20)
     }
     .scrollBounceBehavior(.basedOnSize)
+  }
+
+  private var heroCard: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      HStack {
+        EnvironmentBadge(environment: model.environment)
+        Spacer(minLength: 16)
+        AppEyebrow(title: model.authMode.rawValue, tint: AppPalette.sage)
+      }
+
+      AppSectionHeader(
+        eyebrow: "Staff access",
+        title: "Manager access\nwith floor-ready chrome.",
+        subtitle: "Sign in with the same Supabase-backed staff account used on the web manager. Sessions stay on device in Keychain and can be gated by Face ID or passcode.",
+        tint: AppPalette.brass
+      )
+
+      Group {
+        if #available(iOS 26.0, *) {
+          GlassEffectContainer(spacing: 10) {
+            HStack(spacing: 10) {
+              detailPill(title: "Keychain session", tint: AppPalette.cobalt)
+              detailPill(title: "Native editor", tint: AppPalette.brass)
+              detailPill(title: "Live preview", tint: AppPalette.brand)
+            }
+          }
+        } else {
+          HStack(spacing: 10) {
+            detailPill(title: "Keychain session", tint: AppPalette.cobalt)
+            detailPill(title: "Native editor", tint: AppPalette.brass)
+            detailPill(title: "Live preview", tint: AppPalette.brand)
+          }
+        }
+      }
+    }
+    .appGlassCard(tint: AppPalette.brass, cornerRadius: 38)
+  }
+
+  private var credentialsCard: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      AppEyebrow(title: "Credentials", tint: AppPalette.cobalt)
+
+      fieldGroup(title: "Staff email", systemImage: "envelope.open") {
+        TextField("manager@elroys.example", text: $model.email)
+          .keyboardType(.emailAddress)
+          .textInputAutocapitalization(.never)
+          .autocorrectionDisabled()
+          .font(AppTypography.body(16, weight: .medium))
+          .foregroundStyle(AppPalette.ink)
+          .padding(.horizontal, 16)
+          .padding(.vertical, 16)
+          .appFieldChrome(tint: AppPalette.cobalt)
+      }
+
+      if model.authMode != .reset {
+        fieldGroup(title: "Password", systemImage: "lock") {
+          SecureField("••••••••", text: $model.password)
+            .font(AppTypography.body(16, weight: .medium))
+            .foregroundStyle(AppPalette.ink)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
+            .appFieldChrome(tint: AppPalette.brand)
+        }
+      }
+
+      if model.authMode == .signUp {
+        fieldGroup(title: "Display name", systemImage: "person.text.rectangle") {
+          TextField("Name used on edits and history", text: $model.displayName)
+            .font(AppTypography.body(16, weight: .medium))
+            .foregroundStyle(AppPalette.ink)
+            .padding(.horizontal, 16)
+            .padding(.vertical, 16)
+            .appFieldChrome(tint: AppPalette.sage)
+        }
+      }
+    }
+    .appGlassCard(tint: AppPalette.sage, cornerRadius: 34)
+  }
+
+  private var biometricCard: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      AppEyebrow(title: "Device protection", tint: AppPalette.warning)
+      Text("Require Face ID or passcode before restoring the saved session.")
+        .font(AppTypography.body(15, weight: .medium))
+        .foregroundStyle(AppPalette.espresso)
+      Toggle(
+        "Biometric unlock",
+        isOn: Binding(
+          get: { SessionStore().biometricUnlockEnabled },
+          set: { SessionStore().biometricUnlockEnabled = $0 }
+        )
+      )
+      .tint(AppPalette.brand)
+      .font(AppTypography.body(15, weight: .semibold))
+      .foregroundStyle(AppPalette.ink)
+    }
+    .appGlassCard(tint: AppPalette.warning, cornerRadius: 30)
+  }
+
+  @ViewBuilder
+  private func fieldGroup<Content: View>(title: String, systemImage: String, @ViewBuilder content: () -> Content) -> some View {
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(spacing: 8) {
+        Image(systemName: systemImage)
+          .font(.system(size: 12, weight: .semibold))
+          .foregroundStyle(AppPalette.brand)
+        Text(title.uppercased())
+          .font(AppTypography.micro(10, weight: .bold))
+          .tracking(1.8)
+          .foregroundStyle(AppPalette.espresso.opacity(0.76))
+      }
+      content()
+    }
+  }
+
+  private func detailPill(title: String, tint: Color) -> some View {
+    Text(title.uppercased())
+      .font(AppTypography.micro(9, weight: .bold))
+      .tracking(1.6)
+      .padding(.vertical, 8)
+      .padding(.horizontal, 10)
+      .background(tint.opacity(0.12), in: Capsule(style: .continuous))
+      .overlay {
+        Capsule(style: .continuous)
+          .stroke(tint.opacity(0.22), lineWidth: 0.7)
+      }
+      .foregroundStyle(tint)
   }
 
   private var primaryButtonTitle: String {
@@ -78,14 +185,25 @@ struct AuthGateView: View {
     }
   }
 
+  private var primaryButtonSubtitle: String {
+    switch model.authMode {
+    case .signIn:
+      return "Restore the saved manager session and load the live workspace."
+    case .signUp:
+      return "Create a staff account and move straight into the native manager."
+    case .reset:
+      return "Send the recovery link to the staff email on file."
+    }
+  }
+
   private var primaryButtonSymbol: String {
     switch model.authMode {
     case .signIn:
-      return "person.crop.circle.badge.checkmark"
+      return "arrow.up.right"
     case .signUp:
-      return "person.crop.circle.badge.plus"
+      return "plus"
     case .reset:
-      return "envelope.badge"
+      return "paperplane"
     }
   }
 

--- a/ios/ElRoysManagerApp/Features/Home/HomeViews.swift
+++ b/ios/ElRoysManagerApp/Features/Home/HomeViews.swift
@@ -59,7 +59,7 @@ struct RestaurantChooserView: View {
             theme: theme,
             namespace: switcherNamespace,
             onSelect: { slug in
-              withAnimation(.easeInOut(duration: 0.35)) {
+              withAnimation(AppMotion.settle) {
                 selectedRestaurantSlug = slug
                 expandedUpdateID = nil
               }
@@ -125,7 +125,6 @@ struct RestaurantChooserView: View {
     .navigationTitle("Home")
     .navigationBarTitleDisplayMode(.inline)
     .toolbar(.hidden, for: .navigationBar)
-    .animation(.easeInOut(duration: 0.30), value: selectedRestaurantSlug)
     .task(id: selectedRestaurantSlug) {
       guard let restaurant = selectedRestaurant else { return }
       await model.loadRestaurantTools(for: restaurant.id)
@@ -400,7 +399,7 @@ private struct PulsingDot: View {
       if reduceMotion || scenePhase != .active {
         dot(phase: 0.5)
       } else {
-        TimelineView(.periodic(from: .now, by: 1.0 / 12.0)) { context in
+        TimelineView(.periodic(from: .now, by: 1.0 / 6.0)) { context in
           let t = context.date.timeIntervalSinceReferenceDate
           dot(phase: (sin(t * 2.6) + 1) / 2)
         }
@@ -434,7 +433,7 @@ private struct HomeRestaurantSwitcher: View {
 
   var body: some View {
     HStack(spacing: 0) {
-      ForEach(Array(options.enumerated()), id: \.element.id) { index, option in
+      ForEach(options) { option in
         let isSelected = option.slug == selectedSlug
         Button {
           onSelect(option.slug)
@@ -468,7 +467,7 @@ private struct HomeRestaurantSwitcher: View {
         }
         .buttonStyle(.plain)
 
-        if index < options.count - 1 {
+        if option.id != options.last?.id {
           Rectangle()
             .fill(theme.accent.opacity(0.35))
             .frame(width: 0.6, height: 36)
@@ -526,7 +525,7 @@ private struct HomeRecentUpdatesCard: View {
               isExpanded: expandedUpdateID == update.id,
               theme: theme,
               onToggle: {
-                withAnimation(.easeInOut(duration: 0.22)) {
+                withAnimation(AppMotion.snap) {
                   expandedUpdateID = expandedUpdateID == update.id ? nil : update.id
                 }
               }
@@ -1050,7 +1049,7 @@ private struct HomeMedallionBorder: View {
       if reduceMotion || scenePhase != .active {
         medallion(at: .degrees(0))
       } else {
-        TimelineView(.periodic(from: .now, by: 1.0 / 15.0)) { context in
+        TimelineView(.periodic(from: .now, by: 1.0 / 6.0)) { context in
           let t = context.date.timeIntervalSinceReferenceDate
           let angle = Angle.degrees(t.truncatingRemainder(dividingBy: 12) / 12 * 360)
           medallion(at: angle)
@@ -1124,17 +1123,17 @@ private struct HomeBackground: View {
 
   @ViewBuilder
   private var motifCornerEmblem: some View {
-    GeometryReader { proxy in
-      switch theme.motif {
-      case .chevron:
-        DecoFan(color: theme.patternInk.opacity(0.35), rayCount: 13, radius: 210)
-          .frame(width: 210, height: 210)
-          .position(x: proxy.size.width - 60, y: 60)
-      case .diamond:
-        SunburstRays(color: theme.patternInk.opacity(0.55), rayCount: 30, innerRadius: 22, outerRadius: 220)
-          .frame(width: 220, height: 220)
-          .position(x: proxy.size.width - 40, y: 40)
-      }
+    switch theme.motif {
+    case .chevron:
+      DecoFan(color: theme.patternInk.opacity(0.35), rayCount: 13, radius: 210)
+        .frame(width: 210, height: 210)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+        .offset(x: 45, y: -45)
+    case .diamond:
+      SunburstRays(color: theme.patternInk.opacity(0.55), rayCount: 30, innerRadius: 22, outerRadius: 220)
+        .frame(width: 220, height: 220)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topTrailing)
+        .offset(x: 70, y: -70)
     }
   }
 
@@ -1435,31 +1434,34 @@ private struct HomeBottomBarClusterModifier: ViewModifier {
   let theme: HomeTheme
 
   func body(content: Content) -> some View {
-    if #available(iOS 26.0, *) {
-      content
-        .glassEffect(.regular.tint(theme.bottomNavGlassTint.opacity(0.34)), in: .capsule)
-        .overlay {
+    content
+      .background {
+        ZStack {
           Capsule()
-            .stroke(theme.bottomNavSelectedBorder.opacity(0.56), lineWidth: 1)
-        }
-    } else {
-      content
-        .background(
-          LinearGradient(
-            colors: [
-              theme.bottomNavGlassTint.opacity(0.96),
-              theme.bottomNavGlassTint.opacity(0.84),
-            ],
-            startPoint: .topLeading,
-            endPoint: .bottomTrailing
-          ),
-          in: Capsule()
-        )
-        .overlay {
+            .fill(theme.bottomNavGlassTint.opacity(0.16))
+
           Capsule()
-            .stroke(theme.bottomNavSelectedBorder.opacity(0.56), lineWidth: 1)
+            .stroke(theme.bottomNavSelectedBorder.opacity(0.22), lineWidth: 0.9)
+
+          Capsule()
+            .fill(
+              LinearGradient(
+                colors: [
+                  .white.opacity(0.82),
+                  theme.bottomNavGlassTint.opacity(0.86),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+              )
+            )
+            .padding(5)
+
+          Capsule()
+            .stroke(.white.opacity(0.66), lineWidth: 0.7)
+            .padding(5)
         }
-    }
+        .shadow(color: theme.shadowTint.opacity(0.10), radius: 20, y: 12)
+      }
   }
 }
 
@@ -1467,13 +1469,31 @@ private struct HomeDetachedQRButtonModifier: ViewModifier {
   let theme: HomeTheme
 
   func body(content: Content) -> some View {
-    if #available(iOS 26.0, *) {
-      content
-        .glassEffect(.regular.tint(theme.bottomNavGlassTint.opacity(0.34)).interactive(), in: .circle)
-    } else {
-      content
-        .background(theme.bottomNavGlassTint.opacity(0.94), in: Circle())
-    }
+    content
+      .background {
+        ZStack {
+          Circle()
+            .fill(theme.bottomNavGlassTint.opacity(0.18))
+          Circle()
+            .stroke(theme.bottomNavSelectedBorder.opacity(0.22), lineWidth: 0.9)
+          Circle()
+            .fill(
+              LinearGradient(
+                colors: [
+                  .white.opacity(0.88),
+                  theme.bottomNavGlassTint.opacity(0.92),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+              )
+            )
+            .padding(5)
+          Circle()
+            .stroke(.white.opacity(0.64), lineWidth: 0.7)
+            .padding(5)
+        }
+        .shadow(color: theme.shadowTint.opacity(0.10), radius: 18, y: 10)
+      }
   }
 }
 
@@ -1482,21 +1502,41 @@ private struct HomeGlassChromeModifier: ViewModifier {
   let cornerRadius: CGFloat
 
   func body(content: Content) -> some View {
-    if #available(iOS 26.0, *) {
-      content
-        .glassEffect(.regular.tint(tint.opacity(0.20)), in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-        .overlay {
+    let innerRadius = max(18, cornerRadius - 7)
+
+    content
+      .background {
+        ZStack {
           RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-            .stroke(tint.opacity(0.24), lineWidth: 1)
-        }
-    } else {
-      content
-        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: cornerRadius, style: .continuous))
-        .overlay {
+            .fill(tint.opacity(0.08))
+
           RoundedRectangle(cornerRadius: cornerRadius, style: .continuous)
-            .stroke(tint.opacity(0.20), lineWidth: 1)
+            .stroke(tint.opacity(0.20), lineWidth: 0.9)
+
+          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
+            .fill(
+              LinearGradient(
+                colors: [
+                  .white.opacity(0.82),
+                  tint.opacity(0.14),
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+              )
+            )
+            .padding(6)
+
+          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
+            .stroke(.white.opacity(0.66), lineWidth: 0.7)
+            .padding(6)
         }
-    }
+        .shadow(color: tint.opacity(0.10), radius: 22, y: 12)
+        .shadow(color: themeShadow(tint: tint), radius: 20, y: 12)
+      }
+  }
+
+  private func themeShadow(tint: Color) -> Color {
+    tint.opacity(0.06)
   }
 }
 

--- a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
@@ -11,12 +11,8 @@ struct MenuEditorScreen: View {
   @Environment(\.scenePhase) private var scenePhase
   @Bindable var model: AppModel
   let menu: MenuRecord
-  @State private var addCategoryName = ""
-  @State private var showingAddCategory = false
   @State private var editingDraft = EditableItemDraft()
   @State private var activeSheet: MenuEditorSheet?
-  @State private var renameTarget: MenuCategoryPayload?
-  @State private var renameText = ""
   @State private var showingDiscardDraftConfirm = false
   @State private var reorderingCategoryKey: String?
 
@@ -26,10 +22,6 @@ struct MenuEditorScreen: View {
 
   private var menuAccent: Color {
     menu.isFoodMenu ? theme.foodAccent : theme.drinkAccent
-  }
-
-  private var canEditCategories: Bool {
-    model.canEditCategories
   }
 
   var body: some View {
@@ -65,10 +57,7 @@ struct MenuEditorScreen: View {
 
           if let document = model.currentEditorDocument {
             MenuEditorCategoriesHeader(
-              theme: theme,
-              menuAccent: menuAccent,
-              canEditCategories: canEditCategories,
-              onAddCategory: { showingAddCategory = true }
+              theme: theme
             )
             ForEach(document.visibleCategories) { category in
               MenuEditorCategoryCard(
@@ -76,14 +65,6 @@ struct MenuEditorScreen: View {
                 category: category,
                 theme: theme,
                 menuAccent: menuAccent,
-                canEditCategories: canEditCategories,
-                onRename: {
-                  renameTarget = category
-                  renameText = category.label
-                },
-                onDelete: {
-                  model.deleteCategory(key: category.key)
-                },
                 onSelectItem: { item in
                   reorderingCategoryKey = nil
                   editingDraft = EditableItemDraft(item: item, categoryKey: category.key, isFoodMenu: menu.isFoodMenu)
@@ -169,8 +150,6 @@ struct MenuEditorScreen: View {
     .onChange(of: model.editorRefreshRequirement != nil) { _, required in
       guard required else { return }
       activeSheet = nil
-      showingAddCategory = false
-      renameTarget = nil
       reorderingCategoryKey = nil
     }
     .sheet(item: Binding(
@@ -195,28 +174,6 @@ struct MenuEditorScreen: View {
         }
       }
     }
-    .alert("Add Category", isPresented: $showingAddCategory) {
-      TextField("Category name", text: $addCategoryName)
-      Button("Add") {
-        model.addCategory(label: addCategoryName)
-        addCategoryName = ""
-      }
-      Button("Cancel", role: .cancel) {
-        addCategoryName = ""
-      }
-    }
-    .alert("Rename Category", isPresented: Binding(
-      get: { renameTarget != nil },
-      set: { if !$0 { renameTarget = nil } }
-    )) {
-      TextField("Category name", text: $renameText)
-      Button("Save") {
-        if let target = renameTarget {
-          model.renameCategory(key: target.key, label: renameText)
-        }
-      }
-      Button("Cancel", role: .cancel) {}
-    }
     .alert("Discard Local Draft?", isPresented: $showingDiscardDraftConfirm) {
       Button("Discard Draft", role: .destructive) {
         model.discardLocalDraft()
@@ -235,7 +192,7 @@ struct MenuEditorScreen: View {
       model.notice = AppNotice(
         tone: .warning,
         title: "Add A Category First",
-        message: "Create at least one category before adding menu items."
+        message: "Create at least one category in Restaurant Tools before adding menu items."
       )
     }
   }
@@ -365,6 +322,8 @@ private struct PublishPreviewSheet: View {
   }
 
   var body: some View {
+    let currentSummary = summary
+
     NavigationStack {
       ScrollView {
         VStack(alignment: .leading, spacing: 18) {
@@ -402,26 +361,26 @@ private struct PublishPreviewSheet: View {
             .menuEditorSurface(colors: [theme.previewTop, theme.previewBottom], border: theme.previewBorder)
           }
 
-          if !summary.selectedNotificationChanges.isEmpty {
+          if !currentSummary.selectedNotificationChanges.isEmpty {
             PublishPreviewSummaryCard(
               title: "Changes To Send In Notification",
-              items: summary.selectedNotificationChanges.map(\.displayText),
+              items: currentSummary.selectedNotificationChanges.map(\.displayText),
               theme: theme
             )
           }
 
-          if !summary.clearedNotificationChanges.isEmpty {
+          if !currentSummary.clearedNotificationChanges.isEmpty {
             PublishPreviewSummaryCard(
               title: "Changes To Clear",
-              items: summary.clearedNotificationChanges.map(\.displayText),
+              items: currentSummary.clearedNotificationChanges.map(\.displayText),
               theme: theme
             )
           }
 
-          if !summary.saveOnlyChanges.isEmpty {
+          if !currentSummary.saveOnlyChanges.isEmpty {
             PublishPreviewSummaryCard(
               title: "Save Only Changes",
-              items: summary.saveOnlyChanges.map { $0.label.nilIfBlank ?? $0.message },
+              items: currentSummary.saveOnlyChanges.map { $0.label.nilIfBlank ?? $0.message },
               theme: theme
             )
           }
@@ -517,60 +476,74 @@ private struct PublishPreviewActionButton: View {
   let action: () -> Void
 
   var body: some View {
-    Button(action: action) {
-      HStack(spacing: 14) {
-        VStack(alignment: .leading, spacing: 5) {
-          Text(title)
-            .font(EditorTypography.body(16, weight: .bold))
-            .foregroundStyle(theme.titleText)
-          Text(subtitle)
-            .font(EditorTypography.body(12, weight: .medium))
-            .foregroundStyle(theme.subtleText)
+    Group {
+      if #available(iOS 26.0, *) {
+        Button(action: action) {
+          label
         }
-
-        Spacer()
-
-        Image(systemName: icon)
-          .font(.system(size: 18, weight: .bold))
-          .foregroundStyle(theme.titleText)
-          .frame(width: 46, height: 46)
-          .background(.white.opacity(0.18), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
-          .overlay {
-            RoundedRectangle(cornerRadius: 16, style: .continuous)
-              .stroke(.white.opacity(0.22), lineWidth: 1)
-          }
+        .buttonStyle(.glassProminent)
+        .tint(accent)
+      } else {
+        Button(action: action) {
+          label
+        }
+        .buttonStyle(.plain)
+        .background {
+          let shape = RoundedRectangle(cornerRadius: 24, style: .continuous)
+          shape
+            .fill(.thinMaterial)
+            .overlay {
+              LinearGradient(
+                colors: [
+                  accent.opacity(0.42),
+                  accent.opacity(0.22),
+                  accent.opacity(0.12)
+                ],
+                startPoint: .topLeading,
+                endPoint: .bottomTrailing
+              )
+              .clipShape(shape)
+            }
+        }
+        .overlay {
+          RoundedRectangle(cornerRadius: 24, style: .continuous)
+            .stroke(accent.opacity(0.36), lineWidth: 1)
+        }
+        .shadow(color: accent.opacity(0.2), radius: 18, y: 10)
       }
-      .padding(.horizontal, 18)
-      .padding(.vertical, 16)
-      .frame(maxWidth: .infinity)
-      .background {
-        let shape = RoundedRectangle(cornerRadius: 24, style: .continuous)
-        shape
-          .fill(.thinMaterial)
-          .overlay {
-            LinearGradient(
-              colors: [
-                accent.opacity(0.42),
-                accent.opacity(0.22),
-                accent.opacity(0.12)
-              ],
-              startPoint: .topLeading,
-              endPoint: .bottomTrailing
-            )
-            .clipShape(shape)
-          }
-      }
-      .overlay {
-        RoundedRectangle(cornerRadius: 24, style: .continuous)
-          .stroke(accent.opacity(0.36), lineWidth: 1)
-      }
-      .shadow(color: accent.opacity(0.2), radius: 18, y: 10)
     }
-    .buttonStyle(.plain)
     .disabled(!enabled)
     .opacity(enabled ? 1 : 0.5)
     .scaleEffect(enabled ? 1 : 0.98)
-    .animation(.easeOut(duration: 0.16), value: enabled)
+    .animation(AppMotion.snap, value: enabled)
+  }
+
+  private var label: some View {
+    HStack(spacing: 14) {
+      VStack(alignment: .leading, spacing: 5) {
+        Text(title)
+          .font(EditorTypography.body(16, weight: .bold))
+          .foregroundStyle(theme.titleText)
+        Text(subtitle)
+          .font(EditorTypography.body(12, weight: .medium))
+          .foregroundStyle(theme.subtleText)
+      }
+
+      Spacer()
+
+      Image(systemName: icon)
+        .font(.system(size: 18, weight: .bold))
+        .foregroundStyle(theme.titleText)
+        .frame(width: 46, height: 46)
+        .background(.white.opacity(0.18), in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+        .overlay {
+          RoundedRectangle(cornerRadius: 16, style: .continuous)
+            .stroke(.white.opacity(0.22), lineWidth: 1)
+        }
+    }
+    .padding(.horizontal, 18)
+    .padding(.vertical, 16)
+    .frame(maxWidth: .infinity)
   }
 }
 
@@ -723,27 +696,15 @@ private struct MenuEditorActionPanel: View {
 
 private struct MenuEditorCategoriesHeader: View {
   let theme: MenuEditorTheme
-  let menuAccent: Color
-  let canEditCategories: Bool
-  let onAddCategory: () -> Void
 
   var body: some View {
-    HStack(alignment: .center) {
-      Text("Categories")
+    VStack(alignment: .leading, spacing: 4) {
+      Text("Menu Items")
         .font(EditorTypography.display(20, weight: .bold))
         .foregroundStyle(theme.titleText)
-      Spacer()
-      if canEditCategories {
-        Button(action: onAddCategory) {
-          Label("Add Category", systemImage: "square.split.1x2.fill")
-        }
-        .buttonStyle(SecondaryGlassButtonStyle())
-        .tint(menuAccent)
-      } else {
-        Text("Admin managed")
-          .font(EditorTypography.body(12, weight: .semibold))
-          .foregroundStyle(theme.subtleText)
-      }
+      Text("Categories are managed from Restaurant Tools.")
+        .font(EditorTypography.body(12, weight: .medium))
+        .foregroundStyle(theme.subtleText)
     }
   }
 }
@@ -782,9 +743,6 @@ private struct MenuEditorCategoryCard: View {
   let category: MenuCategoryPayload
   let theme: MenuEditorTheme
   let menuAccent: Color
-  let canEditCategories: Bool
-  let onRename: () -> Void
-  let onDelete: () -> Void
   let onSelectItem: (MenuItemPayload) -> Void
   let onToggleEightySix: (MenuItemPayload) -> Void
   let isReordering: Bool
@@ -797,7 +755,7 @@ private struct MenuEditorCategoryCard: View {
 
   var body: some View {
     VStack(alignment: .leading, spacing: 12) {
-      HStack(alignment: .top) {
+      HStack(alignment: .top, spacing: 12) {
         VStack(alignment: .leading, spacing: 4) {
           Text(category.label)
             .font(EditorTypography.display(22, weight: .bold))
@@ -815,19 +773,14 @@ private struct MenuEditorCategoryCard: View {
           .padding(.horizontal, 8)
           .background(menuAccent.opacity(0.15), in: Capsule())
           .foregroundStyle(menuAccent)
-        if canEditCategories || visibleItems.count > 1 || isReordering {
-          Menu {
-            Button(isReordering ? "Done Reordering" : "Reorder Items", action: onToggleReorder)
-              .disabled(visibleItems.count < 2 && !isReordering)
-            if canEditCategories {
-              Button("Rename", action: onRename)
-              Button("Delete Category", role: .destructive, action: onDelete)
-            }
-          } label: {
-            Image(systemName: "ellipsis.circle.fill")
-              .font(.system(size: 20))
-              .foregroundStyle(theme.subtleText)
+        if visibleItems.count > 1 || isReordering {
+          Button(action: onToggleReorder) {
+            Label(
+              isReordering ? "Done Reordering" : "Reorder",
+              systemImage: isReordering ? "checkmark.circle.fill" : "arrow.up.arrow.down.circle.fill"
+            )
           }
+          .buttonStyle(SecondaryGlassButtonStyle(accent: menuAccent))
         }
       }
 
@@ -865,16 +818,16 @@ private struct MenuEditorSwipeList: View {
     List {
       ForEach(items, id: \.id) { item in
         row(for: item)
-        .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
-        .listRowBackground(Color.clear)
-        .listRowSeparator(.hidden)
-        .background {
-          GeometryReader { proxy in
-            Color.clear
-              .preference(key: MenuEditorRowHeightPreferenceKey.self, value: [item.id: proxy.size.height])
+          .listRowInsets(EdgeInsets(top: 6, leading: 0, bottom: 6, trailing: 0))
+          .listRowBackground(Color.clear)
+          .listRowSeparator(.hidden)
+          .background {
+            GeometryReader { proxy in
+              Color.clear
+                .preference(key: MenuEditorRowHeightPreferenceKey.self, value: [item.id: proxy.size.height])
+            }
           }
-        }
-        .moveDisabled(!isReordering || items.count < 2)
+          .moveDisabled(!isReordering || items.count < 2)
       }
       .onMove(perform: onMoveVisibleItems)
     }
@@ -994,14 +947,13 @@ private struct MenuEditorLoadingCard: View {
   let theme: MenuEditorTheme
 
   var body: some View {
-    VStack(spacing: 12) {
-      ProgressView()
-      Text("Loading editor…")
-        .font(EditorTypography.body(15, weight: .medium))
-        .foregroundStyle(theme.subtleText)
-    }
-    .frame(maxWidth: .infinity)
-    .menuEditorSurface(colors: [theme.panelTop, theme.panelBottom], border: theme.panelBorder)
+    AppLoadingCard(
+      title: "Loading editor",
+      subtitle: "Preparing the live workspace, local draft state, and publish queue.",
+      tint: theme.neutralAccent,
+      titleColor: theme.titleText,
+      subtitleColor: theme.subtleText
+    )
   }
 }
 
@@ -1210,32 +1162,23 @@ private enum EditorTypography {
     case medium
     case semibold
     case bold
+
+    var fontWeight: Font.Weight {
+      switch self {
+      case .regular: return .regular
+      case .medium: return .medium
+      case .semibold: return .semibold
+      case .bold: return .bold
+      }
+    }
   }
 
   static func display(_ size: CGFloat, weight: Weight = .semibold) -> Font {
-    switch weight {
-    case .regular:
-      return .custom("AvenirNextCondensed-Regular", size: size)
-    case .medium:
-      return .custom("AvenirNextCondensed-Medium", size: size)
-    case .semibold:
-      return .custom("AvenirNextCondensed-DemiBold", size: size)
-    case .bold:
-      return .custom("AvenirNextCondensed-Bold", size: size)
-    }
+    AppTypography.display(size, weight: weight.fontWeight)
   }
 
   static func body(_ size: CGFloat, weight: Weight = .regular) -> Font {
-    switch weight {
-    case .regular:
-      return .custom("AvenirNext-Regular", size: size)
-    case .medium:
-      return .custom("AvenirNext-Medium", size: size)
-    case .semibold:
-      return .custom("AvenirNext-DemiBold", size: size)
-    case .bold:
-      return .custom("AvenirNext-Bold", size: size)
-    }
+    AppTypography.body(size, weight: weight.fontWeight)
   }
 }
 
@@ -1245,17 +1188,30 @@ private struct MenuEditorSurfaceModifier: ViewModifier {
   let radius: CGFloat
 
   func body(content: Content) -> some View {
+    let innerRadius = max(18, radius - 7)
+
     content
       .padding(18)
-      .background(
-        LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing),
-        in: RoundedRectangle(cornerRadius: radius, style: .continuous)
-      )
-      .overlay {
-        RoundedRectangle(cornerRadius: radius, style: .continuous)
-          .stroke(border, lineWidth: 1)
+      .background {
+        ZStack {
+          RoundedRectangle(cornerRadius: radius, style: .continuous)
+            .fill(border.opacity(0.08))
+
+          RoundedRectangle(cornerRadius: radius, style: .continuous)
+            .stroke(border.opacity(0.20), lineWidth: 0.9)
+
+          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
+            .fill(
+              LinearGradient(colors: colors, startPoint: .topLeading, endPoint: .bottomTrailing)
+            )
+            .padding(6)
+
+          RoundedRectangle(cornerRadius: innerRadius, style: .continuous)
+            .stroke(.white.opacity(0.64), lineWidth: 0.7)
+            .padding(6)
+        }
+        .shadow(color: border.opacity(0.12), radius: 22, y: 14)
       }
-      .shadow(color: border.opacity(0.16), radius: 18, y: 8)
   }
 }
 

--- a/ios/ElRoysManagerApp/Features/Menu/RestaurantCategoryManagementView.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/RestaurantCategoryManagementView.swift
@@ -1,0 +1,256 @@
+import SwiftUI
+
+struct RestaurantCategoryManagementScreen: View {
+  @Bindable var model: AppModel
+  let menu: MenuRecord
+
+  @State private var addCategoryName = ""
+  @State private var renameTarget: MenuCategoryPayload?
+  @State private var renameText = ""
+  @State private var isReordering = false
+  @State private var showingAddCategory = false
+  @State private var showingDiscardDraftConfirm = false
+  @State private var showingPreview = false
+
+  private var accent: Color {
+    menu.isFoodMenu ? AppPalette.jade : AppPalette.bloodOrange
+  }
+
+  var body: some View {
+    ScrollView(showsIndicators: false) {
+      VStack(alignment: .leading, spacing: 18) {
+        AppSectionHeader(
+          eyebrow: "Restaurant tools",
+          title: "\(menu.displayTypeLabel) categories",
+          subtitle: "Add, rename, delete, and reorder categories without leaving the staff tools flow.",
+          tint: accent
+        )
+
+        if let notice = model.notice {
+          StatusBanner(tone: notice.tone, title: notice.title, message: notice.message)
+        }
+
+        categoryActions
+
+        if let document = model.currentEditorDocument {
+          categoryList(document.visibleCategories)
+        } else {
+          AppLoadingCard(
+            title: "Loading categories",
+            subtitle: "Preparing the live workspace, local draft state, and category structure.",
+            tint: accent
+          )
+        }
+      }
+      .padding(24)
+    }
+    .navigationTitle("\(menu.displayTypeLabel) Categories")
+    .navigationBarTitleDisplayMode(.inline)
+    .task(id: menu.id) {
+      await model.loadEditor(menuId: menu.id)
+    }
+    .sheet(isPresented: $showingPreview) {
+      if let preview = model.currentEditorPreview {
+        RestaurantCategoryPublishPreviewSheet(
+          model: model,
+          preview: preview,
+          accent: accent,
+          onPublish: {
+            Task {
+              await model.publishSelectedChanges()
+              showingPreview = false
+            }
+          }
+        )
+      } else {
+        ProgressView("Loading preview…")
+          .presentationDetents([.medium])
+      }
+    }
+    .alert("Add Category", isPresented: $showingAddCategory) {
+      TextField("Category name", text: $addCategoryName)
+      Button("Add") {
+        model.addCategory(label: addCategoryName)
+        addCategoryName = ""
+      }
+      Button("Cancel", role: .cancel) {
+        addCategoryName = ""
+      }
+    }
+    .alert("Rename Category", isPresented: Binding(
+      get: { renameTarget != nil },
+      set: { isPresented in
+        if !isPresented {
+          renameTarget = nil
+          renameText = ""
+        }
+      }
+    )) {
+      TextField("Category name", text: $renameText)
+      Button("Save") {
+        if let target = renameTarget {
+          model.renameCategory(key: target.key, label: renameText)
+        }
+        renameTarget = nil
+        renameText = ""
+      }
+      Button("Cancel", role: .cancel) {
+        renameTarget = nil
+        renameText = ""
+      }
+    }
+    .alert("Discard Local Draft?", isPresented: $showingDiscardDraftConfirm) {
+      Button("Discard Draft", role: .destructive) {
+        model.discardLocalDraft()
+      }
+      Button("Keep Editing", role: .cancel) {}
+    } message: {
+      Text("This only removes unsaved edits from this device and does not modify the shared server queue.")
+    }
+  }
+
+  private var categoryActions: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      Button("Add Category") {
+        showingAddCategory = true
+      }
+      .buttonStyle(PrimaryGlassButtonStyle(accent: accent))
+      .disabled(!model.canEditCategories)
+
+      HStack(spacing: 12) {
+        Button("Save Quietly") {
+          Task { await model.saveLiveMenu() }
+        }
+        .buttonStyle(SecondaryGlassButtonStyle(accent: accent))
+        .disabled(!model.canSaveQuietlyRemotely)
+
+        Button(model.hasLocalDraftChanges ? "Save & Send" : "Send Update") {
+          Task {
+            await model.loadPublishPreview()
+            showingPreview = model.currentEditorPreview != nil
+          }
+        }
+        .buttonStyle(SecondaryGlassButtonStyle(accent: accent))
+        .disabled(!model.canLoadPublishPreview)
+
+        Button("Discard Draft") {
+          showingDiscardDraftConfirm = true
+        }
+        .buttonStyle(SecondaryGlassButtonStyle(accent: accent))
+        .disabled(!model.canDiscardLocalDraft)
+      }
+    }
+    .appGlassCard(tint: accent, cornerRadius: 28)
+  }
+
+  @ViewBuilder
+  private func categoryList(_ categories: [MenuCategoryPayload]) -> some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack {
+        Text("Categories")
+          .font(AppTypography.display(24, weight: .bold))
+          .foregroundStyle(AppPalette.ink)
+
+        Spacer()
+
+        if categories.count > 1 || isReordering {
+          Button(isReordering ? "Done Reordering" : "Reorder Categories") {
+            isReordering.toggle()
+          }
+          .buttonStyle(SecondaryGlassButtonStyle(accent: accent))
+          .disabled(!model.canEditCategories)
+        }
+      }
+
+      List {
+        ForEach(categories) { category in
+          HStack(spacing: 12) {
+            VStack(alignment: .leading, spacing: 4) {
+              Text(category.label)
+                .font(AppTypography.body(16, weight: .bold))
+              Text("\(category.items.filter(\.onMenu).count) live items")
+                .font(AppTypography.body(12, weight: .medium))
+                .foregroundStyle(.secondary)
+            }
+
+            Spacer()
+
+            if !isReordering {
+              Button("Rename") {
+                renameTarget = category
+                renameText = category.label
+              }
+              .buttonStyle(SecondaryGlassButtonStyle(accent: accent))
+              .disabled(!model.canEditCategories)
+
+              Button("Delete", role: .destructive) {
+                model.deleteCategory(key: category.key)
+              }
+              .buttonStyle(SecondaryGlassButtonStyle(accent: AppPalette.danger))
+              .disabled(!model.canEditCategories)
+            }
+          }
+          .listRowSeparator(.hidden)
+          .listRowBackground(Color.clear)
+          .moveDisabled(!isReordering || !model.canEditCategories)
+        }
+        .onMove(perform: model.moveVisibleCategories)
+      }
+      .environment(\.editMode, .constant(isReordering ? .active : .inactive))
+      .listStyle(.plain)
+      .scrollContentBackground(.hidden)
+      .frame(height: max(CGFloat(categories.count) * 72, 88))
+    }
+    .appGlassCard(tint: accent, cornerRadius: 30)
+  }
+}
+
+private struct RestaurantCategoryPublishPreviewSheet: View {
+  @Environment(\.dismiss) private var dismiss
+  @Bindable var model: AppModel
+  let preview: MenuPreviewPayload
+  let accent: Color
+  let onPublish: () -> Void
+
+  var body: some View {
+    NavigationStack {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 16) {
+          Text(preview.patchMessage.isEmpty ? "Review the queued category changes before sending." : preview.patchMessage)
+            .font(AppTypography.body(14, weight: .medium))
+
+          ForEach(preview.sections) { section in
+            VStack(alignment: .leading, spacing: 10) {
+              Text(section.label)
+                .font(AppTypography.body(16, weight: .bold))
+
+              ForEach(section.changes) { change in
+                Toggle(
+                  isOn: Binding(
+                    get: { model.selectedPreviewChangeIDs.contains(change.id) },
+                    set: { model.updatePreviewSelection(change.id, selected: $0) }
+                  )
+                ) {
+                  Text(change.text)
+                }
+                .tint(accent)
+              }
+            }
+            .appFieldChrome(tint: accent, cornerRadius: 20)
+          }
+        }
+        .padding(24)
+      }
+      .navigationTitle("Send Preview")
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Close") { dismiss() }
+        }
+        ToolbarItem(placement: .confirmationAction) {
+          Button(preview.hasNotificationChanges ? "Send Update" : "Save Changes", action: onPublish)
+            .disabled(!model.canPublishRemotely)
+        }
+      }
+    }
+  }
+}

--- a/ios/ElRoysManagerApp/Features/Preview/RoutePreviewView.swift
+++ b/ios/ElRoysManagerApp/Features/Preview/RoutePreviewView.swift
@@ -2,29 +2,63 @@ import SwiftUI
 import WebKit
 
 struct RoutePreviewScreen: View {
-  @Bindable var model: AppModel
   let menu: MenuRecord
+  let url: URL
 
   var body: some View {
-    VStack(spacing: 0) {
-      HStack {
-        VStack(alignment: .leading, spacing: 4) {
-          Text("Exact Route Preview")
-            .font(.headline)
-          Text(model.exactRoutePreviewURL(for: menu).absoluteString)
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .lineLimit(2)
-        }
-        Spacer()
-      }
-      .padding(16)
-      .background(.thinMaterial)
+    VStack(spacing: 18) {
+      headerCard
+        .padding(.horizontal, 20)
+        .padding(.top, 16)
+        .appEntryReveal()
 
-      WebPreview(url: model.exactRoutePreviewURL(for: menu))
+      ZStack {
+        RoundedRectangle(cornerRadius: 34, style: .continuous)
+          .fill(AppPalette.parchment.opacity(0.24))
+        RoundedRectangle(cornerRadius: 34, style: .continuous)
+          .stroke(AppPalette.cobalt.opacity(0.16), lineWidth: 0.9)
+        RoundedRectangle(cornerRadius: 28, style: .continuous)
+          .fill(.white.opacity(0.55))
+          .padding(6)
+        WebPreview(url: url)
+          .clipShape(RoundedRectangle(cornerRadius: 28, style: .continuous))
+          .padding(6)
+      }
+      .padding(.horizontal, 20)
+      .padding(.bottom, 18)
+      .appEntryReveal(delay: 0.08)
+    }
+    .background {
+      AppBackground()
+        .ignoresSafeArea()
     }
     .navigationTitle(menu.displayTypeLabel)
     .navigationBarTitleDisplayMode(.inline)
+  }
+
+  private var headerCard: some View {
+    VStack(alignment: .leading, spacing: 14) {
+      HStack {
+        AppEyebrow(title: "Exact route preview", tint: AppPalette.cobalt)
+        Spacer(minLength: 12)
+        Text(menu.displayTypeLabel.uppercased())
+          .font(AppTypography.micro(9, weight: .bold))
+          .tracking(1.6)
+          .foregroundStyle(AppPalette.espresso.opacity(0.62))
+      }
+
+      AppSectionHeader(
+        eyebrow: "Route",
+        title: "Deployed guest-facing route",
+        tint: AppPalette.cobalt
+      )
+
+      Text(url.absoluteString)
+        .font(AppTypography.body(13, weight: .medium))
+        .foregroundStyle(AppPalette.espresso.opacity(0.70))
+        .textSelection(.enabled)
+    }
+    .appGlassCard(tint: AppPalette.cobalt, cornerRadius: 34)
   }
 }
 
@@ -36,6 +70,9 @@ private struct WebPreview: UIViewRepresentable {
     configuration.defaultWebpagePreferences.allowsContentJavaScript = true
     let webView = WKWebView(frame: .zero, configuration: configuration)
     webView.scrollView.contentInsetAdjustmentBehavior = .never
+    webView.isOpaque = false
+    webView.backgroundColor = .clear
+    webView.scrollView.backgroundColor = .clear
     webView.load(URLRequest(url: url))
     return webView
   }

--- a/ios/ElRoysManagerApp/Features/Public/PublicMenuViews.swift
+++ b/ios/ElRoysManagerApp/Features/Public/PublicMenuViews.swift
@@ -12,72 +12,109 @@ struct PublicMenuScreen: View {
   }
 
   var body: some View {
-    ScrollView {
-      VStack(alignment: .leading, spacing: 18) {
-        header
+    ScrollView(showsIndicators: false) {
+      VStack(alignment: .leading, spacing: 22) {
+        heroCard
+          .appEntryReveal()
 
         if let notice = model.notice {
           StatusBanner(tone: notice.tone, title: notice.title, message: notice.message)
+            .appEntryReveal(delay: 0.05)
         }
 
         if let payload = model.currentPublicMenu {
+          summaryStrip(payload: payload)
+            .appEntryReveal(delay: 0.08)
+
           if !payload.featuredGroups.isEmpty {
-            FeaturedGroupsSection(groups: payload.featuredGroups)
+            FeaturedGroupsSection(groups: payload.featuredGroups, accent: accent)
+              .appEntryReveal(delay: 0.12)
           }
 
-          ForEach(payload.cats) { category in
-            VStack(alignment: .leading, spacing: 10) {
-              Text(category.label)
-                .font(.title3.weight(.bold))
-              if !category.sub.isEmpty {
-                Text(category.sub)
-                  .font(.subheadline)
-                  .foregroundStyle(.secondary)
-              }
-              ForEach(category.items) { item in
-                PublicMenuItemRow(item: item)
-              }
-            }
-            .appGlassCard(tint: AppPalette.accent)
+          ForEach(Array(payload.cats.enumerated()), id: \.element.id) { index, category in
+            PublicMenuCategoryCard(category: category, accent: accent)
+              .appEntryReveal(delay: 0.16 + (Double(index) * 0.04))
           }
         } else {
-          ProgressView("Loading menu...")
-            .frame(maxWidth: .infinity)
-            .padding()
+          loadingCard
+            .appEntryReveal(delay: 0.10)
         }
+
+        Color.clear.frame(height: 28)
       }
-      .padding(24)
+      .padding(.horizontal, 24)
+      .padding(.top, 24)
+      .padding(.bottom, 24)
     }
     .navigationTitle(restaurant.name)
     .navigationBarTitleDisplayMode(.inline)
-    .task {
+    .task(id: selectedType) {
       await reload()
-    }
-    .onChange(of: selectedType) { _, _ in
-      Task { await reload() }
     }
   }
 
-  private var header: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      Text("Public Menu")
-        .font(.system(size: 30, weight: .bold, design: .rounded))
-      Picker("Menu", selection: $selectedType) {
-        Text("Drinks").tag("drinks")
-        Text("Food").tag("food")
+  private var accent: Color {
+    selectedType == "food" ? AppPalette.jade : AppPalette.bloodOrange
+  }
+
+  private var heroCard: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      HStack(alignment: .top) {
+        AppSectionHeader(
+          eyebrow: "Public menu preview",
+          title: restaurant.name,
+          subtitle: selectedType == "food"
+            ? "Review the guest-facing food presentation with the same editorial spacing and hierarchy customers will see."
+            : "Review the guest-facing drinks presentation with premium card rhythm, featured highlights, and live menu structure.",
+          tint: accent
+        )
+        Spacer(minLength: 16)
       }
-      .pickerStyle(.segmented)
+
+      AppSegmentedControl(
+        options: ["drinks", "food"],
+        selection: $selectedType,
+        accent: accent,
+        title: { $0.capitalized }
+      )
 
       if let menu = selectedMenu {
         NavigationLink(value: AppDestination.routePreview(menu)) {
-          Label("Open Exact Route Preview", systemImage: "safari")
-            .font(.headline)
-            .frame(maxWidth: .infinity)
+          AppIslandButtonLabel(
+            title: "Open exact route preview",
+            subtitle: "Verify the deployed path before publishing or sharing.",
+            systemImage: "arrow.up.right"
+          )
         }
-        .buttonStyle(SecondaryGlassButtonStyle())
+        .buttonStyle(.plain)
+        .appPillChrome(accent: accent, filled: true)
       }
     }
-    .appGlassCard(tint: AppPalette.brand)
+    .appGlassCard(tint: accent, cornerRadius: 38)
+  }
+
+  private func summaryStrip(payload: PublicMenuPayload) -> some View {
+    let itemCount = payload.cats.reduce(into: 0) { partialResult, category in
+      partialResult += category.items.filter(\.onMenu).count
+    }
+
+    return HStack(spacing: 10) {
+      metricPill(title: "sections", value: "\(payload.cats.count)")
+      metricPill(title: "items", value: "\(itemCount)")
+      metricPill(title: "featured", value: "\(payload.featuredGroups.reduce(0) { $0 + $1.slots.count })")
+    }
+  }
+
+  private func metricPill(title: String, value: String) -> some View {
+    AppMetricPill(title: title, value: value, accent: accent)
+  }
+
+  private var loadingCard: some View {
+    AppLoadingCard(
+      title: "Loading public menu",
+      subtitle: "Pulling the live guest-facing sections, featured groups, and pricing.",
+      tint: accent
+    )
   }
 
   private var selectedMenu: MenuRecord? {
@@ -93,74 +130,138 @@ struct PublicMenuScreen: View {
 
 private struct FeaturedGroupsSection: View {
   let groups: [FeaturedGroup]
+  let accent: Color
 
   var body: some View {
     VStack(alignment: .leading, spacing: 14) {
-      Text("Featured")
-        .font(.title3.weight(.bold))
+      HStack {
+        AppSectionHeader(
+          eyebrow: "Featured",
+          title: "Spotlight groups",
+          tint: accent
+        )
+        Spacer(minLength: 16)
+      }
+
       ForEach(groups) { group in
-        VStack(alignment: .leading, spacing: 10) {
-          Text(group.name)
-            .font(.headline)
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Text(group.name)
+              .font(AppTypography.body(18, weight: .bold))
+              .foregroundStyle(AppPalette.espresso)
+            Spacer()
+            Text("\(group.slots.count) items")
+              .font(AppTypography.micro(9, weight: .bold))
+              .tracking(1.4)
+              .padding(.vertical, 7)
+              .padding(.horizontal, 10)
+              .background(accent.opacity(0.10), in: Capsule(style: .continuous))
+              .foregroundStyle(accent)
+          }
+
           ForEach(group.slots) { slot in
             HStack(alignment: .top, spacing: 12) {
-              VStack(alignment: .leading, spacing: 4) {
+              VStack(alignment: .leading, spacing: 5) {
                 Text(slot.item?.name ?? "Featured Item")
-                  .font(.subheadline.weight(.semibold))
+                  .font(AppTypography.body(16, weight: .bold))
+                  .foregroundStyle(AppPalette.ink)
                 if !slot.sellNote.isEmpty {
                   Text(slot.sellNote)
-                    .font(.footnote)
-                    .foregroundStyle(.secondary)
+                    .font(AppTypography.body(13, weight: .medium))
+                    .foregroundStyle(AppPalette.espresso.opacity(0.70))
+                    .fixedSize(horizontal: false, vertical: true)
                 }
               }
-              Spacer()
-              Text(slot.item?.price ?? "")
-                .font(.subheadline.monospacedDigit())
+              Spacer(minLength: 12)
+              if let price = slot.item?.price.nilIfBlank {
+                Text(price)
+                  .font(AppTypography.body(13, weight: .bold))
+                  .foregroundStyle(accent)
+                  .padding(.vertical, 7)
+                  .padding(.horizontal, 10)
+                  .background(accent.opacity(0.10), in: Capsule(style: .continuous))
+              }
             }
+            .padding(14)
+            .appFieldChrome(tint: accent, cornerRadius: 20)
           }
         }
+        .appGlassCard(tint: accent, cornerRadius: 30)
       }
     }
-    .appGlassCard(tint: AppPalette.warning)
+  }
+}
+
+private struct PublicMenuCategoryCard: View {
+  let category: MenuCategoryPayload
+  let accent: Color
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      VStack(alignment: .leading, spacing: 6) {
+        AppEyebrow(title: category.label, tint: accent)
+        if !category.sub.isEmpty {
+          Text(category.sub)
+            .font(AppTypography.body(14, weight: .medium))
+            .foregroundStyle(AppPalette.espresso.opacity(0.72))
+            .fixedSize(horizontal: false, vertical: true)
+        }
+      }
+
+      ForEach(category.items.filter(\.onMenu)) { item in
+        PublicMenuItemRow(item: item, accent: accent)
+      }
+    }
+    .appGlassCard(tint: accent, cornerRadius: 34)
   }
 }
 
 private struct PublicMenuItemRow: View {
   let item: MenuItemPayload
+  let accent: Color
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 6) {
-      HStack(alignment: .top) {
-        VStack(alignment: .leading, spacing: 4) {
-          Text(item.name)
-            .font(.headline)
-            .strikethrough(item.isEightySixed)
+    VStack(alignment: .leading, spacing: 10) {
+      HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 5) {
+          HStack(spacing: 8) {
+            Text(item.name)
+              .font(AppTypography.body(16, weight: .bold))
+              .foregroundStyle(AppPalette.ink)
+              .strikethrough(item.isEightySixed)
+            if item.isEightySixed {
+              Text("86'D")
+                .font(AppTypography.micro(9, weight: .bold))
+                .tracking(1.4)
+                .padding(.vertical, 5)
+                .padding(.horizontal, 8)
+                .background(AppPalette.danger.opacity(0.10), in: Capsule(style: .continuous))
+                .foregroundStyle(AppPalette.danger)
+            }
+          }
           if item.showDescription, !item.desc.isEmpty {
             Text(item.desc)
-              .font(.subheadline)
-              .foregroundStyle(.secondary)
+              .font(AppTypography.body(13, weight: .medium))
+              .foregroundStyle(AppPalette.espresso.opacity(0.70))
+              .fixedSize(horizontal: false, vertical: true)
           }
         }
-        Spacer()
-        Text(item.price)
-          .font(.headline.monospacedDigit())
+        Spacer(minLength: 12)
+        Text(item.price.isEmpty ? "—" : item.price)
+          .font(AppTypography.body(13, weight: .bold))
+          .foregroundStyle(accent)
+          .padding(.vertical, 7)
+          .padding(.horizontal, 10)
+          .background(accent.opacity(0.10), in: Capsule(style: .continuous))
       }
 
       if item.showRecipe, !item.recipe.isEmpty {
         Text(item.recipe.joined(separator: " • "))
-          .font(.footnote)
-          .foregroundStyle(.secondary)
-      }
-
-      if item.isEightySixed {
-        Text("86'D")
-          .font(.caption2.weight(.bold))
-          .padding(.vertical, 4)
-          .padding(.horizontal, 8)
-          .background(AppPalette.danger.opacity(0.16), in: Capsule())
-          .foregroundStyle(AppPalette.danger)
+          .font(AppTypography.body(12, weight: .semibold))
+          .foregroundStyle(accent.opacity(0.86))
       }
     }
-    .padding(.vertical, 6)
+    .padding(15)
+    .appFieldChrome(tint: accent, cornerRadius: 22)
   }
 }

--- a/ios/ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift
+++ b/ios/ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift
@@ -9,108 +9,34 @@ struct RestaurantToolsScreen: View {
   @State private var noteText = ""
 
   var body: some View {
-    ScrollView {
-      VStack(alignment: .leading, spacing: 18) {
-        VStack(alignment: .leading, spacing: 12) {
-          Text("Restaurant Tools")
-            .font(.system(size: 30, weight: .bold, design: .rounded))
-          Picker("Menu", selection: $selectedType) {
-            Text("Drinks").tag("drinks")
-            Text("Food").tag("food")
-          }
-          .pickerStyle(.segmented)
-        }
-        .appGlassCard(tint: AppPalette.brand)
+    ScrollView(showsIndicators: false) {
+      VStack(alignment: .leading, spacing: 22) {
+        headerCard
+          .appEntryReveal()
 
         if let notice = model.notice {
           StatusBanner(tone: notice.tone, title: notice.title, message: notice.message)
+            .appEntryReveal(delay: 0.05)
         }
 
         if let workspace = currentWorkspace {
-          VStack(alignment: .leading, spacing: 12) {
-            HStack {
-              Text("Featured")
-                .font(.headline)
-              Spacer()
-              Button("Add From Catalog") {
-                showingCatalog = true
-              }
-              .buttonStyle(SecondaryGlassButtonStyle())
-              .frame(maxWidth: 170)
-            }
-
-            ForEach(workspace.restaurantTools?.featuredGroups ?? []) { group in
-              ForEach(group.slots) { slot in
-                VStack(alignment: .leading, spacing: 8) {
-                  HStack {
-                    VStack(alignment: .leading, spacing: 4) {
-                      Text(slot.item?.name ?? "Featured Item")
-                        .font(.subheadline.weight(.semibold))
-                      if !slot.sellNote.isEmpty {
-                        Text(slot.sellNote)
-                          .font(.footnote)
-                          .foregroundStyle(.secondary)
-                      }
-                    }
-                    Spacer()
-                    Text(slot.item?.price ?? "")
-                      .font(.subheadline.monospacedDigit())
-                  }
-
-                  HStack {
-                    Button("Up") {
-                      Task { await model.saveFeaturedAction(action: "move", restaurantId: restaurant.id, slotId: slot.id, direction: -1) }
-                    }
-                    .buttonStyle(SecondaryGlassButtonStyle())
-                    Button("Down") {
-                      Task { await model.saveFeaturedAction(action: "move", restaurantId: restaurant.id, slotId: slot.id, direction: 1) }
-                    }
-                    .buttonStyle(SecondaryGlassButtonStyle())
-                    Button("Note") {
-                      noteEditingSlot = slot
-                      noteText = slot.sellNote
-                    }
-                    .buttonStyle(SecondaryGlassButtonStyle())
-                    Button("Remove") {
-                      Task { await model.saveFeaturedAction(action: "remove", restaurantId: restaurant.id, slotId: slot.id) }
-                    }
-                    .buttonStyle(SecondaryGlassButtonStyle())
-                  }
-                }
-                .padding(.vertical, 6)
-              }
-            }
-
-            Button("Confirm Featured Lineup") {
-              Task { await model.saveFeaturedAction(action: "confirm", restaurantId: restaurant.id) }
-            }
-            .buttonStyle(PrimaryGlassButtonStyle())
-          }
-          .appGlassCard(tint: AppPalette.warning)
+          featuredLineupCard(workspace: workspace)
+            .appEntryReveal(delay: 0.08)
+        } else {
+          loadingCard
+            .appEntryReveal(delay: 0.08)
         }
 
-        if let history = currentHistory {
-          VStack(alignment: .leading, spacing: 12) {
-            Text("Recent Changes")
-              .font(.headline)
-            ForEach(history.logs) { entry in
-              VStack(alignment: .leading, spacing: 6) {
-                Text(entry.userName)
-                  .font(.subheadline.weight(.semibold))
-                Text(entry.message.isEmpty ? "No message provided." : entry.message)
-                  .font(.footnote)
-                  .foregroundStyle(.secondary)
-                Text(entry.createdAt)
-                  .font(.caption)
-                  .foregroundStyle(.secondary)
-              }
-              .padding(.vertical, 4)
-            }
-          }
-          .appGlassCard(tint: AppPalette.accent)
+        if let history = currentHistory, !history.logs.isEmpty {
+          historyCard(history)
+            .appEntryReveal(delay: 0.12)
         }
+
+        Color.clear.frame(height: 24)
       }
-      .padding(24)
+      .padding(.horizontal, 24)
+      .padding(.top, 24)
+      .padding(.bottom, 24)
     }
     .navigationTitle(restaurant.name)
     .navigationBarTitleDisplayMode(.inline)
@@ -118,29 +44,16 @@ struct RestaurantToolsScreen: View {
       await model.loadRestaurantTools(for: restaurant.id)
     }
     .sheet(isPresented: $showingCatalog) {
-      NavigationStack {
-        List(currentWorkspace?.restaurantTools?.siblingCatalog ?? []) { item in
-          Button {
-            Task {
-              await model.saveFeaturedAction(action: "add", restaurantId: restaurant.id, itemId: item.id)
-              showingCatalog = false
-            }
-          } label: {
-            VStack(alignment: .leading, spacing: 4) {
-              Text(item.name)
-              Text("\(item.menuLabel) • \(item.cat)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            }
+      FeaturedCatalogSheet(
+        items: currentWorkspace?.restaurantTools?.siblingCatalog ?? [],
+        accent: accent,
+        onSelect: { item in
+          Task {
+            await model.saveFeaturedAction(action: "add", restaurantId: restaurant.id, itemId: item.id)
+            showingCatalog = false
           }
         }
-        .navigationTitle("Add Featured Item")
-        .toolbar {
-          ToolbarItem(placement: .cancellationAction) {
-            Button("Close") { showingCatalog = false }
-          }
-        }
-      }
+      )
     }
     .alert("Edit Sell Note", isPresented: Binding(
       get: { noteEditingSlot != nil },
@@ -156,6 +69,170 @@ struct RestaurantToolsScreen: View {
     }
   }
 
+  private var accent: Color {
+    selectedType == "food" ? AppPalette.jade : AppPalette.bloodOrange
+  }
+
+  private var headerCard: some View {
+    VStack(alignment: .leading, spacing: 18) {
+      HStack(alignment: .top) {
+        AppSectionHeader(
+          eyebrow: "Restaurant tools",
+          title: "Featured lineup control",
+          subtitle: "Curate the floor-facing spotlight list, manage sell notes, and confirm the final sequence before service.",
+          tint: accent
+        )
+        Spacer(minLength: 16)
+      }
+
+      AppSegmentedControl(
+        options: ["drinks", "food"],
+        selection: $selectedType,
+        accent: accent,
+        title: { $0.capitalized }
+      )
+
+      if let menu = model.menu(for: restaurant.id, type: selectedType) {
+        NavigationLink(value: AppDestination.categoryTools(menu)) {
+          AppIslandButtonLabel(
+            title: "Manage Categories",
+            subtitle: "Add, rename, delete, and reorder \(menu.displayTypeLabel.lowercased()) categories.",
+            systemImage: "square.split.1x2.fill"
+          )
+        }
+        .buttonStyle(.plain)
+        .appPillChrome(accent: accent)
+      }
+
+      Button {
+        showingCatalog = true
+      } label: {
+        AppIslandButtonLabel(
+          title: "Add from catalog",
+          subtitle: "Pull an item from the sibling catalog into the featured sequence.",
+          systemImage: "plus"
+        )
+      }
+      .buttonStyle(.plain)
+      .appPillChrome(accent: accent, filled: true)
+      .disabled(currentWorkspace == nil)
+      .opacity(currentWorkspace == nil ? 0.55 : 1)
+    }
+    .appGlassCard(tint: accent, cornerRadius: 38)
+  }
+
+  private func featuredLineupCard(workspace: MenuWorkspacePayload) -> some View {
+    VStack(alignment: .leading, spacing: 16) {
+      HStack(alignment: .center) {
+        VStack(alignment: .leading, spacing: 6) {
+          AppEyebrow(title: "Featured", tint: accent)
+          Text("Current lineup")
+            .font(AppTypography.display(28, weight: .bold))
+            .foregroundStyle(AppPalette.espresso)
+        }
+        Spacer(minLength: 16)
+        Text("\(workspace.restaurantTools?.featuredGroups.reduce(0) { $0 + $1.slots.count } ?? 0) live slots")
+          .font(AppTypography.micro(9, weight: .bold))
+          .tracking(1.6)
+          .padding(.vertical, 8)
+          .padding(.horizontal, 10)
+          .background(accent.opacity(0.10), in: Capsule(style: .continuous))
+          .foregroundStyle(accent)
+      }
+
+      ForEach(workspace.restaurantTools?.featuredGroups ?? []) { group in
+        VStack(alignment: .leading, spacing: 12) {
+          HStack {
+            Text(group.name)
+              .font(AppTypography.body(18, weight: .bold))
+              .foregroundStyle(AppPalette.ink)
+            Spacer(minLength: 12)
+            Text("\(group.slots.count) items")
+              .font(AppTypography.micro(9, weight: .bold))
+              .tracking(1.4)
+              .foregroundStyle(AppPalette.espresso.opacity(0.68))
+          }
+
+          ForEach(group.slots) { slot in
+            FeaturedSlotCard(
+              slot: slot,
+              accent: accent,
+              onMoveUp: {
+                Task { await model.saveFeaturedAction(action: "move", restaurantId: restaurant.id, slotId: slot.id, direction: -1) }
+              },
+              onMoveDown: {
+                Task { await model.saveFeaturedAction(action: "move", restaurantId: restaurant.id, slotId: slot.id, direction: 1) }
+              },
+              onEditNote: {
+                noteEditingSlot = slot
+                noteText = slot.sellNote
+              },
+              onRemove: {
+                Task { await model.saveFeaturedAction(action: "remove", restaurantId: restaurant.id, slotId: slot.id) }
+              }
+            )
+          }
+        }
+        .appGlassCard(tint: accent, cornerRadius: 30)
+      }
+
+      AppIslandActionButton(
+        title: "Confirm featured lineup",
+        subtitle: "Lock the final sell sequence for service.",
+        systemImage: "checkmark",
+        accent: accent,
+        action: {
+          Task { await model.saveFeaturedAction(action: "confirm", restaurantId: restaurant.id) }
+        }
+      )
+    }
+    .appGlassCard(tint: AppPalette.brass, cornerRadius: 36)
+  }
+
+  private func historyCard(_ history: HistoryPayload) -> some View {
+    VStack(alignment: .leading, spacing: 14) {
+      AppEyebrow(title: "History", tint: AppPalette.cobalt)
+      Text("Recent changes")
+        .font(AppTypography.display(26, weight: .bold))
+        .foregroundStyle(AppPalette.espresso)
+
+      ForEach(Array(history.logs.prefix(6).enumerated()), id: \.element.id) { index, entry in
+        VStack(alignment: .leading, spacing: 6) {
+          HStack(spacing: 8) {
+            Text(entry.userName.nilIfBlank ?? "Unknown")
+              .font(AppTypography.body(15, weight: .bold))
+              .foregroundStyle(AppPalette.ink)
+            Text(entry.createdAt)
+              .font(AppTypography.micro(9, weight: .bold))
+              .tracking(1.3)
+              .foregroundStyle(AppPalette.espresso.opacity(0.58))
+          }
+          Text(entry.message.isEmpty ? "No message provided." : entry.message)
+            .font(AppTypography.body(13, weight: .medium))
+            .foregroundStyle(AppPalette.espresso.opacity(0.72))
+            .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(14)
+        .appFieldChrome(tint: AppPalette.cobalt, cornerRadius: 22)
+
+        if index < min(history.logs.count, 6) - 1 {
+          Rectangle()
+            .fill(AppPalette.cobalt.opacity(0.14))
+            .frame(height: 1)
+        }
+      }
+    }
+    .appGlassCard(tint: AppPalette.cobalt, cornerRadius: 34)
+  }
+
+  private var loadingCard: some View {
+    AppLoadingCard(
+      title: "Loading restaurant tools",
+      subtitle: "Fetching the featured lineup, catalog, and recent service history.",
+      tint: accent
+    )
+  }
+
   private var currentWorkspace: MenuWorkspacePayload? {
     if let menu = model.menu(for: restaurant.id, type: selectedType) {
       return model.currentToolsMenus[menu.id]
@@ -168,5 +245,133 @@ struct RestaurantToolsScreen: View {
       return model.currentToolsHistories[menu.id]
     }
     return nil
+  }
+}
+
+private struct FeaturedSlotCard: View {
+  let slot: FeaturedSlot
+  let accent: Color
+  let onMoveUp: () -> Void
+  let onMoveDown: () -> Void
+  let onEditNote: () -> Void
+  let onRemove: () -> Void
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      HStack(alignment: .top, spacing: 12) {
+        VStack(alignment: .leading, spacing: 6) {
+          HStack(spacing: 8) {
+            Text(slot.item?.name ?? "Featured item")
+              .font(AppTypography.body(16, weight: .bold))
+              .foregroundStyle(AppPalette.ink)
+              if let confirmedAt = slot.confirmedAt?.nilIfBlank {
+              Text("CONFIRMED")
+                .font(AppTypography.micro(8, weight: .bold))
+                .tracking(1.4)
+                .padding(.vertical, 5)
+                .padding(.horizontal, 8)
+                .background(AppPalette.success.opacity(0.10), in: Capsule(style: .continuous))
+                .foregroundStyle(AppPalette.success)
+                .help(confirmedAt)
+            }
+          }
+          if !slot.sellNote.isEmpty {
+            Text(slot.sellNote)
+              .font(AppTypography.body(13, weight: .medium))
+              .foregroundStyle(AppPalette.espresso.opacity(0.72))
+              .fixedSize(horizontal: false, vertical: true)
+          }
+        }
+        Spacer(minLength: 12)
+        if let price = slot.item?.price.nilIfBlank {
+          Text(price)
+            .font(AppTypography.body(13, weight: .bold))
+            .foregroundStyle(accent)
+            .padding(.vertical, 7)
+            .padding(.horizontal, 10)
+            .background(accent.opacity(0.10), in: Capsule(style: .continuous))
+        }
+      }
+
+      HStack(spacing: 8) {
+        toolButton(title: "Up", icon: "arrow.up", accent: accent, action: onMoveUp)
+        toolButton(title: "Down", icon: "arrow.down", accent: accent, action: onMoveDown)
+        toolButton(title: "Note", icon: "pencil", accent: AppPalette.brass, action: onEditNote)
+        toolButton(title: "Remove", icon: "trash", accent: AppPalette.danger, action: onRemove)
+      }
+    }
+    .padding(15)
+    .appFieldChrome(tint: accent, cornerRadius: 22)
+  }
+
+  private func toolButton(title: String, icon: String, accent: Color, action: @escaping () -> Void) -> some View {
+    Button(action: action) {
+      Label(title, systemImage: icon)
+        .font(AppTypography.micro(9, weight: .bold))
+        .tracking(1.2)
+        .padding(.horizontal, 11)
+        .padding(.vertical, 10)
+        .frame(maxWidth: .infinity)
+    }
+    .buttonStyle(.plain)
+    .foregroundStyle(accent)
+    .appPillChrome(accent: accent, filled: false)
+  }
+}
+
+private struct FeaturedCatalogSheet: View {
+  @Environment(\.dismiss) private var dismiss
+  let items: [SiblingCatalogItem]
+  let accent: Color
+  let onSelect: (SiblingCatalogItem) -> Void
+
+  var body: some View {
+    NavigationStack {
+      ScrollView(showsIndicators: false) {
+        VStack(alignment: .leading, spacing: 14) {
+          ForEach(items) { item in
+            Button {
+              onSelect(item)
+            } label: {
+              HStack(alignment: .top, spacing: 12) {
+                VStack(alignment: .leading, spacing: 6) {
+                  Text(item.name)
+                    .font(AppTypography.body(16, weight: .bold))
+                    .foregroundStyle(AppPalette.ink)
+                  Text("\(item.menuLabel) • \(item.cat)")
+                    .font(AppTypography.body(13, weight: .medium))
+                    .foregroundStyle(AppPalette.espresso.opacity(0.68))
+                  if !item.onMenu {
+                    Text("Off menu")
+                      .font(AppTypography.micro(8, weight: .bold))
+                      .tracking(1.4)
+                      .foregroundStyle(AppPalette.warning)
+                  }
+                }
+                Spacer(minLength: 12)
+                Image(systemName: "arrow.up.right")
+                  .font(.system(size: 14, weight: .semibold))
+                  .foregroundStyle(accent)
+              }
+              .padding(15)
+            }
+            .buttonStyle(.plain)
+            .appFieldChrome(tint: accent, cornerRadius: 22)
+          }
+        }
+        .padding(24)
+      }
+      .background {
+        AppBackground()
+          .ignoresSafeArea()
+      }
+      .navigationTitle("Add Featured Item")
+      .navigationBarTitleDisplayMode(.inline)
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Close") { dismiss() }
+        }
+      }
+    }
   }
 }

--- a/ios/ElRoysManagerApp/Features/Scanner/BarcodeScannerView.swift
+++ b/ios/ElRoysManagerApp/Features/Scanner/BarcodeScannerView.swift
@@ -8,32 +8,113 @@ struct BarcodeScannerSheet: View {
 
   var body: some View {
     NavigationStack {
-      VStack(spacing: 18) {
-        BarcodeScannerCaptureView { code in
-          scannedCode = code
-        }
-        .frame(height: 320)
-        .clipShape(RoundedRectangle(cornerRadius: 26, style: .continuous))
+      ScrollView(showsIndicators: false) {
+        VStack(alignment: .leading, spacing: 20) {
+          VStack(alignment: .leading, spacing: 14) {
+            AppEyebrow(title: "Barcode capture", tint: AppPalette.cobalt)
+            Text("Scan or paste a UPC")
+              .font(AppTypography.display(32, weight: .bold))
+              .foregroundStyle(AppPalette.espresso)
+            Text("Use the live camera feed for speed, then fall back to manual entry when a label is damaged or hard to frame.")
+              .font(AppTypography.body(15, weight: .medium))
+              .foregroundStyle(AppPalette.espresso.opacity(0.72))
+              .fixedSize(horizontal: false, vertical: true)
+          }
+          .appGlassCard(tint: AppPalette.cobalt, cornerRadius: 36)
+          .appEntryReveal()
 
-        TextField("Manual UPC fallback", text: $scannedCode)
-          .keyboardType(.numberPad)
-          .textFieldStyle(.roundedBorder)
+          ZStack {
+            BarcodeScannerCaptureView { code in
+              scannedCode = code
+            }
+            scannerOverlay
+          }
+          .frame(height: 320)
+          .clipShape(RoundedRectangle(cornerRadius: 32, style: .continuous))
+          .overlay {
+            RoundedRectangle(cornerRadius: 32, style: .continuous)
+              .stroke(AppPalette.cobalt.opacity(0.24), lineWidth: 1)
+          }
+          .appEntryReveal(delay: 0.06)
 
-        Button("Use This Barcode") {
-          onFound(scannedCode)
-          dismiss()
+          VStack(alignment: .leading, spacing: 12) {
+            Text("Manual fallback")
+              .font(AppTypography.micro(10, weight: .bold))
+              .tracking(1.8)
+              .foregroundStyle(AppPalette.cobalt)
+            TextField("Enter UPC", text: $scannedCode)
+              .keyboardType(.numberPad)
+              .font(AppTypography.body(16, weight: .medium))
+              .padding(.horizontal, 16)
+              .padding(.vertical, 16)
+              .appFieldChrome(tint: AppPalette.cobalt)
+          }
+          .appGlassCard(tint: AppPalette.brass, cornerRadius: 30)
+          .appEntryReveal(delay: 0.10)
+
+          AppIslandActionButton(
+            title: "Use this barcode",
+            subtitle: "Insert the captured value into the item editor.",
+            systemImage: "arrow.up.right",
+            accent: AppPalette.brand,
+            isEnabled: !scannedCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+            action: {
+              onFound(scannedCode)
+              dismiss()
+            }
+          )
+          .appEntryReveal(delay: 0.14)
         }
-        .buttonStyle(PrimaryGlassButtonStyle())
-        .disabled(scannedCode.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        .padding(.horizontal, 24)
+        .padding(.top, 24)
+        .padding(.bottom, 24)
       }
-      .padding(24)
+      .background {
+        AppBackground()
+          .ignoresSafeArea()
+      }
       .navigationTitle("Scan Barcode")
+      .navigationBarTitleDisplayMode(.inline)
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
           Button("Close") { dismiss() }
         }
       }
     }
+  }
+
+  private var scannerOverlay: some View {
+    GeometryReader { proxy in
+      let size = min(proxy.size.width, proxy.size.height) * 0.58
+      let line: CGFloat = 26
+      let stroke = AppPalette.ivory.opacity(0.92)
+      let frameRect = CGRect(
+        x: (proxy.size.width - size) / 2,
+        y: (proxy.size.height - size) / 2,
+        width: size,
+        height: size
+      )
+
+      Path { path in
+        path.move(to: CGPoint(x: frameRect.minX, y: frameRect.minY + line))
+        path.addLine(to: CGPoint(x: frameRect.minX, y: frameRect.minY))
+        path.addLine(to: CGPoint(x: frameRect.minX + line, y: frameRect.minY))
+
+        path.move(to: CGPoint(x: frameRect.maxX - line, y: frameRect.minY))
+        path.addLine(to: CGPoint(x: frameRect.maxX, y: frameRect.minY))
+        path.addLine(to: CGPoint(x: frameRect.maxX, y: frameRect.minY + line))
+
+        path.move(to: CGPoint(x: frameRect.minX, y: frameRect.maxY - line))
+        path.addLine(to: CGPoint(x: frameRect.minX, y: frameRect.maxY))
+        path.addLine(to: CGPoint(x: frameRect.minX + line, y: frameRect.maxY))
+
+        path.move(to: CGPoint(x: frameRect.maxX - line, y: frameRect.maxY))
+        path.addLine(to: CGPoint(x: frameRect.maxX, y: frameRect.maxY))
+        path.addLine(to: CGPoint(x: frameRect.maxX, y: frameRect.maxY - line))
+      }
+      .stroke(stroke, style: StrokeStyle(lineWidth: 3, lineCap: .round, lineJoin: .round))
+    }
+    .allowsHitTesting(false)
   }
 }
 
@@ -73,12 +154,22 @@ private struct BarcodeScannerCaptureView: UIViewControllerRepresentable {
 private final class ScannerViewController: UIViewController {
   var delegate: AVCaptureMetadataOutputObjectsDelegate?
   private let session = AVCaptureSession()
+  private let sessionQueue = DispatchQueue(label: "BarcodeScanner.session")
   private var previewLayer: AVCaptureVideoPreviewLayer?
+  private var hasConfiguredSession = false
 
   override func viewDidLoad() {
     super.viewDidLoad()
     view.backgroundColor = .black
-    configureSession()
+    let layer = AVCaptureVideoPreviewLayer(session: session)
+    layer.videoGravity = .resizeAspectFill
+    layer.frame = view.bounds
+    view.layer.addSublayer(layer)
+    previewLayer = layer
+
+    sessionQueue.async { [weak self] in
+      self?.configureSessionIfNeeded()
+    }
   }
 
   override func viewDidLayoutSubviews() {
@@ -88,19 +179,20 @@ private final class ScannerViewController: UIViewController {
 
   override func viewWillAppear(_ animated: Bool) {
     super.viewWillAppear(animated)
-    if !session.isRunning {
-      session.startRunning()
+    sessionQueue.async { [weak self] in
+      self?.startSessionIfNeeded()
     }
   }
 
   override func viewWillDisappear(_ animated: Bool) {
     super.viewWillDisappear(animated)
-    if session.isRunning {
-      session.stopRunning()
+    sessionQueue.async { [weak self] in
+      self?.stopSessionIfNeeded()
     }
   }
 
-  private func configureSession() {
+  private func configureSessionIfNeeded() {
+    guard !hasConfiguredSession else { return }
     guard let videoDevice = AVCaptureDevice.default(for: .video),
           let input = try? AVCaptureDeviceInput(device: videoDevice),
           session.canAddInput(input) else {
@@ -114,11 +206,17 @@ private final class ScannerViewController: UIViewController {
     session.addOutput(output)
     output.setMetadataObjectsDelegate(delegate, queue: DispatchQueue.main)
     output.metadataObjectTypes = [.ean8, .ean13, .upce, .code128]
+    hasConfiguredSession = true
+  }
 
-    let layer = AVCaptureVideoPreviewLayer(session: session)
-    layer.videoGravity = .resizeAspectFill
-    layer.frame = view.bounds
-    view.layer.addSublayer(layer)
-    previewLayer = layer
+  private func startSessionIfNeeded() {
+    configureSessionIfNeeded()
+    guard hasConfiguredSession, !session.isRunning else { return }
+    session.startRunning()
+  }
+
+  private func stopSessionIfNeeded() {
+    guard session.isRunning else { return }
+    session.stopRunning()
   }
 }

--- a/ios/ElRoysManagerApp/Models/AppModels.swift
+++ b/ios/ElRoysManagerApp/Models/AppModels.swift
@@ -565,6 +565,7 @@ struct MenuItemPayload: Codable, Equatable, Hashable, Identifiable {
   var upcharges: [ItemUpcharge]
   var showDescription: Bool
   var showRecipe: Bool
+  fileprivate var canonicalServerDisplayOrder: Int?
 
   enum CodingKeys: String, CodingKey {
     case id
@@ -608,6 +609,7 @@ struct MenuItemPayload: Codable, Equatable, Hashable, Identifiable {
     self.upcharges = upcharges
     self.showDescription = showDescription
     self.showRecipe = showRecipe
+    self.canonicalServerDisplayOrder = displayOrder
   }
 
   init(from decoder: Decoder) throws {
@@ -624,12 +626,14 @@ struct MenuItemPayload: Codable, Equatable, Hashable, Identifiable {
     self.recipe = try container.decodeLossyStringArray(forKey: .recipe)
     self.price = try container.decodeIfPresent(String.self, forKey: .price) ?? ""
     self.isEightySixed = serverIsEightySixed ?? compactIsEightySixed ?? false
-    self.displayOrder = try container.decodeIfPresent(Int.self, forKey: .displayOrder) ?? 0
+    let decodedDisplayOrder = try? container.decodeIfPresent(Int.self, forKey: .displayOrder)
+    self.displayOrder = decodedDisplayOrder ?? 0
     self.onMenu = explicitOnMenu ?? (visibility != "off_menu")
     self.visibility = visibility
     self.upcharges = (try? container.decode([ItemUpcharge].self, forKey: .upcharges)) ?? []
     self.showDescription = try container.decodeIfPresent(Bool.self, forKey: .showDescription) ?? true
     self.showRecipe = try container.decodeIfPresent(Bool.self, forKey: .showRecipe) ?? false
+    self.canonicalServerDisplayOrder = decodedDisplayOrder
   }
 
   func encode(to encoder: Encoder) throws {
@@ -658,6 +662,36 @@ struct MenuItemPayload: Codable, Equatable, Hashable, Identifiable {
     guard let uuid = UUID(uuidString: suffix) else { return }
     id = uuid.uuidString.lowercased()
   }
+
+  static func == (lhs: MenuItemPayload, rhs: MenuItemPayload) -> Bool {
+    lhs.id == rhs.id
+      && lhs.name == rhs.name
+      && lhs.desc == rhs.desc
+      && lhs.recipe == rhs.recipe
+      && lhs.price == rhs.price
+      && lhs.isEightySixed == rhs.isEightySixed
+      && lhs.displayOrder == rhs.displayOrder
+      && lhs.onMenu == rhs.onMenu
+      && lhs.visibility == rhs.visibility
+      && lhs.upcharges == rhs.upcharges
+      && lhs.showDescription == rhs.showDescription
+      && lhs.showRecipe == rhs.showRecipe
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+    hasher.combine(name)
+    hasher.combine(desc)
+    hasher.combine(recipe)
+    hasher.combine(price)
+    hasher.combine(isEightySixed)
+    hasher.combine(displayOrder)
+    hasher.combine(onMenu)
+    hasher.combine(visibility)
+    hasher.combine(upcharges)
+    hasher.combine(showDescription)
+    hasher.combine(showRecipe)
+  }
 }
 
 struct MenuCategoryPayload: Codable, Equatable, Hashable, Identifiable {
@@ -672,6 +706,7 @@ struct MenuCategoryPayload: Codable, Equatable, Hashable, Identifiable {
   var displayOrder: Int
   var untappdEnabled: Bool
   var items: [MenuItemPayload]
+  fileprivate var canonicalServerDisplayOrder: Int?
 
   enum CodingKeys: String, CodingKey {
     case id
@@ -712,6 +747,7 @@ struct MenuCategoryPayload: Codable, Equatable, Hashable, Identifiable {
     self.displayOrder = displayOrder
     self.untappdEnabled = untappdEnabled
     self.items = items
+    self.canonicalServerDisplayOrder = displayOrder
   }
 
   init(from decoder: Decoder) throws {
@@ -724,11 +760,13 @@ struct MenuCategoryPayload: Codable, Equatable, Hashable, Identifiable {
     self.color = try container.decodeString(forKey: .color)
     self.sub = try container.decodeString(forKey: .sub)
     self.placeholder = try container.decodeString(forKey: .placeholder)
-    self.displayOrder = try container.decodeInt(forKey: .displayOrder)
+    let decodedDisplayOrder = try? container.decodeIfPresent(Int.self, forKey: .displayOrder)
+    self.displayOrder = decodedDisplayOrder ?? 0
     self.untappdEnabled = try container.decodeIfPresent(Bool.self, forKey: .untappdEnabled)
       ?? container.decodeIfPresent(Bool.self, forKey: .untappd_enabled)
       ?? false
     self.items = (try? container.decode([MenuItemPayload].self, forKey: .items)) ?? []
+    self.canonicalServerDisplayOrder = decodedDisplayOrder
   }
 
   func encode(to encoder: Encoder) throws {
@@ -744,6 +782,67 @@ struct MenuCategoryPayload: Codable, Equatable, Hashable, Identifiable {
     try container.encode(displayOrder, forKey: .displayOrder)
     try container.encode(untappdEnabled, forKey: .untappdEnabled)
     try container.encode(items, forKey: .items)
+  }
+
+  static func == (lhs: MenuCategoryPayload, rhs: MenuCategoryPayload) -> Bool {
+    lhs.id == rhs.id
+      && lhs.menuId == rhs.menuId
+      && lhs.key == rhs.key
+      && lhs.label == rhs.label
+      && lhs.icon == rhs.icon
+      && lhs.color == rhs.color
+      && lhs.sub == rhs.sub
+      && lhs.placeholder == rhs.placeholder
+      && lhs.displayOrder == rhs.displayOrder
+      && lhs.untappdEnabled == rhs.untappdEnabled
+      && lhs.items == rhs.items
+  }
+
+  func hash(into hasher: inout Hasher) {
+    hasher.combine(id)
+    hasher.combine(menuId)
+    hasher.combine(key)
+    hasher.combine(label)
+    hasher.combine(icon)
+    hasher.combine(color)
+    hasher.combine(sub)
+    hasher.combine(placeholder)
+    hasher.combine(displayOrder)
+    hasher.combine(untappdEnabled)
+    hasher.combine(items)
+  }
+}
+
+private enum MenuOrdering {
+  static func canonicalize(items: [MenuItemPayload]) -> [MenuItemPayload] {
+    items.sorted { lhs, rhs in
+      canonicalItemKey(for: lhs) < canonicalItemKey(for: rhs)
+    }
+  }
+
+  static func canonicalize(categories: [MenuCategoryPayload]) -> [MenuCategoryPayload] {
+    categories
+      .map { category in
+        var next = category
+        next.items = canonicalize(items: category.items)
+        return next
+      }
+      .sorted { lhs, rhs in
+        canonicalCategoryKey(for: lhs) < canonicalCategoryKey(for: rhs)
+      }
+  }
+
+  private static func canonicalCategoryKey(for category: MenuCategoryPayload) -> (Int, Int, String, String) {
+    (
+      category.key == EditableMenuDocument.uncategorizedKey ? 1 : 0,
+      category.canonicalServerDisplayOrder ?? Int.max,
+      category.key,
+      category.id
+    )
+  }
+
+  private static func canonicalItemKey(for item: MenuItemPayload) -> (Int, String, String) {
+    (item.canonicalServerDisplayOrder ?? Int.max, item.id, item.name)
   }
 }
 
@@ -1016,6 +1115,29 @@ struct PublicMenuPayload: Codable, Equatable {
   var featuredGroups: [FeaturedGroup]
   var context: MenuContext
   var capabilities: PublicMenuCapabilities
+}
+
+extension PublicMenuPayload {
+  enum CodingKeys: String, CodingKey {
+    case cats
+    case meta
+    case restaurant
+    case featuredGroups
+    case context
+    case capabilities
+  }
+
+  init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    self.cats = MenuOrdering.canonicalize(
+      categories: try container.decode([MenuCategoryPayload].self, forKey: .cats)
+    )
+    self.meta = try container.decode(MenuMetaPayload.self, forKey: .meta)
+    self.restaurant = try container.decodeIfPresent(RestaurantRecord.self, forKey: .restaurant)
+    self.featuredGroups = try container.decode([FeaturedGroup].self, forKey: .featuredGroups)
+    self.context = try container.decode(MenuContext.self, forKey: .context)
+    self.capabilities = try container.decode(PublicMenuCapabilities.self, forKey: .capabilities)
+  }
 }
 
 struct HistoryContext: Codable, Equatable {
@@ -1548,7 +1670,7 @@ struct EditableMenuDocument: Codable, Equatable {
       menuType: workspace.context.menu?.type ?? "drinks"
     )
     cats = Self.normalizeIdentifiers(
-      in: workspace.cats.sorted { $0.displayOrder < $1.displayOrder },
+      in: MenuOrdering.canonicalize(categories: workspace.cats),
       menuId: workspace.context.menu?.id ?? ""
     )
     meta = workspace.meta

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -209,6 +209,135 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(document.category(for: "beer")?.items.last?.onMenu, false)
   }
 
+  func testEditableDocumentWorkspaceCanonicalizesServerOrdering() {
+    let workspace = makeWorkspace(categories: [
+      MenuCategoryPayload(
+        id: "cat-wine",
+        menuId: "menu",
+        key: "wine",
+        label: "Wine",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 2,
+        items: [
+          makeItem(id: "item-b", name: "Bordeaux", displayOrder: 1),
+          makeItem(id: "item-a", name: "Albarino", displayOrder: 1),
+          makeItem(id: "item-c", name: "Chianti", displayOrder: 0)
+        ]
+      ),
+      MenuCategoryPayload(
+        id: "cat-uncat",
+        menuId: "menu",
+        key: EditableMenuDocument.uncategorizedKey,
+        label: "Uncategorized",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 0,
+        items: [
+          makeItem(id: "hidden-1", name: "Hidden", displayOrder: 0, onMenu: false, visibility: "off_menu")
+        ]
+      ),
+      MenuCategoryPayload(
+        id: "cat-beer",
+        menuId: "menu",
+        key: "beer",
+        label: "Beer",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 0,
+        items: [
+          makeItem(id: "beer-2", name: "Z Lager", displayOrder: 1),
+          makeItem(id: "beer-1", name: "A Lager", displayOrder: 1)
+        ]
+      )
+    ])
+
+    let document = EditableMenuDocument(workspace: workspace)
+
+    XCTAssertEqual(document.cats.map { $0.key }, ["beer", "wine", EditableMenuDocument.uncategorizedKey])
+    XCTAssertEqual(document.category(for: "beer")?.items.map { $0.id }, ["beer-1", "beer-2"])
+    XCTAssertEqual(document.category(for: "wine")?.items.map { $0.id }, ["item-c", "item-a", "item-b"])
+  }
+
+  func testEditableDocumentWorkspaceMissingDisplayOrderSortsToEnd() throws {
+    let data = Data("""
+    {
+      "cats": [
+        {
+          "id": "cat-missing",
+          "key": "seasonal",
+          "label": "Seasonal",
+          "items": [
+            {
+              "id": "item-missing",
+              "name": "Mystery Pour",
+              "visibility": "public",
+              "on_menu": true
+            }
+          ]
+        },
+        {
+          "id": "cat-beer",
+          "key": "beer",
+          "label": "Beer",
+          "display_order": 0,
+          "items": [
+            {
+              "id": "beer-missing",
+              "name": "Late Tap",
+              "visibility": "public",
+              "on_menu": true
+            },
+            {
+              "id": "beer-first",
+              "name": "First Tap",
+              "display_order": 0,
+              "visibility": "public",
+              "on_menu": true
+            }
+          ]
+        }
+      ],
+      "meta": {},
+      "context": {
+        "kind": "menu-workspace",
+        "menu": {
+          "id": "menu",
+          "slug": "drinks",
+          "name": "Drinks",
+          "type": "drinks",
+          "restaurant_id": "leroys-lounge"
+        }
+      },
+      "workspace": {
+        "accessible_menu_ids": ["menu"],
+        "shared_draft": { "exists": false },
+        "permissions": { "can_manage": true },
+        "capabilities": {
+          "can_save_draft": true,
+          "can_save_live_menu": true,
+          "can_publish_updates": true
+        },
+        "revisions": {
+          "live_revision": 10
+        }
+      }
+    }
+    """.utf8)
+
+    let payload = try JSONDecoder.backend.decode(MenuWorkspacePayload.self, from: data)
+    let document = EditableMenuDocument(workspace: payload)
+
+    XCTAssertEqual(document.cats.map(\.key), ["beer", "seasonal"])
+    XCTAssertEqual(document.category(for: "beer")?.items.map(\.id), ["beer-first", "beer-missing"])
+  }
+
   func testEditableDocumentNormalizesDuplicateAndMissingIdentifiers() {
     let workspace = makeWorkspace(categories: [
       MenuCategoryPayload(
@@ -294,7 +423,7 @@ final class MenuDocumentTests: XCTestCase {
     let cardSource = String(source[cardRange.lowerBound..<recoveryRange.lowerBound])
 
     XCTAssertTrue(cardSource.contains("List {"))
-    XCTAssertTrue(cardSource.contains("Reorder Items"))
+    XCTAssertTrue(cardSource.contains("Button(action: onToggleReorder)"))
   }
 
   func testMenuEditorSwipeListUsesTrailingEightySixActionOnly() throws {
@@ -656,6 +785,198 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(payload.workspace.hasUnsentChanges, true)
     XCTAssertEqual(payload.workspace.revisions.liveRevision, 200)
     XCTAssertEqual(payload.workspace.revisions.notificationBaselineRevision, 150)
+  }
+
+  func testPublicMenuPayloadDecodingCanonicalizesServerOrdering() throws {
+    let data = Data("""
+    {
+      "cats": [
+        {
+          "id": "cat-z",
+          "menu_id": "menu",
+          "key": "wine",
+          "label": "Wine",
+          "display_order": 2,
+          "items": [
+            {
+              "id": "item-b",
+              "name": "Bordeaux",
+              "display_order": 1,
+              "visibility": "public",
+              "on_menu": true
+            },
+            {
+              "id": "item-a",
+              "name": "Albarino",
+              "display_order": 1,
+              "visibility": "public",
+              "on_menu": true
+            },
+            {
+              "id": "item-c",
+              "name": "Chianti",
+              "display_order": 0,
+              "visibility": "public",
+              "on_menu": true
+            }
+          ]
+        },
+        {
+          "id": "cat-u",
+          "menu_id": "menu",
+          "key": "__uncategorized__",
+          "label": "Uncategorized",
+          "display_order": 0,
+          "items": [
+            {
+              "id": "hidden-1",
+              "name": "Hidden",
+              "display_order": 0,
+              "visibility": "off_menu",
+              "on_menu": false
+            }
+          ]
+        },
+        {
+          "id": "cat-a",
+          "menu_id": "menu",
+          "key": "beer",
+          "label": "Beer",
+          "display_order": 0,
+          "items": [
+            {
+              "id": "beer-2",
+              "name": "Z Lager",
+              "display_order": 1,
+              "visibility": "public",
+              "on_menu": true
+            },
+            {
+              "id": "beer-1",
+              "name": "A Lager",
+              "display_order": 1,
+              "visibility": "public",
+              "on_menu": true
+            }
+          ]
+        }
+      ],
+      "meta": {
+        "last_updated_ts": 1712705100000
+      },
+      "restaurant": {
+        "id": "leroys-lounge",
+        "slug": "leroyslounge",
+        "name": "Leroy's Lounge"
+      },
+      "featured_groups": [],
+      "context": {
+        "kind": "menu-public",
+        "menu": {
+          "id": "menu",
+          "slug": "drinks",
+          "name": "Drinks",
+          "type": "drinks",
+          "restaurant_id": "leroys-lounge"
+        }
+      },
+      "capabilities": {
+        "guest_readable": true,
+        "requires_auth": false,
+        "includes_draft_state": false,
+        "includes_notification_config": false
+      }
+    }
+    """.utf8)
+
+    let payload = try JSONDecoder.backend.decode(PublicMenuPayload.self, from: data)
+
+    XCTAssertEqual(payload.cats.map(\.key), ["beer", "wine", EditableMenuDocument.uncategorizedKey])
+    XCTAssertEqual(payload.cats[0].items.map(\.id), ["beer-1", "beer-2"])
+    XCTAssertEqual(payload.cats[1].items.map(\.id), ["item-c", "item-a", "item-b"])
+  }
+
+  func testPublicMenuPayloadDecodingMissingDisplayOrderSortsToEnd() throws {
+    let data = Data("""
+    {
+      "cats": [
+        {
+          "id": "cat-missing",
+          "key": "seasonal",
+          "label": "Seasonal",
+          "items": [
+            {
+              "id": "item-missing",
+              "name": "Mystery Pour",
+              "visibility": "public",
+              "on_menu": true
+            }
+          ]
+        },
+        {
+          "id": "cat-beer",
+          "key": "beer",
+          "label": "Beer",
+          "display_order": 0,
+          "items": [
+            {
+              "id": "beer-missing",
+              "name": "Late Tap",
+              "visibility": "public",
+              "on_menu": true
+            },
+            {
+              "id": "beer-first",
+              "name": "First Tap",
+              "display_order": 0,
+              "visibility": "public",
+              "on_menu": true
+            }
+          ]
+        }
+      ],
+      "meta": {},
+      "featured_groups": [],
+      "context": {
+        "kind": "menu-public",
+        "menu": {
+          "id": "menu",
+          "slug": "drinks",
+          "name": "Drinks",
+          "type": "drinks",
+          "restaurant_id": "leroys-lounge"
+        }
+      },
+      "capabilities": {
+        "guest_readable": true,
+        "requires_auth": false,
+        "includes_draft_state": false,
+        "includes_notification_config": false
+      }
+    }
+    """.utf8)
+
+    let payload = try JSONDecoder.backend.decode(PublicMenuPayload.self, from: data)
+
+    XCTAssertEqual(payload.cats.map(\.key), ["beer", "seasonal"])
+    XCTAssertEqual(payload.cats[0].items.map(\.id), ["beer-first", "beer-missing"])
+  }
+
+  func testPublicMenuPayloadDecodingRequiresCatsMetaAndFeaturedGroups() {
+    let missingMeta = Data("""
+    {
+      "cats": [],
+      "context": { "kind": "menu-public" },
+      "capabilities": {
+        "guest_readable": true,
+        "requires_auth": false,
+        "includes_draft_state": false,
+        "includes_notification_config": false
+      }
+    }
+    """.utf8)
+
+    XCTAssertThrowsError(try JSONDecoder.backend.decode(PublicMenuPayload.self, from: missingMeta))
   }
 
   @MainActor
@@ -2444,7 +2765,15 @@ final class MenuDocumentTests: XCTestCase {
     )
   }
 
-  private func makeItem(id: String, name: String, price: String = "$14", desc: String = "") -> MenuItemPayload {
+  private func makeItem(
+    id: String,
+    name: String,
+    price: String = "$14",
+    desc: String = "",
+    displayOrder: Int = 0,
+    onMenu: Bool = true,
+    visibility: String = "public"
+  ) -> MenuItemPayload {
     MenuItemPayload(
       id: id,
       name: name,
@@ -2452,9 +2781,9 @@ final class MenuDocumentTests: XCTestCase {
       recipe: [],
       price: price,
       isEightySixed: false,
-      displayOrder: 0,
-      onMenu: true,
-      visibility: "public",
+      displayOrder: displayOrder,
+      onMenu: onMenu,
+      visibility: visibility,
       upcharges: [],
       showDescription: true,
       showRecipe: false

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -319,6 +319,75 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertFalse(swipeSource.contains(".frame(height: estimatedListHeight)"))
   }
 
+  func testEditableDocumentMovesVisibleCategoriesAndKeepsRecoveryBucketLast() {
+    let workspace = makeWorkspace(categories: [
+      MenuCategoryPayload(
+        id: "beer",
+        menuId: "menu",
+        key: "beer",
+        label: "Beer",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 0,
+        items: [makeItem(id: "item-1", name: "Pilsner")]
+      ),
+      MenuCategoryPayload(
+        id: "wine",
+        menuId: "menu",
+        key: "wine",
+        label: "Wine",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 1,
+        items: [makeItem(id: "item-2", name: "Orange Wine")]
+      ),
+      MenuCategoryPayload(
+        id: "uncategorized",
+        menuId: "menu",
+        key: EditableMenuDocument.uncategorizedKey,
+        label: "Uncategorized",
+        icon: "",
+        color: "",
+        sub: "",
+        placeholder: "",
+        displayOrder: 2,
+        items: []
+      )
+    ])
+
+    var document = EditableMenuDocument(workspace: workspace)
+    document.moveVisibleCategories(from: IndexSet(integer: 0), to: 2)
+
+    XCTAssertEqual(document.visibleCategories.map(\.key), ["wine", "beer"])
+    XCTAssertEqual(document.visibleCategories.map(\.displayOrder), [0, 1])
+    XCTAssertEqual(document.cats.last?.key, EditableMenuDocument.uncategorizedKey)
+  }
+
+  func testRestaurantToolsProvidesCategoryManagementEntryPoint() throws {
+    let toolsSource = try String(contentsOf: restaurantToolsSourceURL(), encoding: .utf8)
+    let appSource = try String(contentsOf: appEntrySourceURL(), encoding: .utf8)
+
+    XCTAssertTrue(toolsSource.contains("Manage Categories"))
+    XCTAssertTrue(appSource.contains("case categoryTools(MenuRecord)"))
+    XCTAssertTrue(appSource.contains("RestaurantCategoryManagementScreen"))
+  }
+
+  func testMenuEditorCategoryCardUsesVisibleReorderButtonInsteadOfOverflowMenu() throws {
+    let source = try String(contentsOf: menuViewsSourceURL(), encoding: .utf8)
+    let cardRange = try XCTUnwrap(source.range(of: "private struct MenuEditorCategoryCard"))
+    let swipeRange = try XCTUnwrap(source.range(of: "private struct MenuEditorSwipeList"))
+    let cardSource = String(source[cardRange.lowerBound..<swipeRange.lowerBound])
+
+    XCTAssertTrue(cardSource.contains("Button(action: onToggleReorder)"))
+    XCTAssertTrue(cardSource.contains("Done Reordering"))
+    XCTAssertFalse(cardSource.contains("Menu {"))
+    XCTAssertFalse(cardSource.contains("ellipsis.circle.fill"))
+  }
+
   func testEditableDocumentDefinesVisibleItemReorderMutation() throws {
     let source = try String(contentsOf: appModelsSourceURL(), encoding: .utf8)
     XCTAssertTrue(source.contains("mutating func moveVisibleItems(in categoryKey: String, from source: IndexSet, to destination: Int)"))
@@ -2454,6 +2523,20 @@ private func menuViewsSourceURL(filePath: StaticString = #filePath) -> URL {
     .deletingLastPathComponent()
     .deletingLastPathComponent()
     .appendingPathComponent("ElRoysManagerApp/Features/Menu/MenuViews.swift")
+}
+
+private func restaurantToolsSourceURL(filePath: StaticString = #filePath) -> URL {
+  URL(fileURLWithPath: "\(filePath)")
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .appendingPathComponent("ElRoysManagerApp/Features/RestaurantTools/RestaurantToolsView.swift")
+}
+
+private func appEntrySourceURL(filePath: StaticString = #filePath) -> URL {
+  URL(fileURLWithPath: "\(filePath)")
+    .deletingLastPathComponent()
+    .deletingLastPathComponent()
+    .appendingPathComponent("ElRoysManagerApp/App/ElRoysManagerApp.swift")
 }
 
 private func appModelsSourceURL(filePath: StaticString = #filePath) -> URL {

--- a/server/_menu-read.js
+++ b/server/_menu-read.js
@@ -25,6 +25,49 @@ function sortByKnownOrder(values = [], knownOrder = [], key = 'id') {
   return values.slice().sort((a, b) => knownOrder.indexOf(a[key]) - knownOrder.indexOf(b[key]));
 }
 
+function numericDisplayOrder(value, fallback = Number.MAX_SAFE_INTEGER) {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : fallback;
+}
+
+function compareText(left = '', right = '') {
+  return String(left || '').localeCompare(String(right || ''));
+}
+
+function compareCategoryOrder(left = {}, right = {}) {
+  const leftIsUncategorized = left?.key === '__uncategorized__';
+  const rightIsUncategorized = right?.key === '__uncategorized__';
+  if (leftIsUncategorized !== rightIsUncategorized) {
+    return leftIsUncategorized ? 1 : -1;
+  }
+
+  const displayDelta = numericDisplayOrder(left?.display_order) - numericDisplayOrder(right?.display_order);
+  if (displayDelta !== 0) return displayDelta;
+
+  const keyDelta = compareText(left?.key, right?.key);
+  if (keyDelta !== 0) return keyDelta;
+
+  return compareText(left?.id, right?.id);
+}
+
+function compareItemOrder(left = {}, right = {}) {
+  const displayDelta = numericDisplayOrder(left?.display_order) - numericDisplayOrder(right?.display_order);
+  if (displayDelta !== 0) return displayDelta;
+
+  const idDelta = compareText(left?.id, right?.id);
+  if (idDelta !== 0) return idDelta;
+
+  return compareText(left?.name, right?.name);
+}
+
+function sortCategories(categories = []) {
+  return (Array.isArray(categories) ? categories : []).slice().sort(compareCategoryOrder);
+}
+
+function sortCategoryItems(items = []) {
+  return (Array.isArray(items) ? items : []).slice().sort(compareItemOrder);
+}
+
 export function getKnownMenus() {
   return sortByKnownOrder(Object.values(MENUS)
     .filter(menu => menu?.id)
@@ -141,7 +184,10 @@ export async function readMenuStateBundle(menuId) {
       type: menuRow.type || 'drinks',
       restaurantId: menuRow.restaurant_id || '',
     },
-    cats: Array.isArray(cats) ? cats : [],
+    cats: sortCategories(cats).map(category => ({
+      ...category,
+      items: sortCategoryItems(category?.items),
+    })),
     meta: metaRows?.[0] || {},
     restaurant: restaurantRows?.[0] || null,
     featuredCurrentIds,
@@ -220,7 +266,7 @@ function sanitizePublicCategory(category = {}) {
     sub: category.sub || '',
     placeholder: category.placeholder || '',
     display_order: Number.isFinite(Number(category.display_order)) ? Number(category.display_order) : 0,
-    items: (Array.isArray(category.items) ? category.items : [])
+    items: sortCategoryItems(category.items)
       .filter(isGuestVisibleItem)
       .map(sanitizePublicItem),
   };
@@ -387,7 +433,7 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
 
 export function createPublicMenuPayload(bundle, { featuredGroups = [], featuredCompatibility = null } = {}) {
   return {
-    cats: (bundle?.cats || [])
+    cats: sortCategories(bundle?.cats || [])
       .map(sanitizePublicCategory)
       .filter(category => category.key !== '__uncategorized__')
       .filter(category => Array.isArray(category.items) ? category.items.length > 0 : true),

--- a/tests/manager-item-reorder-draft-state.test.cjs
+++ b/tests/manager-item-reorder-draft-state.test.cjs
@@ -23,6 +23,23 @@ function createMenuItem(id, name) {
   };
 }
 
+function createPersistedDraftItem(id, name, displayOrder) {
+  return {
+    id,
+    name,
+    desc: '',
+    recipe: [],
+    price: '',
+    is_eighty_sixed: false,
+    on_menu: true,
+    visibility: 'public',
+    upcharges: [],
+    show_description: true,
+    show_recipe: false,
+    display_order: displayOrder,
+  };
+}
+
 test('reordering manager items creates a saveable quiet draft change', () => {
   const sandbox = loadAppSandbox();
   const alpha = createMenuItem('alpha', 'Alpha');
@@ -71,4 +88,105 @@ test('reordering manager items creates a saveable quiet draft change', () => {
   assert.equal(getState(sandbox, 'getDraftSaveOnlyChanges().length'), 1);
   assert.equal(getState(sandbox, 'getDraftChangeCount()'), 1);
   assert.equal(getState(sandbox, 'getMenuActionState().saveDisabled'), false);
+});
+
+test('hydrateState canonicalizes item ties by id after display order', () => {
+  const sandbox = loadAppSandbox();
+
+  setState(sandbox, {
+    CATEGORY_DEFS: [],
+    menuState: {},
+  });
+
+  getState(sandbox, `
+    hydrateState({
+      cats: [{
+        id: 'cat-beer',
+        key: 'beer',
+        label: 'Beer',
+        display_order: 0,
+        items: [
+          { id: 'item-b', name: 'Bordeaux', display_order: 1, onMenu: true, visibility: 'public' },
+          { id: 'item-a', name: 'Albarino', display_order: 1, onMenu: true, visibility: 'public' },
+          { id: 'item-c', name: 'Chianti', display_order: 0, onMenu: true, visibility: 'public' },
+        ],
+      }],
+      meta: {},
+      restaurant: null,
+    })
+  `);
+
+  assert.deepEqual(
+    getState(sandbox, 'JSON.parse(JSON.stringify(menuState.beer.items.map(item => item.id)))'),
+    ['item-c', 'item-a', 'item-b'],
+  );
+});
+
+test('applyPersistedDraftState canonicalizes tied draft items without false dirty state', () => {
+  const sandbox = loadAppSandbox();
+  const canonicalItems = [
+    createPersistedDraftItem('item-c', 'Chianti', 0),
+    createPersistedDraftItem('item-a', 'Albarino', 1),
+    createPersistedDraftItem('item-b', 'Bordeaux', 1),
+  ];
+  const reversedTieItems = [
+    createPersistedDraftItem('item-c', 'Chianti', 0),
+    createPersistedDraftItem('item-b', 'Bordeaux', 1),
+    createPersistedDraftItem('item-a', 'Albarino', 1),
+  ];
+
+  setState(sandbox, {
+    CATEGORY_DEFS: [],
+    menuState: {},
+    currentUser: { uid: 'manager-1' },
+    MENU_ID: 'menu-1',
+  });
+
+  setState(sandbox, {
+    __baseDraftSnapshot: {
+      cats: [{
+        id: 'cat-beer',
+        key: 'beer',
+        label: 'Beer',
+        icon: '',
+        color: '',
+        sub: '',
+        placeholder: '',
+        untappd_enabled: false,
+        display_order: 0,
+        items: canonicalItems,
+      }],
+      meta: {},
+      restaurant: null,
+      featured_groups: [],
+      save_only_changes: [],
+    },
+    __resumedDraftSnapshot: {
+      cats: [{
+        id: 'cat-beer',
+        key: 'beer',
+        label: 'Beer',
+        icon: '',
+        color: '',
+        sub: '',
+        placeholder: '',
+        untappd_enabled: false,
+        display_order: 0,
+        items: reversedTieItems,
+      }],
+      meta: {},
+      restaurant: null,
+      featured_groups: [],
+      save_only_changes: [],
+    },
+  });
+
+  getState(sandbox, 'setLocalDraftBaseSnapshot(__baseDraftSnapshot);');
+  assert.equal(getState(sandbox, 'applyPersistedDraftState(__resumedDraftSnapshot)'), true);
+
+  assert.deepEqual(
+    getState(sandbox, 'JSON.parse(JSON.stringify(menuState.beer.items.map(item => item.id)))'),
+    ['item-c', 'item-a', 'item-b'],
+  );
+  assert.equal(getState(sandbox, 'hasActualLocalDraftChanges()'), false);
 });

--- a/tests/phase7-server-read-boundaries.test.cjs
+++ b/tests/phase7-server-read-boundaries.test.cjs
@@ -15,6 +15,15 @@ async function importApiModule(relativePath) {
   return import(`${fileUrl}?wave1=${Date.now()}-${Math.random()}`);
 }
 
+function createJsonResponse(body, ok = true) {
+  return {
+    ok,
+    async json() {
+      return body;
+    },
+  };
+}
+
 test('consolidated read routes delegate through shared menu-read helpers', () => {
   const workspaceSource = read('api/manager.js');
   const publicSource = read('api/public.js');
@@ -108,7 +117,10 @@ test('workspace payload preserves the live menu snapshot shape and adds staff co
     },
   });
 
-  assert.deepEqual(payload.cats, bundle.cats);
+  assert.deepEqual(payload.cats, bundle.cats.map(category => ({
+    ...category,
+    untappd_enabled: false,
+  })));
   assert.equal(payload.meta.last_updated_ts, 1712705100000);
   assert.deepEqual(payload.meta.draft_state, bundle.meta.draft_state);
   assert.equal(payload.workspace.actor.role, 'manager');
@@ -174,6 +186,105 @@ test('workspace payload projects server-owned Live | Unsent queue state from sta
   assert.ok(payload.workspace.publishState.queue.selectableGroupIds.some(groupId => groupId.includes('rename')));
 });
 
+test('readMenuStateBundle canonicalizes workspace category and item ordering', async () => {
+  const helper = await importApiModule('server/_menu-read.js');
+  const menu = helper.getKnownMenus()[0];
+  assert.ok(menu?.id, 'expected a known menu id for readMenuStateBundle coverage');
+
+  const originalFetch = global.fetch;
+  const originalSupabaseUrl = process.env.SUPABASE_URL;
+  const originalSupabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+  global.fetch = async url => {
+    const requestUrl = String(url);
+
+    if (requestUrl.includes('/rest/v1/menus?')) {
+      return createJsonResponse([{
+        id: menu.id,
+        slug: menu.slug,
+        name: menu.name,
+        type: menu.type,
+        restaurant_id: menu.restaurantId,
+        archived: false,
+      }]);
+    }
+
+    if (requestUrl.includes('/rest/v1/categories?')) {
+      return createJsonResponse([
+        {
+          id: 'cat-b',
+          menu_id: menu.id,
+          key: 'wine',
+          label: 'Wine',
+          display_order: 0,
+          items: [
+            { id: 'wine-b', name: 'Bordeaux', display_order: 1, on_menu: true, visibility: 'public' },
+            { id: 'wine-a', name: 'Albarino', display_order: 1, on_menu: true, visibility: 'public' },
+            { id: 'wine-c', name: 'Chianti', display_order: 0, on_menu: true, visibility: 'public' },
+          ],
+        },
+        {
+          id: 'cat-u',
+          menu_id: menu.id,
+          key: '__uncategorized__',
+          label: 'Uncategorized',
+          display_order: 0,
+          items: [
+            { id: 'uncat-a', name: 'Hidden', display_order: 0, on_menu: false, visibility: 'off_menu' },
+          ],
+        },
+        {
+          id: 'cat-a',
+          menu_id: menu.id,
+          key: 'beer',
+          label: 'Beer',
+          display_order: 0,
+          items: [
+            { id: 'beer-b', name: 'Z Lager', display_order: 1, on_menu: true, visibility: 'public' },
+            { id: 'beer-a', name: 'A Lager', display_order: 1, on_menu: true, visibility: 'public' },
+          ],
+        },
+      ]);
+    }
+
+    if (requestUrl.includes('/rest/v1/menu_meta?')) {
+      return createJsonResponse([{ last_updated_ts: 1712705100000 }]);
+    }
+
+    if (requestUrl.includes('/rest/v1/restaurants?')) {
+      return createJsonResponse([{
+        id: menu.restaurantId,
+        name: 'Restaurant',
+        slug: 'restaurant',
+        design: {},
+        use_custom_design: false,
+      }]);
+    }
+
+    if (requestUrl.includes('/rest/v1/featured_groups?')) {
+      return createJsonResponse([]);
+    }
+
+    if (requestUrl.includes('/rest/v1/featured_slots?')) {
+      return createJsonResponse([]);
+    }
+
+    throw new Error(`Unexpected fetch in test: ${requestUrl}`);
+  };
+
+  try {
+    const bundle = await helper.readMenuStateBundle(menu.id);
+    assert.deepEqual(bundle.cats.map(category => category.key), ['beer', 'wine', '__uncategorized__']);
+    assert.deepEqual(bundle.cats[0].items.map(item => item.id), ['beer-a', 'beer-b']);
+    assert.deepEqual(bundle.cats[1].items.map(item => item.id), ['wine-c', 'wine-a', 'wine-b']);
+  } finally {
+    global.fetch = originalFetch;
+    process.env.SUPABASE_URL = originalSupabaseUrl;
+    process.env.SUPABASE_SERVICE_ROLE_KEY = originalSupabaseServiceKey;
+  }
+});
+
 test('public payload strips staff-only menu metadata and filters non-public items', async () => {
   const helper = await importApiModule('server/_menu-read.js');
   const payload = helper.createPublicMenuPayload({
@@ -225,6 +336,71 @@ test('public payload strips staff-only menu metadata and filters non-public item
   assert.deepEqual(payload.meta.last_sent_featured, ['featured-1']);
   assert.equal(Object.prototype.hasOwnProperty.call(payload.meta, 'draft_state'), false);
   assert.equal(Object.prototype.hasOwnProperty.call(payload.meta, 'bot_id'), false);
+});
+
+test('createPublicMenuPayload canonicalizes category and item ordering', async () => {
+  const helper = await importApiModule('server/_menu-read.js');
+  const payload = helper.createPublicMenuPayload({
+    menu: {
+      id: 'menu-1',
+      slug: 'drinks',
+      name: 'Drinks',
+      type: 'drinks',
+      restaurantId: 'rest-1',
+    },
+    cats: [
+      {
+        id: 'cat-c',
+        menu_id: 'menu-1',
+        key: 'amaro',
+        label: 'Amaro',
+        display_order: 0,
+        items: [
+          { id: 'amaro-1', name: 'Averna', display_order: 2, on_menu: true, visibility: 'public' },
+        ],
+      },
+      {
+        id: 'cat-z',
+        menu_id: 'menu-1',
+        key: 'wine',
+        label: 'Wine',
+        display_order: 2,
+        items: [
+          { id: 'item-b', name: 'Bordeaux', display_order: 1, on_menu: true, visibility: 'public' },
+          { id: 'item-a', name: 'Albarino', display_order: 1, on_menu: true, visibility: 'public' },
+          { id: 'item-c', name: 'Chianti', display_order: 0, on_menu: true, visibility: 'public' },
+        ],
+      },
+      {
+        id: 'cat-u',
+        menu_id: 'menu-1',
+        key: '__uncategorized__',
+        label: 'Uncategorized',
+        display_order: 0,
+        items: [
+          { id: 'hidden-1', name: 'Hidden', display_order: 0, on_menu: false, visibility: 'off_menu' },
+        ],
+      },
+      {
+        id: 'cat-a',
+        menu_id: 'menu-1',
+        key: 'beer',
+        label: 'Beer',
+        display_order: 0,
+        items: [
+          { id: 'beer-2', name: 'Z Lager', display_order: 1, on_menu: true, visibility: 'public' },
+          { id: 'beer-1', name: 'A Lager', display_order: 1, on_menu: true, visibility: 'public' },
+        ],
+      },
+    ],
+    meta: {},
+    restaurant: null,
+  });
+
+  assert.deepEqual(payload.cats.map(category => category.key), ['amaro', 'beer', 'wine']);
+  assert.equal(payload.cats[0].id, 'cat-c');
+  assert.deepEqual(payload.cats[1].items.map(item => item.id), ['beer-1', 'beer-2']);
+  assert.deepEqual(payload.cats[2].items.map(item => item.id), ['item-c', 'item-a', 'item-b']);
 });
 
 test('session bootstrap payload exposes actor capabilities against the fixed menu registry', async () => {


### PR DESCRIPTION
## What changed
- refreshed the iOS redesign branch across the app shell, home/auth/public preview surfaces, restaurant tools, and category management flow
- added native category-management UI for iOS and included the tracked `RestaurantCategoryManagementView.swift` implementation in the branch
- canonicalized category/item ordering across server reads, the web runtime, and iOS models so tied `displayOrder` values resolve deterministically
- restored immediate local draft persistence in the iOS editor to avoid losing the last device-only edit during quick navigation, sign-out, or backgrounding
- added and updated regression coverage for ordering consistency and local draft behavior, plus included the redesign planning artifacts and clean patch snapshot in the branch

## Why it changed
This branch combines the chat-driven iOS redesign work with the ordering-consistency fixes that were reviewed afterward. The ordering work was needed to keep workspace/public rendering stable when the backend returns tied `displayOrder` values, and the follow-up iOS draft change fixes the review-found regression where debounced local draft writes could miss the latest edit.

## Impact
Managers get the refreshed native iOS surfaces, a dedicated category-management screen, and more stable public/editor ordering across tied-order content. The server and web runtime now canonicalize menu ordering the same way as the iOS client, which reduces false dirty/conflict states when drafts are restored or compared.

## Root cause
Tied `displayOrder` values were previously left to source/wire ordering in several layers, so category/item order could drift between server, web, and iOS payload handling. A later optimization to debounce iOS local draft persistence also created a small but real data-loss window for the last unsaved edit.

## Validation
- `node --test tests/manager-item-reorder-draft-state.test.cjs tests/phase7-server-read-boundaries.test.cjs`
- `python3 scripts/verify-manager-shell-contract.py`
- `xcodebuild test -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,id=1CDAD734-AE93-48EC-9260-6E45AE2086DC' -only-testing:ElRoysManagerAppTests/MenuDocumentTests/testDiscardLocalDraftRestoresServerStateAndClearsOfflineDraft`
