### PR TITLE
[codex] Fix iOS orientation support

### DIFF
--- a/ios/ElRoysManagerApp.xcodeproj/project.pbxproj
+++ b/ios/ElRoysManagerApp.xcodeproj/project.pbxproj
@@ -509,6 +509,8 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -617,6 +619,8 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -817,6 +821,8 @@
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchScreen_Generation = YES;
+				INFOPLIST_KEY_UISupportedInterfaceOrientations = "UIInterfaceOrientationPortrait UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
+				INFOPLIST_KEY_UISupportedInterfaceOrientations_iPad = "UIInterfaceOrientationPortrait UIInterfaceOrientationPortraitUpsideDown UIInterfaceOrientationLandscapeLeft UIInterfaceOrientationLandscapeRight";
 				IPHONEOS_DEPLOYMENT_TARGET = 18.0;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",


### PR DESCRIPTION
## What changed
- added explicit `UISupportedInterfaceOrientations` values to the generated app Info.plist settings in `ios/ElRoysManagerApp.xcodeproj/project.pbxproj`
- added the full iPad orientation set, including upside-down portrait, while keeping the iPhone orientation list explicit

## Why
- Xcode was failing validation with: `All interface orientations must be supported unless the app requires full screen.`
- the app target supports both iPhone and iPad (`TARGETED_DEVICE_FAMILY = "1,2"`) but did not declare the required iPad orientations in the generated plist

## Impact
- the iOS app target now validates cleanly for iPad-capable builds without forcing full-screen mode
- this keeps the fix localized to project build settings and avoids changing app behavior beyond supported orientations metadata

## Validation
- `xcodebuild -showBuildSettings -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -configuration Debug | rg "UISupportedInterfaceOrientations|TARGETED_DEVICE_FAMILY|UIRequiresFullScreen"`
- `xcodebuild -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -configuration Debug -destination 'platform=iOS Simulator,name=iPad (A16)' build`