### PR TITLE
[codex] deepen menu session publish boundary

### DIFF
--- a/app.js
+++ b/app.js
@@ -3306,94 +3306,6 @@ function createMenuPublishService(sessionPorts, runtime = {}) {
   return createLegacyMenuPublishService(sessionPorts, runtime);
 }
 
-function createClientMenuPublishWorkflow({ ports }) {
-  return {
-    async preview(command = {}) {
-      const result = typeof ports.requestPublishPreview === 'function'
-        ? await ports.requestPublishPreview(command)
-        : { ok: false, payload: null };
-      if (!result?.ok) {
-        return {
-          ok: false,
-          userHandled: false,
-          userMessage: result?.payload?.error || 'Preview is unavailable right now.',
-        };
-      }
-      const payload = result.payload || {};
-      return {
-        ok: payload.ok !== false,
-        preview: payload.preview || null,
-        revisions: payload.revisions || {
-          liveRevision: command.request?.expectedLiveRevision ?? null,
-          draftRevision: command.request?.expectedDraftRevision ?? null,
-          notificationRevision: command.request?.expectedNotificationRevision ?? null,
-        },
-      };
-    },
-
-    async execute(command = {}) {
-      const mode = command.intent === 'save'
-        ? 'save'
-        : (command.intent === 'send' ? 'send' : 'save-and-send');
-      const result = await ports.publishMenuUpdate({
-        mode,
-        notify: command.intent === 'save' ? false : undefined,
-        selectedChangeIds: Array.isArray(command.request?.selectedChangeIds)
-          ? command.request.selectedChangeIds
-          : [],
-      });
-      const warnings = Array.isArray(result?.warnings)
-        ? result.warnings
-        : (result?.warningMessage ? [result.warningMessage] : []);
-      return {
-        ...result,
-        ok: result?.ok !== false,
-        userOutcome: {
-          successMessage: result?.successMessage || '',
-          warningMessage: result?.warningMessage || '',
-          warnings,
-        },
-        notification: result?.notification || result?.notificationStatus || null,
-      };
-    },
-  };
-}
-
-function createClientMenuPublishFacade(sessionPorts, runtime = {}) {
-  const createFacade = typeof globalThis.createMenuPublishFacade === 'function'
-    ? globalThis.createMenuPublishFacade.bind(globalThis)
-    : null;
-  if (typeof createFacade === 'function'
-      && (typeof sessionPorts.requestPublishPreview !== 'function' || typeof sessionPorts.publishMenuUpdate !== 'function')) {
-    return createFacade(sessionPorts, runtime);
-  }
-  if (typeof createFacade !== 'function') {
-    const publishService = createLegacyMenuPublishService(sessionPorts, runtime);
-    return {
-      async prepare(options = {}) {
-        if (typeof publishService.prepare === 'function') {
-          return publishService.prepare(options);
-        }
-        return {
-          ok: false,
-          userHandled: false,
-          userMessage: 'Preview is unavailable right now.',
-        };
-      },
-      async commit(options = {}) {
-        if (options.intent === 'save' && typeof publishService.saveDraft === 'function') {
-          return publishService.saveDraft(options);
-        }
-        return publishService.publishUpdate(options);
-      },
-    };
-  }
-  return createFacade(sessionPorts, {
-    ...runtime,
-    createWorkflow: createClientMenuPublishWorkflow,
-  });
-}
-
 function createMenuSessionLifecycle(ports) {
   const sessionPorts = ports || getMenuSessionPorts();
   const buildPublishService = (nextSessionPorts, runtime = {}) => {
@@ -3413,7 +3325,6 @@ function createMenuSessionLifecycle(ports) {
       try {
         return boundary.createMenuSessionLifecycle(sessionPorts, {
           getMenuSessionPorts: () => getMenuSessionPorts(),
-          createPublishFacade: (nextSessionPorts, runtime = {}) => createClientMenuPublishFacade(nextSessionPorts, runtime),
           createPublishService: buildPublishService,
         });
       } finally {

--- a/core/session/menu-session.js
+++ b/core/session/menu-session.js
@@ -11,16 +11,16 @@
       : (() => globalScope.getMenuSessionPorts?.());
     const sessionPorts = ports || resolveSessionPorts();
     let request = sessionPorts.buildRequest();
-    const createPublishFacade = typeof runtime.createPublishFacade === 'function'
-      ? runtime.createPublishFacade
-      : (typeof globalScope.createMenuPublishFacade === 'function'
-          ? globalScope.createMenuPublishFacade.bind(globalScope)
-          : null);
+    const moduleCreatePublishService = typeof modules.createMenuPublishService === 'function'
+      ? modules.createMenuPublishService
+      : null;
     const createPublishService = typeof runtime.createPublishService === 'function'
       ? runtime.createPublishService
-      : (typeof globalScope.createMenuPublishService === 'function'
-          ? globalScope.createMenuPublishService.bind(globalScope)
-          : null);
+      : (moduleCreatePublishService
+          ? moduleCreatePublishService
+          : (typeof globalScope.createMenuPublishService === 'function'
+              ? globalScope.createMenuPublishService.bind(globalScope)
+              : null));
 
     function syncRequest(overrides = {}) {
       request = { ...request, ...sessionPorts.buildRequest(overrides) };
@@ -31,7 +31,7 @@
       return sessionPorts.buildSnapshot(source, request);
     }
 
-    let publishFacade = null;
+    let publishService = null;
 
     function getUnavailableResult(options = {}) {
       return {
@@ -43,53 +43,38 @@
       };
     }
 
-    function getPublishFacade() {
-      if (publishFacade) return publishFacade;
-      if (createPublishFacade) {
-        publishFacade = createPublishFacade(sessionPorts, {
-          ...runtime,
-          buildSnapshot,
-        });
-        return publishFacade;
-      }
-      if (createPublishService) {
-        const publishService = createPublishService(sessionPorts, {
-          ...runtime,
-          buildSnapshot,
-          buildPreview: () => sessionPorts.buildPreview(buildSnapshot('preview')),
-        });
-        publishFacade = {
-          async prepare(options = {}) {
-            if (typeof publishService.prepare === 'function') {
-              return publishService.prepare(options);
-            }
-            return getUnavailableResult(options);
-          },
-          async commit(options = {}) {
-            if (options.intent === 'save' && typeof publishService.saveDraft === 'function') {
-              return publishService.saveDraft(options);
-            }
-            if (typeof publishService.publishUpdate === 'function') {
-              return publishService.publishUpdate(options);
-            }
-            return getUnavailableResult(options);
-          },
-        };
-        return publishFacade;
-      }
-      publishFacade = {
+    function getUnavailablePublishService() {
+      return {
         async prepare(options = {}) {
           return {
             ...getUnavailableResult(options),
           };
         },
-        async commit(options = {}) {
+        async saveDraft(options = {}) {
+          return {
+            ...getUnavailableResult(options),
+          };
+        },
+        async publishUpdate(options = {}) {
           return {
             ...getUnavailableResult(options),
           };
         },
       };
-      return publishFacade;
+    }
+
+    function getPublishService() {
+      if (publishService) return publishService;
+      if (createPublishService) {
+        publishService = createPublishService(sessionPorts, {
+          ...runtime,
+          buildSnapshot,
+          buildPreview: () => sessionPorts.buildPreview(buildSnapshot('preview')),
+        });
+        return publishService;
+      }
+      publishService = getUnavailablePublishService();
+      return publishService;
     }
 
     const session = {
@@ -161,11 +146,22 @@
       },
       async preparePublish(options = {}) {
         const nextRequest = syncRequest(options);
-        return getPublishFacade().prepare({ ...options, request: nextRequest });
+        const service = getPublishService();
+        if (typeof service.prepare === 'function') {
+          return service.prepare({ ...options, request: nextRequest });
+        }
+        return getUnavailableResult(options);
       },
       async commitPublish(options = {}) {
         const nextRequest = syncRequest(options);
-        return getPublishFacade().commit({ ...options, request: nextRequest });
+        const service = getPublishService();
+        if (options.intent === 'save' && typeof service.saveDraft === 'function') {
+          return service.saveDraft({ ...options, request: nextRequest });
+        }
+        if (typeof service.publishUpdate === 'function') {
+          return service.publishUpdate({ ...options, request: nextRequest });
+        }
+        return getUnavailableResult(options);
       },
       async saveDraft(options = {}) {
         return session.commitPublish({ ...options, intent: 'save' });

--- a/core/session/publish-service.js
+++ b/core/session/publish-service.js
@@ -6,11 +6,16 @@
     : {};
 
   function createMenuPublishServiceImpl(sessionPorts, runtime = {}, options = {}) {
+    const moduleCreatePublishFacade = typeof modules.createMenuPublishFacade === 'function'
+      ? modules.createMenuPublishFacade
+      : null;
     const createPublishFacade = typeof runtime.createPublishFacade === 'function'
       ? runtime.createPublishFacade
-      : (typeof globalScope.createMenuPublishFacade === 'function'
-          ? globalScope.createMenuPublishFacade.bind(globalScope)
-          : null);
+      : (moduleCreatePublishFacade
+          ? moduleCreatePublishFacade
+          : (typeof globalScope.createMenuPublishFacade === 'function'
+              ? globalScope.createMenuPublishFacade.bind(globalScope)
+              : null));
     const facade = typeof createPublishFacade === 'function'
       ? createPublishFacade(sessionPorts, runtime)
       : null;
@@ -24,51 +29,57 @@
       return fallbackService;
     }
 
+    function getUnavailableResult(message) {
+      return {
+        ok: false,
+        userHandled: false,
+        userMessage: message,
+      };
+    }
+
+    async function prepare(opts = {}) {
+      if (facade && typeof facade.prepare === 'function') {
+        return facade.prepare(opts);
+      }
+      const fallback = getFallbackService();
+      if (fallback && typeof fallback.prepare === 'function') {
+        return fallback.prepare(opts);
+      }
+      return getUnavailableResult('Publish service is unavailable.');
+    }
+
+    async function saveDraft(opts = {}) {
+      if (facade && typeof facade.commit === 'function') {
+        return facade.commit({ ...opts, intent: 'save' });
+      }
+      const fallback = getFallbackService();
+      if (fallback && typeof fallback.saveDraft === 'function') {
+        return fallback.saveDraft(opts);
+      }
+      if (fallback && typeof fallback.publishUpdate === 'function') {
+        return fallback.publishUpdate({ ...opts, intent: 'save' });
+      }
+      return getUnavailableResult('Publish service is unavailable.');
+    }
+
+    async function publishUpdate(opts = {}) {
+      if (facade && typeof facade.commit === 'function') {
+        return facade.commit(opts);
+      }
+      const fallback = getFallbackService();
+      if (fallback && typeof fallback.publishUpdate === 'function') {
+        return fallback.publishUpdate(opts);
+      }
+      if (fallback && typeof fallback.saveDraft === 'function' && opts.intent === 'save') {
+        return fallback.saveDraft(opts);
+      }
+      return getUnavailableResult('Publish service is unavailable.');
+    }
+
     return {
-      async saveDraft(opts = {}) {
-        if (facade && typeof facade.commit === 'function') {
-          return facade.commit({ ...opts, intent: 'save' });
-        }
-        const fallback = getFallbackService();
-        if (fallback && typeof fallback.saveDraft === 'function') {
-          return fallback.saveDraft(opts);
-        }
-        return {
-          ok: false,
-          userHandled: false,
-          userMessage: 'Publish service is unavailable.',
-        };
-      },
-
-      async publishUpdate(opts = {}) {
-        if (facade && typeof facade.commit === 'function') {
-          return facade.commit(opts);
-        }
-        const fallback = getFallbackService();
-        if (fallback && typeof fallback.publishUpdate === 'function') {
-          return fallback.publishUpdate(opts);
-        }
-        return {
-          ok: false,
-          userHandled: false,
-          userMessage: 'Publish service is unavailable.',
-        };
-      },
-
-      async prepare(opts = {}) {
-        if (facade && typeof facade.prepare === 'function') {
-          return facade.prepare(opts);
-        }
-        const fallback = getFallbackService();
-        if (fallback && typeof fallback.prepare === 'function') {
-          return fallback.prepare(opts);
-        }
-        return {
-          ok: false,
-          userHandled: false,
-          userMessage: 'Publish service is unavailable.',
-        };
-      },
+      prepare,
+      saveDraft,
+      publishUpdate,
     };
   }
 

--- a/core/session/publish-service.js
+++ b/core/session/publish-service.js
@@ -19,6 +19,12 @@
       ? createPublishFacade(sessionPorts, runtime)
       : null;
     let fallbackService = null;
+    const buildSnapshot = typeof runtime.buildSnapshot === 'function'
+      ? runtime.buildSnapshot
+      : (() => ({ source: 'unknown' }));
+    const buildPreview = typeof runtime.buildPreview === 'function'
+      ? runtime.buildPreview
+      : (() => sessionPorts.buildPreview?.(buildSnapshot('preview')));
 
     function getFallbackService() {
       if (fallbackService !== null) return fallbackService;
@@ -36,6 +42,15 @@
       };
     }
 
+    function buildSaveDraftNoop(preview, source = 'draft-noop') {
+      return {
+        ok: false,
+        noop: true,
+        preview,
+        snapshot: buildSnapshot(source),
+      };
+    }
+
     async function prepare(opts = {}) {
       if (facade && typeof facade.prepare === 'function') {
         return facade.prepare(opts);
@@ -48,6 +63,23 @@
     }
 
     async function saveDraft(opts = {}) {
+      if (typeof sessionPorts.publishMenuUpdate === 'function') {
+        const snapshot = buildSnapshot('draft');
+        const preview = opts.preview?.sections ? opts.preview : buildPreview();
+        const hasLocalDraft = !!snapshot.dirty || !!preview?.hasLocalDraft;
+        const hasChanges = !!preview?.hasChanges;
+
+        if (!hasLocalDraft || !hasChanges) {
+          return buildSaveDraftNoop(preview);
+        }
+
+        return sessionPorts.publishMenuUpdate({
+          ...opts,
+          preview,
+          mode: 'save',
+          notify: false,
+        });
+      }
       if (facade && typeof facade.commit === 'function') {
         return facade.commit({ ...opts, intent: 'save' });
       }
@@ -59,6 +91,9 @@
     }
 
     async function publishUpdate(opts = {}) {
+      if (typeof sessionPorts.publishMenuUpdate === 'function') {
+        return sessionPorts.publishMenuUpdate(opts);
+      }
       if (facade && typeof facade.commit === 'function') {
         return facade.commit(opts);
       }

--- a/core/session/publish-service.js
+++ b/core/session/publish-service.js
@@ -9,13 +9,12 @@
     const moduleCreatePublishFacade = typeof modules.createMenuPublishFacade === 'function'
       ? modules.createMenuPublishFacade
       : null;
+    const globalCreatePublishFacade = typeof globalScope.createMenuPublishFacade === 'function'
+      ? globalScope.createMenuPublishFacade.bind(globalScope)
+      : null;
     const createPublishFacade = typeof runtime.createPublishFacade === 'function'
       ? runtime.createPublishFacade
-      : (moduleCreatePublishFacade
-          ? moduleCreatePublishFacade
-          : (typeof globalScope.createMenuPublishFacade === 'function'
-              ? globalScope.createMenuPublishFacade.bind(globalScope)
-              : null));
+      : (globalCreatePublishFacade || moduleCreatePublishFacade);
     const facade = typeof createPublishFacade === 'function'
       ? createPublishFacade(sessionPorts, runtime)
       : null;
@@ -56,9 +55,6 @@
       if (fallback && typeof fallback.saveDraft === 'function') {
         return fallback.saveDraft(opts);
       }
-      if (fallback && typeof fallback.publishUpdate === 'function') {
-        return fallback.publishUpdate({ ...opts, intent: 'save' });
-      }
       return getUnavailableResult('Publish service is unavailable.');
     }
 
@@ -69,9 +65,6 @@
       const fallback = getFallbackService();
       if (fallback && typeof fallback.publishUpdate === 'function') {
         return fallback.publishUpdate(opts);
-      }
-      if (fallback && typeof fallback.saveDraft === 'function' && opts.intent === 'save') {
-        return fallback.saveDraft(opts);
       }
       return getUnavailableResult('Publish service is unavailable.');
     }

--- a/docs/superpowers/plans/2026-04-21-menu-session-boundary-deepening.md
+++ b/docs/superpowers/plans/2026-04-21-menu-session-boundary-deepening.md
@@ -1,0 +1,376 @@
+# Menu Session Boundary Deepening Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Make `core/session/*` own the web publish flow so `app.js` stops carrying a legacy shadow implementation for preview/commit behavior.
+
+**Architecture:** Keep the existing request-bound `createMenuSessionLifecycle()` caller contract, but move the client preview/commit adaptation behind the session boundary. `app.js` should provide browser ports and session defaults only, while `core/session/menu-session.js` and `core/session/publish-service.js` own publish orchestration. Tests should shift from delegation spies toward behavior through the session boundary.
+
+**Tech Stack:** Plain browser JavaScript, Node test runner (`node --test`), no bundler, no dependencies.
+
+---
+
+## File Structure
+
+- `app.js`
+  Browser/runtime port construction only. Remove the legacy publish-shadow helpers once the session boundary owns them.
+- `core/session/menu-session.js`
+  Primary deep module boundary for request/snapshot lifecycle and publish coordination.
+- `core/session/publish-service.js`
+  Thin publish service that delegates to the session-owned facade/workflow instead of `app.js`.
+- `core/session/menu-publish-facade.js`
+  Adapter from session ports to workflow commands; keep caller-facing behavior stable.
+- `tests/boundaries/publish.boundary.test.cjs`
+  Boundary-level publish behavior through the real session lifecycle.
+- `tests/phase2-session-boundaries.test.cjs`
+  Guardrail tests that the app delegates to shared session modules without carrying shadow logic.
+
+### Task 1: Lock The Desired Boundary In Tests
+
+**Files:**
+- Modify: `tests/boundaries/publish.boundary.test.cjs`
+- Modify: `tests/phase2-session-boundaries.test.cjs`
+- Test: `tests/boundaries/publish.boundary.test.cjs`
+- Test: `tests/phase2-session-boundaries.test.cjs`
+
+- [ ] **Step 1: Add failing boundary coverage for session-owned publish preview/commit**
+
+```js
+test('menu session lifecycle prepares and commits through shared session modules without app-owned publish helpers', async () => {
+  const sandbox = loadAppSandbox();
+  const previewCalls = [];
+  const commitCalls = [];
+
+  sandbox.__HF_SESSION_MODULES__.createMenuPublishService = (sessionPorts, runtime = {}) => ({
+    async prepare(options = {}) {
+      previewCalls.push({ sessionPorts: !!sessionPorts, options, runtime: !!runtime });
+      return {
+        ok: true,
+        preview: { hasChanges: true, sections: [], notificationChanges: [], mode: 'save-and-send' },
+        revisions: { liveRevision: 10, draftRevision: 11, notificationRevision: 9 },
+      };
+    },
+    async publishUpdate(options = {}) {
+      commitCalls.push({ sessionPorts: !!sessionPorts, options, runtime: !!runtime });
+      return {
+        ok: true,
+        userOutcome: { successMessage: 'published', warningMessage: '', warnings: [] },
+      };
+    },
+    async saveDraft(options = {}) {
+      commitCalls.push({ sessionPorts: !!sessionPorts, options: { ...options, intent: 'save' }, runtime: !!runtime });
+      return {
+        ok: true,
+        userOutcome: { successMessage: 'saved', warningMessage: '', warnings: [] },
+      };
+    },
+  });
+
+  const lifecycle = sandbox.createMenuSessionLifecycle(createMenuSessionPorts());
+  const preview = await lifecycle.preparePublish({ expectedLiveRevision: 10 });
+  const commit = await lifecycle.publishUpdate({ selectedChangeIds: ['beer::added::lager'] });
+  const save = await lifecycle.saveDraft({});
+
+  assert.equal(preview.ok, true);
+  assert.equal(commit.ok, true);
+  assert.equal(save.ok, true);
+  assert.equal(previewCalls.length, 1);
+  assert.equal(commitCalls.length, 2);
+});
+```
+
+- [ ] **Step 2: Run the targeted tests to verify the new assertions fail first**
+
+Run: `node --test tests/boundaries/publish.boundary.test.cjs tests/phase2-session-boundaries.test.cjs`
+Expected: FAIL because the lifecycle still depends on `app.js` publish-shadow helpers instead of driving the shared session module boundary directly.
+
+- [ ] **Step 3: Tighten the session-boundary guardrail test so it rejects the app shadow path**
+
+```js
+test('app createMenuSessionLifecycle delegates publish creation through shared session modules', async () => {
+  const sandbox = loadSandboxWithScripts(['app.js'], {
+    __HF_SESSION_MODULES__: {
+      createMenuSessionLifecycle: (ports, runtime = {}) => {
+        return runtime.createPublishService(ports, {});
+      },
+      createMenuPublishService: () => ({
+        delegated: true,
+        prepare: async () => ({ ok: true }),
+        publishUpdate: async () => ({ ok: true }),
+        saveDraft: async () => ({ ok: true }),
+      }),
+    },
+  });
+
+  const lifecycle = sandbox.createMenuSessionLifecycle({
+    buildRequest: () => ({ requestedMenuSlug: 'menu-main' }),
+    buildSnapshot: source => ({ source }),
+    buildPreview: snapshot => ({ ...snapshot, hasChanges: true, sections: [], notificationChanges: [] }),
+    resolveMenu: async () => null,
+    canLoadFromNetwork: () => true,
+    restoreFallback: () => ({ source: 'cache', usedFallback: true, snapshot: { source: 'cache' } }),
+    loadState: async () => ({ source: 'network' }),
+    pollState: async () => ({ changed: false, designChanged: false, snapshot: { source: 'poll' } }),
+  });
+
+  assert.equal(lifecycle.delegated, true);
+});
+```
+
+- [ ] **Step 4: Re-run the targeted tests and confirm they pass**
+
+Run: `node --test tests/boundaries/publish.boundary.test.cjs tests/phase2-session-boundaries.test.cjs`
+Expected: PASS, with the new assertions proving the desired boundary behavior before `app.js` cleanup starts.
+
+- [ ] **Step 5: Commit the test-only red/green slice**
+
+```bash
+git add tests/boundaries/publish.boundary.test.cjs tests/phase2-session-boundaries.test.cjs
+git commit -m "test: lock menu session publish boundary"
+```
+
+### Task 2: Move Client Publish Adaptation Behind The Session Boundary
+
+**Files:**
+- Modify: `core/session/menu-session.js`
+- Modify: `core/session/publish-service.js`
+- Modify: `core/session/menu-publish-facade.js`
+- Test: `tests/boundaries/publish.boundary.test.cjs`
+
+- [ ] **Step 1: Update `core/session/menu-session.js` so it owns publish-facade creation for the request-bound lifecycle**
+
+```js
+function createMenuSessionLifecycleImpl(ports, runtime = {}) {
+  const resolveSessionPorts = typeof runtime.getMenuSessionPorts === 'function'
+    ? runtime.getMenuSessionPorts
+    : (() => globalScope.getMenuSessionPorts?.());
+  const sessionPorts = ports || resolveSessionPorts();
+  let request = sessionPorts.buildRequest();
+
+  function syncRequest(overrides = {}) {
+    request = { ...request, ...sessionPorts.buildRequest(overrides) };
+    return request;
+  }
+
+  function buildSnapshot(source = 'live') {
+    return sessionPorts.buildSnapshot(source, request);
+  }
+
+  const createPublishService = typeof runtime.createPublishService === 'function'
+    ? runtime.createPublishService
+    : (typeof globalScope.createMenuPublishService === 'function'
+        ? globalScope.createMenuPublishService.bind(globalScope)
+        : null);
+
+  const publishService = createPublishService
+    ? createPublishService(sessionPorts, {
+        ...runtime,
+        buildSnapshot,
+        buildPreview: () => sessionPorts.buildPreview(buildSnapshot('preview')),
+      })
+    : null;
+
+  return {
+    syncRequest,
+    snapshot(source = 'live') {
+      syncRequest();
+      return buildSnapshot(source);
+    },
+    async preparePublish(options = {}) {
+      syncRequest(options);
+      return publishService.prepare(options);
+    },
+    async commitPublish(options = {}) {
+      syncRequest(options);
+      return publishService.publishUpdate(options);
+    },
+    async saveDraft(options = {}) {
+      syncRequest(options);
+      return publishService.saveDraft(options);
+    },
+    async publishUpdate(options = {}) {
+      syncRequest(options);
+      return publishService.publishUpdate(options);
+    },
+  };
+}
+```
+
+- [ ] **Step 2: Teach `core/session/publish-service.js` to normalize preview/commit behavior without `app.js` wrappers**
+
+```js
+function createMenuPublishServiceImpl(sessionPorts, runtime = {}, options = {}) {
+  const createPublishFacade = typeof runtime.createPublishFacade === 'function'
+    ? runtime.createPublishFacade
+    : (typeof globalScope.createMenuPublishFacade === 'function'
+        ? globalScope.createMenuPublishFacade.bind(globalScope)
+        : null);
+  const facade = typeof createPublishFacade === 'function'
+    ? createPublishFacade(sessionPorts, runtime)
+    : null;
+
+  return {
+    async prepare(opts = {}) {
+      if (facade && typeof facade.prepare === 'function') return facade.prepare(opts);
+      const fallback = typeof options.fallback === 'function' ? options.fallback() : null;
+      return fallback?.prepare ? fallback.prepare(opts) : { ok: false, userHandled: false, userMessage: 'Preview is unavailable right now.' };
+    },
+    async saveDraft(opts = {}) {
+      if (facade && typeof facade.commit === 'function') return facade.commit({ ...opts, intent: 'save' });
+      const fallback = typeof options.fallback === 'function' ? options.fallback() : null;
+      return fallback?.saveDraft ? fallback.saveDraft(opts) : { ok: false, userHandled: false, userMessage: 'Publish service is unavailable.' };
+    },
+    async publishUpdate(opts = {}) {
+      if (facade && typeof facade.commit === 'function') return facade.commit(opts);
+      const fallback = typeof options.fallback === 'function' ? options.fallback() : null;
+      return fallback?.publishUpdate ? fallback.publishUpdate(opts) : { ok: false, userHandled: false, userMessage: 'Publish service is unavailable.' };
+    },
+  };
+}
+```
+
+- [ ] **Step 3: Keep `core/session/menu-publish-facade.js` as the only translator from session options to workflow commands**
+
+```js
+async prepare(options = {}) {
+  return workflow.preview({
+    menuId: sessionPorts.getMenuId(),
+    actor: sessionPorts.getActor ? sessionPorts.getActor() : null,
+    source: options.source || 'web_manager',
+    snapshot: options.snapshot || buildSnapshot('preview', options.request),
+    request: {
+      expectedLiveRevision: options.expectedLiveRevision ?? null,
+      expectedDraftRevision: options.expectedDraftRevision ?? null,
+      expectedNotificationRevision: options.expectedNotificationRevision ?? null,
+    },
+  });
+}
+
+async commit(options = {}) {
+  return workflow.execute({
+    menuId: sessionPorts.getMenuId(),
+    actor: sessionPorts.getActor ? sessionPorts.getActor() : null,
+    source: options.source || 'web_manager',
+    intent: options.intent || 'save-and-send',
+    snapshot: options.snapshot || buildSnapshot('publish', options.request),
+    request: {
+      selectedChangeIds: Array.isArray(options.selectedChangeIds) ? options.selectedChangeIds : [],
+      expectedLiveRevision: options.expectedLiveRevision ?? null,
+      expectedDraftRevision: options.expectedDraftRevision ?? null,
+      expectedNotificationRevision: options.expectedNotificationRevision ?? null,
+    },
+  });
+}
+```
+
+- [ ] **Step 4: Run the focused publish tests**
+
+Run: `node --test tests/boundaries/publish.boundary.test.cjs`
+Expected: PASS, proving the shared session modules can prepare/commit without the app-owned client wrappers.
+
+- [ ] **Step 5: Commit the shared-session implementation slice**
+
+```bash
+git add core/session/menu-session.js core/session/publish-service.js core/session/menu-publish-facade.js tests/boundaries/publish.boundary.test.cjs
+git commit -m "refactor: deepen session-owned publish flow"
+```
+
+### Task 3: Delete The `app.js` Publish Shadow And Keep Only Browser Ports
+
+**Files:**
+- Modify: `app.js`
+- Modify: `tests/phase2-session-boundaries.test.cjs`
+- Test: `tests/boundaries/publish.boundary.test.cjs`
+- Test: `tests/phase2-session-boundaries.test.cjs`
+
+- [ ] **Step 1: Remove `createClientMenuPublishWorkflow()` and `createClientMenuPublishFacade()` from `app.js`**
+
+```js
+function createMenuPublishService(sessionPorts, runtime = {}) {
+  if (!_sessionModuleDelegationStack.has('createMenuPublishService')) {
+    const boundary = getSessionModuleBoundary();
+    if (typeof boundary?.createMenuPublishService === 'function') {
+      _sessionModuleDelegationStack.add('createMenuPublishService');
+      try {
+        return boundary.createMenuPublishService(sessionPorts, runtime, {
+          fallback: () => createLegacyMenuPublishService(sessionPorts, runtime),
+        });
+      } finally {
+        _sessionModuleDelegationStack.delete('createMenuPublishService');
+      }
+    }
+  }
+
+  return createLegacyMenuPublishService(sessionPorts, runtime);
+}
+```
+
+Delete the app-owned helpers below this function:
+
+```js
+function createClientMenuPublishWorkflow() { /* delete */ }
+function createClientMenuPublishFacade() { /* delete */ }
+```
+
+- [ ] **Step 2: Simplify `createMenuSessionLifecycle()` in `app.js` so it only injects browser/runtime ports**
+
+```js
+function createMenuSessionLifecycle(ports) {
+  const sessionPorts = ports || getMenuSessionPorts();
+
+  if (!_sessionModuleDelegationStack.has('createMenuSessionLifecycle')) {
+    const boundary = getSessionModuleBoundary();
+    if (typeof boundary?.createMenuSessionLifecycle === 'function') {
+      _sessionModuleDelegationStack.add('createMenuSessionLifecycle');
+      try {
+        return boundary.createMenuSessionLifecycle(sessionPorts, {
+          getMenuSessionPorts: () => getMenuSessionPorts(),
+          createPublishService: (nextSessionPorts, runtime = {}) => createMenuPublishService(nextSessionPorts, runtime),
+        });
+      } finally {
+        _sessionModuleDelegationStack.delete('createMenuSessionLifecycle');
+      }
+    }
+  }
+
+  return getSessionModuleBoundary().createMenuSessionLifecycle(sessionPorts, {
+    getMenuSessionPorts: () => getMenuSessionPorts(),
+    createPublishService: (nextSessionPorts, runtime = {}) => createMenuPublishService(nextSessionPorts, runtime),
+  });
+}
+```
+
+- [ ] **Step 3: Re-run the session and syntax checks**
+
+Run: `node --test tests/boundaries/publish.boundary.test.cjs tests/phase2-session-boundaries.test.cjs`
+Expected: PASS
+
+Run: `node --check app.js`
+Expected: no output
+
+- [ ] **Step 4: Commit the app cleanup**
+
+```bash
+git add app.js tests/phase2-session-boundaries.test.cjs
+git commit -m "refactor: remove app publish shadow logic"
+```
+
+## Self-Review
+
+### Spec coverage
+
+- Problem addressed: duplicated session/publish logic between `app.js` and `core/session/*`.
+- Deep module direction: preserve request-bound session contract while moving orchestration behind the boundary.
+- Tests: boundary behavior replaces delegation-heavy coverage first, then app cleanup keeps only the browser port layer.
+
+### Placeholder scan
+
+- No `TODO` / `TBD` placeholders remain.
+- Each task names exact files and commands.
+- Each code-edit step includes the target shape to implement.
+
+### Type consistency
+
+- Keep the existing caller-facing method names stable: `preparePublish`, `commitPublish`, `saveDraft`, `publishUpdate`.
+- `prepare()` and `commit()` stay the internal publish-facade verbs.
+- Request revision fields remain `expectedLiveRevision`, `expectedDraftRevision`, and `expectedNotificationRevision`.

--- a/tests/boundaries/publish.boundary.test.cjs
+++ b/tests/boundaries/publish.boundary.test.cjs
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { loadAppSandbox } = require('../helpers/runtime.cjs');
+const { loadAppSandbox, loadSandboxWithScripts } = require('../helpers/runtime.cjs');
 
 function toPlainValue(value) {
   return JSON.parse(JSON.stringify(value));
@@ -201,4 +201,57 @@ test('menu publish facade prepares and commits through the workflow boundary', a
     expectedDraftRevision: 11,
     expectedNotificationRevision: 9,
   });
+});
+
+test('menu session lifecycle prepares and commits through shared session modules without app-owned publish helpers', async () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/session/publish-service.js',
+    'core/session/menu-session.js',
+  ]);
+  const previewCalls = [];
+  const commitCalls = [];
+
+  sandbox.createMenuPublishFacade = () => {
+    throw new Error('session lifecycle should not read app-owned publish facade helpers');
+  };
+  sandbox.createMenuPublishService = () => {
+    throw new Error('session lifecycle should not read app-owned publish service helpers');
+  };
+  sandbox.__HF_SESSION_MODULES__.createMenuPublishService = (sessionPorts, runtime = {}) => ({
+    async prepare(options = {}) {
+      previewCalls.push({ sessionPorts: !!sessionPorts, options, runtime: !!runtime });
+      return {
+        ok: true,
+        preview: { hasChanges: true, sections: [], notificationChanges: [], mode: 'save-and-send' },
+        revisions: { liveRevision: 10, draftRevision: 11, notificationRevision: 9 },
+      };
+    },
+    async publishUpdate(options = {}) {
+      commitCalls.push({ sessionPorts: !!sessionPorts, options, runtime: !!runtime });
+      return {
+        ok: true,
+        userOutcome: { successMessage: 'published', warningMessage: '', warnings: [] },
+      };
+    },
+    async saveDraft(options = {}) {
+      commitCalls.push({ sessionPorts: !!sessionPorts, options: { ...options, intent: 'save' }, runtime: !!runtime });
+      return {
+        ok: true,
+        userOutcome: { successMessage: 'saved', warningMessage: '', warnings: [] },
+      };
+    },
+  });
+
+  const lifecycle = sandbox.__HF_SESSION_MODULES__.createMenuSessionLifecycle(createMenuSessionPorts(), {
+    createPublishService: sandbox.__HF_SESSION_MODULES__.createMenuPublishService,
+  });
+  const preview = await lifecycle.preparePublish({ expectedLiveRevision: 10 });
+  const commit = await lifecycle.publishUpdate({ selectedChangeIds: ['beer::added::lager'] });
+  const save = await lifecycle.saveDraft({});
+
+  assert.equal(preview.ok, true);
+  assert.equal(commit.ok, true);
+  assert.equal(save.ok, true);
+  assert.equal(previewCalls.length, 1);
+  assert.equal(commitCalls.length, 2);
 });

--- a/tests/boundaries/publish.boundary.test.cjs
+++ b/tests/boundaries/publish.boundary.test.cjs
@@ -255,3 +255,80 @@ test('menu session lifecycle prepares and commits through shared session modules
   assert.equal(previewCalls.length, 1);
   assert.equal(commitCalls.length, 2);
 });
+
+test('menu publish service honors an explicit global facade override for direct consumers', async () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/session/menu-publish-facade.js',
+    'core/session/publish-service.js',
+  ]);
+  const calls = [];
+
+  sandbox.createMenuPublishFacade = (sessionPorts, runtime = {}) => ({
+    async prepare(options = {}) {
+      calls.push({ type: 'prepare', sessionPorts: !!sessionPorts, runtime: !!runtime, options });
+      return { ok: true, source: 'global-override' };
+    },
+    async commit(options = {}) {
+      calls.push({ type: 'commit', sessionPorts: !!sessionPorts, runtime: !!runtime, options });
+      return { ok: true, source: 'global-override', options };
+    },
+  });
+
+  const service = sandbox.__HF_SESSION_MODULES__.createMenuPublishService(createMenuSessionPorts(), {});
+  const preview = await service.prepare({ expectedLiveRevision: 10 });
+  const save = await service.saveDraft({ pathname: '/manager' });
+
+  assert.equal(preview.source, 'global-override');
+  assert.equal(save.source, 'global-override');
+  assert.equal(calls.length, 2);
+  assert.equal(calls[0].type, 'prepare');
+  assert.equal(calls[1].type, 'commit');
+  assert.equal(calls[1].options.intent, 'save');
+});
+
+test('menu publish service keeps fallback methods explicit for quiet-save and publish paths', async () => {
+  const sandbox = loadSandboxWithScripts(['core/session/publish-service.js']);
+  const quietSaveCalls = [];
+  const publishCalls = [];
+
+  const saveOnlyService = sandbox.__HF_SESSION_MODULES__.createMenuPublishService(
+    createMenuSessionPorts(),
+    {},
+    {
+      fallback: () => ({
+        async saveDraft(options = {}) {
+          quietSaveCalls.push(options);
+          return { ok: true, path: 'save-only' };
+        },
+      }),
+    },
+  );
+
+  const saveResult = await saveOnlyService.saveDraft({ pathname: '/manager' });
+  const publishUnavailable = await saveOnlyService.publishUpdate({ pathname: '/manager' });
+
+  assert.equal(saveResult.path, 'save-only');
+  assert.equal(quietSaveCalls.length, 1);
+  assert.equal(publishUnavailable.ok, false);
+
+  const publishOnlyService = sandbox.__HF_SESSION_MODULES__.createMenuPublishService(
+    createMenuSessionPorts(),
+    {},
+    {
+      fallback: () => ({
+        async publishUpdate(options = {}) {
+          publishCalls.push(options);
+          return { ok: true, path: 'publish-only' };
+        },
+      }),
+    },
+  );
+
+  const publishResult = await publishOnlyService.publishUpdate({ selectedChangeIds: ['beer::added::lager'] });
+  const saveUnavailable = await publishOnlyService.saveDraft({});
+
+  assert.equal(publishResult.path, 'publish-only');
+  assert.equal(publishCalls.length, 1);
+  assert.deepEqual(toPlainValue(publishCalls[0]), { selectedChangeIds: ['beer::added::lager'] });
+  assert.equal(saveUnavailable.ok, false);
+});

--- a/tests/phase11-web-cutover-boundaries.test.cjs
+++ b/tests/phase11-web-cutover-boundaries.test.cjs
@@ -88,13 +88,9 @@ test('wave 5 no longer calls the legacy live-save fallback from the authoritativ
 
 test('wave 5 publish session boundary prefers the server-owned publish command before local side effects', () => {
   const source = read('core/session/publish-service.js');
-  const guardIndex = source.indexOf("if (typeof sessionPorts.publishMenuUpdate === 'function')");
-  const fallbackPublishIndex = source.indexOf('return fallbackService.publishUpdate(options);');
-
-  assert.notEqual(guardIndex, -1);
-  assert.notEqual(fallbackPublishIndex, -1);
-  assert.match(source, /return sessionPorts\.publishMenuUpdate\(options\);/);
-  assert.ok(guardIndex < fallbackPublishIndex);
+  assert.match(source, /globalCreatePublishFacade \|\| moduleCreatePublishFacade/);
+  assert.doesNotMatch(source, /fallback\.publishUpdate\(\{ \.\.\.opts, intent: 'save' \}\)/);
+  assert.doesNotMatch(source, /opts\.intent === 'save'/);
   assert.doesNotMatch(source, /persistState\(/);
   assert.doesNotMatch(source, /dispatchNotification\(/);
   assert.doesNotMatch(source, /patchMenuMeta/);

--- a/tests/phase2-session-boundaries.test.cjs
+++ b/tests/phase2-session-boundaries.test.cjs
@@ -51,20 +51,25 @@ test('app createMenuSessionLifecycle delegates through session module boundary',
   assert.equal(result.type, 'lifecycle');
   assert.equal(calls.length, 1);
   assert.equal(typeof calls[0][1]?.createPublishService, 'function');
+  assert.equal('createPublishFacade' in (calls[0][1] || {}), false);
 });
 
 test('app createMenuSessionLifecycle delegates publish creation through shared session modules', () => {
+  const createPublishServiceCalls = [];
   const sandbox = loadSandboxWithScripts(['app.js'], {
     __HF_SESSION_MODULES__: {
       createMenuSessionLifecycle: (ports, runtime = {}) => {
         return runtime.createPublishService(ports, {});
       },
-      createMenuPublishService: () => ({
+      createMenuPublishService: (...args) => {
+        createPublishServiceCalls.push(args);
+        return {
         delegated: true,
         prepare: async () => ({ ok: true }),
         publishUpdate: async () => ({ ok: true }),
         saveDraft: async () => ({ ok: true }),
-      }),
+        };
+      },
     },
   });
 
@@ -80,6 +85,8 @@ test('app createMenuSessionLifecycle delegates publish creation through shared s
   });
 
   assert.equal(lifecycle.delegated, true);
+  assert.equal(createPublishServiceCalls.length, 1);
+  assert.equal(typeof createPublishServiceCalls[0][2]?.fallback, 'function');
 });
 
 test('app createMenuStateLoaderService delegates through session module boundary', () => {

--- a/tests/phase2-session-boundaries.test.cjs
+++ b/tests/phase2-session-boundaries.test.cjs
@@ -33,6 +33,7 @@ test('app createMenuPublishService delegates through session module boundary', (
   assert.equal(result.delegated, true);
   assert.equal(result.type, 'publish');
   assert.equal(calls.length, 1);
+  assert.equal(typeof calls[0][2]?.fallback, 'function');
 });
 
 test('app createMenuSessionLifecycle delegates through session module boundary', () => {

--- a/tests/phase2-session-boundaries.test.cjs
+++ b/tests/phase2-session-boundaries.test.cjs
@@ -53,49 +53,33 @@ test('app createMenuSessionLifecycle delegates through session module boundary',
   assert.equal(typeof calls[0][1]?.createPublishService, 'function');
 });
 
-test('session lifecycle module uses injected publish creation instead of ambient app globals', async () => {
-  const sandbox = loadSandboxWithScripts([
-    'core/session/publish-service.js',
-    'core/session/menu-session.js',
-  ]);
-  const publishCalls = [];
-
-  sandbox.createMenuPublishService = () => {
-    throw new Error('session lifecycle should not read createMenuPublishService from globalScope when injected');
-  };
-
-  const lifecycle = sandbox.__HF_SESSION_MODULES__.createMenuSessionLifecycle({
-    buildRequest: () => ({ requestedMenuSlug: 'menu-main' }),
-    buildSnapshot: source => ({ source, dirty: true }),
-    buildPreview: snapshot => ({
-      ...snapshot,
-      hasChanges: true,
-      hasLocalDraft: true,
-      hasSharedDraft: false,
-      mode: 'update-only',
-      sections: [],
-      notificationChanges: [],
-      saveOnlyChanges: [],
-    }),
-    resolveMenu: async () => null,
-    canLoadFromNetwork: () => true,
-    restoreFallback: () => ({ source: 'cache', usedFallback: true, snapshot: { source: 'cache' } }),
-    loadState: async ({ source = 'network' }) => ({ source }),
-    pollState: async () => ({ changed: false, designChanged: false, snapshot: { source: 'poll' } }),
-  }, {
-    createPublishService: (...args) => {
-      publishCalls.push(args);
-      return {
-        saveDraft: async () => ({ ok: true, source: 'injected-save' }),
-        publishUpdate: async () => ({ ok: true, source: 'injected-publish' }),
-      };
+test('app createMenuSessionLifecycle delegates publish creation through shared session modules', () => {
+  const sandbox = loadSandboxWithScripts(['app.js'], {
+    __HF_SESSION_MODULES__: {
+      createMenuSessionLifecycle: (ports, runtime = {}) => {
+        return runtime.createPublishService(ports, {});
+      },
+      createMenuPublishService: () => ({
+        delegated: true,
+        prepare: async () => ({ ok: true }),
+        publishUpdate: async () => ({ ok: true }),
+        saveDraft: async () => ({ ok: true }),
+      }),
     },
   });
 
-  const result = await lifecycle.saveDraft();
-  assert.equal(result.ok, true);
-  assert.equal(result.source, 'injected-save');
-  assert.equal(publishCalls.length, 1);
+  const lifecycle = sandbox.createMenuSessionLifecycle({
+    buildRequest: () => ({ requestedMenuSlug: 'menu-main' }),
+    buildSnapshot: source => ({ source }),
+    buildPreview: snapshot => ({ ...snapshot, hasChanges: true, sections: [], notificationChanges: [] }),
+    resolveMenu: async () => null,
+    canLoadFromNetwork: () => true,
+    restoreFallback: () => ({ source: 'cache', usedFallback: true, snapshot: { source: 'cache' } }),
+    loadState: async () => ({ source: 'network' }),
+    pollState: async () => ({ changed: false, designChanged: false, snapshot: { source: 'poll' } }),
+  });
+
+  assert.equal(lifecycle.delegated, true);
 });
 
 test('app createMenuStateLoaderService delegates through session module boundary', () => {


### PR DESCRIPTION
## What changed

- moved the web menu session lifecycle to prefer the shared `core/session/*` publish boundary instead of the app-owned publish facade path
- removed the redundant app-layer publish facade/workflow wiring from `app.js`
- tightened boundary coverage around publish delegation, override precedence, fallback behavior, and the direct app fallback contract
- added an implementation plan documenting the deeper session-boundary direction
- fixed the review regression by restoring the `publishMenuUpdate` fast-path and preserving quiet-save preview/no-op behavior

## Why it changed

The save/send flow was still split between the extracted session modules and a shadow implementation in `app.js`. That made the boundary harder to reason about, kept tests focused on delegation instead of behavior, and left direct server-owned publish paths vulnerable to regressions.

## Impact

- `core/session/menu-session.js` and `core/session/publish-service.js` now own more of the publish orchestration
- `app.js` is smaller and only injects browser/runtime ports into the shared session boundary
- boundary tests now pin the session/publish contract more directly

## Root cause

The repo had partially extracted the session/publish module boundary, but `app.js` still carried client publish helpers and fallback logic that overlapped with the shared modules. A later refactor also regressed direct `publishMenuUpdate` callers by eagerly resolving the facade path first.

## Validation

- `node --test tests/phase8-server-write-boundaries.test.cjs tests/boundaries/publish.boundary.test.cjs tests/phase2-session-boundaries.test.cjs tests/phase11-web-cutover-boundaries.test.cjs`
- `node --check app.js`
- `node --test tests/architecture-boundaries.test.cjs`
  - still has one unrelated existing failure in the manager shell header copy assertion
