### PR TITLE
[codex] landing runtime cleanup and plans

### DIFF
--- a/admin/index.html
+++ b/admin/index.html
@@ -489,6 +489,11 @@
 <script src="/core/session/menu-session.js"></script>
 <script src="/core/data/menu-state-loader.js"></script>
 <script src="/core/session/poll-scheduler.js"></script>
+<script src="/core/landing/model.js"></script>
+<script src="/core/landing/store.js"></script>
+<script src="/core/landing/data-service.js"></script>
+<script src="/core/landing/admin-workspace.js"></script>
+<script src="/core/landing/root-renderer.js"></script>
 <script src="/app.js"></script>
 </body>
 </html>

--- a/app.js
+++ b/app.js
@@ -86,6 +86,7 @@ let _landingPageLoadPromise = null;
 let _landingPageLoadError = '';
 let _activeLandingAdminPanel = 'landing-admin-panel-overview';
 let _landingAdminFilters = null;
+let _landingAdminFiltersLoaded = false;
 let _landingReviewCarouselIndex = 0;
 let _previewAuditAvailability = { manager: null, admin: null };
 let _previewAuditAvailabilityPromise = { manager: null, admin: null };
@@ -227,7 +228,7 @@ function syncLandingLegacyStateFromStore() {
   _landingPageLoadPromise = LANDING_STORE.getLoadPromise();
   _landingPageLoadError = LANDING_STORE.getLoadError();
   _activeLandingAdminPanel = LANDING_STORE.getActivePanel();
-  _landingAdminFilters = LANDING_STORE.getFilters();
+  if (_landingAdminFiltersLoaded) _landingAdminFilters = LANDING_STORE.getFilters();
   _landingReviewCarouselIndex = LANDING_STORE.getReviewCarouselIndex();
   return _landingPageState;
 }
@@ -432,51 +433,26 @@ function getLandingActiveItems(items = []) {
 function getLandingVisibleItems(items = [], showArchived = false) {
   return LANDING_MODEL.getVisibleItems(items, showArchived);
 }
+function getLandingRenderableNews(section = {}) {
+  return LANDING_MODEL.getRenderableNews(section);
+}
+function buildLandingReviewPairs(section = {}) {
+  return LANDING_MODEL.buildReviewPairs(section);
+}
 function getLandingDefaultFilters() {
-  return {
-    events: { showArchived: false },
-    news: { showArchived: false },
-    reviews: { showArchived: false },
-  };
+  return LANDING_MODEL.getDefaultFilters();
 }
 function normalizeLandingFilters(raw = {}) {
-  const defaults = getLandingDefaultFilters();
-  return {
-    events: { ...defaults.events, showArchived: !!raw?.events?.showArchived },
-    news: { ...defaults.news, showArchived: !!raw?.news?.showArchived },
-    reviews: { ...defaults.reviews, showArchived: !!raw?.reviews?.showArchived },
-  };
+  return LANDING_MODEL.normalizeFilters(raw);
 }
 function formatLandingHoursRange(day = {}) {
   return LANDING_MODEL.formatHoursRange(day);
 }
 function getLandingDayOffsetKey(dayKey, offset = 0) {
-  const index = LANDING_DAY_ORDER.indexOf(dayKey);
-  if (index < 0) return LANDING_DAY_ORDER[0];
-  return LANDING_DAY_ORDER[(index + offset + LANDING_DAY_ORDER.length) % LANDING_DAY_ORDER.length];
+  return LANDING_MODEL.getDayOffsetKey(dayKey, offset);
 }
 function getRestaurantLocalParts(now = Date.now(), timeZone = RESTAURANT_TIME_ZONE) {
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    timeZone,
-    weekday: 'short',
-    hour: '2-digit',
-    minute: '2-digit',
-    hour12: false,
-  });
-  const parts = formatter.formatToParts(new Date(now));
-  const lookup = Object.create(null);
-  parts.forEach(part => {
-    lookup[part.type] = part.value;
-  });
-  const weekday = String(lookup.weekday || '').slice(0, 3).toLowerCase();
-  const dayKeyMap = { mon: 'mon', tue: 'tue', wed: 'wed', thu: 'thu', fri: 'fri', sat: 'sat', sun: 'sun' };
-  const dayKey = dayKeyMap[weekday] || 'mon';
-  const hour = Number(lookup.hour || 0);
-  const minute = Number(lookup.minute || 0);
-  return {
-    dayKey,
-    minutes: (Number.isFinite(hour) ? hour : 0) * 60 + (Number.isFinite(minute) ? minute : 0),
-  };
+  return LANDING_MODEL.getRestaurantLocalParts(now, timeZone);
 }
 function getLandingHoursForRestaurant(section = {}, restaurantId = '') {
   return LANDING_MODEL.getHoursForRestaurant(section, restaurantId);
@@ -485,13 +461,17 @@ function buildLandingWeekRows(section = {}, restaurantId = '', todayKey = 'mon')
   return LANDING_MODEL.buildWeekRows(section, restaurantId, todayKey);
 }
 function loadLandingFilters() {
-  if (_landingAdminFilters) return _landingAdminFilters;
+  if (_landingAdminFiltersLoaded) {
+    if (!_landingAdminFilters) _landingAdminFilters = LANDING_STORE.getFilters();
+    return _landingAdminFilters;
+  }
   try {
     LANDING_STORE.setFilters(normalizeLandingFilters(JSON.parse(sessionStorage.getItem(LANDING_FILTER_STORAGE_KEY) || '{}')));
   } catch (_) {
     LANDING_STORE.setFilters(getLandingDefaultFilters());
   }
-  syncLandingLegacyStateFromStore();
+  _landingAdminFiltersLoaded = true;
+  _landingAdminFilters = LANDING_STORE.getFilters();
   return _landingAdminFilters;
 }
 function getLandingSectionFilter(sectionId = '') {
@@ -508,6 +488,7 @@ function setLandingSectionFilter(sectionId = '', key = '', value = false) {
   if (!filters[sectionId]) filters[sectionId] = { showArchived: false };
   filters[sectionId][key] = !!value;
   LANDING_STORE.setFilters(filters);
+  _landingAdminFiltersLoaded = true;
   syncLandingLegacyStateFromStore();
   saveLandingFilters();
 }
@@ -530,11 +511,7 @@ function validateLandingReviewsSection(section = {}) {
   return LANDING_MODEL.validateReviewsSection(section);
 }
 function getLandingSectionValidation(sectionId = '', record = _landingPageState) {
-  if (sectionId === 'hours') {
-    const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-    return validateLandingHoursSection(normalized.draftContent.hours);
-  }
-  return LANDING_MODEL.getSectionValidation(sectionId, record || createDefaultLandingPageRecord());
+  return LANDING_MODEL.getSectionValidation(sectionId, getLandingValidationRecord(record));
 }
 function findLandingItemById(items = [], itemId = '') {
   return Array.isArray(items) ? items.find(item => item?.id === itemId) || null : null;
@@ -3910,9 +3887,7 @@ function formatLandingTimestampLabel(value) {
 function getLandingSectionStatus(sectionId, record = _landingPageState) {
   const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
   const hasDraftDiff = landingSectionHasDiff(sectionId, normalized);
-  const validation = sectionId === 'hours'
-    ? validateLandingHoursSection(getLandingHoursSectionForValidation(normalized))
-    : getLandingSectionValidation(sectionId, normalized);
+  const validation = getLandingSectionValidation(sectionId, normalized);
   return {
     sectionId,
     label: LANDING_PAGE_SECTION_LABELS[sectionId] || sectionId,
@@ -4129,228 +4104,103 @@ function renderLandingReviewCardHtml(item = {}, restaurantId = '', liveItems = [
       </div>
     </article>`;
 }
+let _landingAdminWorkspaceService = null;
+function getLandingAdminWorkspaceService() {
+  if (_landingAdminWorkspaceService) return _landingAdminWorkspaceService;
+  _landingAdminWorkspaceService = globalThis.__HF_LANDING_MODULES__.createLandingAdminWorkspaceService({
+    model: LANDING_MODEL,
+    store: LANDING_STORE,
+    dataService: LANDING_DATA_SERVICE,
+    document,
+    escHtml,
+    escAttrJs,
+    showToast,
+    hasAdminShell: () => hasLandingAdminShell(),
+    hasRootShell: () => hasLandingRootShell(),
+    focusAdminPanel: panelId => focusLandingAdminPanel(panelId),
+    syncLegacyStateFromStore: () => syncLandingLegacyStateFromStore(),
+    getSectionFilter: sectionId => getLandingSectionFilter(sectionId),
+    getVisibleItems: (items, showArchived) => getLandingVisibleItems(items, showArchived),
+    sortEvents: items => sortLandingEvents(items),
+    sortNews: items => sortLandingNews(items),
+    sortReviews: items => sortLandingReviews(items),
+    renderEventCardHtml: (item, liveSection) => renderLandingEventCardHtml(item, liveSection),
+    renderNewsCardHtml: (item, liveSection) => renderLandingNewsCardHtml(item, liveSection),
+    renderReviewCardHtml: (item, restaurantId, liveItems) => renderLandingReviewCardHtml(item, restaurantId, liveItems),
+    renderHoursRowsHtml: (section, restaurantId, restaurantLabel) => renderLandingHoursRowsHtml(section, restaurantId, restaurantLabel),
+    knownRestaurants: () => knownLandingRestaurants(),
+    restaurants: RESTAURANTS,
+    getTargetAccentClass: target => getLandingTargetAccentClass(target),
+    getSectionStatus: (sectionId, record) => getLandingSectionStatus(sectionId, record),
+    getDraftDiffSectionIds: record => getLandingDraftDiffSectionIds(record),
+    formatTimestampLabel: value => formatLandingTimestampLabel(value),
+    computeStatusForRestaurant: (section, restaurantId) => computeLandingStatusForRestaurant(section, restaurantId),
+    syncHoursDraftFromDom: record => syncLandingHoursDraftFromDom(record),
+    renderRootPage: record => renderLandingRootPage(record),
+    createDefaultRecord: () => createDefaultLandingPageRecord(),
+    normalizeRecord: record => normalizeLandingPageRecord(record),
+    validateEventsSection: section => validateLandingEventsSection(section),
+    validateNewsSection: section => validateLandingNewsSection(section),
+    validateReviewsSection: section => validateLandingReviewsSection(section),
+    getHoursSectionValidation: record => getLandingSectionValidation('hours', record),
+    sectionOrder: LANDING_PAGE_SECTION_ORDER,
+    setPanelBadge: (sectionId, validation) => setLandingPanelBadge(sectionId, validation),
+    landingTargetBoth: LANDING_TARGET_BOTH,
+    renderTargetOptionsHtml: (selectedTarget, options = {}) => renderLandingTargetOptionsHtml(selectedTarget, options),
+    createDefaultHoursRestaurant: () => createDefaultLandingHoursRestaurant(),
+    createDefaultDay: () => createDefaultLandingDay(),
+    normalizeDay: day => normalizeLandingDay(day),
+    landingImportStatusImported: LANDING_IMPORT_STATUS_IMPORTED,
+    landingImportStatusPartial: LANDING_IMPORT_STATUS_PARTIAL,
+    landingImportStatusFailed: LANDING_IMPORT_STATUS_FAILED,
+    setSectionFilter: (sectionId, key, value) => setLandingSectionFilter(sectionId, key, value),
+    setTimeout,
+    postApiJson: (url, body, options = {}) => postApiJson(url, body, options),
+    getAuthorizedApiHeaders: () => getAuthorizedApiHeaders(),
+    getCurrentUser: () => currentUser,
+  });
+  return _landingAdminWorkspaceService;
+}
+
 function renderLandingEventsPanel(record = _landingPageState) {
-  const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-  const bodyEl = document.getElementById('landing-events-panel-body');
-  const issuesEl = document.getElementById('landing-events-issues');
-  const validation = validateLandingEventsSection(normalized.draftContent.events);
-  const filter = getLandingSectionFilter('events');
-  const visibleItems = getLandingVisibleItems(sortLandingEvents(normalized.draftContent.events.items), filter.showArchived);
-  if (bodyEl) {
-    bodyEl.innerHTML = `
-      <div class="landing-admin-toolbar-row">
-        <button type="button" class="btn-small admin-console-primary-btn" onclick="addLandingEventDraft()">Add Event</button>
-        <label class="landing-admin-toggle">
-          <input type="checkbox" ${filter.showArchived ? 'checked' : ''} onchange="toggleLandingSectionArchivedFilter('events', this.checked)">
-          Show archived
-        </label>
-      </div>
-      ${visibleItems.length ? `<div class="landing-admin-editor-list">${visibleItems.map(item => renderLandingEventCardHtml(item, normalized.liveContent.events)).join('')}</div>` : `
-        <article class="landing-admin-note">
-          <strong>No ${filter.showArchived ? '' : 'active '}events yet.</strong>
-          <p>Manual event cards live here. Add a night, tag the room, and publish the full section when it is ready.</p>
-        </article>`}
-    `;
-  }
-  if (issuesEl) issuesEl.innerHTML = validation.valid ? '' : validation.issues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
-  setLandingPanelBadge('events', validation);
+  return getLandingAdminWorkspaceService().renderEventsPanel(record);
 }
 function renderLandingNewsPanel(record = _landingPageState) {
-  const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-  const bodyEl = document.getElementById('landing-news-panel-body');
-  const issuesEl = document.getElementById('landing-news-issues');
-  const validation = validateLandingNewsSection(normalized.draftContent.news);
-  const filter = getLandingSectionFilter('news');
-  const visibleItems = getLandingVisibleItems(sortLandingNews(normalized.draftContent.news.items), filter.showArchived);
-  if (bodyEl) {
-    bodyEl.innerHTML = `
-      <div class="landing-admin-toolbar-row landing-admin-toolbar-row--stack">
-        <div class="landing-admin-import-row">
-          <select id="landing-news-import-target" class="landing-admin-input">
-            ${renderLandingTargetOptionsHtml(LANDING_TARGET_BOTH, { includeBoth: true })}
-          </select>
-          <input id="landing-news-import-url" class="landing-admin-input landing-admin-input--grow" type="url" placeholder="Paste article URL to import" onpaste="handleLandingNewsImportPaste()">
-          <button type="button" class="btn-small admin-console-primary-btn" onclick="importLandingNewsDraft()">Import Story</button>
-        </div>
-        <label class="landing-admin-toggle">
-          <input type="checkbox" ${filter.showArchived ? 'checked' : ''} onchange="toggleLandingSectionArchivedFilter('news', this.checked)">
-          Show archived
-        </label>
-      </div>
-      ${visibleItems.length ? `<div class="landing-admin-editor-list">${visibleItems.map(item => renderLandingNewsCardHtml(item, normalized.liveContent.news)).join('')}</div>` : `
-        <article class="landing-admin-note">
-          <strong>No ${filter.showArchived ? '' : 'active '}stories yet.</strong>
-          <p>Paste an article URL to create or refresh a draft news card. Missing fields stay editable in draft until the section is ready.</p>
-        </article>`}
-    `;
-  }
-  if (issuesEl) issuesEl.innerHTML = validation.valid ? '' : validation.issues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
-  setLandingPanelBadge('news', validation);
+  return getLandingAdminWorkspaceService().renderNewsPanel(record);
 }
 function renderLandingReviewsPanel(record = _landingPageState) {
-  const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-  const bodyEl = document.getElementById('landing-reviews-panel-body');
-  const issuesEl = document.getElementById('landing-reviews-issues');
-  const validation = validateLandingReviewsSection(normalized.draftContent.reviews);
-  const filter = getLandingSectionFilter('reviews');
-  if (bodyEl) {
-    bodyEl.innerHTML = `
-      <div class="landing-admin-toolbar-row">
-        <label class="landing-admin-toggle">
-          <input type="checkbox" ${filter.showArchived ? 'checked' : ''} onchange="toggleLandingSectionArchivedFilter('reviews', this.checked)">
-          Show archived
-        </label>
-      </div>
-      <div class="landing-admin-review-lanes">
-        ${knownLandingRestaurants().map(restaurant => {
-          const items = getLandingVisibleItems(sortLandingReviews(normalized.draftContent.reviews.restaurants[restaurant.id]), filter.showArchived);
-          return `
-            <section class="landing-admin-review-lane">
-              <div class="landing-admin-review-lane-head">
-                <div>
-                  <p class="settings-section-kicker">${escHtml(restaurant.name)}</p>
-                  <h5>${escHtml(restaurant.name)}</h5>
-                </div>
-                <span class="landing-tag ${getLandingTargetAccentClass(restaurant.id)}">${escHtml(items.length)} draft</span>
-              </div>
-              <div class="landing-admin-import-row">
-                <input id="landing-review-import-url-${escHtml(restaurant.id)}" class="landing-admin-input landing-admin-input--grow" type="url" placeholder="Paste Google review URL" onpaste="handleLandingReviewImportPaste(${escAttrJs(restaurant.id)})">
-                <button type="button" class="btn-small admin-console-primary-btn" onclick="importLandingReviewDraft(${escAttrJs(restaurant.id)})">Import Review</button>
-              </div>
-              ${items.length ? `<div class="landing-admin-editor-list">${items.map(item => renderLandingReviewCardHtml(item, restaurant.id, normalized.liveContent.reviews.restaurants[restaurant.id])).join('')}</div>` : `
-                <article class="landing-admin-note">
-                  <strong>No ${filter.showArchived ? '' : 'active '}reviews yet.</strong>
-                  <p>Imported Google reviews stay frozen as draft snapshots until you explicitly refresh and republish them.</p>
-                </article>`}
-            </section>`;
-        }).join('')}
-      </div>
-    `;
-  }
-  if (issuesEl) issuesEl.innerHTML = validation.valid ? '' : validation.issues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
-  setLandingPanelBadge('reviews', validation);
+  return getLandingAdminWorkspaceService().renderReviewsPanel(record);
 }
 
 function renderLandingOverview(record = _landingPageState) {
-  const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-  const diffSectionIds = getLandingDraftDiffSectionIds(normalized);
-  const sectionValidations = ['hours', 'events', 'news', 'reviews'].map(sectionId => ({
-    sectionId,
-    validation: getLandingSectionValidation(sectionId, normalized),
-  }));
-  const blockingIssues = sectionValidations.flatMap(entry => entry.validation.issues);
-  const allValid = sectionValidations.every(entry => entry.validation.valid);
-  const rootStatusEl = document.getElementById('landing-overview-root-status');
-  const rootCopyEl = document.getElementById('landing-overview-root-copy');
-  const draftSavedEl = document.getElementById('landing-overview-draft-saved');
-  const draftCopyEl = document.getElementById('landing-overview-draft-copy');
-  const livePublishedEl = document.getElementById('landing-overview-live-published');
-  const liveCopyEl = document.getElementById('landing-overview-live-copy');
-  const heroLinesEl = document.getElementById('landing-overview-hero-lines');
-  const heroCopyEl = document.getElementById('landing-overview-hero-copy');
-  const listEl = document.getElementById('landing-overview-section-list');
-  const issuesEl = document.getElementById('landing-overview-issues');
-  const healthBadgeEl = document.getElementById('landing-overview-health-badge');
-  const leroysStatus = computeLandingStatusForRestaurant(normalized.liveContent.hours, RESTAURANTS.LEROYS.id);
-  const elroysStatus = computeLandingStatusForRestaurant(normalized.liveContent.hours, RESTAURANTS.ELROYS.id);
-
-  if (rootStatusEl) rootStatusEl.textContent = _landingPageLoadError ? 'Fallback ready' : 'Live shell ready';
-  if (rootCopyEl) rootCopyEl.textContent = _landingPageLoadError
-    ? 'The public root can fall back to the simple chooser if landing data fails.'
-    : 'The richer root shell can render from the published landing-page snapshot.';
-  if (draftSavedEl) draftSavedEl.textContent = formatLandingTimestampLabel(normalized.draftSavedTs);
-  if (draftCopyEl) draftCopyEl.textContent = diffSectionIds.length
-    ? `${diffSectionIds.length} subsection draft${diffSectionIds.length === 1 ? '' : 's'} differ from live.`
-    : 'Draft and live are currently aligned.';
-  if (livePublishedEl) livePublishedEl.textContent = formatLandingTimestampLabel(normalized.livePublishedTs);
-  if (liveCopyEl) liveCopyEl.textContent = normalized.livePublishedTs
-    ? 'Publish promotes only the sections you select.'
-    : 'No landing-page sections have been published live yet.';
-  if (heroLinesEl) heroLinesEl.textContent = `${leroysStatus.label} / ${elroysStatus.label}`;
-  if (heroCopyEl) heroCopyEl.textContent = 'These public hero lines are generated from the live recurring-hours schedules.';
-  if (healthBadgeEl) {
-    healthBadgeEl.textContent = allValid ? 'Healthy' : 'Needs attention';
-    healthBadgeEl.className = `landing-admin-section-badge ${allValid ? 'is-ready' : 'is-blocked'}`;
-  }
-  if (listEl) {
-    listEl.innerHTML = LANDING_PAGE_SECTION_ORDER.map(sectionId => {
-      const status = getLandingSectionStatus(sectionId, normalized);
-      const badgeClass = status.isValid ? 'is-ready' : 'is-blocked';
-      const badgeText = !status.isValid ? 'Blocked' : (status.hasDraftDiff ? 'Drafting' : 'Live');
-      const description = status.hasDraftDiff
-        ? 'Draft differs from the currently published snapshot.'
-        : 'Draft and live match right now.';
-      return `
-        <article class="landing-overview-section-item">
-          <div>
-            <strong>${escHtml(status.label)}</strong>
-            <span>${escHtml(description)}</span>
-          </div>
-          <span class="landing-admin-section-badge ${badgeClass}">${escHtml(badgeText)}</span>
-        </article>`;
-    }).join('');
-  }
-  if (issuesEl) {
-    issuesEl.innerHTML = allValid
-      ? ''
-      : blockingIssues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
-  }
+  return getLandingAdminWorkspaceService().renderOverview(record);
 }
 
-function syncLandingHoursDraftFromDom() {
-  if (!hasLandingAdminShell()) return _landingPageState || createDefaultLandingPageRecord();
-  const fields = Array.from(document.querySelectorAll('[data-landing-hours-field]'));
-  if (!fields.length) return _landingPageState || createDefaultLandingPageRecord();
+function syncLandingHoursDraftFromDom(baseRecord = _landingPageState || createDefaultLandingPageRecord()) {
+  const sourceRecord = normalizeLandingPageRecord(baseRecord || createDefaultLandingPageRecord());
+  if (!hasLandingAdminShell()) return sourceRecord;
+  const fieldStates = Array.from(document.querySelectorAll('[data-landing-hours-field]'))
+    .map(fieldEl => {
+      const field = fieldEl.getAttribute('data-landing-hours-field') || '';
+      return {
+        restaurantId: fieldEl.getAttribute('data-landing-hours-restaurant') || '',
+        dayKey: fieldEl.getAttribute('data-landing-hours-day') || '',
+        field,
+        value: field === 'closed' ? !!fieldEl.checked : fieldEl.value,
+      };
+    })
+    .filter(fieldState => fieldState.restaurantId && fieldState.dayKey && fieldState.field);
+  if (!fieldStates.length) return sourceRecord;
 
-  const record = setLandingPageState(_landingPageState || createDefaultLandingPageRecord(), { dirty: _landingPageDirty });
-  const groupedDays = new Map();
+  return LANDING_MODEL.applyHoursFieldDraft(sourceRecord, fieldStates);
+}
 
-  fields.forEach(fieldEl => {
-    const restaurantId = fieldEl.getAttribute('data-landing-hours-restaurant') || '';
-    const dayKey = fieldEl.getAttribute('data-landing-hours-day') || '';
-    const field = fieldEl.getAttribute('data-landing-hours-field') || '';
-    if (!restaurantId || !dayKey || !field) return;
-    const key = `${restaurantId}:${dayKey}`;
-    const entry = groupedDays.get(key) || { restaurantId, dayKey };
-    if (field === 'closed') {
-      entry.closed = !!fieldEl.checked;
-    } else if (field === 'open' || field === 'close') {
-      entry[field] = normalizeLandingTimeValue(fieldEl.value);
-    }
-    groupedDays.set(key, entry);
-  });
-
-  groupedDays.forEach(({ restaurantId, dayKey, open, close, closed }) => {
-    if (!record.draftContent.hours.restaurants[restaurantId]) {
-      record.draftContent.hours.restaurants[restaurantId] = createDefaultLandingHoursRestaurant();
-    }
-    const currentDay = record.draftContent.hours.restaurants[restaurantId].days[dayKey] || createDefaultLandingDay();
-    record.draftContent.hours.restaurants[restaurantId].days[dayKey] = normalizeLandingDay({
-      ...currentDay,
-      closed: !!closed,
-      open: closed ? '' : (typeof open === 'string' ? open : currentDay.open),
-      close: closed ? '' : (typeof close === 'string' ? close : currentDay.close),
-    });
-  });
-
-  return record;
+function getLandingValidationRecord(record = _landingPageState) {
+  return syncLandingHoursDraftFromDom(record || createDefaultLandingPageRecord());
 }
 
 function renderLandingHoursValidationState(record = _landingPageState) {
-  const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-  const issuesEl = document.getElementById('landing-hours-issues');
-  const badgeEl = document.getElementById('landing-hours-panel-badge');
-  const validation = validateLandingHoursSection(getLandingHoursSectionForValidation(normalized));
-
-  if (issuesEl) {
-    issuesEl.innerHTML = validation.valid
-      ? ''
-      : validation.issues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
-  }
-  if (badgeEl) {
-    badgeEl.textContent = validation.valid ? 'Ready' : 'Blocked';
-    badgeEl.className = `landing-admin-section-badge ${validation.valid ? 'is-ready' : 'is-blocked'}`;
-  }
+  return getLandingAdminWorkspaceService().renderHoursValidationState(record);
 }
 
 function refreshLandingHoursAdminState(record = _landingPageState) {
@@ -4362,255 +4212,58 @@ function refreshLandingHoursAdminState(record = _landingPageState) {
 }
 
 function updateLandingAdminToolbar(record = _landingPageState) {
-  const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-  const diffSectionIds = getLandingDraftDiffSectionIds(normalized);
-  const draftButton = document.getElementById('landing-save-draft-btn');
-  const publishButton = document.getElementById('landing-publish-btn');
-  const livePill = document.getElementById('landing-admin-live-pill');
-  const draftPill = document.getElementById('landing-admin-draft-pill');
-  const noteEl = document.getElementById('landing-admin-toolbar-note');
-
-  if (draftButton) draftButton.disabled = !_landingPageDirty;
-  if (publishButton) publishButton.disabled = diffSectionIds.length === 0;
-
-  if (livePill) {
-    livePill.textContent = normalized.livePublishedTs
-      ? `Live ${formatLandingTimestampLabel(normalized.livePublishedTs)}`
-      : 'Live shell pending';
-    livePill.className = `landing-admin-status-pill ${normalized.livePublishedTs ? 'is-live' : ''}`;
-  }
-  if (draftPill) {
-    const draftText = _landingPageDirty
-      ? 'Unsaved draft changes'
-      : (diffSectionIds.length ? `${diffSectionIds.length} draft sections ready` : 'No draft changes');
-    draftPill.textContent = draftText;
-    draftPill.className = `landing-admin-status-pill ${_landingPageDirty || diffSectionIds.length ? 'is-draft' : ''}`;
-  }
-  if (noteEl) {
-    noteEl.textContent = _landingPageLoadError
-      ? _landingPageLoadError
-      : (_landingPageDirty
-          ? 'Save Draft stores the shared landing snapshot without changing the public root.'
-          : (diffSectionIds.length
-              ? 'Publish Live promotes only the subsections you select.'
-              : 'Landing-page draft and live snapshots are currently aligned.'));
-  }
+  return getLandingAdminWorkspaceService().updateToolbar(record);
 }
 
 function renderLandingHoursPanel(record = _landingPageState) {
-  const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-  const gridEl = document.getElementById('landing-admin-hours-grid');
-  if (gridEl) {
-    gridEl.innerHTML = knownLandingRestaurants().map(restaurant => (
-      renderLandingHoursRowsHtml(normalized.draftContent.hours, restaurant.id, restaurant.name)
-    )).join('');
-  }
-  renderLandingHoursValidationState(normalized);
+  return getLandingAdminWorkspaceService().renderHoursPanel(record);
 }
 
 function renderLandingAdminWorkspace(options = {}) {
-  if (!hasLandingAdminShell()) return;
-  const { forceReload = false } = options;
-  const render = (record) => {
-    const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-    setLandingPageState(normalized, { dirty: _landingPageDirty });
-    renderLandingOverview(normalized);
-    renderLandingHoursPanel(normalized);
-    renderLandingEventsPanel(normalized);
-    renderLandingNewsPanel(normalized);
-    renderLandingReviewsPanel(normalized);
-    updateLandingAdminToolbar(normalized);
-    focusLandingAdminPanel(_activeLandingAdminPanel);
-  };
-
-  if (_landingPageState && !forceReload) {
-    render(_landingPageState);
-    return;
-  }
-
-  updateLandingAdminToolbar(createDefaultLandingPageRecord());
-  ensureLandingPageStateLoaded({ force: forceReload })
-    .then(render)
-    .catch(() => {
-      const fallbackRecord = _landingPageState || createDefaultLandingPageRecord();
-      setLandingPageState(fallbackRecord, { dirty: false });
-      render(fallbackRecord);
-    });
+  return getLandingAdminWorkspaceService().renderWorkspace(options);
 }
 
+let _landingRootRendererService = null;
+function getLandingRootRendererService() {
+  if (_landingRootRendererService) return _landingRootRendererService;
+  _landingRootRendererService = globalThis.__HF_LANDING_MODULES__.createLandingRootRendererService({
+    model: LANDING_MODEL,
+    store: LANDING_STORE,
+    document,
+    escHtml,
+    restaurants: RESTAURANTS,
+    setReviewCarouselHandlerName: 'setLandingReviewCarouselIndex',
+    hasRootShell: () => hasLandingRootShell(),
+    syncLegacyStateFromStore: () => syncLandingLegacyStateFromStore(),
+  });
+  return _landingRootRendererService;
+}
 function setLandingRootSectionVisible(sectionId = '', visible = true) {
-  const sectionEl = document.getElementById(sectionId);
-  if (sectionEl) sectionEl.hidden = !visible;
-  const dotEl = document.querySelector(`[data-landing-dot="${sectionId}"]`);
-  if (dotEl) dotEl.hidden = !visible;
-}
-function getLandingRenderableEvents(section = {}) {
-  return LANDING_MODEL.getRenderableEvents(section);
-}
-function getLandingRenderableNews(section = {}) {
-  return LANDING_MODEL.getRenderableNews(section);
-}
-function getLandingRenderableReviews(section = {}, restaurantId = '') {
-  return LANDING_MODEL.getRenderableReviews(section, restaurantId);
-}
-function buildLandingReviewPairs(section = {}) {
-  return LANDING_MODEL.buildReviewPairs(section);
+  return getLandingRootRendererService().setSectionVisible(sectionId, visible);
 }
 function renderLandingRootEvents(section = {}) {
-  const listEl = document.getElementById('landing-events-list');
-  const emptyEl = document.getElementById('landing-events-empty');
-  if (!listEl || !emptyEl) return;
-  const items = getLandingRenderableEvents(section);
-  setLandingRootSectionVisible('events', true);
-  if (!items.length) {
-    listEl.innerHTML = '';
-    emptyEl.hidden = false;
-    return;
-  }
-  emptyEl.hidden = true;
-  listEl.innerHTML = items.map(item => `
-    <article class="landing-story-card landing-story-card--event">
-      <p class="landing-card-kicker"><span class="landing-tag ${getLandingTargetAccentClass(item.target)}">${escHtml(getLandingTargetLabel(item.target))}</span></p>
-      <h3>${escHtml(item.title || 'Upcoming event')}</h3>
-      <p>${escHtml(item.body || '')}</p>
-      <p class="landing-card-kicker">${escHtml(formatLandingEventScheduleLine(item))}</p>
-    </article>
-  `).join('');
+  return getLandingRootRendererService().renderRootEvents(section);
 }
 function renderLandingRootNews(section = {}) {
-  const listEl = document.getElementById('landing-news-list');
-  const emptyEl = document.getElementById('landing-news-empty');
-  const items = getLandingRenderableNews(section);
-  if (!listEl || !emptyEl) return;
-  setLandingRootSectionVisible('news', items.length > 0);
-  if (!items.length) {
-    listEl.innerHTML = '';
-    emptyEl.hidden = true;
-    return;
-  }
-  emptyEl.hidden = true;
-  listEl.innerHTML = items.map(item => `
-    <a class="landing-story-card landing-story-card--news ${item.imageUrl ? 'has-image' : 'is-text-only'}" href="${escHtml(item.href)}" target="_blank" rel="noreferrer">
-      ${item.imageUrl ? `<img class="landing-story-image" src="${escHtml(item.imageUrl)}" alt="${escHtml(item.title || item.source || 'News image')}">` : ''}
-      <div class="landing-story-copy">
-        <p class="landing-card-kicker">
-          <span class="landing-tag ${getLandingTargetAccentClass(item.target)}">${escHtml(getLandingTargetLabel(item.target))}</span>
-          <span>${escHtml([item.source, formatLandingDateLabel(item.publishedDate, { short: true, year: false })].filter(Boolean).join(' · '))}</span>
-        </p>
-        <h3>${escHtml(item.title || 'Imported story')}</h3>
-        ${item.body ? `<p>${escHtml(item.body)}</p>` : ''}
-        <span class="landing-story-link">Read Story ↗</span>
-      </div>
-    </a>
-  `).join('');
+  return getLandingRootRendererService().renderRootNews(section);
 }
 function renderLandingRootReviews(section = {}) {
-  const sectionEl = document.getElementById('reviews');
-  const listEl = document.getElementById('landing-reviews-list');
-  const emptyEl = document.getElementById('landing-reviews-empty');
-  const controlsEl = document.getElementById('landing-reviews-controls');
-  const dotsEl = document.getElementById('landing-reviews-dots');
-  if (!sectionEl || !listEl || !emptyEl || !controlsEl || !dotsEl) return;
-  const pairs = buildLandingReviewPairs(section);
-  const visible = pairs.length > 0;
-  setLandingRootSectionVisible('reviews', visible);
-  if (!visible) {
-    listEl.innerHTML = '';
-    emptyEl.hidden = true;
-    controlsEl.hidden = true;
-    LANDING_STORE.setReviewCarouselIndex(0);
-    syncLandingLegacyStateFromStore();
-    return;
-  }
-  emptyEl.hidden = true;
-  controlsEl.hidden = pairs.length <= 1;
-  LANDING_STORE.setReviewCarouselIndex(Math.max(0, Math.min(_landingReviewCarouselIndex, pairs.length - 1)));
-  syncLandingLegacyStateFromStore();
-  listEl.innerHTML = pairs.map((pair, index) => `
-    <article class="landing-review-pair ${index === _landingReviewCarouselIndex ? 'is-active' : ''}" data-landing-review-pair="${index}">
-      <article class="landing-review-card landing-review-card--leroys">
-        <p class="landing-card-kicker">${escHtml(RESTAURANTS.LEROYS.name)}</p>
-        <h3>${'★'.repeat(Math.max(1, Math.min(5, Number(pair.leroys.rating) || 5)))}</h3>
-        <p>${escHtml(pair.leroys.quote || '')}</p>
-        <p class="landing-card-kicker">${escHtml(pair.leroys.author || '')}${pair.leroys.source ? ` · ${escHtml(pair.leroys.source)}` : ''}</p>
-      </article>
-      <article class="landing-review-card landing-review-card--elroys">
-        <p class="landing-card-kicker">${escHtml(RESTAURANTS.ELROYS.name)}</p>
-        <h3>${'★'.repeat(Math.max(1, Math.min(5, Number(pair.elroys.rating) || 5)))}</h3>
-        <p>${escHtml(pair.elroys.quote || '')}</p>
-        <p class="landing-card-kicker">${escHtml(pair.elroys.author || '')}${pair.elroys.source ? ` · ${escHtml(pair.elroys.source)}` : ''}</p>
-      </article>
-    </article>
-  `).join('');
-  dotsEl.innerHTML = pairs.map((pair, index) => (
-    `<button type="button" class="landing-review-dot ${index === _landingReviewCarouselIndex ? 'is-active' : ''}" aria-label="Review pair ${index + 1}" onclick="setLandingReviewCarouselIndex(${index})"></button>`
-  )).join('');
+  return getLandingRootRendererService().renderRootReviews(section);
 }
 function setLandingReviewCarouselIndex(nextIndex = 0) {
-  const pairEls = Array.from(document.querySelectorAll('[data-landing-review-pair]'));
-  if (!pairEls.length) return;
-  LANDING_STORE.setReviewCarouselIndex(Math.max(0, Math.min(Number(nextIndex) || 0, pairEls.length - 1)));
-  syncLandingLegacyStateFromStore();
-  pairEls.forEach((pairEl, index) => {
-    pairEl.classList.toggle('is-active', index === _landingReviewCarouselIndex);
-  });
-  document.querySelectorAll('.landing-review-dot').forEach((dotEl, index) => {
-    dotEl.classList.toggle('is-active', index === _landingReviewCarouselIndex);
-  });
+  return getLandingRootRendererService().setReviewCarouselIndex(nextIndex);
 }
 function stepLandingReviewCarousel(direction = 1) {
-  const pairCount = document.querySelectorAll('[data-landing-review-pair]').length;
-  if (!pairCount) return;
-  const nextIndex = (_landingReviewCarouselIndex + direction + pairCount) % pairCount;
-  setLandingReviewCarouselIndex(nextIndex);
+  return getLandingRootRendererService().stepReviewCarousel(direction);
 }
-
 function renderLandingRootHours(section = {}) {
-  const restaurantPairs = [
-    { restaurant: RESTAURANTS.LEROYS, heroId: 'landing-hero-status-leroys', todayId: 'landing-hours-today-leroys', listId: 'landing-hours-list-leroys' },
-    { restaurant: RESTAURANTS.ELROYS, heroId: 'landing-hero-status-elroys', todayId: 'landing-hours-today-elroys', listId: 'landing-hours-list-elroys' },
-  ];
-  restaurantPairs.forEach(({ restaurant, heroId, todayId, listId }) => {
-    const status = computeLandingStatusForRestaurant(section, restaurant.id);
-    const heroEl = document.getElementById(heroId);
-    const todayEl = document.getElementById(todayId);
-    const listEl = document.getElementById(listId);
-    if (heroEl) {
-      heroEl.textContent = status.label;
-      heroEl.classList.toggle('is-open', !!status.isOpen);
-      heroEl.classList.toggle('is-closed', !status.isOpen);
-    }
-    if (todayEl) {
-      todayEl.innerHTML = `<span>Today</span><strong>${escHtml(status.todayRangeLabel)}</strong>`;
-    }
-    if (listEl) {
-      listEl.innerHTML = status.weekRows.map(row => (
-        `<div class="landing-hours-row">
-          <dt>${escHtml(row.label)}${row.isToday ? ' · Today' : ''}</dt>
-          <dd>${escHtml(row.rangeLabel)}</dd>
-        </div>`
-      )).join('');
-    }
-  });
+  return getLandingRootRendererService().renderRootHours(section);
 }
-
 function setLandingRootFallbackVisible(visible) {
-  const shellEl = document.getElementById('landing-root-shell');
-  const fallbackEl = document.getElementById('landing-root-fallback');
-  const dotNavEl = document.querySelector('.landing-dot-nav');
-  if (shellEl) shellEl.hidden = !!visible;
-  if (fallbackEl) fallbackEl.hidden = !visible;
-  if (dotNavEl) dotNavEl.hidden = !!visible;
+  return getLandingRootRendererService().setFallbackVisible(visible);
 }
-
 function renderLandingRootPage(record = _landingPageState) {
-  if (!hasLandingRootShell()) return;
-  const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-  renderLandingRootHours(normalized.liveContent.hours);
-  renderLandingRootEvents(normalized.liveContent.events);
-  renderLandingRootNews(normalized.liveContent.news);
-  renderLandingRootReviews(normalized.liveContent.reviews);
-  setLandingRootFallbackVisible(false);
+  return getLandingRootRendererService().renderRootPage(record);
 }
 
 async function initLandingRootPage() {
@@ -4640,372 +4293,73 @@ function focusLandingAdminPanel(panelId = 'landing-admin-panel-overview', trigge
 }
 
 function setLandingHoursField(restaurantId, dayKey, field, value) {
-  const record = setLandingPageState(_landingPageState || createDefaultLandingPageRecord(), { dirty: true });
-  if (!record.draftContent.hours.restaurants[restaurantId]) {
-    record.draftContent.hours.restaurants[restaurantId] = createDefaultLandingHoursRestaurant();
-  }
-  const targetDay = record.draftContent.hours.restaurants[restaurantId].days[dayKey] || createDefaultLandingDay();
-  if (field === 'closed') {
-    targetDay.closed = !!value;
-    if (targetDay.closed) {
-      targetDay.open = '';
-      targetDay.close = '';
-    }
-  } else if (field === 'open' || field === 'close') {
-    targetDay[field] = normalizeLandingTimeValue(value);
-    if (targetDay[field]) targetDay.closed = false;
-  }
-  record.draftContent.hours.restaurants[restaurantId].days[dayKey] = normalizeLandingDay(targetDay);
-  syncLandingDirtyFlag(true);
-  if (field === 'closed') {
-    renderLandingAdminWorkspace();
-    return;
-  }
-  refreshLandingHoursAdminState(record);
+  return getLandingAdminWorkspaceService().setHoursField(restaurantId, dayKey, field, value);
 }
 
 function updateLandingDraftRecord(mutator = () => {}, options = {}) {
-  const { rerender = true } = options;
-  const record = setLandingPageState(_landingPageState || createDefaultLandingPageRecord(), { dirty: true });
-  mutator(record);
-  syncLandingDirtyFlag(true);
-  if (rerender) renderLandingAdminWorkspace();
-  return record;
-}
-function markLandingItemUpdated(item = {}) {
-  item.updatedAt = String(Date.now());
-  return item;
-}
-function findLandingNewsItemByUrl(items = [], url = '') {
-  const candidate = String(url || '').trim();
-  if (!candidate) return null;
-  return items.find(item => (
-    item?.href === candidate || item?.importMeta?.sourceUrl === candidate
-  )) || null;
-}
-function findLandingReviewItemByUrl(items = [], url = '') {
-  const candidate = String(url || '').trim();
-  if (!candidate) return null;
-  return items.find(item => (
-    item?.href === candidate || item?.importMeta?.sourceUrl === candidate
-  )) || null;
-}
-async function requestLandingImport(kind = 'import_news', payload = {}) {
-  if (!currentUser?.accessToken) throw new Error('Sign in as an admin to import landing-page content.');
-  const result = await postApiJson('/api/admin', {
-    action: kind,
-    ...payload,
-  }, {
-    headers: getAuthorizedApiHeaders(),
-  });
-  if (!result.ok) throw new Error(result.payload?.error || result.payload?.message || 'Import failed.');
-  return result.payload || {};
-}
-function applyLandingImportMeta(currentMeta = {}, result = {}) {
-  const attemptedAt = result?.attemptedAt ? String(result.attemptedAt) : String(Date.now());
-  const nextStatus = result?.status || LANDING_IMPORT_STATUS_FAILED;
-  const wasSuccessful = nextStatus === LANDING_IMPORT_STATUS_IMPORTED || nextStatus === LANDING_IMPORT_STATUS_PARTIAL;
-  return normalizeLandingImportMeta({
-    ...currentMeta,
-    sourceUrl: result?.sourceUrl || result?.href || currentMeta?.sourceUrl || '',
-    lastAttemptTs: attemptedAt,
-    lastSuccessTs: wasSuccessful ? attemptedAt : currentMeta?.lastSuccessTs,
-    status: nextStatus,
-    messages: Array.isArray(result?.messages) ? result.messages : currentMeta?.messages,
-  });
-}
-function upsertLandingNewsDraftFromImport(target = LANDING_TARGET_BOTH, result = {}) {
-  const sourceUrl = String(result?.sourceUrl || result?.href || '').trim();
-  updateLandingDraftRecord(record => {
-    const items = record.draftContent.news.items;
-    const existing = findLandingNewsItemByUrl(items, sourceUrl);
-    const base = existing || createDefaultLandingNewsItem();
-    const nextItem = normalizeLandingNewsItem({
-      ...base,
-      target: existing?.target || normalizeLandingTarget(target, { allowBoth: true }),
-      title: result?.title || base.title,
-      body: result?.body || base.body,
-      href: result?.href || sourceUrl || base.href,
-      source: result?.source || base.source,
-      publishedDate: result?.publishedDate || base.publishedDate,
-      imageUrl: result?.imageUrl || base.imageUrl,
-      importMeta: applyLandingImportMeta(base.importMeta, result),
-      updatedAt: String(Date.now()),
-    });
-    if (existing) {
-      const index = items.findIndex(item => item.id === existing.id);
-      if (index >= 0) items[index] = nextItem;
-    } else {
-      items.unshift(nextItem);
-    }
-  });
-}
-function upsertLandingReviewDraftFromImport(restaurantId = '', result = {}) {
-  updateLandingDraftRecord(record => {
-    if (!record.draftContent.reviews.restaurants[restaurantId]) {
-      record.draftContent.reviews.restaurants[restaurantId] = [];
-    }
-    const items = record.draftContent.reviews.restaurants[restaurantId];
-    const sourceUrl = String(result?.sourceUrl || result?.href || '').trim();
-    const existing = findLandingReviewItemByUrl(items, sourceUrl);
-    const base = existing || createDefaultLandingReviewItem();
-    const nextItem = normalizeLandingReviewItem({
-      ...base,
-      href: result?.href || sourceUrl || base.href,
-      author: result?.author || base.author,
-      quote: result?.quote || base.quote,
-      source: result?.source || base.source || 'Google Review',
-      rating: result?.rating || base.rating,
-      importMeta: applyLandingImportMeta(base.importMeta, result),
-      updatedAt: String(Date.now()),
-    });
-    if (existing) {
-      const index = items.findIndex(item => item.id === existing.id);
-      if (index >= 0) items[index] = nextItem;
-    } else {
-      items.unshift(nextItem);
-    }
-  });
+  return getLandingAdminWorkspaceService().updateDraftRecord(mutator, options);
 }
 function addLandingEventDraft() {
-  updateLandingDraftRecord(record => {
-    record.draftContent.events.items.unshift(normalizeLandingEventItem({
-      ...createDefaultLandingEventItem(),
-      updatedAt: String(Date.now()),
-    }));
-  });
+  return getLandingAdminWorkspaceService().addEventDraft();
 }
 function updateLandingEventField(itemId = '', field = '', value = '') {
-  updateLandingDraftRecord(record => {
-    const item = findLandingItemById(record.draftContent.events.items, itemId);
-    if (!item) return;
-    if (field === 'target') item.target = normalizeLandingTarget(value, { allowBoth: true });
-    else if (field === 'eventDate') item.eventDate = String(value || '');
-    else if (field === 'startTime' || field === 'endTime') item[field] = normalizeLandingTimeValue(value);
-    else item[field] = typeof value === 'string' ? value : '';
-    if (field === 'endTime' && item.endTime) item.timingNote = '';
-    markLandingItemUpdated(item);
-  });
+  return getLandingAdminWorkspaceService().updateEventField(itemId, field, value);
 }
 function toggleLandingEventArchived(itemId = '', archived = false) {
-  updateLandingDraftRecord(record => {
-    const item = findLandingItemById(record.draftContent.events.items, itemId);
-    if (!item) return;
-    item.archived = !!archived;
-    item.archivedAt = archived ? String(Date.now()) : '';
-    markLandingItemUpdated(item);
-  });
+  return getLandingAdminWorkspaceService().toggleEventArchived(itemId, archived);
 }
 function updateLandingNewsField(itemId = '', field = '', value = '') {
-  updateLandingDraftRecord(record => {
-    const item = findLandingItemById(record.draftContent.news.items, itemId);
-    if (!item) return;
-    if (field === 'target') item.target = normalizeLandingTarget(value, { allowBoth: true });
-    else item[field] = typeof value === 'string' ? value : '';
-    if (field === 'href' && !item.importMeta?.sourceUrl) {
-      item.importMeta = normalizeLandingImportMeta({ ...item.importMeta, sourceUrl: item.href });
-    }
-    markLandingItemUpdated(item);
-  });
+  return getLandingAdminWorkspaceService().updateNewsField(itemId, field, value);
 }
 function toggleLandingNewsArchived(itemId = '', archived = false) {
-  updateLandingDraftRecord(record => {
-    const item = findLandingItemById(record.draftContent.news.items, itemId);
-    if (!item) return;
-    item.archived = !!archived;
-    item.archivedAt = archived ? String(Date.now()) : '';
-    markLandingItemUpdated(item);
-  });
+  return getLandingAdminWorkspaceService().toggleNewsArchived(itemId, archived);
 }
 function updateLandingReviewField(restaurantId = '', itemId = '', field = '', value = '') {
-  updateLandingDraftRecord(record => {
-    const items = record.draftContent.reviews.restaurants[restaurantId] || [];
-    const item = findLandingItemById(items, itemId);
-    if (!item) return;
-    if (field === 'rating') item.rating = value ? String(Number(value)) : '';
-    else item[field] = typeof value === 'string' ? value : '';
-    if (field === 'href' && !item.importMeta?.sourceUrl) {
-      item.importMeta = normalizeLandingImportMeta({ ...item.importMeta, sourceUrl: item.href });
-    }
-    markLandingItemUpdated(item);
-  });
+  return getLandingAdminWorkspaceService().updateReviewField(restaurantId, itemId, field, value);
 }
 function toggleLandingReviewArchived(restaurantId = '', itemId = '', archived = false) {
-  updateLandingDraftRecord(record => {
-    const items = record.draftContent.reviews.restaurants[restaurantId] || [];
-    const item = findLandingItemById(items, itemId);
-    if (!item) return;
-    item.archived = !!archived;
-    item.archivedAt = archived ? String(Date.now()) : '';
-    markLandingItemUpdated(item);
-  });
+  return getLandingAdminWorkspaceService().toggleReviewArchived(restaurantId, itemId, archived);
 }
 function toggleLandingSectionArchivedFilter(sectionId = '', checked = false) {
-  setLandingSectionFilter(sectionId, 'showArchived', checked);
-  renderLandingAdminWorkspace();
+  return getLandingAdminWorkspaceService().toggleSectionArchivedFilter(sectionId, checked);
 }
 function handleLandingNewsImportPaste() {
-  setTimeout(() => {
-    importLandingNewsDraft();
-  }, 0);
+  return getLandingAdminWorkspaceService().handleNewsImportPaste();
 }
 function handleLandingReviewImportPaste(restaurantId = '') {
-  setTimeout(() => {
-    importLandingReviewDraft(restaurantId);
-  }, 0);
+  return getLandingAdminWorkspaceService().handleReviewImportPaste(restaurantId);
 }
 async function importLandingNewsDraft() {
-  const targetSelect = document.getElementById('landing-news-import-target');
-  const urlInput = document.getElementById('landing-news-import-url');
-  const target = targetSelect?.value || LANDING_TARGET_BOTH;
-  const url = String(urlInput?.value || '').trim();
-  if (!url) return;
-  try {
-    const result = await requestLandingImport('import_news', { url, target });
-    upsertLandingNewsDraftFromImport(target, result);
-    if (urlInput) urlInput.value = '';
-    showToast(`✅ ${result?.status === LANDING_IMPORT_STATUS_IMPORTED ? 'Imported' : 'Imported with repairs needed'} news draft.`, 'success');
-  } catch (error) {
-    showToast(`⚠️ ${error?.message || 'News import failed.'}`, 'error');
-  }
+  return getLandingAdminWorkspaceService().importNewsDraft();
 }
 async function refreshLandingNewsItem(itemId = '') {
-  const record = normalizeLandingPageRecord(_landingPageState || createDefaultLandingPageRecord());
-  const item = findLandingItemById(record.draftContent.news.items, itemId);
-  const sourceUrl = String(item?.importMeta?.sourceUrl || item?.href || '').trim();
-  if (!item || !sourceUrl) {
-    showToast('⚠️ Add an article URL before refreshing this story.', 'error');
-    return;
-  }
-  try {
-    const result = await requestLandingImport('import_news', { url: sourceUrl, target: item.target });
-    upsertLandingNewsDraftFromImport(item.target, result);
-    showToast('✅ News draft refreshed.', 'success');
-  } catch (error) {
-    showToast(`⚠️ ${error?.message || 'News refresh failed.'}`, 'error');
-  }
+  return getLandingAdminWorkspaceService().refreshNewsItem(itemId);
 }
 async function importLandingReviewDraft(restaurantId = '') {
-  const urlInput = document.getElementById(`landing-review-import-url-${restaurantId}`);
-  const url = String(urlInput?.value || '').trim();
-  if (!url) return;
-  try {
-    const result = await requestLandingImport('import_review', { url, restaurantId });
-    upsertLandingReviewDraftFromImport(restaurantId, result);
-    if (urlInput) urlInput.value = '';
-    showToast(`✅ ${result?.status === LANDING_IMPORT_STATUS_IMPORTED ? 'Imported' : 'Imported with repairs needed'} review draft.`, 'success');
-  } catch (error) {
-    showToast(`⚠️ ${error?.message || 'Review import failed.'}`, 'error');
-  }
+  return getLandingAdminWorkspaceService().importReviewDraft(restaurantId);
 }
 async function refreshLandingReviewItem(restaurantId = '', itemId = '') {
-  const record = normalizeLandingPageRecord(_landingPageState || createDefaultLandingPageRecord());
-  const item = findLandingItemById(record.draftContent.reviews.restaurants[restaurantId] || [], itemId);
-  const sourceUrl = String(item?.importMeta?.sourceUrl || item?.href || '').trim();
-  if (!item || !sourceUrl) {
-    showToast('⚠️ Add a review URL before refreshing this review.', 'error');
-    return;
-  }
-  try {
-    const result = await requestLandingImport('import_review', { url: sourceUrl, restaurantId });
-    upsertLandingReviewDraftFromImport(restaurantId, result);
-    showToast('✅ Review draft refreshed.', 'success');
-  } catch (error) {
-    showToast(`⚠️ ${error?.message || 'Review refresh failed.'}`, 'error');
-  }
+  return getLandingAdminWorkspaceService().refreshReviewItem(restaurantId, itemId);
 }
 
 async function saveLandingPageDraft() {
-  try {
-    const record = normalizeLandingPageRecord(syncLandingHoursDraftFromDom() || await ensureLandingPageStateLoaded());
-    const timestamp = Date.now();
-    await LANDING_DATA_SERVICE.saveDraft(record, timestamp);
-    syncLandingLegacyStateFromStore();
-    renderLandingAdminWorkspace();
-    showToast('✅ Landing page draft saved.', 'success');
-  } catch (error) {
-    showToast(`⚠️ ${error?.message || 'Landing page draft save failed.'}`, 'error');
-  }
+  return getLandingAdminWorkspaceService().saveDraft();
 }
 
 function renderLandingPublishModal() {
-  const modalEl = document.getElementById('landing-publish-modal');
-  const listEl = document.getElementById('landing-publish-list');
-  const issuesEl = document.getElementById('landing-publish-issues');
-  const confirmButton = document.getElementById('landing-publish-confirm-btn');
-  if (!modalEl || !listEl || !issuesEl || !confirmButton) return;
-  const record = normalizeLandingPageRecord(syncLandingHoursDraftFromDom() || _landingPageState || createDefaultLandingPageRecord());
-  const statuses = LANDING_PAGE_SECTION_ORDER.map(sectionId => getLandingSectionStatus(sectionId, record));
-  const publishableCount = statuses.filter(status => status.hasDraftDiff && status.isValid).length;
-  listEl.innerHTML = statuses.map(status => {
-    const disabled = !status.hasDraftDiff || !status.isValid;
-    const badgeClass = status.isValid ? 'is-ready' : 'is-blocked';
-    const badgeText = !status.isValid ? 'Blocked' : (status.hasDraftDiff ? 'Ready' : 'Live');
-    const helpText = !status.hasDraftDiff
-      ? 'Draft and live match right now.'
-      : (status.isValid ? 'Draft is ready to promote.' : 'Fix the validation issue before publishing.');
-    return `
-      <label class="landing-publish-option">
-        <input type="checkbox" data-landing-publish-section="${escHtml(status.sectionId)}" ${disabled ? 'disabled' : 'checked'}>
-        <div>
-          <strong>${escHtml(status.label)}</strong>
-          <p>${escHtml(helpText)}</p>
-        </div>
-        <span class="landing-admin-section-badge ${badgeClass}">${escHtml(badgeText)}</span>
-      </label>`;
-  }).join('');
-  issuesEl.innerHTML = statuses
-    .filter(status => !status.isValid)
-    .flatMap(status => status.issues)
-    .map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`)
-    .join('');
-  confirmButton.disabled = publishableCount === 0;
+  return getLandingAdminWorkspaceService().renderPublishModal();
 }
 
 function openLandingPublishModal() {
-  if (!hasLandingAdminShell()) return;
-  renderLandingPublishModal();
-  const modalEl = document.getElementById('landing-publish-modal');
-  if (!modalEl) return;
-  modalEl.classList.add('is-open');
-  modalEl.setAttribute('aria-hidden', 'false');
+  return getLandingAdminWorkspaceService().openPublishModal();
 }
 
 function closeLandingPublishModal() {
-  const modalEl = document.getElementById('landing-publish-modal');
-  if (!modalEl) return;
-  modalEl.classList.remove('is-open');
-  modalEl.setAttribute('aria-hidden', 'true');
+  return getLandingAdminWorkspaceService().closePublishModal();
 }
 
 async function publishLandingPageSections() {
-  const selectedSectionIds = Array.from(document.querySelectorAll('[data-landing-publish-section]:checked'))
-    .map(input => input.getAttribute('data-landing-publish-section'))
-    .filter(Boolean);
-  if (!selectedSectionIds.length) {
-    showToast('Select at least one landing-page subsection to publish.', 'info');
-    return;
-  }
-  try {
-    const currentRecord = normalizeLandingPageRecord(syncLandingHoursDraftFromDom() || await ensureLandingPageStateLoaded());
-    const blockedSection = selectedSectionIds
-      .map(sectionId => getLandingSectionStatus(sectionId, currentRecord))
-      .find(status => !status.isValid);
-    if (blockedSection) {
-      renderLandingPublishModal();
-      showToast(`⚠️ Fix ${blockedSection.label.toLowerCase()} before publishing it live.`, 'error');
-      return;
-    }
-    const timestamp = Date.now();
-    await LANDING_DATA_SERVICE.publishSections(currentRecord, selectedSectionIds, timestamp);
-    syncLandingLegacyStateFromStore();
-    renderLandingAdminWorkspace();
-    if (hasLandingRootShell()) renderLandingRootPage(_landingPageState);
-    closeLandingPublishModal();
-    showToast(`✅ Published ${selectedSectionIds.length} landing-page section${selectedSectionIds.length === 1 ? '' : 's'} live.`, 'success');
-  } catch (error) {
-    showToast(`⚠️ ${error?.message || 'Landing page publish failed.'}`, 'error');
-  }
+  return getLandingAdminWorkspaceService().publishSections();
 }
 
 // Resolve which menu to load based on ?menu={slug}, localStorage cache, or

--- a/app.js
+++ b/app.js
@@ -382,130 +382,55 @@ function normalizeLandingTimeValue(value = '') {
   return LANDING_MODEL.normalizeTimeValue(value);
 }
 function parseLandingTimeToMinutes(value = '') {
-  const normalized = normalizeLandingTimeValue(value);
-  if (!normalized) return null;
-  const [hours, minutes] = normalized.split(':').map(Number);
-  if (!Number.isInteger(hours) || !Number.isInteger(minutes)) return null;
-  if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
-  return hours * 60 + minutes;
+  return LANDING_MODEL.parseTimeToMinutes(value);
 }
 function formatLandingMinutes(minutes) {
-  if (!Number.isFinite(minutes)) return '';
-  const normalized = ((Math.floor(minutes) % 1440) + 1440) % 1440;
-  const hours24 = Math.floor(normalized / 60);
-  const mins = normalized % 60;
-  const suffix = hours24 >= 12 ? 'PM' : 'AM';
-  const hours12 = hours24 % 12 || 12;
-  return mins === 0 ? `${hours12} ${suffix}` : `${hours12}:${String(mins).padStart(2, '0')} ${suffix}`;
+  return LANDING_MODEL.formatMinutes(minutes);
 }
 function getLandingTimeSelectOptions() {
-  const options = [];
-  for (let minutes = 0; minutes < 1440; minutes += 15) {
-    const hours24 = Math.floor(minutes / 60);
-    const mins = minutes % 60;
-    options.push({
-      value: `${String(hours24).padStart(2, '0')}:${String(mins).padStart(2, '0')}`,
-      label: formatLandingMinutes(minutes),
-    });
-  }
-  return options;
+  return LANDING_MODEL.getTimeSelectOptions();
 }
-const LANDING_TIME_SELECT_OPTIONS = getLandingTimeSelectOptions();
 function renderLandingTimeSelectOptions(selectedValue = '', placeholder = 'Select time') {
-  const normalized = normalizeLandingTimeValue(selectedValue);
-  const optionMarkup = [`<option value="">${escHtml(placeholder)}</option>`];
-  const hasSelectedValue = normalized && LANDING_TIME_SELECT_OPTIONS.some(option => option.value === normalized);
-  if (normalized && !hasSelectedValue) {
-    const fallbackMinutes = parseLandingTimeToMinutes(normalized);
-    optionMarkup.push(
-      `<option value="${escHtml(normalized)}" selected>${escHtml(fallbackMinutes === null ? normalized : formatLandingMinutes(fallbackMinutes))}</option>`
-    );
-  }
-  LANDING_TIME_SELECT_OPTIONS.forEach(option => {
-    optionMarkup.push(
-      `<option value="${escHtml(option.value)}" ${option.value === normalized ? 'selected' : ''}>${escHtml(option.label)}</option>`
-    );
-  });
-  return optionMarkup.join('');
+  return LANDING_MODEL.renderTimeSelectOptions(selectedValue, placeholder);
 }
 function isLandingIsoDate(value = '') {
-  return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value);
+  return LANDING_MODEL.isIsoDate(value);
 }
 function formatLandingDateLabel(value = '', options = {}) {
-  if (!isLandingIsoDate(value)) return value ? String(value) : '';
-  const [year, month, day] = value.split('-').map(Number);
-  const utcDate = new Date(Date.UTC(year, month - 1, day));
-  const formatter = new Intl.DateTimeFormat('en-US', {
-    month: options.short ? 'short' : 'long',
-    day: 'numeric',
-    year: options.year === false ? undefined : 'numeric',
-    timeZone: 'UTC',
-  });
-  return formatter.format(utcDate).replace(', ', options.short && options.year === false ? ' ' : ', ');
+  return LANDING_MODEL.formatDateLabel(value, options);
 }
 function getLandingTargetLabel(target = '') {
-  if (target === LANDING_TARGET_BOTH) return 'Both';
-  const restaurant = knownLandingRestaurants().find(entry => entry.id === target);
-  return restaurant ? restaurant.name : 'Both';
+  return LANDING_MODEL.getTargetLabel(target);
 }
 function getLandingTargetAccentClass(target = '') {
-  if (target === RESTAURANTS.LEROYS.id) return 'landing-tag--leroys';
-  if (target === RESTAURANTS.ELROYS.id) return 'landing-tag--elroys';
-  return 'landing-tag--both';
+  return LANDING_MODEL.getTargetAccentClass(target);
 }
 function formatLandingImportStatusLabel(status = '') {
-  if (status === LANDING_IMPORT_STATUS_IMPORTED) return 'Imported';
-  if (status === LANDING_IMPORT_STATUS_PARTIAL) return 'Partial';
-  if (status === LANDING_IMPORT_STATUS_FAILED) return 'Needs Repair';
-  return 'Waiting';
+  return LANDING_MODEL.formatImportStatusLabel(status);
 }
 function formatLandingImportTimestamp(meta = {}) {
-  return meta?.lastSuccessTs
-    ? `Imported ${formatLandingTimestampLabel(meta.lastSuccessTs)}`
-    : (meta?.lastAttemptTs ? `Tried ${formatLandingTimestampLabel(meta.lastAttemptTs)}` : 'Not imported yet');
+  return LANDING_MODEL.formatImportTimestamp(meta);
 }
 function isLandingAbsoluteUrl(value = '') {
-  try {
-    const url = new URL(String(value || '').trim());
-    return url.protocol === 'http:' || url.protocol === 'https:';
-  } catch (_) {
-    return false;
-  }
+  return LANDING_MODEL.isAbsoluteUrl(value);
 }
 function getLandingEventDateRank(value = '') {
-  if (!isLandingIsoDate(value)) return Number.MAX_SAFE_INTEGER;
-  return Date.parse(`${value}T00:00:00Z`);
+  return LANDING_MODEL.getEventDateRank(value);
 }
 function sortLandingEvents(items = []) {
-  return items.slice().sort((a, b) => {
-    const rankDelta = getLandingEventDateRank(a.eventDate) - getLandingEventDateRank(b.eventDate);
-    if (rankDelta !== 0) return rankDelta;
-    const startDelta = (parseLandingTimeToMinutes(a.startTime) ?? Number.MAX_SAFE_INTEGER) - (parseLandingTimeToMinutes(b.startTime) ?? Number.MAX_SAFE_INTEGER);
-    if (startDelta !== 0) return startDelta;
-    return String(a.title || '').localeCompare(String(b.title || ''));
-  });
+  return LANDING_MODEL.sortEvents(items);
 }
 function sortLandingNews(items = []) {
-  return items.slice().sort((a, b) => {
-    const aRank = isLandingIsoDate(a.publishedDate) ? Date.parse(`${a.publishedDate}T00:00:00Z`) : 0;
-    const bRank = isLandingIsoDate(b.publishedDate) ? Date.parse(`${b.publishedDate}T00:00:00Z`) : 0;
-    if (aRank !== bRank) return bRank - aRank;
-    return (Number(b.updatedAt || 0) || 0) - (Number(a.updatedAt || 0) || 0);
-  });
+  return LANDING_MODEL.sortNews(items);
 }
 function sortLandingReviews(items = []) {
-  return items.slice().sort((a, b) => {
-    const successDelta = (Number(b.importMeta?.lastSuccessTs || 0) || 0) - (Number(a.importMeta?.lastSuccessTs || 0) || 0);
-    if (successDelta !== 0) return successDelta;
-    return (Number(b.updatedAt || 0) || 0) - (Number(a.updatedAt || 0) || 0);
-  });
+  return LANDING_MODEL.sortReviews(items);
 }
 function getLandingActiveItems(items = []) {
-  return Array.isArray(items) ? items.filter(item => !item?.archived) : [];
+  return LANDING_MODEL.getActiveItems(items);
 }
 function getLandingVisibleItems(items = [], showArchived = false) {
-  if (showArchived) return Array.isArray(items) ? items.slice() : [];
-  return getLandingActiveItems(items);
+  return LANDING_MODEL.getVisibleItems(items, showArchived);
 }
 function getLandingDefaultFilters() {
   return {
@@ -523,11 +448,7 @@ function normalizeLandingFilters(raw = {}) {
   };
 }
 function formatLandingHoursRange(day = {}) {
-  if (day?.closed) return 'Closed';
-  const openMinutes = parseLandingTimeToMinutes(day.open);
-  const closeMinutes = parseLandingTimeToMinutes(day.close);
-  if (openMinutes === null || closeMinutes === null) return 'Hours unavailable';
-  return `${formatLandingMinutes(openMinutes)} - ${formatLandingMinutes(closeMinutes)}`;
+  return LANDING_MODEL.formatHoursRange(day);
 }
 function getLandingDayOffsetKey(dayKey, offset = 0) {
   const index = LANDING_DAY_ORDER.indexOf(dayKey);
@@ -558,16 +479,10 @@ function getRestaurantLocalParts(now = Date.now(), timeZone = RESTAURANT_TIME_ZO
   };
 }
 function getLandingHoursForRestaurant(section = {}, restaurantId = '') {
-  return normalizeLandingHoursRestaurant(section?.restaurants?.[restaurantId] || {});
+  return LANDING_MODEL.getHoursForRestaurant(section, restaurantId);
 }
 function buildLandingWeekRows(section = {}, restaurantId = '', todayKey = 'mon') {
-  const restaurantHours = getLandingHoursForRestaurant(section, restaurantId);
-  return LANDING_DAY_ORDER.map(dayKey => ({
-    dayKey,
-    label: LANDING_DAY_LABELS[dayKey] || dayKey,
-    isToday: dayKey === todayKey,
-    rangeLabel: formatLandingHoursRange(restaurantHours.days[dayKey]),
-  }));
+  return LANDING_MODEL.buildWeekRows(section, restaurantId, todayKey);
 }
 function loadLandingFilters() {
   if (_landingAdminFilters) return _landingAdminFilters;

--- a/app.js
+++ b/app.js
@@ -306,58 +306,16 @@ function createDefaultLandingHoursRestaurant() {
   return LANDING_MODEL.createDefaultHoursRestaurant();
 }
 function createDefaultLandingImportMeta(sourceUrl = '') {
-  return {
-    sourceUrl: sourceUrl ? String(sourceUrl) : '',
-    lastAttemptTs: '',
-    lastSuccessTs: '',
-    status: LANDING_IMPORT_STATUS_IDLE,
-    messages: [],
-  };
+  return LANDING_MODEL.createDefaultImportMeta(sourceUrl);
 }
 function createDefaultLandingEventItem() {
-  return {
-    id: uid(),
-    target: LANDING_TARGET_BOTH,
-    title: '',
-    eventDate: '',
-    startTime: '',
-    endTime: '',
-    timingNote: '',
-    body: '',
-    archived: false,
-    archivedAt: '',
-    updatedAt: '',
-  };
+  return LANDING_MODEL.createDefaultEventItem();
 }
 function createDefaultLandingNewsItem() {
-  return {
-    id: uid(),
-    target: LANDING_TARGET_BOTH,
-    title: '',
-    body: '',
-    href: '',
-    source: '',
-    publishedDate: '',
-    imageUrl: '',
-    archived: false,
-    archivedAt: '',
-    updatedAt: '',
-    importMeta: createDefaultLandingImportMeta(),
-  };
+  return LANDING_MODEL.createDefaultNewsItem();
 }
 function createDefaultLandingReviewItem() {
-  return {
-    id: uid(),
-    href: '',
-    author: '',
-    quote: '',
-    source: 'Google Review',
-    rating: '',
-    archived: false,
-    archivedAt: '',
-    updatedAt: '',
-    importMeta: createDefaultLandingImportMeta(),
-  };
+  return LANDING_MODEL.createDefaultReviewItem();
 }
 function createDefaultLandingContent() {
   return LANDING_MODEL.createDefaultContent();
@@ -366,9 +324,7 @@ function createDefaultLandingPageRecord() {
   return LANDING_MODEL.createDefaultRecord();
 }
 function normalizeLandingTimestamp(value) {
-  if (value === null || value === undefined || value === '') return '';
-  const num = Number(value);
-  return Number.isFinite(num) && num > 0 ? String(num) : '';
+  return LANDING_MODEL.normalizeTimestamp(value);
 }
 function normalizeLandingDay(rawDay = {}) {
   return LANDING_MODEL.normalizeDay(rawDay);
@@ -383,51 +339,13 @@ function normalizeLandingImportMeta(rawMeta = {}) {
   return LANDING_MODEL.normalizeImportMeta(rawMeta);
 }
 function normalizeLandingEventItem(rawItem = {}) {
-  return {
-    id: rawItem?.id ? String(rawItem.id) : uid(),
-    target: normalizeLandingTarget(rawItem?.target, { allowBoth: true }),
-    title: rawItem?.title ? String(rawItem.title) : '',
-    eventDate: rawItem?.eventDate ? String(rawItem.eventDate) : '',
-    startTime: normalizeLandingTimeValue(rawItem?.startTime),
-    endTime: normalizeLandingTimeValue(rawItem?.endTime),
-    timingNote: rawItem?.timingNote ? String(rawItem.timingNote) : '',
-    body: rawItem?.body ? String(rawItem.body) : '',
-    archived: !!rawItem?.archived,
-    archivedAt: normalizeLandingTimestamp(rawItem?.archivedAt),
-    updatedAt: normalizeLandingTimestamp(rawItem?.updatedAt),
-  };
+  return LANDING_MODEL.normalizeEventItem(rawItem);
 }
 function normalizeLandingNewsItem(rawItem = {}) {
-  return {
-    id: rawItem?.id ? String(rawItem.id) : uid(),
-    target: normalizeLandingTarget(rawItem?.target, { allowBoth: true }),
-    title: rawItem?.title ? String(rawItem.title) : '',
-    body: rawItem?.body ? String(rawItem.body) : '',
-    href: rawItem?.href ? String(rawItem.href) : '',
-    source: rawItem?.source ? String(rawItem.source) : '',
-    publishedDate: rawItem?.publishedDate ? String(rawItem.publishedDate) : (rawItem?.publishedAt ? String(rawItem.publishedAt) : ''),
-    imageUrl: rawItem?.imageUrl ? String(rawItem.imageUrl) : '',
-    archived: !!rawItem?.archived,
-    archivedAt: normalizeLandingTimestamp(rawItem?.archivedAt),
-    updatedAt: normalizeLandingTimestamp(rawItem?.updatedAt),
-    importMeta: normalizeLandingImportMeta(rawItem?.importMeta || {}),
-  };
+  return LANDING_MODEL.normalizeNewsItem(rawItem);
 }
 function normalizeLandingReviewItem(rawItem = {}) {
-  const rating = Number(rawItem?.rating);
-  const normalizedRating = Number.isFinite(rating) && rating >= 1 && rating <= 5 ? Math.round(rating) : '';
-  return {
-    id: rawItem?.id ? String(rawItem.id) : uid(),
-    href: rawItem?.href ? String(rawItem.href) : '',
-    author: rawItem?.author ? String(rawItem.author) : '',
-    quote: rawItem?.quote ? String(rawItem.quote) : '',
-    source: rawItem?.source ? String(rawItem.source) : 'Google Review',
-    rating: normalizedRating,
-    archived: !!rawItem?.archived,
-    archivedAt: normalizeLandingTimestamp(rawItem?.archivedAt),
-    updatedAt: normalizeLandingTimestamp(rawItem?.updatedAt),
-    importMeta: normalizeLandingImportMeta(rawItem?.importMeta || {}),
-  };
+  return LANDING_MODEL.normalizeReviewItem(rawItem);
 }
 function normalizeLandingContent(rawContent = {}) {
   return LANDING_MODEL.normalizeContent(rawContent);
@@ -654,42 +572,13 @@ function setLandingSectionFilter(sectionId = '', key = '', value = false) {
   saveLandingFilters();
 }
 function validateLandingEventItem(item = {}) {
-  const issues = [];
-  if (!item.target) issues.push('target');
-  if (!item.title?.trim()) issues.push('title');
-  if (!isLandingIsoDate(item.eventDate)) issues.push('date');
-  if (parseLandingTimeToMinutes(item.startTime) === null) issues.push('start time');
-  if (parseLandingTimeToMinutes(item.endTime) === null && !item.timingNote?.trim()) issues.push('end time or note');
-  if (!item.body?.trim()) issues.push('description');
-  return {
-    valid: issues.length === 0,
-    missingFields: issues,
-  };
+  return LANDING_MODEL.validateEventItem(item);
 }
 function validateLandingNewsItem(item = {}) {
-  const issues = [];
-  if (!item.target) issues.push('target');
-  if (!item.title?.trim()) issues.push('headline');
-  if (!isLandingAbsoluteUrl(item.href)) issues.push('article URL');
-  if (!item.source?.trim()) issues.push('source');
-  if (!isLandingIsoDate(item.publishedDate)) issues.push('publish date');
-  if (!item.importMeta?.lastAttemptTs) issues.push('import record');
-  return {
-    valid: issues.length === 0,
-    missingFields: issues,
-  };
+  return LANDING_MODEL.validateNewsItem(item);
 }
 function validateLandingReviewItem(item = {}) {
-  const issues = [];
-  if (!isLandingAbsoluteUrl(item.href)) issues.push('review URL');
-  if (!item.author?.trim()) issues.push('author');
-  if (!item.quote?.trim()) issues.push('quote');
-  if (!Number.isFinite(Number(item.rating)) || Number(item.rating) < 1 || Number(item.rating) > 5) issues.push('rating');
-  if (!item.importMeta?.lastAttemptTs) issues.push('import record');
-  return {
-    valid: issues.length === 0,
-    missingFields: issues,
-  };
+  return LANDING_MODEL.validateReviewItem(item);
 }
 function validateLandingEventsSection(section = {}) {
   return LANDING_MODEL.validateEventsSection(section);
@@ -4100,7 +3989,9 @@ function getLandingSectionStatus(sectionId, record = _landingPageState) {
 }
 
 function renderLandingHoursRowsHtml(section = {}, restaurantId = '', restaurantLabel = '') {
-  return LANDING_MODEL.renderHoursRowsHtml(section, restaurantId, restaurantLabel);
+  return LANDING_MODEL.renderHoursRowsHtml(section, restaurantId, restaurantLabel, {
+    setFieldHandlerName: 'setLandingHoursField',
+  });
 }
 function renderLandingTargetOptionsHtml(selectedTarget = '', options = {}) {
   return LANDING_MODEL.renderTargetOptionsHtml(selectedTarget, options);

--- a/app.js
+++ b/app.js
@@ -165,6 +165,17 @@ const LANDING_FILTER_STORAGE_KEY = 'hf_landing_admin_filters';
 const LANDING_MODEL = globalThis.__HF_LANDING_MODULES__.createLandingModel({
   domainConstants: DOMAIN_CONSTANTS,
 });
+const LANDING_STORE = globalThis.__HF_LANDING_MODULES__.createLandingStore({
+  model: LANDING_MODEL,
+  defaultActivePanel: 'landing-admin-panel-overview',
+  defaultFilters: getLandingDefaultFilters(),
+});
+const LANDING_DATA_SERVICE = globalThis.__HF_LANDING_MODULES__.createLandingDataService({
+  model: LANDING_MODEL,
+  store: LANDING_STORE,
+  fetchRecord: fetchLandingPageRecordThroughApi,
+  upsertRecord: upsertLandingPageRecordThroughApi,
+});
 
 function buildFallbackDomainConstants() {
   const restaurants = {
@@ -208,6 +219,17 @@ function buildFallbackDomainConstants() {
       admin: '/admin',
     },
   };
+}
+
+function syncLandingLegacyStateFromStore() {
+  _landingPageState = LANDING_STORE.getRecord();
+  _landingPageDirty = LANDING_STORE.isDirty();
+  _landingPageLoadPromise = LANDING_STORE.getLoadPromise();
+  _landingPageLoadError = LANDING_STORE.getLoadError();
+  _activeLandingAdminPanel = LANDING_STORE.getActivePanel();
+  _landingAdminFilters = LANDING_STORE.getFilters();
+  _landingReviewCarouselIndex = LANDING_STORE.getReviewCarouselIndex();
+  return _landingPageState;
 }
 
 function colorAt(palette, index) {
@@ -550,10 +572,11 @@ function buildLandingWeekRows(section = {}, restaurantId = '', todayKey = 'mon')
 function loadLandingFilters() {
   if (_landingAdminFilters) return _landingAdminFilters;
   try {
-    _landingAdminFilters = normalizeLandingFilters(JSON.parse(sessionStorage.getItem(LANDING_FILTER_STORAGE_KEY) || '{}'));
+    LANDING_STORE.setFilters(normalizeLandingFilters(JSON.parse(sessionStorage.getItem(LANDING_FILTER_STORAGE_KEY) || '{}')));
   } catch (_) {
-    _landingAdminFilters = getLandingDefaultFilters();
+    LANDING_STORE.setFilters(getLandingDefaultFilters());
   }
+  syncLandingLegacyStateFromStore();
   return _landingAdminFilters;
 }
 function getLandingSectionFilter(sectionId = '') {
@@ -569,6 +592,8 @@ function setLandingSectionFilter(sectionId = '', key = '', value = false) {
   const filters = loadLandingFilters();
   if (!filters[sectionId]) filters[sectionId] = { showArchived: false };
   filters[sectionId][key] = !!value;
+  LANDING_STORE.setFilters(filters);
+  syncLandingLegacyStateFromStore();
   saveLandingFilters();
 }
 function validateLandingEventItem(item = {}) {
@@ -3906,9 +3931,11 @@ function hasLandingAdminShell() {
 }
 
 function setLandingPageState(record, options = {}) {
-  _landingPageState = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-  if (typeof options.dirty === 'boolean') _landingPageDirty = options.dirty;
-  return _landingPageState;
+  LANDING_STORE.setRecord(record || createDefaultLandingPageRecord(), {
+    dirty: typeof options.dirty === 'boolean' ? options.dirty : undefined,
+    loaded: true,
+  });
+  return syncLandingLegacyStateFromStore();
 }
 
 function landingSectionHasDiff(sectionId, record = _landingPageState) {
@@ -3920,11 +3947,12 @@ function getLandingDraftDiffSectionIds(record = _landingPageState) {
 }
 
 function syncLandingDirtyFlag(value = false) {
-  _landingPageDirty = !!value;
+  LANDING_STORE.setDirty(value);
+  syncLandingLegacyStateFromStore();
   return _landingPageDirty;
 }
 
-async function fetchLandingPageRecordFromSupabase(options = {}) {
+async function fetchLandingPageRecordThroughApi(options = {}) {
   const includeDraft = options.includeDraft === true;
   const payload = await readApiJsonOrNull(getLandingPageEndpoint(includeDraft), {
     headers: includeDraft ? getAuthorizedApiHeaders() : {},
@@ -3934,27 +3962,20 @@ async function fetchLandingPageRecordFromSupabase(options = {}) {
 }
 
 async function ensureLandingPageStateLoaded(options = {}) {
-  const { force = false, includeDraft = hasLandingAdminShell() } = options;
-  if (_landingPageState && !force) return _landingPageState;
-  if (_landingPageLoadPromise && !force) return _landingPageLoadPromise;
-  _landingPageLoadPromise = (async () => {
-    try {
-      const record = await fetchLandingPageRecordFromSupabase({ includeDraft });
-      _landingPageLoadError = '';
-      setLandingPageState(record, { dirty: false });
-      syncLandingDirtyFlag(false);
-      return _landingPageState;
-    } catch (error) {
-      _landingPageLoadError = error?.message || 'Landing page state could not be loaded.';
-      throw error;
-    } finally {
-      _landingPageLoadPromise = null;
-    }
-  })();
-  return _landingPageLoadPromise;
+  try {
+    const loaded = await LANDING_DATA_SERVICE.ensureLoaded({
+      ...options,
+      includeDraft: options.includeDraft ?? hasLandingAdminShell(),
+    });
+    syncLandingLegacyStateFromStore();
+    return loaded;
+  } catch (error) {
+    syncLandingLegacyStateFromStore();
+    throw error;
+  }
 }
 
-async function upsertLandingPageRecord(payload = {}, action = 'save_landing_page_draft') {
+async function upsertLandingPageRecordThroughApi(payload = {}, action = 'save_landing_page_draft') {
   if (!currentUser?.accessToken) throw new Error('Sign in as an admin to edit the landing page.');
   const result = await postApiJson('/api/admin', {
     action,
@@ -4584,12 +4605,14 @@ function renderLandingRootReviews(section = {}) {
     listEl.innerHTML = '';
     emptyEl.hidden = true;
     controlsEl.hidden = true;
-    _landingReviewCarouselIndex = 0;
+    LANDING_STORE.setReviewCarouselIndex(0);
+    syncLandingLegacyStateFromStore();
     return;
   }
   emptyEl.hidden = true;
   controlsEl.hidden = pairs.length <= 1;
-  _landingReviewCarouselIndex = Math.max(0, Math.min(_landingReviewCarouselIndex, pairs.length - 1));
+  LANDING_STORE.setReviewCarouselIndex(Math.max(0, Math.min(_landingReviewCarouselIndex, pairs.length - 1)));
+  syncLandingLegacyStateFromStore();
   listEl.innerHTML = pairs.map((pair, index) => `
     <article class="landing-review-pair ${index === _landingReviewCarouselIndex ? 'is-active' : ''}" data-landing-review-pair="${index}">
       <article class="landing-review-card landing-review-card--leroys">
@@ -4613,7 +4636,8 @@ function renderLandingRootReviews(section = {}) {
 function setLandingReviewCarouselIndex(nextIndex = 0) {
   const pairEls = Array.from(document.querySelectorAll('[data-landing-review-pair]'));
   if (!pairEls.length) return;
-  _landingReviewCarouselIndex = Math.max(0, Math.min(Number(nextIndex) || 0, pairEls.length - 1));
+  LANDING_STORE.setReviewCarouselIndex(Math.max(0, Math.min(Number(nextIndex) || 0, pairEls.length - 1)));
+  syncLandingLegacyStateFromStore();
   pairEls.forEach((pairEl, index) => {
     pairEl.classList.toggle('is-active', index === _landingReviewCarouselIndex);
   });
@@ -4691,7 +4715,8 @@ async function initLandingRootPage() {
 }
 
 function focusLandingAdminPanel(panelId = 'landing-admin-panel-overview', trigger = null) {
-  _activeLandingAdminPanel = panelId || _activeLandingAdminPanel;
+  LANDING_STORE.setActivePanel(panelId || _activeLandingAdminPanel);
+  syncLandingLegacyStateFromStore();
   document.querySelectorAll('.landing-admin-panel').forEach(panel => {
     panel.classList.toggle('is-active', panel.id === _activeLandingAdminPanel);
   });
@@ -4718,7 +4743,7 @@ function setLandingHoursField(restaurantId, dayKey, field, value) {
     if (targetDay[field]) targetDay.closed = false;
   }
   record.draftContent.hours.restaurants[restaurantId].days[dayKey] = normalizeLandingDay(targetDay);
-  _landingPageDirty = true;
+  syncLandingDirtyFlag(true);
   if (field === 'closed') {
     renderLandingAdminWorkspace();
     return;
@@ -4730,7 +4755,7 @@ function updateLandingDraftRecord(mutator = () => {}, options = {}) {
   const { rerender = true } = options;
   const record = setLandingPageState(_landingPageState || createDefaultLandingPageRecord(), { dirty: true });
   mutator(record);
-  _landingPageDirty = true;
+  syncLandingDirtyFlag(true);
   if (rerender) renderLandingAdminWorkspace();
   return record;
 }
@@ -4981,14 +5006,8 @@ async function saveLandingPageDraft() {
   try {
     const record = normalizeLandingPageRecord(syncLandingHoursDraftFromDom() || await ensureLandingPageStateLoaded());
     const timestamp = Date.now();
-    const nextRecord = await upsertLandingPageRecord({
-      draft_content: record.draftContent,
-      live_content: record.liveContent,
-      draft_saved_ts: timestamp,
-      live_published_ts: record.livePublishedTs ? Number(record.livePublishedTs) : null,
-    }, 'save_landing_page_draft');
-    setLandingPageState(nextRecord, { dirty: false });
-    syncLandingDirtyFlag(false);
+    await LANDING_DATA_SERVICE.saveDraft(record, timestamp);
+    syncLandingLegacyStateFromStore();
     renderLandingAdminWorkspace();
     showToast('✅ Landing page draft saved.', 'success');
   } catch (error) {
@@ -5064,20 +5083,9 @@ async function publishLandingPageSections() {
       showToast(`⚠️ Fix ${blockedSection.label.toLowerCase()} before publishing it live.`, 'error');
       return;
     }
-    const nextLiveRecord = applyLandingSectionPublish(currentRecord, selectedSectionIds);
     const timestamp = Date.now();
-    const persistedRecord = await upsertLandingPageRecord({
-      draft_content: currentRecord.draftContent,
-      live_content: nextLiveRecord.liveContent,
-      draft_saved_ts: currentRecord.draftSavedTs ? Number(currentRecord.draftSavedTs) : null,
-      live_published_ts: timestamp,
-    }, 'publish_landing_sections');
-    setLandingPageState({
-      ...persistedRecord,
-      liveContent: nextLiveRecord.liveContent,
-      livePublishedTs: String(timestamp),
-    }, { dirty: false });
-    syncLandingDirtyFlag(false);
+    await LANDING_DATA_SERVICE.publishSections(currentRecord, selectedSectionIds, timestamp);
+    syncLandingLegacyStateFromStore();
     renderLandingAdminWorkspace();
     if (hasLandingRootShell()) renderLandingRootPage(_landingPageState);
     closeLandingPublishModal();

--- a/app.js
+++ b/app.js
@@ -162,6 +162,9 @@ const LANDING_ITEM_STATUS_DRAFT = 'Draft';
 const LANDING_ITEM_STATUS_MISSING = 'Missing Fields';
 const LANDING_ITEM_STATUS_ARCHIVED = 'ARCHIVED';
 const LANDING_FILTER_STORAGE_KEY = 'hf_landing_admin_filters';
+const LANDING_MODEL = globalThis.__HF_LANDING_MODULES__.createLandingModel({
+  domainConstants: DOMAIN_CONSTANTS,
+});
 
 function buildFallbackDomainConstants() {
   const restaurants = {
@@ -376,14 +379,7 @@ function createDefaultLandingContent() {
   };
 }
 function createDefaultLandingPageRecord() {
-  const content = createDefaultLandingContent();
-  return {
-    id: LANDING_PAGE_STATE_ID,
-    draftContent: cloneJsonCompatible(content, content),
-    liveContent: cloneJsonCompatible(content, content),
-    draftSavedTs: '',
-    livePublishedTs: '',
-  };
+  return LANDING_MODEL.createDefaultRecord();
 }
 function normalizeLandingTimestamp(value) {
   if (value === null || value === undefined || value === '') return '';
@@ -408,31 +404,10 @@ function normalizeLandingHoursRestaurant(rawRestaurant = {}) {
   return { days };
 }
 function normalizeLandingTarget(value = '', options = {}) {
-  const { allowBoth = true, fallback = allowBoth ? LANDING_TARGET_BOTH : knownLandingRestaurants()[0]?.id || '' } = options;
-  const candidate = value ? String(value) : '';
-  if (allowBoth && candidate === LANDING_TARGET_BOTH) return LANDING_TARGET_BOTH;
-  if (candidate && knownLandingRestaurants().some(restaurant => restaurant.id === candidate)) return candidate;
-  return fallback;
+  return LANDING_MODEL.normalizeTarget(value, options);
 }
 function normalizeLandingImportMeta(rawMeta = {}) {
-  const status = [
-    LANDING_IMPORT_STATUS_IDLE,
-    LANDING_IMPORT_STATUS_IMPORTED,
-    LANDING_IMPORT_STATUS_PARTIAL,
-    LANDING_IMPORT_STATUS_FAILED,
-  ].includes(rawMeta?.status)
-    ? rawMeta.status
-    : LANDING_IMPORT_STATUS_IDLE;
-  const rawMessages = Array.isArray(rawMeta?.messages)
-    ? rawMeta.messages
-    : (rawMeta?.message ? [rawMeta.message] : []);
-  return {
-    sourceUrl: rawMeta?.sourceUrl ? String(rawMeta.sourceUrl) : '',
-    lastAttemptTs: normalizeLandingTimestamp(rawMeta?.lastAttemptTs),
-    lastSuccessTs: normalizeLandingTimestamp(rawMeta?.lastSuccessTs),
-    status,
-    messages: rawMessages.map(message => String(message || '')).filter(Boolean),
-  };
+  return LANDING_MODEL.normalizeImportMeta(rawMeta);
 }
 function normalizeLandingEventItem(rawItem = {}) {
   return {
@@ -506,24 +481,13 @@ function normalizeLandingContent(rawContent = {}) {
   };
 }
 function normalizeLandingPageRecord(rawRecord = {}) {
-  const defaults = createDefaultLandingPageRecord();
-  return {
-    id: rawRecord?.id ? String(rawRecord.id) : defaults.id,
-    draftContent: normalizeLandingContent(rawRecord?.draft_content || rawRecord?.draftContent || defaults.draftContent),
-    liveContent: normalizeLandingContent(rawRecord?.live_content || rawRecord?.liveContent || defaults.liveContent),
-    draftSavedTs: normalizeLandingTimestamp(rawRecord?.draft_saved_ts || rawRecord?.draftSavedTs),
-    livePublishedTs: normalizeLandingTimestamp(rawRecord?.live_published_ts || rawRecord?.livePublishedTs),
-  };
+  return LANDING_MODEL.normalizeRecord(rawRecord);
 }
 function getLandingSectionContent(record = createDefaultLandingPageRecord(), source = 'draft') {
   return source === 'live' ? record.liveContent : record.draftContent;
 }
 function normalizeLandingTimeValue(value = '') {
-  if (typeof value !== 'string') return '';
-  const trimmed = value.trim();
-  const match = trimmed.match(/^(\d{2}):(\d{2})(?::(\d{2}))?$/);
-  if (!match) return '';
-  return `${match[1]}:${match[2]}`;
+  return LANDING_MODEL.normalizeTimeValue(value);
 }
 function parseLandingTimeToMinutes(value = '') {
   const normalized = normalizeLandingTimeValue(value);
@@ -776,46 +740,20 @@ function validateLandingReviewItem(item = {}) {
   };
 }
 function validateLandingEventsSection(section = {}) {
-  const issues = [];
-  const items = sortLandingEvents(getLandingActiveItems(Array.isArray(section?.items) ? section.items.map(normalizeLandingEventItem) : []));
-  items.forEach(item => {
-    const validation = validateLandingEventItem(item);
-    if (validation.valid) return;
-    issues.push(`${item.title?.trim() || 'Untitled event'}: missing ${validation.missingFields.join(', ')}.`);
-  });
-  return { valid: issues.length === 0, issues };
+  return LANDING_MODEL.validateEventsSection(section);
 }
 function validateLandingNewsSection(section = {}) {
-  const issues = [];
-  const items = sortLandingNews(getLandingActiveItems(Array.isArray(section?.items) ? section.items.map(normalizeLandingNewsItem) : []));
-  items.forEach(item => {
-    const validation = validateLandingNewsItem(item);
-    if (validation.valid) return;
-    issues.push(`${item.title?.trim() || item.href?.trim() || 'Imported story'}: missing ${validation.missingFields.join(', ')}.`);
-  });
-  return { valid: issues.length === 0, issues };
+  return LANDING_MODEL.validateNewsSection(section);
 }
 function validateLandingReviewsSection(section = {}) {
-  const issues = [];
-  knownLandingRestaurants().forEach(restaurant => {
-    const items = sortLandingReviews(
-      getLandingActiveItems(Array.isArray(section?.restaurants?.[restaurant.id]) ? section.restaurants[restaurant.id].map(normalizeLandingReviewItem) : [])
-    );
-    items.forEach(item => {
-      const validation = validateLandingReviewItem(item);
-      if (validation.valid) return;
-      issues.push(`${restaurant.name}: ${item.author?.trim() || item.href?.trim() || 'Imported review'} is missing ${validation.missingFields.join(', ')}.`);
-    });
-  });
-  return { valid: issues.length === 0, issues };
+  return LANDING_MODEL.validateReviewsSection(section);
 }
 function getLandingSectionValidation(sectionId = '', record = _landingPageState) {
-  const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-  if (sectionId === 'hours') return validateLandingHoursSection(normalized.draftContent.hours);
-  if (sectionId === 'events') return validateLandingEventsSection(normalized.draftContent.events);
-  if (sectionId === 'news') return validateLandingNewsSection(normalized.draftContent.news);
-  if (sectionId === 'reviews') return validateLandingReviewsSection(normalized.draftContent.reviews);
-  return { valid: true, issues: [] };
+  if (sectionId === 'hours') {
+    const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
+    return validateLandingHoursSection(normalized.draftContent.hours);
+  }
+  return LANDING_MODEL.getSectionValidation(sectionId, record || createDefaultLandingPageRecord());
 }
 function findLandingItemById(items = [], itemId = '') {
   return Array.isArray(items) ? items.find(item => item?.id === itemId) || null : null;
@@ -838,114 +776,17 @@ function getLandingItemStatusLabel(sectionId = '', item = {}, liveSection = null
   return LANDING_ITEM_STATUS_DRAFT;
 }
 function validateLandingHoursSection(section = {}) {
-  const issues = [];
-  knownLandingRestaurants().forEach(restaurant => {
-    const restaurantHours = getLandingHoursForRestaurant(section, restaurant.id);
-    LANDING_DAY_ORDER.forEach(dayKey => {
-      const day = restaurantHours.days[dayKey];
-      if (day.closed) return;
-      const openMinutes = parseLandingTimeToMinutes(day.open);
-      const closeMinutes = parseLandingTimeToMinutes(day.close);
-      if (openMinutes === null || closeMinutes === null) {
-        issues.push(`${restaurant.name}: ${LANDING_DAY_LABELS[dayKey]} needs both an open and close time.`);
-        return;
-      }
-      if (openMinutes === closeMinutes) {
-        issues.push(`${restaurant.name}: ${LANDING_DAY_LABELS[dayKey]} cannot open and close at the same time.`);
-      }
-    });
-  });
-  return {
-    valid: issues.length === 0,
-    issues,
-  };
+  return LANDING_MODEL.validateHoursSection(section);
 }
 function getLandingHoursSectionForValidation(record = _landingPageState) {
   const source = syncLandingHoursDraftFromDom() || record || createDefaultLandingPageRecord();
   return normalizeLandingPageRecord(source).draftContent.hours;
 }
 function computeLandingStatusForRestaurant(section = {}, restaurantId = '', now = Date.now(), timeZone = RESTAURANT_TIME_ZONE) {
-  const restaurantHours = getLandingHoursForRestaurant(section, restaurantId);
-  const local = getRestaurantLocalParts(now, timeZone);
-  const previousDayKey = getLandingDayOffsetKey(local.dayKey, -1);
-  const today = restaurantHours.days[local.dayKey];
-  const previous = restaurantHours.days[previousDayKey];
-  const todayOpen = parseLandingTimeToMinutes(today.open);
-  const todayClose = parseLandingTimeToMinutes(today.close);
-  const previousOpen = parseLandingTimeToMinutes(previous.open);
-  const previousClose = parseLandingTimeToMinutes(previous.close);
-  const previousOvernight = !previous.closed && previousOpen !== null && previousClose !== null && previousClose <= previousOpen;
-  const todayOvernight = !today.closed && todayOpen !== null && todayClose !== null && todayClose <= todayOpen;
-
-  if (previousOvernight && local.minutes < previousClose) {
-    return {
-      isOpen: true,
-      currentDayKey: local.dayKey,
-      label: `Open until ${formatLandingMinutes(previousClose)}`,
-      todayRangeLabel: formatLandingHoursRange(today),
-      weekRows: buildLandingWeekRows(section, restaurantId, local.dayKey),
-    };
-  }
-
-  if (!today.closed && todayOpen !== null && todayClose !== null) {
-    const isOpen = todayOvernight
-      ? local.minutes >= todayOpen
-      : (local.minutes >= todayOpen && local.minutes < todayClose);
-    if (isOpen) {
-      return {
-        isOpen: true,
-        currentDayKey: local.dayKey,
-        label: `Open until ${formatLandingMinutes(todayClose)}`,
-        todayRangeLabel: formatLandingHoursRange(today),
-        weekRows: buildLandingWeekRows(section, restaurantId, local.dayKey),
-      };
-    }
-  }
-
-  if (!today.closed && todayOpen !== null && local.minutes < todayOpen) {
-    return {
-      isOpen: false,
-      currentDayKey: local.dayKey,
-      label: `Closed until ${formatLandingMinutes(todayOpen)}`,
-      todayRangeLabel: formatLandingHoursRange(today),
-      weekRows: buildLandingWeekRows(section, restaurantId, local.dayKey),
-    };
-  }
-
-  for (let offset = 1; offset <= LANDING_DAY_ORDER.length; offset += 1) {
-    const nextDayKey = getLandingDayOffsetKey(local.dayKey, offset);
-    const nextDay = restaurantHours.days[nextDayKey];
-    if (nextDay.closed) continue;
-    const nextOpen = parseLandingTimeToMinutes(nextDay.open);
-    if (nextOpen === null) continue;
-    const prefix = offset === 1 ? 'tomorrow' : (LANDING_DAY_LABELS[nextDayKey] || nextDayKey);
-    return {
-      isOpen: false,
-      currentDayKey: local.dayKey,
-      label: `Closed until ${prefix} ${formatLandingMinutes(nextOpen)}`,
-      todayRangeLabel: formatLandingHoursRange(today),
-      weekRows: buildLandingWeekRows(section, restaurantId, local.dayKey),
-    };
-  }
-
-  return {
-    isOpen: false,
-    currentDayKey: local.dayKey,
-    label: 'Closed for now',
-    todayRangeLabel: formatLandingHoursRange(today),
-    weekRows: buildLandingWeekRows(section, restaurantId, local.dayKey),
-  };
+  return LANDING_MODEL.computeRestaurantStatus(section, restaurantId, now, timeZone);
 }
 function applyLandingSectionPublish(record = createDefaultLandingPageRecord(), sectionIds = []) {
-  const nextRecord = normalizeLandingPageRecord(record);
-  const draftContent = cloneJsonCompatible(nextRecord.draftContent, createDefaultLandingContent());
-  const liveContent = cloneJsonCompatible(nextRecord.liveContent, createDefaultLandingContent());
-  const appliedSectionIds = sectionIds.filter(sectionId => LANDING_PAGE_SECTION_ORDER.includes(sectionId));
-  appliedSectionIds.forEach(sectionId => {
-    liveContent[sectionId] = cloneJsonCompatible(draftContent[sectionId], {});
-  });
-  nextRecord.liveContent = normalizeLandingContent(liveContent);
-  return nextRecord;
+  return LANDING_MODEL.applySectionPublish(record, sectionIds);
 }
 function lsSet(key, val, options = {}) {
   const { silent = false } = options;
@@ -4230,12 +4071,11 @@ function setLandingPageState(record, options = {}) {
 }
 
 function landingSectionHasDiff(sectionId, record = _landingPageState) {
-  const normalized = normalizeLandingPageRecord(record || createDefaultLandingPageRecord());
-  return JSON.stringify(normalized.draftContent[sectionId] || {}) !== JSON.stringify(normalized.liveContent[sectionId] || {});
+  return LANDING_MODEL.landingSectionHasDiff(sectionId, record || createDefaultLandingPageRecord());
 }
 
 function getLandingDraftDiffSectionIds(record = _landingPageState) {
-  return LANDING_PAGE_SECTION_ORDER.filter(sectionId => landingSectionHasDiff(sectionId, record));
+  return LANDING_MODEL.getDraftDiffSectionIds(record || createDefaultLandingPageRecord());
 }
 
 function syncLandingDirtyFlag(value = false) {
@@ -4308,88 +4148,13 @@ function getLandingSectionStatus(sectionId, record = _landingPageState) {
 }
 
 function renderLandingHoursRowsHtml(section = {}, restaurantId = '', restaurantLabel = '') {
-  const restaurantHours = getLandingHoursForRestaurant(section, restaurantId);
-  return `
-    <article class="landing-admin-hours-card">
-      <div class="landing-admin-hours-card-header">
-        <div>
-          <p class="settings-section-kicker">${escHtml(restaurantLabel)}</p>
-          <h5>${escHtml(restaurantLabel)}</h5>
-        </div>
-        <span class="landing-hours-summary">Published hero line follows this recurring schedule.</span>
-      </div>
-      <div class="landing-hours-day-grid">
-        ${LANDING_DAY_ORDER.map(dayKey => {
-          const day = restaurantHours.days[dayKey];
-          const safeRestaurantId = escAttrJs(restaurantId);
-          const safeDayKey = escAttrJs(dayKey);
-          return `
-            <div class="landing-hours-day-row">
-              <div class="landing-hours-day-header">
-                <label for="landing-hours-${escHtml(restaurantId)}-${escHtml(dayKey)}-open">${escHtml(LANDING_DAY_LABELS[dayKey])}</label>
-              </div>
-              <div class="landing-hours-day-controls">
-                <select
-                  id="landing-hours-${escHtml(restaurantId)}-${escHtml(dayKey)}-open"
-                  data-landing-hours-field="open"
-                  data-landing-hours-restaurant="${escHtml(restaurantId)}"
-                  data-landing-hours-day="${escHtml(dayKey)}"
-                  aria-label="${escHtml(`${restaurantLabel} ${LANDING_DAY_LABELS[dayKey]} open time`)}"
-                  ${day.closed ? 'disabled' : ''}
-                  onchange="setLandingHoursField(${safeRestaurantId}, ${safeDayKey}, 'open', this.value)"
-                >
-                  ${renderLandingTimeSelectOptions(day.open, 'Open time')}
-                </select>
-                <select
-                  id="landing-hours-${escHtml(restaurantId)}-${escHtml(dayKey)}-close"
-                  data-landing-hours-field="close"
-                  data-landing-hours-restaurant="${escHtml(restaurantId)}"
-                  data-landing-hours-day="${escHtml(dayKey)}"
-                  aria-label="${escHtml(`${restaurantLabel} ${LANDING_DAY_LABELS[dayKey]} close time`)}"
-                  ${day.closed ? 'disabled' : ''}
-                  onchange="setLandingHoursField(${safeRestaurantId}, ${safeDayKey}, 'close', this.value)"
-                >
-                  ${renderLandingTimeSelectOptions(day.close, 'Close time')}
-                </select>
-              </div>
-              <div class="landing-hours-day-footer">
-                <label class="landing-hours-toggle" for="landing-hours-${escHtml(restaurantId)}-${escHtml(dayKey)}-closed">
-                  <input
-                    id="landing-hours-${escHtml(restaurantId)}-${escHtml(dayKey)}-closed"
-                    type="checkbox"
-                    data-landing-hours-field="closed"
-                    data-landing-hours-restaurant="${escHtml(restaurantId)}"
-                    data-landing-hours-day="${escHtml(dayKey)}"
-                    ${day.closed ? 'checked' : ''}
-                    onchange="setLandingHoursField(${safeRestaurantId}, ${safeDayKey}, 'closed', this.checked)"
-                  >
-                  Closed
-                </label>
-              </div>
-            </div>`;
-        }).join('')}
-      </div>
-    </article>`;
+  return LANDING_MODEL.renderHoursRowsHtml(section, restaurantId, restaurantLabel);
 }
 function renderLandingTargetOptionsHtml(selectedTarget = '', options = {}) {
-  const { includeBoth = true } = options;
-  const values = [];
-  if (includeBoth) values.push({ value: LANDING_TARGET_BOTH, label: 'Both' });
-  knownLandingRestaurants().forEach(restaurant => {
-    values.push({ value: restaurant.id, label: restaurant.name });
-  });
-  return values.map(option => (
-    `<option value="${escHtml(option.value)}" ${option.value === selectedTarget ? 'selected' : ''}>${escHtml(option.label)}</option>`
-  )).join('');
+  return LANDING_MODEL.renderTargetOptionsHtml(selectedTarget, options);
 }
 function renderLandingRatingOptionsHtml(selectedValue = '') {
-  const rating = Number(selectedValue);
-  const normalized = Number.isFinite(rating) ? String(rating) : '';
-  const options = ['<option value="">Rating</option>'];
-  for (let value = 5; value >= 1; value -= 1) {
-    options.push(`<option value="${value}" ${normalized === String(value) ? 'selected' : ''}>${value} Stars</option>`);
-  }
-  return options.join('');
+  return LANDING_MODEL.renderRatingOptionsHtml(selectedValue);
 }
 function getLandingItemStatusClass(status = '') {
   if (status === LANDING_ITEM_STATUS_LIVE) return 'is-live';
@@ -4903,30 +4668,16 @@ function setLandingRootSectionVisible(sectionId = '', visible = true) {
   if (dotEl) dotEl.hidden = !visible;
 }
 function getLandingRenderableEvents(section = {}) {
-  return sortLandingEvents(
-    getLandingActiveItems(Array.isArray(section?.items) ? section.items.map(normalizeLandingEventItem) : [])
-  ).filter(item => validateLandingEventItem(item).valid);
+  return LANDING_MODEL.getRenderableEvents(section);
 }
 function getLandingRenderableNews(section = {}) {
-  return sortLandingNews(
-    getLandingActiveItems(Array.isArray(section?.items) ? section.items.map(normalizeLandingNewsItem) : [])
-  ).filter(item => validateLandingNewsItem(item).valid);
+  return LANDING_MODEL.getRenderableNews(section);
 }
 function getLandingRenderableReviews(section = {}, restaurantId = '') {
-  return sortLandingReviews(
-    getLandingActiveItems(Array.isArray(section?.restaurants?.[restaurantId]) ? section.restaurants[restaurantId].map(normalizeLandingReviewItem) : [])
-  ).filter(item => validateLandingReviewItem(item).valid);
+  return LANDING_MODEL.getRenderableReviews(section, restaurantId);
 }
 function buildLandingReviewPairs(section = {}) {
-  const leroysReviews = getLandingRenderableReviews(section, RESTAURANTS.LEROYS.id);
-  const elroysReviews = getLandingRenderableReviews(section, RESTAURANTS.ELROYS.id);
-  if (leroysReviews.length < 3 || elroysReviews.length < 3) return [];
-  const pairCount = Math.min(leroysReviews.length, elroysReviews.length);
-  return Array.from({ length: pairCount }, (_, index) => ({
-    id: `pair-${index}`,
-    leroys: leroysReviews[index],
-    elroys: elroysReviews[index],
-  }));
+  return LANDING_MODEL.buildReviewPairs(section);
 }
 function renderLandingRootEvents(section = {}) {
   const listEl = document.getElementById('landing-events-list');

--- a/app.js
+++ b/app.js
@@ -300,14 +300,10 @@ function knownLandingRestaurants() {
   return Object.values(RESTAURANTS).sort((a, b) => KNOWN_RESTAURANT_ORDER.indexOf(a.id) - KNOWN_RESTAURANT_ORDER.indexOf(b.id));
 }
 function createDefaultLandingDay() {
-  return { closed: true, open: '', close: '' };
+  return LANDING_MODEL.createDefaultDay();
 }
 function createDefaultLandingHoursRestaurant() {
-  const days = {};
-  LANDING_DAY_ORDER.forEach(dayKey => {
-    days[dayKey] = createDefaultLandingDay();
-  });
-  return { days };
+  return LANDING_MODEL.createDefaultHoursRestaurant();
 }
 function createDefaultLandingImportMeta(sourceUrl = '') {
   return {
@@ -364,19 +360,7 @@ function createDefaultLandingReviewItem() {
   };
 }
 function createDefaultLandingContent() {
-  const restaurants = {};
-  const reviewRestaurants = {};
-  knownLandingRestaurants().forEach(restaurant => {
-    restaurants[restaurant.id] = createDefaultLandingHoursRestaurant();
-    reviewRestaurants[restaurant.id] = [];
-  });
-  return {
-    overview: {},
-    hours: { restaurants },
-    events: { items: [] },
-    news: { items: [] },
-    reviews: { restaurants: reviewRestaurants },
-  };
+  return LANDING_MODEL.createDefaultContent();
 }
 function createDefaultLandingPageRecord() {
   return LANDING_MODEL.createDefaultRecord();
@@ -387,21 +371,10 @@ function normalizeLandingTimestamp(value) {
   return Number.isFinite(num) && num > 0 ? String(num) : '';
 }
 function normalizeLandingDay(rawDay = {}) {
-  const closed = !!rawDay?.closed;
-  const open = normalizeLandingTimeValue(rawDay?.open);
-  const close = normalizeLandingTimeValue(rawDay?.close);
-  return {
-    closed,
-    open: closed ? '' : open,
-    close: closed ? '' : close,
-  };
+  return LANDING_MODEL.normalizeDay(rawDay);
 }
 function normalizeLandingHoursRestaurant(rawRestaurant = {}) {
-  const days = {};
-  LANDING_DAY_ORDER.forEach(dayKey => {
-    days[dayKey] = normalizeLandingDay(rawRestaurant?.days?.[dayKey]);
-  });
-  return { days };
+  return LANDING_MODEL.normalizeHoursRestaurant(rawRestaurant);
 }
 function normalizeLandingTarget(value = '', options = {}) {
   return LANDING_MODEL.normalizeTarget(value, options);
@@ -457,28 +430,7 @@ function normalizeLandingReviewItem(rawItem = {}) {
   };
 }
 function normalizeLandingContent(rawContent = {}) {
-  const defaults = createDefaultLandingContent();
-  const hoursRestaurants = {};
-  const reviewRestaurants = {};
-  knownLandingRestaurants().forEach(restaurant => {
-    hoursRestaurants[restaurant.id] = normalizeLandingHoursRestaurant(rawContent?.hours?.restaurants?.[restaurant.id] || defaults.hours.restaurants[restaurant.id]);
-    reviewRestaurants[restaurant.id] = Array.isArray(rawContent?.reviews?.restaurants?.[restaurant.id])
-      ? rawContent.reviews.restaurants[restaurant.id].map(normalizeLandingReviewItem)
-      : defaults.reviews.restaurants[restaurant.id];
-  });
-  return {
-    overview: rawContent?.overview && typeof rawContent.overview === 'object' ? cloneJsonCompatible(rawContent.overview, {}) : {},
-    hours: { restaurants: hoursRestaurants },
-    events: {
-      items: Array.isArray(rawContent?.events?.items) ? rawContent.events.items.map(normalizeLandingEventItem) : [],
-    },
-    news: {
-      items: Array.isArray(rawContent?.news?.items) ? rawContent.news.items.map(normalizeLandingNewsItem) : [],
-    },
-    reviews: {
-      restaurants: reviewRestaurants,
-    },
-  };
+  return LANDING_MODEL.normalizeContent(rawContent);
 }
 function normalizeLandingPageRecord(rawRecord = {}) {
   return LANDING_MODEL.normalizeRecord(rawRecord);

--- a/app.js
+++ b/app.js
@@ -3989,9 +3989,7 @@ async function upsertLandingPageRecordThroughApi(payload = {}, action = 'save_la
 }
 
 function formatLandingTimestampLabel(value) {
-  const ts = Number(value || 0);
-  if (!ts) return 'Not yet';
-  return formatUpdatedAt(ts);
+  return LANDING_MODEL.formatLandingTimestampLabel(value);
 }
 
 function getLandingSectionStatus(sectionId, record = _landingPageState) {

--- a/core/landing/admin-workspace.js
+++ b/core/landing/admin-workspace.js
@@ -1,0 +1,13 @@
+(function bootstrapLandingAdminWorkspaceModule(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+
+  modules.createLandingAdminWorkspaceService = function createLandingAdminWorkspaceService() {
+    return {};
+  };
+
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/core/landing/admin-workspace.js
+++ b/core/landing/admin-workspace.js
@@ -5,8 +5,855 @@
     ? globalScope.__HF_LANDING_MODULES__
     : {};
 
-  modules.createLandingAdminWorkspaceService = function createLandingAdminWorkspaceService() {
-    return {};
+  modules.createLandingAdminWorkspaceService = function createLandingAdminWorkspaceService(options = {}) {
+    const model = options.model && typeof options.model === 'object' ? options.model : null;
+    const store = options.store && typeof options.store === 'object' ? options.store : null;
+    const dataService = options.dataService && typeof options.dataService === 'object' ? options.dataService : null;
+    const document = options.document || globalScope.document || null;
+    const escHtml = typeof options.escHtml === 'function' ? options.escHtml : (value => String(value || ''));
+    const now = typeof options.now === 'function' ? options.now : (() => Date.now());
+    const showToast = typeof options.showToast === 'function' ? options.showToast : (() => {});
+    const hasAdminShell = typeof options.hasAdminShell === 'function' ? options.hasAdminShell : (() => false);
+    const hasRootShell = typeof options.hasRootShell === 'function' ? options.hasRootShell : (() => false);
+    const focusAdminPanel = typeof options.focusAdminPanel === 'function' ? options.focusAdminPanel : (() => {});
+    const syncLegacyStateFromStore = typeof options.syncLegacyStateFromStore === 'function'
+      ? options.syncLegacyStateFromStore
+      : (() => (store && typeof store.getRecord === 'function' ? store.getRecord() : null));
+    const getSectionFilter = typeof options.getSectionFilter === 'function'
+      ? options.getSectionFilter
+      : (() => ({ showArchived: false }));
+    const getVisibleItems = typeof options.getVisibleItems === 'function'
+      ? options.getVisibleItems
+      : (items => Array.isArray(items) ? items.slice() : []);
+    const sortEvents = typeof options.sortEvents === 'function' ? options.sortEvents : (items => Array.isArray(items) ? items.slice() : []);
+    const sortNews = typeof options.sortNews === 'function' ? options.sortNews : (items => Array.isArray(items) ? items.slice() : []);
+    const sortReviews = typeof options.sortReviews === 'function' ? options.sortReviews : (items => Array.isArray(items) ? items.slice() : []);
+    const renderEventCardHtml = typeof options.renderEventCardHtml === 'function' ? options.renderEventCardHtml : (() => '');
+    const renderNewsCardHtml = typeof options.renderNewsCardHtml === 'function' ? options.renderNewsCardHtml : (() => '');
+    const renderReviewCardHtml = typeof options.renderReviewCardHtml === 'function' ? options.renderReviewCardHtml : (() => '');
+    const renderHoursRowsHtml = typeof options.renderHoursRowsHtml === 'function' ? options.renderHoursRowsHtml : (() => '');
+    const knownRestaurants = typeof options.knownRestaurants === 'function' ? options.knownRestaurants : (() => []);
+    const restaurants = options.restaurants && typeof options.restaurants === 'object' ? options.restaurants : {};
+    const getTargetAccentClass = typeof options.getTargetAccentClass === 'function' ? options.getTargetAccentClass : (() => '');
+    const getSectionStatus = typeof options.getSectionStatus === 'function'
+      ? options.getSectionStatus
+      : ((sectionId, record) => {
+          const validation = model && typeof model.getSectionValidation === 'function'
+            ? model.getSectionValidation(sectionId, record)
+            : { valid: true, issues: [] };
+          return {
+            sectionId,
+            label: sectionId,
+            hasDraftDiff: false,
+            isValid: validation.valid,
+            issues: validation.issues || [],
+          };
+        });
+    const getDraftDiffSectionIds = typeof options.getDraftDiffSectionIds === 'function'
+      ? options.getDraftDiffSectionIds
+      : (() => []);
+    const formatTimestampLabel = typeof options.formatTimestampLabel === 'function'
+      ? options.formatTimestampLabel
+      : (() => 'Not yet');
+    const computeStatusForRestaurant = typeof options.computeStatusForRestaurant === 'function'
+      ? options.computeStatusForRestaurant
+      : (() => ({ label: '' }));
+    const syncHoursDraftFromDom = typeof options.syncHoursDraftFromDom === 'function'
+      ? options.syncHoursDraftFromDom
+      : (record => record);
+    const renderRootPage = typeof options.renderRootPage === 'function' ? options.renderRootPage : (() => {});
+    const normalizeRecord = typeof options.normalizeRecord === 'function'
+      ? options.normalizeRecord
+      : (record => (model && typeof model.normalizeRecord === 'function' ? model.normalizeRecord(record) : record));
+    const createDefaultRecord = typeof options.createDefaultRecord === 'function'
+      ? options.createDefaultRecord
+      : (() => (model && typeof model.createDefaultRecord === 'function' ? model.createDefaultRecord() : {}));
+    const validateEventsSection = typeof options.validateEventsSection === 'function'
+      ? options.validateEventsSection
+      : (section => (model && typeof model.validateEventsSection === 'function' ? model.validateEventsSection(section) : { valid: true, issues: [] }));
+    const validateNewsSection = typeof options.validateNewsSection === 'function'
+      ? options.validateNewsSection
+      : (section => (model && typeof model.validateNewsSection === 'function' ? model.validateNewsSection(section) : { valid: true, issues: [] }));
+    const validateReviewsSection = typeof options.validateReviewsSection === 'function'
+      ? options.validateReviewsSection
+      : (section => (model && typeof model.validateReviewsSection === 'function' ? model.validateReviewsSection(section) : { valid: true, issues: [] }));
+    const getHoursSectionValidation = typeof options.getHoursSectionValidation === 'function'
+      ? options.getHoursSectionValidation
+      : ((record) => (model && typeof model.getSectionValidation === 'function' ? model.getSectionValidation('hours', record) : { valid: true, issues: [] }));
+    const sectionOrder = Array.isArray(options.sectionOrder) ? options.sectionOrder.slice() : [];
+    const setPanelBadge = typeof options.setPanelBadge === 'function' ? options.setPanelBadge : (() => {});
+    const landingTargetBoth = options.landingTargetBoth || '';
+    const landingImportStatusImported = options.landingImportStatusImported || '';
+    const setSectionFilter = typeof options.setSectionFilter === 'function' ? options.setSectionFilter : null;
+    const scheduleTask = typeof options.setTimeout === 'function' ? options.setTimeout : globalScope.setTimeout;
+    const postApiJson = typeof options.postApiJson === 'function' ? options.postApiJson : null;
+    const getAuthorizedApiHeaders = typeof options.getAuthorizedApiHeaders === 'function'
+      ? options.getAuthorizedApiHeaders
+      : (() => ({}));
+    const getCurrentUser = typeof options.getCurrentUser === 'function'
+      ? options.getCurrentUser
+      : (() => null);
+
+    if (!model || !store || !dataService || !document) {
+      return {};
+    }
+
+    function getRecord(record) {
+      return normalizeRecord(record || store.getRecord() || createDefaultRecord());
+    }
+
+    function syncStoreRecord(record, options = {}) {
+      const normalized = getRecord(record);
+      store.setRecord(normalized, {
+        dirty: typeof options.dirty === 'boolean' ? options.dirty : store.isDirty(),
+        loadScope: 'draft',
+      });
+      syncLegacyStateFromStore();
+      return normalized;
+    }
+
+    function renderEventsPanel(record = store.getRecord()) {
+      const normalized = getRecord(record);
+      const bodyEl = document.getElementById('landing-events-panel-body');
+      const issuesEl = document.getElementById('landing-events-issues');
+      const validation = validateEventsSection(normalized.draftContent.events);
+      const filter = getSectionFilter('events');
+      const visibleItems = getVisibleItems(sortEvents(normalized.draftContent.events.items), filter.showArchived);
+      if (bodyEl) {
+        bodyEl.innerHTML = `
+      <div class="landing-admin-toolbar-row">
+        <button type="button" class="btn-small admin-console-primary-btn" onclick="addLandingEventDraft()">Add Event</button>
+        <label class="landing-admin-toggle">
+          <input type="checkbox" ${filter.showArchived ? 'checked' : ''} onchange="toggleLandingSectionArchivedFilter('events', this.checked)">
+          Show archived
+        </label>
+      </div>
+      ${visibleItems.length ? `<div class="landing-admin-editor-list">${visibleItems.map(item => renderEventCardHtml(item, normalized.liveContent.events)).join('')}</div>` : `
+        <article class="landing-admin-note">
+          <strong>No ${filter.showArchived ? '' : 'active '}events yet.</strong>
+          <p>Manual event cards live here. Add a night, tag the room, and publish the full section when it is ready.</p>
+        </article>`}
+    `;
+      }
+      if (issuesEl) {
+        issuesEl.innerHTML = validation.valid
+          ? ''
+          : validation.issues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
+      }
+      setPanelBadge('events', validation);
+      return normalized;
+    }
+
+    function renderNewsPanel(record = store.getRecord()) {
+      const normalized = getRecord(record);
+      const bodyEl = document.getElementById('landing-news-panel-body');
+      const issuesEl = document.getElementById('landing-news-issues');
+      const validation = validateNewsSection(normalized.draftContent.news);
+      const filter = getSectionFilter('news');
+      const visibleItems = getVisibleItems(sortNews(normalized.draftContent.news.items), filter.showArchived);
+      if (bodyEl) {
+        bodyEl.innerHTML = `
+      <div class="landing-admin-toolbar-row landing-admin-toolbar-row--stack">
+        <div class="landing-admin-import-row">
+          <select id="landing-news-import-target" class="landing-admin-input">
+            ${options.renderTargetOptionsHtml ? options.renderTargetOptionsHtml(options.landingTargetBoth || '', { includeBoth: true }) : ''}
+          </select>
+          <input id="landing-news-import-url" class="landing-admin-input landing-admin-input--grow" type="url" placeholder="Paste article URL to import" onpaste="handleLandingNewsImportPaste()">
+          <button type="button" class="btn-small admin-console-primary-btn" onclick="importLandingNewsDraft()">Import Story</button>
+        </div>
+        <label class="landing-admin-toggle">
+          <input type="checkbox" ${filter.showArchived ? 'checked' : ''} onchange="toggleLandingSectionArchivedFilter('news', this.checked)">
+          Show archived
+        </label>
+      </div>
+      ${visibleItems.length ? `<div class="landing-admin-editor-list">${visibleItems.map(item => renderNewsCardHtml(item, normalized.liveContent.news)).join('')}</div>` : `
+        <article class="landing-admin-note">
+          <strong>No ${filter.showArchived ? '' : 'active '}stories yet.</strong>
+          <p>Paste an article URL to create or refresh a draft news card. Missing fields stay editable in draft until the section is ready.</p>
+        </article>`}
+    `;
+      }
+      if (issuesEl) {
+        issuesEl.innerHTML = validation.valid
+          ? ''
+          : validation.issues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
+      }
+      setPanelBadge('news', validation);
+      return normalized;
+    }
+
+    function renderReviewsPanel(record = store.getRecord()) {
+      const normalized = getRecord(record);
+      const bodyEl = document.getElementById('landing-reviews-panel-body');
+      const issuesEl = document.getElementById('landing-reviews-issues');
+      const validation = validateReviewsSection(normalized.draftContent.reviews);
+      const filter = getSectionFilter('reviews');
+      if (bodyEl) {
+        bodyEl.innerHTML = `
+      <div class="landing-admin-toolbar-row">
+        <label class="landing-admin-toggle">
+          <input type="checkbox" ${filter.showArchived ? 'checked' : ''} onchange="toggleLandingSectionArchivedFilter('reviews', this.checked)">
+          Show archived
+        </label>
+      </div>
+      <div class="landing-admin-review-lanes">
+        ${knownRestaurants().map(restaurant => {
+          const items = getVisibleItems(sortReviews(normalized.draftContent.reviews.restaurants[restaurant.id]), filter.showArchived);
+          return `
+            <section class="landing-admin-review-lane">
+              <div class="landing-admin-review-lane-head">
+                <div>
+                  <p class="settings-section-kicker">${escHtml(restaurant.name)}</p>
+                  <h5>${escHtml(restaurant.name)}</h5>
+                </div>
+                <span class="landing-tag ${getTargetAccentClass(restaurant.id)}">${escHtml(items.length)} draft</span>
+              </div>
+              <div class="landing-admin-import-row">
+                <input id="landing-review-import-url-${escHtml(restaurant.id)}" class="landing-admin-input landing-admin-input--grow" type="url" placeholder="Paste Google review URL" onpaste="handleLandingReviewImportPaste(${options.escAttrJs ? options.escAttrJs(restaurant.id) : JSON.stringify(String(restaurant.id))})">
+                <button type="button" class="btn-small admin-console-primary-btn" onclick="importLandingReviewDraft(${options.escAttrJs ? options.escAttrJs(restaurant.id) : JSON.stringify(String(restaurant.id))})">Import Review</button>
+              </div>
+              ${items.length ? `<div class="landing-admin-editor-list">${items.map(item => renderReviewCardHtml(item, restaurant.id, normalized.liveContent.reviews.restaurants[restaurant.id])).join('')}</div>` : `
+                <article class="landing-admin-note">
+                  <strong>No ${filter.showArchived ? '' : 'active '}reviews yet.</strong>
+                  <p>Imported Google reviews stay frozen as draft snapshots until you explicitly refresh and republish them.</p>
+                </article>`}
+            </section>`;
+        }).join('')}
+      </div>
+    `;
+      }
+      if (issuesEl) {
+        issuesEl.innerHTML = validation.valid
+          ? ''
+          : validation.issues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
+      }
+      setPanelBadge('reviews', validation);
+      return normalized;
+    }
+
+    function renderOverview(record = store.getRecord()) {
+      const normalized = getRecord(record);
+      const diffSectionIds = getDraftDiffSectionIds(normalized);
+      const statuses = ['hours', 'events', 'news', 'reviews'].map(sectionId => getSectionStatus(sectionId, normalized));
+      const blockingIssues = statuses.flatMap(status => status.issues || []);
+      const allValid = statuses.every(status => status.isValid);
+      const rootStatusEl = document.getElementById('landing-overview-root-status');
+      const rootCopyEl = document.getElementById('landing-overview-root-copy');
+      const draftSavedEl = document.getElementById('landing-overview-draft-saved');
+      const draftCopyEl = document.getElementById('landing-overview-draft-copy');
+      const livePublishedEl = document.getElementById('landing-overview-live-published');
+      const liveCopyEl = document.getElementById('landing-overview-live-copy');
+      const heroLinesEl = document.getElementById('landing-overview-hero-lines');
+      const heroCopyEl = document.getElementById('landing-overview-hero-copy');
+      const listEl = document.getElementById('landing-overview-section-list');
+      const issuesEl = document.getElementById('landing-overview-issues');
+      const healthBadgeEl = document.getElementById('landing-overview-health-badge');
+      const leroysStatus = restaurants.LEROYS ? computeStatusForRestaurant(normalized.liveContent.hours, restaurants.LEROYS.id) : { label: '' };
+      const elroysStatus = restaurants.ELROYS ? computeStatusForRestaurant(normalized.liveContent.hours, restaurants.ELROYS.id) : { label: '' };
+
+      if (rootStatusEl) rootStatusEl.textContent = store.getLoadError() ? 'Fallback ready' : 'Live shell ready';
+      if (rootCopyEl) {
+        rootCopyEl.textContent = store.getLoadError()
+          ? 'The public root can fall back to the simple chooser if landing data fails.'
+          : 'The richer root shell can render from the published landing-page snapshot.';
+      }
+      if (draftSavedEl) draftSavedEl.textContent = formatTimestampLabel(normalized.draftSavedTs);
+      if (draftCopyEl) {
+        draftCopyEl.textContent = diffSectionIds.length
+          ? `${diffSectionIds.length} subsection draft${diffSectionIds.length === 1 ? '' : 's'} differ from live.`
+          : 'Draft and live are currently aligned.';
+      }
+      if (livePublishedEl) livePublishedEl.textContent = formatTimestampLabel(normalized.livePublishedTs);
+      if (liveCopyEl) {
+        liveCopyEl.textContent = normalized.livePublishedTs
+          ? 'Publish promotes only the sections you select.'
+          : 'No landing-page sections have been published live yet.';
+      }
+      if (heroLinesEl) heroLinesEl.textContent = `${leroysStatus.label || ''} / ${elroysStatus.label || ''}`;
+      if (heroCopyEl) heroCopyEl.textContent = 'These public hero lines are generated from the live recurring-hours schedules.';
+      if (healthBadgeEl) {
+        healthBadgeEl.textContent = allValid ? 'Healthy' : 'Needs attention';
+        healthBadgeEl.className = `landing-admin-section-badge ${allValid ? 'is-ready' : 'is-blocked'}`;
+      }
+      if (listEl) {
+        listEl.innerHTML = sectionOrder.map(sectionId => {
+          const status = getSectionStatus(sectionId, normalized);
+          const badgeClass = status.isValid ? 'is-ready' : 'is-blocked';
+          const badgeText = !status.isValid ? 'Blocked' : (status.hasDraftDiff ? 'Drafting' : 'Live');
+          const description = status.hasDraftDiff
+            ? 'Draft differs from the currently published snapshot.'
+            : 'Draft and live match right now.';
+          return `
+        <article class="landing-overview-section-item">
+          <div>
+            <strong>${escHtml(status.label)}</strong>
+            <span>${escHtml(description)}</span>
+          </div>
+          <span class="landing-admin-section-badge ${badgeClass}">${escHtml(badgeText)}</span>
+        </article>`;
+        }).join('');
+      }
+      if (issuesEl) {
+        issuesEl.innerHTML = allValid
+          ? ''
+          : blockingIssues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
+      }
+      return normalized;
+    }
+
+    function renderHoursValidationState(record = store.getRecord()) {
+      const normalized = getRecord(record);
+      const issuesEl = document.getElementById('landing-hours-issues');
+      const badgeEl = document.getElementById('landing-hours-panel-badge');
+      const validation = getHoursSectionValidation(normalized);
+
+      if (issuesEl) {
+        issuesEl.innerHTML = validation.valid
+          ? ''
+          : validation.issues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
+      }
+      if (badgeEl) {
+        badgeEl.textContent = validation.valid ? 'Ready' : 'Blocked';
+        badgeEl.className = `landing-admin-section-badge ${validation.valid ? 'is-ready' : 'is-blocked'}`;
+      }
+      return normalized;
+    }
+
+    function updateToolbar(record = store.getRecord()) {
+      const normalized = getRecord(record);
+      const diffSectionIds = getDraftDiffSectionIds(normalized);
+      const draftButton = document.getElementById('landing-save-draft-btn');
+      const publishButton = document.getElementById('landing-publish-btn');
+      const livePill = document.getElementById('landing-admin-live-pill');
+      const draftPill = document.getElementById('landing-admin-draft-pill');
+      const noteEl = document.getElementById('landing-admin-toolbar-note');
+
+      if (draftButton) draftButton.disabled = !store.isDirty();
+      if (publishButton) publishButton.disabled = diffSectionIds.length === 0;
+
+      if (livePill) {
+        livePill.textContent = normalized.livePublishedTs
+          ? `Live ${formatTimestampLabel(normalized.livePublishedTs)}`
+          : 'Live shell pending';
+        livePill.className = `landing-admin-status-pill ${normalized.livePublishedTs ? 'is-live' : ''}`;
+      }
+      if (draftPill) {
+        const draftText = store.isDirty()
+          ? 'Unsaved draft changes'
+          : (diffSectionIds.length ? `${diffSectionIds.length} draft sections ready` : 'No draft changes');
+        draftPill.textContent = draftText;
+        draftPill.className = `landing-admin-status-pill ${store.isDirty() || diffSectionIds.length ? 'is-draft' : ''}`;
+      }
+      if (noteEl) {
+        noteEl.textContent = store.getLoadError()
+          ? store.getLoadError()
+          : (store.isDirty()
+              ? 'Save Draft stores the shared landing snapshot without changing the public root.'
+              : (diffSectionIds.length
+                  ? 'Publish Live promotes only the subsections you select.'
+                  : 'Landing-page draft and live snapshots are currently aligned.'));
+      }
+      return normalized;
+    }
+
+    function renderHoursPanel(record = store.getRecord()) {
+      const normalized = getRecord(record);
+      const gridEl = document.getElementById('landing-admin-hours-grid');
+      if (gridEl) {
+        gridEl.innerHTML = knownRestaurants().map(restaurant => (
+          renderHoursRowsHtml(normalized.draftContent.hours, restaurant.id, restaurant.name)
+        )).join('');
+      }
+      renderHoursValidationState(normalized);
+      return normalized;
+    }
+
+    function renderWorkspace(options = {}) {
+      if (!hasAdminShell()) return null;
+      const forceReload = options && options.forceReload === true;
+      const render = (record) => {
+        const normalized = syncStoreRecord(record, { dirty: store.isDirty() });
+        renderOverview(normalized);
+        renderHoursPanel(normalized);
+        renderEventsPanel(normalized);
+        renderNewsPanel(normalized);
+        renderReviewsPanel(normalized);
+        updateToolbar(normalized);
+        focusAdminPanel(store.getActivePanel());
+        return normalized;
+      };
+
+      if (store.hasLoaded({ includeDraft: true }) && !forceReload) {
+        return render(store.getRecord());
+      }
+
+      updateToolbar(createDefaultRecord());
+      return dataService.ensureLoaded({ force: forceReload, includeDraft: true })
+        .then(render)
+        .catch(() => {
+          const fallbackRecord = store.getRecord() || createDefaultRecord();
+          syncStoreRecord(fallbackRecord, { dirty: false });
+          return render(fallbackRecord);
+        });
+    }
+
+    function refreshHoursAdminState(record = store.getRecord()) {
+      const normalized = syncStoreRecord(record, { dirty: store.isDirty() });
+      renderOverview(normalized);
+      renderHoursValidationState(normalized);
+      updateToolbar(normalized);
+      return normalized;
+    }
+
+    function setHoursField(restaurantId, dayKey, field, value) {
+      const record = updateDraftRecord(nextRecord => {
+        if (!nextRecord.draftContent.hours.restaurants[restaurantId]) {
+          nextRecord.draftContent.hours.restaurants[restaurantId] = options.createDefaultHoursRestaurant
+            ? options.createDefaultHoursRestaurant()
+            : { days: {} };
+        }
+        const targetDay = nextRecord.draftContent.hours.restaurants[restaurantId].days[dayKey] || (
+          options.createDefaultDay ? options.createDefaultDay() : { closed: true, open: '', close: '' }
+        );
+        if (field === 'closed') {
+          targetDay.closed = !!value;
+          if (targetDay.closed) {
+            targetDay.open = '';
+            targetDay.close = '';
+          }
+        } else if (field === 'open' || field === 'close') {
+          targetDay[field] = typeof model.normalizeTimeValue === 'function' ? model.normalizeTimeValue(value) : value;
+          if (targetDay[field]) targetDay.closed = false;
+        }
+        nextRecord.draftContent.hours.restaurants[restaurantId].days[dayKey] = options.normalizeDay
+          ? options.normalizeDay(targetDay)
+          : targetDay;
+      }, { rerender: false });
+      if (field === 'closed') {
+        renderWorkspace();
+        return record;
+      }
+      refreshHoursAdminState(record);
+      return record;
+    }
+
+    function updateDraftRecord(mutator = () => {}, options = {}) {
+      const rerender = options && options.rerender !== false;
+      const record = store.updateRecord(mutator, { dirty: true, loadScope: 'draft' });
+      syncLegacyStateFromStore();
+      if (rerender) renderWorkspace();
+      return record;
+    }
+
+    function findItemById(items = [], itemId = '') {
+      return Array.isArray(items) ? items.find(item => item && item.id === itemId) || null : null;
+    }
+
+    function markItemUpdated(item = {}) {
+      item.updatedAt = String(now());
+      return item;
+    }
+
+    function findNewsItemByUrl(items = [], url = '') {
+      const candidate = String(url || '').trim();
+      if (!candidate) return null;
+      return items.find(item => (
+        item && (item.href === candidate || item.importMeta?.sourceUrl === candidate)
+      )) || null;
+    }
+
+    function findReviewItemByUrl(items = [], url = '') {
+      const candidate = String(url || '').trim();
+      if (!candidate) return null;
+      return items.find(item => (
+        item && (item.href === candidate || item.importMeta?.sourceUrl === candidate)
+      )) || null;
+    }
+
+    function applyImportMeta(currentMeta = {}, result = {}) {
+      const attemptedAt = result && result.attemptedAt ? String(result.attemptedAt) : String(now());
+      const nextStatus = result && result.status ? result.status : options.landingImportStatusFailed || 'failed';
+      const wasSuccessful = nextStatus === landingImportStatusImported || nextStatus === (options.landingImportStatusPartial || 'partial');
+      return typeof model.normalizeImportMeta === 'function'
+        ? model.normalizeImportMeta({
+            ...currentMeta,
+            sourceUrl: result && (result.sourceUrl || result.href) || currentMeta?.sourceUrl || '',
+            lastAttemptTs: attemptedAt,
+            lastSuccessTs: wasSuccessful ? attemptedAt : currentMeta?.lastSuccessTs,
+            status: nextStatus,
+            messages: Array.isArray(result && result.messages) ? result.messages : currentMeta?.messages,
+          })
+        : currentMeta;
+    }
+
+    async function requestImport(kind = 'import_news', payload = {}) {
+      const currentUser = getCurrentUser();
+      if (!currentUser?.accessToken || typeof postApiJson !== 'function') {
+        throw new Error('Sign in as an admin to import landing-page content.');
+      }
+      const result = await postApiJson('/api/admin', {
+        action: kind,
+        ...payload,
+      }, {
+        headers: getAuthorizedApiHeaders(),
+      });
+      if (!result.ok) throw new Error(result.payload?.error || result.payload?.message || 'Import failed.');
+      return result.payload || {};
+    }
+
+    function upsertNewsDraftFromImport(target = landingTargetBoth, result = {}) {
+      const sourceUrl = String(result?.sourceUrl || result?.href || '').trim();
+      return updateDraftRecord(record => {
+        const items = record.draftContent.news.items;
+        const existing = findNewsItemByUrl(items, sourceUrl);
+        const base = existing || (typeof model.createDefaultNewsItem === 'function' ? model.createDefaultNewsItem() : {});
+        const nextItem = typeof model.normalizeNewsItem === 'function'
+          ? model.normalizeNewsItem({
+              ...base,
+              target: existing?.target || (typeof model.normalizeTarget === 'function' ? model.normalizeTarget(target, { allowBoth: true }) : target),
+              title: result?.title || base.title,
+              body: result?.body || base.body,
+              href: result?.href || sourceUrl || base.href,
+              source: result?.source || base.source,
+              publishedDate: result?.publishedDate || base.publishedDate,
+              imageUrl: result?.imageUrl || base.imageUrl,
+              importMeta: applyImportMeta(base.importMeta, result),
+              updatedAt: String(now()),
+            })
+          : base;
+        if (existing) {
+          const index = items.findIndex(item => item.id === existing.id);
+          if (index >= 0) items[index] = nextItem;
+        } else {
+          items.unshift(nextItem);
+        }
+      });
+    }
+
+    function upsertReviewDraftFromImport(restaurantId = '', result = {}) {
+      return updateDraftRecord(record => {
+        if (!record.draftContent.reviews.restaurants[restaurantId]) {
+          record.draftContent.reviews.restaurants[restaurantId] = [];
+        }
+        const items = record.draftContent.reviews.restaurants[restaurantId];
+        const sourceUrl = String(result?.sourceUrl || result?.href || '').trim();
+        const existing = findReviewItemByUrl(items, sourceUrl);
+        const base = existing || (typeof model.createDefaultReviewItem === 'function' ? model.createDefaultReviewItem() : {});
+        const nextItem = typeof model.normalizeReviewItem === 'function'
+          ? model.normalizeReviewItem({
+              ...base,
+              href: result?.href || sourceUrl || base.href,
+              author: result?.author || base.author,
+              quote: result?.quote || base.quote,
+              source: result?.source || base.source || 'Google Review',
+              rating: result?.rating || base.rating,
+              importMeta: applyImportMeta(base.importMeta, result),
+              updatedAt: String(now()),
+            })
+          : base;
+        if (existing) {
+          const index = items.findIndex(item => item.id === existing.id);
+          if (index >= 0) items[index] = nextItem;
+        } else {
+          items.unshift(nextItem);
+        }
+      });
+    }
+
+    function addEventDraft() {
+      return updateDraftRecord(record => {
+        record.draftContent.events.items.unshift({
+          ...(typeof model.createDefaultEventItem === 'function' ? model.createDefaultEventItem() : {}),
+          updatedAt: String(now()),
+        });
+      });
+    }
+
+    function updateEventField(itemId = '', field = '', value = '') {
+      return updateDraftRecord(record => {
+        const item = findItemById(record.draftContent.events.items, itemId);
+        if (!item) return;
+        if (field === 'target') item.target = typeof model.normalizeTarget === 'function' ? model.normalizeTarget(value, { allowBoth: true }) : value;
+        else if (field === 'eventDate') item.eventDate = String(value || '');
+        else if (field === 'startTime' || field === 'endTime') item[field] = typeof model.normalizeTimeValue === 'function' ? model.normalizeTimeValue(value) : value;
+        else item[field] = typeof value === 'string' ? value : '';
+        if (field === 'endTime' && item.endTime) item.timingNote = '';
+        markItemUpdated(item);
+      });
+    }
+
+    function toggleEventArchived(itemId = '', archived = false) {
+      return updateDraftRecord(record => {
+        const item = findItemById(record.draftContent.events.items, itemId);
+        if (!item) return;
+        item.archived = !!archived;
+        item.archivedAt = archived ? String(now()) : '';
+        markItemUpdated(item);
+      });
+    }
+
+    function updateNewsField(itemId = '', field = '', value = '') {
+      return updateDraftRecord(record => {
+        const item = findItemById(record.draftContent.news.items, itemId);
+        if (!item) return;
+        if (field === 'target') item.target = typeof model.normalizeTarget === 'function' ? model.normalizeTarget(value, { allowBoth: true }) : value;
+        else item[field] = typeof value === 'string' ? value : '';
+        if (field === 'href' && !item.importMeta?.sourceUrl) {
+          item.importMeta = typeof model.normalizeImportMeta === 'function'
+            ? model.normalizeImportMeta({ ...item.importMeta, sourceUrl: item.href })
+            : item.importMeta;
+        }
+        markItemUpdated(item);
+      });
+    }
+
+    function toggleNewsArchived(itemId = '', archived = false) {
+      return updateDraftRecord(record => {
+        const item = findItemById(record.draftContent.news.items, itemId);
+        if (!item) return;
+        item.archived = !!archived;
+        item.archivedAt = archived ? String(now()) : '';
+        markItemUpdated(item);
+      });
+    }
+
+    function updateReviewField(restaurantId = '', itemId = '', field = '', value = '') {
+      return updateDraftRecord(record => {
+        const items = record.draftContent.reviews.restaurants[restaurantId] || [];
+        const item = findItemById(items, itemId);
+        if (!item) return;
+        if (field === 'rating') item.rating = value ? String(Number(value)) : '';
+        else item[field] = typeof value === 'string' ? value : '';
+        if (field === 'href' && !item.importMeta?.sourceUrl) {
+          item.importMeta = typeof model.normalizeImportMeta === 'function'
+            ? model.normalizeImportMeta({ ...item.importMeta, sourceUrl: item.href })
+            : item.importMeta;
+        }
+        markItemUpdated(item);
+      });
+    }
+
+    function toggleReviewArchived(restaurantId = '', itemId = '', archived = false) {
+      return updateDraftRecord(record => {
+        const items = record.draftContent.reviews.restaurants[restaurantId] || [];
+        const item = findItemById(items, itemId);
+        if (!item) return;
+        item.archived = !!archived;
+        item.archivedAt = archived ? String(now()) : '';
+        markItemUpdated(item);
+      });
+    }
+
+    function toggleSectionArchivedFilter(sectionId = '', checked = false) {
+      if (typeof setSectionFilter === 'function') {
+        setSectionFilter(sectionId, 'showArchived', checked);
+      }
+      return renderWorkspace();
+    }
+
+    function handleNewsImportPaste() {
+      if (typeof scheduleTask === 'function') {
+        scheduleTask(() => {
+          importNewsDraft();
+        }, 0);
+      }
+    }
+
+    function handleReviewImportPaste(restaurantId = '') {
+      if (typeof scheduleTask === 'function') {
+        scheduleTask(() => {
+          importReviewDraft(restaurantId);
+        }, 0);
+      }
+    }
+
+    async function importNewsDraft() {
+      const targetSelect = document.getElementById('landing-news-import-target');
+      const urlInput = document.getElementById('landing-news-import-url');
+      const target = targetSelect && targetSelect.value ? targetSelect.value : landingTargetBoth;
+      const url = String(urlInput && urlInput.value || '').trim();
+      if (!url || typeof requestImport !== 'function' || typeof upsertNewsDraftFromImport !== 'function') return;
+      try {
+        const result = await requestImport('import_news', { url: url, target: target });
+        upsertNewsDraftFromImport(target, result);
+        if (urlInput) urlInput.value = '';
+        showToast(`✅ ${result && result.status === landingImportStatusImported ? 'Imported' : 'Imported with repairs needed'} news draft.`, 'success');
+      } catch (error) {
+        showToast(`⚠️ ${error && error.message ? error.message : 'News import failed.'}`, 'error');
+      }
+    }
+
+    async function refreshNewsItem(itemId = '') {
+      const record = getRecord(store.getRecord() || createDefaultRecord());
+      const item = findItemById(record.draftContent.news.items, itemId);
+      const sourceUrl = String(item && item.importMeta && item.importMeta.sourceUrl || item && item.href || '').trim();
+      if (!item || !sourceUrl || typeof requestImport !== 'function' || typeof upsertNewsDraftFromImport !== 'function') {
+        showToast('⚠️ Add an article URL before refreshing this story.', 'error');
+        return;
+      }
+      try {
+        const result = await requestImport('import_news', { url: sourceUrl, target: item.target });
+        upsertNewsDraftFromImport(item.target, result);
+        showToast('✅ News draft refreshed.', 'success');
+      } catch (error) {
+        showToast(`⚠️ ${error && error.message ? error.message : 'News refresh failed.'}`, 'error');
+      }
+    }
+
+    async function importReviewDraft(restaurantId = '') {
+      const urlInput = document.getElementById(`landing-review-import-url-${restaurantId}`);
+      const url = String(urlInput && urlInput.value || '').trim();
+      if (!url || typeof requestImport !== 'function' || typeof upsertReviewDraftFromImport !== 'function') return;
+      try {
+        const result = await requestImport('import_review', { url: url, restaurantId: restaurantId });
+        upsertReviewDraftFromImport(restaurantId, result);
+        if (urlInput) urlInput.value = '';
+        showToast(`✅ ${result && result.status === landingImportStatusImported ? 'Imported' : 'Imported with repairs needed'} review draft.`, 'success');
+      } catch (error) {
+        showToast(`⚠️ ${error && error.message ? error.message : 'Review import failed.'}`, 'error');
+      }
+    }
+
+    async function refreshReviewItem(restaurantId = '', itemId = '') {
+      const record = getRecord(store.getRecord() || createDefaultRecord());
+      const item = findItemById(record.draftContent.reviews.restaurants[restaurantId] || [], itemId);
+      const sourceUrl = String(item && item.importMeta && item.importMeta.sourceUrl || item && item.href || '').trim();
+      if (!item || !sourceUrl || typeof requestImport !== 'function' || typeof upsertReviewDraftFromImport !== 'function') {
+        showToast('⚠️ Add a review URL before refreshing this review.', 'error');
+        return;
+      }
+      try {
+        const result = await requestImport('import_review', { url: sourceUrl, restaurantId: restaurantId });
+        upsertReviewDraftFromImport(restaurantId, result);
+        showToast('✅ Review draft refreshed.', 'success');
+      } catch (error) {
+        showToast(`⚠️ ${error && error.message ? error.message : 'Review refresh failed.'}`, 'error');
+      }
+    }
+
+    async function saveDraft() {
+      try {
+        const record = getRecord(syncHoursDraftFromDom(store.getRecord()) || await dataService.ensureLoaded({ includeDraft: true }));
+        await dataService.saveDraft(record, now());
+        syncLegacyStateFromStore();
+        renderWorkspace();
+        showToast('✅ Landing page draft saved.', 'success');
+      } catch (error) {
+        showToast(`⚠️ ${error && error.message ? error.message : 'Landing page draft save failed.'}`, 'error');
+      }
+    }
+
+    function renderPublishModal() {
+      const modalEl = document.getElementById('landing-publish-modal');
+      const listEl = document.getElementById('landing-publish-list');
+      const issuesEl = document.getElementById('landing-publish-issues');
+      const confirmButton = document.getElementById('landing-publish-confirm-btn');
+      if (!modalEl || !listEl || !issuesEl || !confirmButton) return null;
+      const record = getRecord(syncHoursDraftFromDom(store.getRecord()) || store.getRecord() || createDefaultRecord());
+      const statuses = sectionOrder.map(sectionId => getSectionStatus(sectionId, record));
+      const publishableCount = statuses.filter(status => status.hasDraftDiff && status.isValid).length;
+      listEl.innerHTML = statuses.map(status => {
+        const disabled = !status.hasDraftDiff || !status.isValid;
+        const badgeClass = status.isValid ? 'is-ready' : 'is-blocked';
+        const badgeText = !status.isValid ? 'Blocked' : (status.hasDraftDiff ? 'Ready' : 'Live');
+        const helpText = !status.hasDraftDiff
+          ? 'Draft and live match right now.'
+          : (status.isValid ? 'Draft is ready to promote.' : 'Fix the validation issue before publishing.');
+        return `
+      <label class="landing-publish-option">
+        <input type="checkbox" data-landing-publish-section="${escHtml(status.sectionId)}" ${disabled ? 'disabled' : 'checked'}>
+        <div>
+          <strong>${escHtml(status.label)}</strong>
+          <p>${escHtml(helpText)}</p>
+        </div>
+        <span class="landing-admin-section-badge ${badgeClass}">${escHtml(badgeText)}</span>
+      </label>`;
+      }).join('');
+      issuesEl.innerHTML = statuses
+        .filter(status => !status.isValid)
+        .flatMap(status => status.issues || [])
+        .map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`)
+        .join('');
+      confirmButton.disabled = publishableCount === 0;
+      return record;
+    }
+
+    function openPublishModal() {
+      if (!hasAdminShell()) return;
+      renderPublishModal();
+      const modalEl = document.getElementById('landing-publish-modal');
+      if (!modalEl) return;
+      modalEl.classList.add('is-open');
+      modalEl.setAttribute('aria-hidden', 'false');
+    }
+
+    function closePublishModal() {
+      const modalEl = document.getElementById('landing-publish-modal');
+      if (!modalEl) return;
+      modalEl.classList.remove('is-open');
+      modalEl.setAttribute('aria-hidden', 'true');
+    }
+
+    async function publishSections() {
+      const selectedSectionIds = Array.from(document.querySelectorAll('[data-landing-publish-section]:checked'))
+        .map(input => input.getAttribute('data-landing-publish-section'))
+        .filter(Boolean);
+      if (!selectedSectionIds.length) {
+        showToast('Select at least one landing-page subsection to publish.', 'info');
+        return;
+      }
+      try {
+        const currentRecord = getRecord(syncHoursDraftFromDom(store.getRecord()) || await dataService.ensureLoaded({ includeDraft: true }));
+        const blockedSection = selectedSectionIds
+          .map(sectionId => getSectionStatus(sectionId, currentRecord))
+          .find(status => !status.isValid);
+        if (blockedSection) {
+          renderPublishModal();
+          showToast(`⚠️ Fix ${String(blockedSection.label || blockedSection.sectionId).toLowerCase()} before publishing it live.`, 'error');
+          return;
+        }
+        await dataService.publishSections(currentRecord, selectedSectionIds, now());
+        syncLegacyStateFromStore();
+        renderWorkspace();
+        if (hasRootShell()) renderRootPage(store.getRecord());
+        closePublishModal();
+        showToast(`✅ Published ${selectedSectionIds.length} landing-page section${selectedSectionIds.length === 1 ? '' : 's'} live.`, 'success');
+      } catch (error) {
+        showToast(`⚠️ ${error && error.message ? error.message : 'Landing page publish failed.'}`, 'error');
+      }
+    }
+
+    return {
+      renderEventsPanel: renderEventsPanel,
+      renderNewsPanel: renderNewsPanel,
+      renderReviewsPanel: renderReviewsPanel,
+      renderOverview: renderOverview,
+      renderHoursValidationState: renderHoursValidationState,
+      updateToolbar: updateToolbar,
+      renderHoursPanel: renderHoursPanel,
+      renderWorkspace: renderWorkspace,
+      setHoursField: setHoursField,
+      updateDraftRecord: updateDraftRecord,
+      addEventDraft: addEventDraft,
+      updateEventField: updateEventField,
+      toggleEventArchived: toggleEventArchived,
+      updateNewsField: updateNewsField,
+      toggleNewsArchived: toggleNewsArchived,
+      updateReviewField: updateReviewField,
+      toggleReviewArchived: toggleReviewArchived,
+      toggleSectionArchivedFilter: toggleSectionArchivedFilter,
+      handleNewsImportPaste: handleNewsImportPaste,
+      handleReviewImportPaste: handleReviewImportPaste,
+      importNewsDraft: importNewsDraft,
+      refreshNewsItem: refreshNewsItem,
+      importReviewDraft: importReviewDraft,
+      refreshReviewItem: refreshReviewItem,
+      saveDraft: saveDraft,
+      renderPublishModal: renderPublishModal,
+      openPublishModal: openPublishModal,
+      closePublishModal: closePublishModal,
+      publishSections: publishSections,
+    };
   };
 
   globalScope.__HF_LANDING_MODULES__ = modules;

--- a/core/landing/data-service.js
+++ b/core/landing/data-service.js
@@ -1,0 +1,13 @@
+(function bootstrapLandingDataServiceModule(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+
+  modules.createLandingDataService = function createLandingDataService() {
+    return {};
+  };
+
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/core/landing/data-service.js
+++ b/core/landing/data-service.js
@@ -5,8 +5,86 @@
     ? globalScope.__HF_LANDING_MODULES__
     : {};
 
-  modules.createLandingDataService = function createLandingDataService() {
-    return {};
+  modules.createLandingDataService = function createLandingDataService(options = {}) {
+    const model = (options.model && typeof options.model === 'object')
+      ? options.model
+      : (modules.createLandingModel ? modules.createLandingModel() : null);
+    const store = options.store && typeof options.store === 'object'
+      ? options.store
+      : (modules.createLandingStore ? modules.createLandingStore({ model }) : null);
+    const fetchRecord = typeof options.fetchRecord === 'function' ? options.fetchRecord : null;
+    const upsertRecord = typeof options.upsertRecord === 'function' ? options.upsertRecord : null;
+
+    if (!model || typeof model.normalizeRecord !== 'function' || typeof model.applySectionPublish !== 'function') {
+      throw new Error('Landing data service requires a landing model.');
+    }
+    if (!store || typeof store.getRecord !== 'function' || typeof store.setRecord !== 'function') {
+      throw new Error('Landing data service requires a landing store.');
+    }
+    if (!fetchRecord || !upsertRecord) {
+      throw new Error('Landing data service requires fetchRecord and upsertRecord ports.');
+    }
+
+    return {
+      ensureLoaded(options = {}) {
+        const force = options.force === true;
+        if (!force && store.hasLoaded()) return store.getRecord();
+        if (!force && store.getLoadPromise()) return store.getLoadPromise();
+
+        const loadPromise = (async () => {
+          try {
+            const record = await fetchRecord(options);
+            store.setLoadError('');
+            store.setRecord(record, { dirty: false, loaded: true });
+            store.setDirty(false);
+            return store.getRecord();
+          } catch (error) {
+            store.setLoadError(error && error.message ? error.message : 'Landing page state could not be loaded.');
+            throw error;
+          } finally {
+            store.setLoadPromise(null);
+          }
+        })();
+
+        store.setLoadPromise(loadPromise);
+        return loadPromise;
+      },
+
+      async saveDraft(record, timestamp) {
+        const normalized = model.normalizeRecord(record || store.getRecord());
+        const savedAt = Number(timestamp) || Date.now();
+        const persistedRecord = await upsertRecord({
+          draft_content: normalized.draftContent,
+          live_content: normalized.liveContent,
+          draft_saved_ts: savedAt,
+          live_published_ts: normalized.livePublishedTs ? Number(normalized.livePublishedTs) : null,
+        }, 'save_landing_page_draft');
+        store.setRecord(persistedRecord, { dirty: false, loaded: true });
+        store.setDirty(false);
+        store.setLoadError('');
+        return store.getRecord();
+      },
+
+      async publishSections(record, selectedSectionIds, timestamp) {
+        const normalized = model.normalizeRecord(record || store.getRecord());
+        const publishedRecord = model.applySectionPublish(normalized, selectedSectionIds);
+        const publishedAt = Number(timestamp) || Date.now();
+        const persistedRecord = await upsertRecord({
+          draft_content: normalized.draftContent,
+          live_content: publishedRecord.liveContent,
+          draft_saved_ts: normalized.draftSavedTs ? Number(normalized.draftSavedTs) : null,
+          live_published_ts: publishedAt,
+        }, 'publish_landing_sections');
+        store.setRecord({
+          ...persistedRecord,
+          liveContent: publishedRecord.liveContent,
+          livePublishedTs: String(publishedAt),
+        }, { dirty: false, loaded: true });
+        store.setDirty(false);
+        store.setLoadError('');
+        return store.getRecord();
+      },
+    };
   };
 
   globalScope.__HF_LANDING_MODULES__ = modules;

--- a/core/landing/data-service.js
+++ b/core/landing/data-service.js
@@ -28,25 +28,29 @@
     return {
       ensureLoaded(options = {}) {
         const force = options.force === true;
-        if (!force && store.hasLoaded()) return store.getRecord();
-        if (!force && store.getLoadPromise()) return store.getLoadPromise();
+        if (!force && store.hasLoaded(options)) return store.getRecord();
+        if (!force && store.getLoadPromise(options)) return store.getLoadPromise(options);
 
         const loadPromise = (async () => {
           try {
             const record = await fetchRecord(options);
             store.setLoadError('');
-            store.setRecord(record, { dirty: false, loaded: true });
+            store.setRecord(record, {
+              dirty: false,
+              loaded: true,
+              loadScope: options.includeDraft === true ? 'draft' : 'live',
+            });
             store.setDirty(false);
             return store.getRecord();
           } catch (error) {
             store.setLoadError(error && error.message ? error.message : 'Landing page state could not be loaded.');
             throw error;
           } finally {
-            store.setLoadPromise(null);
+            store.setLoadPromise(null, options);
           }
         })();
 
-        store.setLoadPromise(loadPromise);
+        store.setLoadPromise(loadPromise, options);
         return loadPromise;
       },
 
@@ -59,7 +63,7 @@
           draft_saved_ts: savedAt,
           live_published_ts: normalized.livePublishedTs ? Number(normalized.livePublishedTs) : null,
         }, 'save_landing_page_draft');
-        store.setRecord(persistedRecord, { dirty: false, loaded: true });
+        store.setRecord(persistedRecord, { dirty: false, loaded: true, loadScope: 'draft' });
         store.setDirty(false);
         store.setLoadError('');
         return store.getRecord();
@@ -79,7 +83,7 @@
           ...persistedRecord,
           liveContent: publishedRecord.liveContent,
           livePublishedTs: String(publishedAt),
-        }, { dirty: false, loaded: true });
+        }, { dirty: false, loaded: true, loadScope: 'draft' });
         store.setDirty(false);
         store.setLoadError('');
         return store.getRecord();

--- a/core/landing/model.js
+++ b/core/landing/model.js
@@ -1,0 +1,13 @@
+(function bootstrapLandingModelModule(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+
+  modules.createLandingModel = function createLandingModel() {
+    return {};
+  };
+
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/core/landing/model.js
+++ b/core/landing/model.js
@@ -47,6 +47,11 @@
     const landingImportStatusImported = 'imported';
     const landingImportStatusPartial = 'partial';
     const landingImportStatusFailed = 'failed';
+    const landingItemStatusLive = 'Live';
+    const landingItemStatusDraft = 'Draft';
+    const landingItemStatusMissing = 'Missing Fields';
+    const landingItemStatusArchived = 'ARCHIVED';
+    const landingFilterStorageKey = 'hf_landing_admin_filters';
 
     function uid() {
       return `hf-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
@@ -163,6 +168,14 @@
       };
     }
 
+    function getDefaultFilters() {
+      return {
+        events: { showArchived: false },
+        news: { showArchived: false },
+        reviews: { showArchived: false },
+      };
+    }
+
     function createDefaultRecord() {
       const content = createDefaultContent();
       return {
@@ -249,6 +262,16 @@
         lastSuccessTs: normalizeTimestamp(meta.lastSuccessTs),
         status,
         messages: rawMessages.map(message => String(message || '')).filter(Boolean),
+      };
+    }
+
+    function normalizeFilters(rawFilters) {
+      const filters = rawFilters && typeof rawFilters === 'object' ? rawFilters : {};
+      const defaults = getDefaultFilters();
+      return {
+        events: { ...defaults.events, showArchived: !!(filters.events && filters.events.showArchived) },
+        news: { ...defaults.news, showArchived: !!(filters.news && filters.news.showArchived) },
+        reviews: { ...defaults.reviews, showArchived: !!(filters.reviews && filters.reviews.showArchived) },
       };
     }
 
@@ -544,6 +567,44 @@
         liveContent[sectionId] = cloneJsonCompatible(draftContent[sectionId], {});
       });
       nextRecord.liveContent = normalizeContent(liveContent);
+      return nextRecord;
+    }
+
+    function applyHoursFieldDraft(record, fieldStates) {
+      const nextRecord = normalizeRecord(record || createDefaultRecord());
+      if (!Array.isArray(fieldStates) || !fieldStates.length) return nextRecord;
+
+      const groupedDays = new Map();
+
+      fieldStates.forEach(fieldState => {
+        const restaurantId = fieldState && fieldState.restaurantId ? String(fieldState.restaurantId) : '';
+        const dayKey = fieldState && fieldState.dayKey ? String(fieldState.dayKey) : '';
+        const field = fieldState && fieldState.field ? String(fieldState.field) : '';
+        if (!restaurantId || !landingDayOrder.includes(dayKey) || !['closed', 'open', 'close'].includes(field)) return;
+
+        const key = `${restaurantId}:${dayKey}`;
+        const entry = groupedDays.get(key) || { restaurantId: restaurantId, dayKey: dayKey };
+        if (field === 'closed') {
+          entry.closed = !!fieldState.value;
+        } else {
+          entry[field] = normalizeTimeValue(fieldState.value);
+        }
+        groupedDays.set(key, entry);
+      });
+
+      groupedDays.forEach(({ restaurantId, dayKey, open, close, closed }) => {
+        if (!nextRecord.draftContent.hours.restaurants[restaurantId]) {
+          nextRecord.draftContent.hours.restaurants[restaurantId] = createDefaultHoursRestaurant();
+        }
+        const currentDay = nextRecord.draftContent.hours.restaurants[restaurantId].days[dayKey] || createDefaultLandingDay();
+        nextRecord.draftContent.hours.restaurants[restaurantId].days[dayKey] = normalizeDay({
+          ...currentDay,
+          closed: !!closed,
+          open: closed ? '' : (typeof open === 'string' ? open : currentDay.open),
+          close: closed ? '' : (typeof close === 'string' ? close : currentDay.close),
+        });
+      });
+
       return nextRecord;
     }
 
@@ -889,6 +950,13 @@
         RESTAURANT_TIME_ZONE: restaurantTimeZone,
         LANDING_PAGE_STATE_ID: landingPageStateId,
         LANDING_PAGE_SECTION_ORDER: landingSectionOrder.slice(),
+        LANDING_PAGE_SECTION_LABELS: {
+          overview: 'Overview',
+          hours: 'Hours',
+          events: 'Events',
+          news: 'News',
+          reviews: 'Reviews',
+        },
         LANDING_DAY_ORDER: landingDayOrder.slice(),
         LANDING_DAY_LABELS: cloneJsonCompatible(landingDayLabels, landingDayLabels),
         LANDING_TARGET_BOTH: landingTargetBoth,
@@ -896,6 +964,11 @@
         LANDING_IMPORT_STATUS_IMPORTED: landingImportStatusImported,
         LANDING_IMPORT_STATUS_PARTIAL: landingImportStatusPartial,
         LANDING_IMPORT_STATUS_FAILED: landingImportStatusFailed,
+        LANDING_ITEM_STATUS_LIVE: landingItemStatusLive,
+        LANDING_ITEM_STATUS_DRAFT: landingItemStatusDraft,
+        LANDING_ITEM_STATUS_MISSING: landingItemStatusMissing,
+        LANDING_ITEM_STATUS_ARCHIVED: landingItemStatusArchived,
+        LANDING_FILTER_STORAGE_KEY: landingFilterStorageKey,
       };
     }
 
@@ -909,6 +982,7 @@
       createDefaultReviewItem: createDefaultReviewItem,
       createDefaultContent: createDefaultContent,
       createDefaultRecord: createDefaultRecord,
+      getDefaultFilters: getDefaultFilters,
       normalizeDay: normalizeDay,
       normalizeHoursRestaurant: normalizeHoursRestaurant,
       normalizeEventItem: normalizeEventItem,
@@ -916,6 +990,7 @@
       normalizeReviewItem: normalizeReviewItem,
       normalizeContent: normalizeContent,
       normalizeRecord: normalizeRecord,
+      normalizeFilters: normalizeFilters,
       normalizeTarget: normalizeTarget,
       normalizeImportMeta: normalizeImportMeta,
       normalizeTimeValue: normalizeTimeValue,
@@ -939,6 +1014,8 @@
       formatHoursRange: formatHoursRange,
       getHoursForRestaurant: getHoursForRestaurant,
       buildWeekRows: buildWeekRows,
+      getDayOffsetKey: getDayOffsetKey,
+      getRestaurantLocalParts: getRestaurantLocalParts,
       validateEventItem: validateEventItem,
       validateNewsItem: validateNewsItem,
       validateReviewItem: validateReviewItem,
@@ -950,6 +1027,7 @@
       getDraftDiffSectionIds: getDraftDiffSectionIds,
       landingSectionHasDiff: landingSectionHasDiff,
       applySectionPublish: applySectionPublish,
+      applyHoursFieldDraft: applyHoursFieldDraft,
       computeRestaurantStatus: computeRestaurantStatus,
       getRenderableEvents: getRenderableEvents,
       getRenderableNews: getRenderableNews,

--- a/core/landing/model.js
+++ b/core/landing/model.js
@@ -5,9 +5,875 @@
     ? globalScope.__HF_LANDING_MODULES__
     : {};
 
-  modules.createLandingModel = function createLandingModel() {
-    return {};
-  };
+  function buildFallbackDomainConstants() {
+    const restaurants = {
+      LEROYS: { id: '00000000-0000-0000-0000-000000000010', name: "Leroy's Lounge", slug: 'leroys-lounge' },
+      ELROYS: { id: '00000000-0000-0000-0000-000000000001', name: "El Roy's Cantina", slug: 'el-roys-cantina' },
+    };
+    return {
+      RESTAURANT_TIME_ZONE: 'America/Detroit',
+      RESTAURANTS: restaurants,
+      KNOWN_RESTAURANT_ORDER: [restaurants.LEROYS.id, restaurants.ELROYS.id],
+    };
+  }
 
+  function createLandingModel(options = {}) {
+    const fallbackConstants = buildFallbackDomainConstants();
+    const domainConstants = (options.domainConstants && typeof options.domainConstants === 'object')
+      ? options.domainConstants
+      : ((globalScope.__HF_DOMAIN_CONSTANTS__ && typeof globalScope.__HF_DOMAIN_CONSTANTS__ === 'object')
+        ? globalScope.__HF_DOMAIN_CONSTANTS__
+        : fallbackConstants);
+    const restaurants = domainConstants.RESTAURANTS || fallbackConstants.RESTAURANTS;
+    const knownRestaurantOrder = Array.isArray(domainConstants.KNOWN_RESTAURANT_ORDER) && domainConstants.KNOWN_RESTAURANT_ORDER.length
+      ? domainConstants.KNOWN_RESTAURANT_ORDER.slice()
+      : fallbackConstants.KNOWN_RESTAURANT_ORDER.slice();
+    const restaurantTimeZone = domainConstants.RESTAURANT_TIME_ZONE || fallbackConstants.RESTAURANT_TIME_ZONE;
+    const appVersion = domainConstants.APP_VERSION || fallbackConstants.APP_VERSION || '';
+    const landingPageStateId = 'root';
+    const landingSectionOrder = ['overview', 'hours', 'events', 'news', 'reviews'];
+    const landingDayOrder = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+    const landingDayLabels = {
+      mon: 'Monday',
+      tue: 'Tuesday',
+      wed: 'Wednesday',
+      thu: 'Thursday',
+      fri: 'Friday',
+      sat: 'Saturday',
+      sun: 'Sunday',
+    };
+    const landingTargetBoth = 'both';
+    const landingImportStatusIdle = 'idle';
+    const landingImportStatusImported = 'imported';
+    const landingImportStatusPartial = 'partial';
+    const landingImportStatusFailed = 'failed';
+
+    function uid() {
+      return `hf-${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`;
+    }
+
+    function escHtml(value) {
+      return String(value)
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/'/g, '&#39;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+    }
+
+    function escAttrJs(value) {
+      return escHtml(JSON.stringify(String(value)));
+    }
+
+    function cloneJsonCompatible(value, fallback) {
+      try {
+        return JSON.parse(JSON.stringify(value ?? fallback));
+      } catch (_) {
+        return JSON.parse(JSON.stringify(fallback));
+      }
+    }
+
+    function knownLandingRestaurants() {
+      return Object.values(restaurants).sort((a, b) => knownRestaurantOrder.indexOf(a.id) - knownRestaurantOrder.indexOf(b.id));
+    }
+
+    function createDefaultLandingDay() {
+      return { closed: true, open: '', close: '' };
+    }
+
+    function createDefaultLandingHoursRestaurant() {
+      const days = {};
+      landingDayOrder.forEach(dayKey => {
+        days[dayKey] = createDefaultLandingDay();
+      });
+      return { days };
+    }
+
+    function createDefaultImportMeta(sourceUrl) {
+      return {
+        sourceUrl: sourceUrl ? String(sourceUrl) : '',
+        lastAttemptTs: '',
+        lastSuccessTs: '',
+        status: landingImportStatusIdle,
+        messages: [],
+      };
+    }
+
+    function createDefaultEventItem() {
+      return {
+        id: uid(),
+        target: landingTargetBoth,
+        title: '',
+        eventDate: '',
+        startTime: '',
+        endTime: '',
+        timingNote: '',
+        body: '',
+        archived: false,
+        archivedAt: '',
+        updatedAt: '',
+      };
+    }
+
+    function createDefaultNewsItem() {
+      return {
+        id: uid(),
+        target: landingTargetBoth,
+        title: '',
+        body: '',
+        href: '',
+        source: '',
+        publishedDate: '',
+        imageUrl: '',
+        archived: false,
+        archivedAt: '',
+        updatedAt: '',
+        importMeta: createDefaultImportMeta(),
+      };
+    }
+
+    function createDefaultReviewItem() {
+      return {
+        id: uid(),
+        href: '',
+        author: '',
+        quote: '',
+        source: 'Google Review',
+        rating: '',
+        archived: false,
+        archivedAt: '',
+        updatedAt: '',
+        importMeta: createDefaultImportMeta(),
+      };
+    }
+
+    function createDefaultContent() {
+      const hoursRestaurants = {};
+      const reviewRestaurants = {};
+      knownLandingRestaurants().forEach(restaurant => {
+        hoursRestaurants[restaurant.id] = createDefaultLandingHoursRestaurant();
+        reviewRestaurants[restaurant.id] = [];
+      });
+      return {
+        overview: {},
+        hours: { restaurants: hoursRestaurants },
+        events: { items: [] },
+        news: { items: [] },
+        reviews: { restaurants: reviewRestaurants },
+      };
+    }
+
+    function createDefaultRecord() {
+      const content = createDefaultContent();
+      return {
+        id: landingPageStateId,
+        draftContent: cloneJsonCompatible(content, content),
+        liveContent: cloneJsonCompatible(content, content),
+        draftSavedTs: '',
+        livePublishedTs: '',
+      };
+    }
+
+    function normalizeTimestamp(value) {
+      if (value === null || value === undefined || value === '') return '';
+      const numberValue = Number(value);
+      return Number.isFinite(numberValue) && numberValue > 0 ? String(numberValue) : '';
+    }
+
+    function normalizeTimeValue(value) {
+      if (typeof value !== 'string') return '';
+      const trimmed = value.trim();
+      const match = trimmed.match(/^(\d{2}):(\d{2})(?::(\d{2}))?$/);
+      if (!match) return '';
+      return `${match[1]}:${match[2]}`;
+    }
+
+    function parseTimeToMinutes(value) {
+      const normalized = normalizeTimeValue(value);
+      if (!normalized) return null;
+      const parts = normalized.split(':').map(Number);
+      if (parts.length !== 2 || parts.some(part => !Number.isInteger(part))) return null;
+      const hours = parts[0];
+      const minutes = parts[1];
+      if (hours < 0 || hours > 23 || minutes < 0 || minutes > 59) return null;
+      return (hours * 60) + minutes;
+    }
+
+    function normalizeDay(rawDay) {
+      const closed = !!(rawDay && rawDay.closed);
+      const open = normalizeTimeValue(rawDay && rawDay.open);
+      const close = normalizeTimeValue(rawDay && rawDay.close);
+      return {
+        closed,
+        open: closed ? '' : open,
+        close: closed ? '' : close,
+      };
+    }
+
+    function normalizeHoursRestaurant(rawRestaurant) {
+      const days = {};
+      landingDayOrder.forEach(dayKey => {
+        days[dayKey] = normalizeDay(rawRestaurant && rawRestaurant.days && rawRestaurant.days[dayKey]);
+      });
+      return { days };
+    }
+
+    function normalizeTarget(value, options) {
+      const settings = options && typeof options === 'object' ? options : {};
+      const allowBoth = settings.allowBoth !== false;
+      const fallback = Object.prototype.hasOwnProperty.call(settings, 'fallback')
+        ? settings.fallback
+        : (allowBoth ? landingTargetBoth : (knownLandingRestaurants()[0] ? knownLandingRestaurants()[0].id : ''));
+      const candidate = value ? String(value) : '';
+      if (allowBoth && candidate === landingTargetBoth) return landingTargetBoth;
+      if (candidate && knownLandingRestaurants().some(restaurant => restaurant.id === candidate)) return candidate;
+      return fallback;
+    }
+
+    function normalizeImportMeta(rawMeta) {
+      const meta = rawMeta && typeof rawMeta === 'object' ? rawMeta : {};
+      const status = [
+        landingImportStatusIdle,
+        landingImportStatusImported,
+        landingImportStatusPartial,
+        landingImportStatusFailed,
+      ].includes(meta.status)
+        ? meta.status
+        : landingImportStatusIdle;
+      const rawMessages = Array.isArray(meta.messages)
+        ? meta.messages
+        : (meta.message ? [meta.message] : []);
+      return {
+        sourceUrl: meta.sourceUrl ? String(meta.sourceUrl) : '',
+        lastAttemptTs: normalizeTimestamp(meta.lastAttemptTs),
+        lastSuccessTs: normalizeTimestamp(meta.lastSuccessTs),
+        status,
+        messages: rawMessages.map(message => String(message || '')).filter(Boolean),
+      };
+    }
+
+    function normalizeEventItem(rawItem) {
+      const item = rawItem && typeof rawItem === 'object' ? rawItem : {};
+      return {
+        id: item.id ? String(item.id) : uid(),
+        target: normalizeTarget(item.target, { allowBoth: true }),
+        title: item.title ? String(item.title) : '',
+        eventDate: item.eventDate ? String(item.eventDate) : '',
+        startTime: normalizeTimeValue(item.startTime),
+        endTime: normalizeTimeValue(item.endTime),
+        timingNote: item.timingNote ? String(item.timingNote) : '',
+        body: item.body ? String(item.body) : '',
+        archived: !!item.archived,
+        archivedAt: normalizeTimestamp(item.archivedAt),
+        updatedAt: normalizeTimestamp(item.updatedAt),
+      };
+    }
+
+    function normalizeNewsItem(rawItem) {
+      const item = rawItem && typeof rawItem === 'object' ? rawItem : {};
+      return {
+        id: item.id ? String(item.id) : uid(),
+        target: normalizeTarget(item.target, { allowBoth: true }),
+        title: item.title ? String(item.title) : '',
+        body: item.body ? String(item.body) : '',
+        href: item.href ? String(item.href) : '',
+        source: item.source ? String(item.source) : '',
+        publishedDate: item.publishedDate ? String(item.publishedDate) : (item.publishedAt ? String(item.publishedAt) : ''),
+        imageUrl: item.imageUrl ? String(item.imageUrl) : '',
+        archived: !!item.archived,
+        archivedAt: normalizeTimestamp(item.archivedAt),
+        updatedAt: normalizeTimestamp(item.updatedAt),
+        importMeta: normalizeImportMeta(item.importMeta || {}),
+      };
+    }
+
+    function normalizeReviewItem(rawItem) {
+      const item = rawItem && typeof rawItem === 'object' ? rawItem : {};
+      const rating = Number(item.rating);
+      const normalizedRating = Number.isFinite(rating) && rating >= 1 && rating <= 5
+        ? Math.round(rating)
+        : '';
+      return {
+        id: item.id ? String(item.id) : uid(),
+        href: item.href ? String(item.href) : '',
+        author: item.author ? String(item.author) : '',
+        quote: item.quote ? String(item.quote) : '',
+        source: item.source ? String(item.source) : 'Google Review',
+        rating: normalizedRating,
+        archived: !!item.archived,
+        archivedAt: normalizeTimestamp(item.archivedAt),
+        updatedAt: normalizeTimestamp(item.updatedAt),
+        importMeta: normalizeImportMeta(item.importMeta || {}),
+      };
+    }
+
+    function normalizeContent(rawContent) {
+      const content = rawContent && typeof rawContent === 'object' ? rawContent : {};
+      const defaults = createDefaultContent();
+      const hoursRestaurants = {};
+      const reviewRestaurants = {};
+      knownLandingRestaurants().forEach(restaurant => {
+        hoursRestaurants[restaurant.id] = normalizeHoursRestaurant(
+          (content.hours && content.hours.restaurants && content.hours.restaurants[restaurant.id]) || defaults.hours.restaurants[restaurant.id]
+        );
+        reviewRestaurants[restaurant.id] = Array.isArray(content.reviews && content.reviews.restaurants && content.reviews.restaurants[restaurant.id])
+          ? content.reviews.restaurants[restaurant.id].map(normalizeReviewItem)
+          : defaults.reviews.restaurants[restaurant.id];
+      });
+      return {
+        overview: content.overview && typeof content.overview === 'object'
+          ? cloneJsonCompatible(content.overview, {})
+          : {},
+        hours: { restaurants: hoursRestaurants },
+        events: {
+          items: Array.isArray(content.events && content.events.items) ? content.events.items.map(normalizeEventItem) : [],
+        },
+        news: {
+          items: Array.isArray(content.news && content.news.items) ? content.news.items.map(normalizeNewsItem) : [],
+        },
+        reviews: {
+          restaurants: reviewRestaurants,
+        },
+      };
+    }
+
+    function normalizeRecord(rawRecord) {
+      const record = rawRecord && typeof rawRecord === 'object' ? rawRecord : {};
+      const defaults = createDefaultRecord();
+      return {
+        id: record.id ? String(record.id) : defaults.id,
+        draftContent: normalizeContent(record.draft_content || record.draftContent || defaults.draftContent),
+        liveContent: normalizeContent(record.live_content || record.liveContent || defaults.liveContent),
+        draftSavedTs: normalizeTimestamp(record.draft_saved_ts || record.draftSavedTs),
+        livePublishedTs: normalizeTimestamp(record.live_published_ts || record.livePublishedTs),
+      };
+    }
+
+    function isIsoDate(value) {
+      return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value);
+    }
+
+    function isAbsoluteUrl(value) {
+      try {
+        const url = new URL(String(value || '').trim());
+        return url.protocol === 'http:' || url.protocol === 'https:';
+      } catch (_) {
+        return false;
+      }
+    }
+
+    function getEventDateRank(value) {
+      return isIsoDate(value) ? Date.parse(`${value}T00:00:00Z`) : Number.MAX_SAFE_INTEGER;
+    }
+
+    function sortEvents(items) {
+      return items.slice().sort((a, b) => {
+        const rankDelta = getEventDateRank(a.eventDate) - getEventDateRank(b.eventDate);
+        if (rankDelta !== 0) return rankDelta;
+        const startDelta = (parseTimeToMinutes(a.startTime) ?? Number.MAX_SAFE_INTEGER) - (parseTimeToMinutes(b.startTime) ?? Number.MAX_SAFE_INTEGER);
+        if (startDelta !== 0) return startDelta;
+        return String(a.title || '').localeCompare(String(b.title || ''));
+      });
+    }
+
+    function sortNews(items) {
+      return items.slice().sort((a, b) => {
+        const aRank = isIsoDate(a.publishedDate) ? Date.parse(`${a.publishedDate}T00:00:00Z`) : 0;
+        const bRank = isIsoDate(b.publishedDate) ? Date.parse(`${b.publishedDate}T00:00:00Z`) : 0;
+        if (aRank !== bRank) return bRank - aRank;
+        return (Number(b.updatedAt || 0) || 0) - (Number(a.updatedAt || 0) || 0);
+      });
+    }
+
+    function sortReviews(items) {
+      return items.slice().sort((a, b) => {
+        const successDelta = (Number(b.importMeta && b.importMeta.lastSuccessTs || 0) || 0) - (Number(a.importMeta && a.importMeta.lastSuccessTs || 0) || 0);
+        if (successDelta !== 0) return successDelta;
+        return (Number(b.updatedAt || 0) || 0) - (Number(a.updatedAt || 0) || 0);
+      });
+    }
+
+    function getActiveItems(items) {
+      return Array.isArray(items) ? items.filter(item => !item || !item.archived ? true : false) : [];
+    }
+
+    function validateEventItem(item) {
+      const issues = [];
+      if (!item.target) issues.push('target');
+      if (!item.title || !item.title.trim()) issues.push('title');
+      if (!isIsoDate(item.eventDate)) issues.push('date');
+      if (parseTimeToMinutes(item.startTime) === null) issues.push('start time');
+      if (parseTimeToMinutes(item.endTime) === null && !(item.timingNote && item.timingNote.trim())) issues.push('end time or note');
+      if (!item.body || !item.body.trim()) issues.push('description');
+      return {
+        valid: issues.length === 0,
+        missingFields: issues,
+      };
+    }
+
+    function validateNewsItem(item) {
+      const issues = [];
+      if (!item.target) issues.push('target');
+      if (!item.title || !item.title.trim()) issues.push('headline');
+      if (!isAbsoluteUrl(item.href)) issues.push('article URL');
+      if (!item.source || !item.source.trim()) issues.push('source');
+      if (!isIsoDate(item.publishedDate)) issues.push('publish date');
+      if (!(item.importMeta && item.importMeta.lastAttemptTs)) issues.push('import record');
+      return {
+        valid: issues.length === 0,
+        missingFields: issues,
+      };
+    }
+
+    function validateReviewItem(item) {
+      const issues = [];
+      if (!isAbsoluteUrl(item.href)) issues.push('review URL');
+      if (!item.author || !item.author.trim()) issues.push('author');
+      if (!item.quote || !item.quote.trim()) issues.push('quote');
+      if (!Number.isFinite(Number(item.rating)) || Number(item.rating) < 1 || Number(item.rating) > 5) issues.push('rating');
+      if (!(item.importMeta && item.importMeta.lastAttemptTs)) issues.push('import record');
+      return {
+        valid: issues.length === 0,
+        missingFields: issues,
+      };
+    }
+
+    function validateHoursSection(section) {
+      const issues = [];
+      knownLandingRestaurants().forEach(restaurant => {
+        const restaurantHours = normalizeHoursRestaurant(section && section.restaurants && section.restaurants[restaurant.id]);
+        landingDayOrder.forEach(dayKey => {
+          const day = restaurantHours.days[dayKey];
+          if (day.closed) return;
+          const openMinutes = parseTimeToMinutes(day.open);
+          const closeMinutes = parseTimeToMinutes(day.close);
+          if (openMinutes === null || closeMinutes === null) {
+            issues.push(`${restaurant.name}: ${landingDayLabels[dayKey]} needs both an open and close time.`);
+            return;
+          }
+          if (openMinutes === closeMinutes) {
+            issues.push(`${restaurant.name}: ${landingDayLabels[dayKey]} cannot open and close at the same time.`);
+          }
+        });
+      });
+      return { valid: issues.length === 0, issues: issues };
+    }
+
+    function validateEventsSection(section) {
+      const issues = [];
+      const items = sortEvents(getActiveItems(Array.isArray(section && section.items) ? section.items.map(normalizeEventItem) : []));
+      items.forEach(item => {
+        const validation = validateEventItem(item);
+        if (validation.valid) return;
+        issues.push(`${item.title && item.title.trim() || 'Untitled event'}: missing ${validation.missingFields.join(', ')}.`);
+      });
+      return { valid: issues.length === 0, issues: issues };
+    }
+
+    function validateNewsSection(section) {
+      const issues = [];
+      const items = sortNews(getActiveItems(Array.isArray(section && section.items) ? section.items.map(normalizeNewsItem) : []));
+      items.forEach(item => {
+        const validation = validateNewsItem(item);
+        if (validation.valid) return;
+        issues.push(`${item.title && item.title.trim() || item.href && item.href.trim() || 'Imported story'}: missing ${validation.missingFields.join(', ')}.`);
+      });
+      return { valid: issues.length === 0, issues: issues };
+    }
+
+    function validateReviewsSection(section) {
+      const issues = [];
+      knownLandingRestaurants().forEach(restaurant => {
+        const items = sortReviews(
+          getActiveItems(Array.isArray(section && section.restaurants && section.restaurants[restaurant.id]) ? section.restaurants[restaurant.id].map(normalizeReviewItem) : [])
+        );
+        items.forEach(item => {
+          const validation = validateReviewItem(item);
+          if (validation.valid) return;
+          issues.push(`${restaurant.name}: ${item.author && item.author.trim() || item.href && item.href.trim() || 'Imported review'} is missing ${validation.missingFields.join(', ')}.`);
+        });
+      });
+      return { valid: issues.length === 0, issues: issues };
+    }
+
+    function getSectionValidation(sectionId, record) {
+      const normalized = normalizeRecord(record || createDefaultRecord());
+      if (sectionId === 'hours') return validateHoursSection(normalized.draftContent.hours);
+      if (sectionId === 'events') return validateEventsSection(normalized.draftContent.events);
+      if (sectionId === 'news') return validateNewsSection(normalized.draftContent.news);
+      if (sectionId === 'reviews') return validateReviewsSection(normalized.draftContent.reviews);
+      return { valid: true, issues: [] };
+    }
+
+    function landingSectionHasDiff(sectionId, record) {
+      const normalized = normalizeRecord(record || createDefaultRecord());
+      return JSON.stringify(normalized.draftContent[sectionId] || {}) !== JSON.stringify(normalized.liveContent[sectionId] || {});
+    }
+
+    function getDraftDiffSectionIds(record) {
+      return landingSectionOrder.filter(sectionId => landingSectionHasDiff(sectionId, record));
+    }
+
+    function applySectionPublish(record, sectionIds) {
+      const nextRecord = normalizeRecord(record || createDefaultRecord());
+      const draftContent = cloneJsonCompatible(nextRecord.draftContent, createDefaultContent());
+      const liveContent = cloneJsonCompatible(nextRecord.liveContent, createDefaultContent());
+      const appliedSectionIds = Array.isArray(sectionIds)
+        ? sectionIds.filter(sectionId => landingSectionOrder.includes(sectionId))
+        : [];
+      appliedSectionIds.forEach(sectionId => {
+        liveContent[sectionId] = cloneJsonCompatible(draftContent[sectionId], {});
+      });
+      nextRecord.liveContent = normalizeContent(liveContent);
+      return nextRecord;
+    }
+
+    function formatMinutes(minutes) {
+      if (!Number.isFinite(minutes)) return '';
+      const normalized = ((Math.floor(minutes) % 1440) + 1440) % 1440;
+      const hours24 = Math.floor(normalized / 60);
+      const mins = normalized % 60;
+      const suffix = hours24 >= 12 ? 'PM' : 'AM';
+      const hours12 = hours24 % 12 || 12;
+      return mins === 0 ? `${hours12} ${suffix}` : `${hours12}:${String(mins).padStart(2, '0')} ${suffix}`;
+    }
+
+    function formatHoursRange(day) {
+      if (day && day.closed) return 'Closed';
+      const openMinutes = parseTimeToMinutes(day && day.open);
+      const closeMinutes = parseTimeToMinutes(day && day.close);
+      if (openMinutes === null || closeMinutes === null) return 'Hours unavailable';
+      return `${formatMinutes(openMinutes)} - ${formatMinutes(closeMinutes)}`;
+    }
+
+    function getDayOffsetKey(dayKey, offset) {
+      const index = landingDayOrder.indexOf(dayKey);
+      if (index < 0) return landingDayOrder[0];
+      return landingDayOrder[(index + offset + landingDayOrder.length) % landingDayOrder.length];
+    }
+
+    function getRestaurantLocalParts(now, timeZone) {
+      const formatter = new Intl.DateTimeFormat('en-US', {
+        timeZone: timeZone || restaurantTimeZone,
+        weekday: 'short',
+        hour: '2-digit',
+        minute: '2-digit',
+        hour12: false,
+      });
+      const parts = formatter.formatToParts(new Date(now || Date.now()));
+      const lookup = Object.create(null);
+      parts.forEach(part => {
+        lookup[part.type] = part.value;
+      });
+      const weekday = String(lookup.weekday || '').slice(0, 3).toLowerCase();
+      const dayKeyMap = { mon: 'mon', tue: 'tue', wed: 'wed', thu: 'thu', fri: 'fri', sat: 'sat', sun: 'sun' };
+      const hour = Number(lookup.hour || 0);
+      const minute = Number(lookup.minute || 0);
+      return {
+        dayKey: dayKeyMap[weekday] || 'mon',
+        minutes: (Number.isFinite(hour) ? hour : 0) * 60 + (Number.isFinite(minute) ? minute : 0),
+      };
+    }
+
+    function getHoursForRestaurant(section, restaurantId) {
+      return normalizeHoursRestaurant(section && section.restaurants && section.restaurants[restaurantId]);
+    }
+
+    function buildWeekRows(section, restaurantId, todayKey) {
+      const restaurantHours = getHoursForRestaurant(section, restaurantId);
+      return landingDayOrder.map(dayKey => ({
+        dayKey: dayKey,
+        label: landingDayLabels[dayKey] || dayKey,
+        isToday: dayKey === todayKey,
+        rangeLabel: formatHoursRange(restaurantHours.days[dayKey]),
+      }));
+    }
+
+    function computeRestaurantStatus(section, restaurantId, now, timeZone) {
+      const restaurantHours = getHoursForRestaurant(section, restaurantId);
+      const local = getRestaurantLocalParts(now, timeZone || restaurantTimeZone);
+      const previousDayKey = getDayOffsetKey(local.dayKey, -1);
+      const today = restaurantHours.days[local.dayKey];
+      const previous = restaurantHours.days[previousDayKey];
+      const todayOpen = parseTimeToMinutes(today.open);
+      const todayClose = parseTimeToMinutes(today.close);
+      const previousOpen = parseTimeToMinutes(previous.open);
+      const previousClose = parseTimeToMinutes(previous.close);
+      const previousOvernight = !previous.closed && previousOpen !== null && previousClose !== null && previousClose <= previousOpen;
+      const todayOvernight = !today.closed && todayOpen !== null && todayClose !== null && todayClose <= todayOpen;
+
+      if (previousOvernight && local.minutes < previousClose) {
+        return {
+          isOpen: true,
+          currentDayKey: local.dayKey,
+          label: `Open until ${formatMinutes(previousClose)}`,
+          todayRangeLabel: formatHoursRange(today),
+          weekRows: buildWeekRows(section, restaurantId, local.dayKey),
+        };
+      }
+
+      if (!today.closed && todayOpen !== null && todayClose !== null) {
+        const isOpen = todayOvernight
+          ? local.minutes >= todayOpen
+          : (local.minutes >= todayOpen && local.minutes < todayClose);
+        if (isOpen) {
+          return {
+            isOpen: true,
+            currentDayKey: local.dayKey,
+            label: `Open until ${formatMinutes(todayClose)}`,
+            todayRangeLabel: formatHoursRange(today),
+            weekRows: buildWeekRows(section, restaurantId, local.dayKey),
+          };
+        }
+      }
+
+      if (!today.closed && todayOpen !== null && local.minutes < todayOpen) {
+        return {
+          isOpen: false,
+          currentDayKey: local.dayKey,
+          label: `Closed until ${formatMinutes(todayOpen)}`,
+          todayRangeLabel: formatHoursRange(today),
+          weekRows: buildWeekRows(section, restaurantId, local.dayKey),
+        };
+      }
+
+      for (let offset = 1; offset <= landingDayOrder.length; offset += 1) {
+        const nextDayKey = getDayOffsetKey(local.dayKey, offset);
+        const nextDay = restaurantHours.days[nextDayKey];
+        if (nextDay.closed) continue;
+        const nextOpen = parseTimeToMinutes(nextDay.open);
+        if (nextOpen === null) continue;
+        const prefix = offset === 1 ? 'tomorrow' : (landingDayLabels[nextDayKey] || nextDayKey);
+        return {
+          isOpen: false,
+          currentDayKey: local.dayKey,
+          label: `Closed until ${prefix} ${formatMinutes(nextOpen)}`,
+          todayRangeLabel: formatHoursRange(today),
+          weekRows: buildWeekRows(section, restaurantId, local.dayKey),
+        };
+      }
+
+      return {
+        isOpen: false,
+        currentDayKey: local.dayKey,
+        label: 'Closed for now',
+        todayRangeLabel: formatHoursRange(today),
+        weekRows: buildWeekRows(section, restaurantId, local.dayKey),
+      };
+    }
+
+    function getRenderableEvents(section) {
+      return sortEvents(
+        getActiveItems(Array.isArray(section && section.items) ? section.items.map(normalizeEventItem) : [])
+      ).filter(item => validateEventItem(item).valid);
+    }
+
+    function getRenderableNews(section) {
+      return sortNews(
+        getActiveItems(Array.isArray(section && section.items) ? section.items.map(normalizeNewsItem) : [])
+      ).filter(item => validateNewsItem(item).valid);
+    }
+
+    function getRenderableReviews(section, restaurantId) {
+      return sortReviews(
+        getActiveItems(Array.isArray(section && section.restaurants && section.restaurants[restaurantId]) ? section.restaurants[restaurantId].map(normalizeReviewItem) : [])
+      ).filter(item => validateReviewItem(item).valid);
+    }
+
+    function buildReviewPairs(section) {
+      const leroysId = restaurants.LEROYS && restaurants.LEROYS.id;
+      const elroysId = restaurants.ELROYS && restaurants.ELROYS.id;
+      const leroysReviews = getRenderableReviews(section, leroysId);
+      const elroysReviews = getRenderableReviews(section, elroysId);
+      if (leroysReviews.length < 3 || elroysReviews.length < 3) return [];
+      const pairCount = Math.min(leroysReviews.length, elroysReviews.length);
+      return Array.from({ length: pairCount }, (_, index) => ({
+        id: `pair-${index}`,
+        leroys: leroysReviews[index],
+        elroys: elroysReviews[index],
+      }));
+    }
+
+    function getTimeSelectOptions() {
+      const options = [];
+      for (let minutes = 0; minutes < 1440; minutes += 15) {
+        const hours24 = Math.floor(minutes / 60);
+        const mins = minutes % 60;
+        options.push({
+          value: `${String(hours24).padStart(2, '0')}:${String(mins).padStart(2, '0')}`,
+          label: formatMinutes(minutes),
+        });
+      }
+      return options;
+    }
+
+    const landingTimeSelectOptions = getTimeSelectOptions();
+
+    function renderTimeSelectOptions(selectedValue, placeholder) {
+      const normalized = normalizeTimeValue(selectedValue);
+      const optionMarkup = [`<option value="">${escHtml(placeholder || 'Select time')}</option>`];
+      const hasSelectedValue = normalized && landingTimeSelectOptions.some(option => option.value === normalized);
+      if (normalized && !hasSelectedValue) {
+        const fallbackMinutes = parseTimeToMinutes(normalized);
+        optionMarkup.push(
+          `<option value="${escHtml(normalized)}" selected>${escHtml(fallbackMinutes === null ? normalized : formatMinutes(fallbackMinutes))}</option>`
+        );
+      }
+      landingTimeSelectOptions.forEach(option => {
+        optionMarkup.push(
+          `<option value="${escHtml(option.value)}" ${option.value === normalized ? 'selected' : ''}>${escHtml(option.label)}</option>`
+        );
+      });
+      return optionMarkup.join('');
+    }
+
+    function renderHoursRowsHtml(section, restaurantId, restaurantLabel) {
+      const restaurantHours = getHoursForRestaurant(section, restaurantId);
+      return `
+    <article class="landing-admin-hours-card">
+      <div class="landing-admin-hours-card-header">
+        <div>
+          <p class="settings-section-kicker">${escHtml(restaurantLabel || '')}</p>
+          <h5>${escHtml(restaurantLabel || '')}</h5>
+        </div>
+        <span class="landing-hours-summary">Published hero line follows this recurring schedule.</span>
+      </div>
+      <div class="landing-hours-day-grid">
+        ${landingDayOrder.map(dayKey => {
+          const day = restaurantHours.days[dayKey];
+          const safeRestaurantId = escAttrJs(restaurantId || '');
+          const safeDayKey = escAttrJs(dayKey);
+          return `
+            <div class="landing-hours-day-row">
+              <div class="landing-hours-day-header">
+                <label for="landing-hours-${escHtml(restaurantId || '')}-${escHtml(dayKey)}-open">${escHtml(landingDayLabels[dayKey])}</label>
+              </div>
+              <div class="landing-hours-day-controls">
+                <select
+                  id="landing-hours-${escHtml(restaurantId || '')}-${escHtml(dayKey)}-open"
+                  data-landing-hours-field="open"
+                  data-landing-hours-restaurant="${escHtml(restaurantId || '')}"
+                  data-landing-hours-day="${escHtml(dayKey)}"
+                  aria-label="${escHtml(`${restaurantLabel || ''} ${landingDayLabels[dayKey]} open time`)}"
+                  ${day.closed ? 'disabled' : ''}
+                  onchange="setLandingHoursField(${safeRestaurantId}, ${safeDayKey}, 'open', this.value)"
+                >
+                  ${renderTimeSelectOptions(day.open, 'Open time')}
+                </select>
+                <select
+                  id="landing-hours-${escHtml(restaurantId || '')}-${escHtml(dayKey)}-close"
+                  data-landing-hours-field="close"
+                  data-landing-hours-restaurant="${escHtml(restaurantId || '')}"
+                  data-landing-hours-day="${escHtml(dayKey)}"
+                  aria-label="${escHtml(`${restaurantLabel || ''} ${landingDayLabels[dayKey]} close time`)}"
+                  ${day.closed ? 'disabled' : ''}
+                  onchange="setLandingHoursField(${safeRestaurantId}, ${safeDayKey}, 'close', this.value)"
+                >
+                  ${renderTimeSelectOptions(day.close, 'Close time')}
+                </select>
+              </div>
+              <div class="landing-hours-day-footer">
+                <label class="landing-hours-toggle" for="landing-hours-${escHtml(restaurantId || '')}-${escHtml(dayKey)}-closed">
+                  <input
+                    id="landing-hours-${escHtml(restaurantId || '')}-${escHtml(dayKey)}-closed"
+                    type="checkbox"
+                    data-landing-hours-field="closed"
+                    data-landing-hours-restaurant="${escHtml(restaurantId || '')}"
+                    data-landing-hours-day="${escHtml(dayKey)}"
+                    ${day.closed ? 'checked' : ''}
+                    onchange="setLandingHoursField(${safeRestaurantId}, ${safeDayKey}, 'closed', this.checked)"
+                  >
+                  Closed
+                </label>
+              </div>
+            </div>`;
+        }).join('')}
+      </div>
+    </article>`;
+    }
+
+    function renderTargetOptionsHtml(selectedTarget, options) {
+      const settings = options && typeof options === 'object' ? options : {};
+      const includeBoth = settings.includeBoth !== false;
+      const values = [];
+      if (includeBoth) values.push({ value: landingTargetBoth, label: 'Both' });
+      knownLandingRestaurants().forEach(restaurant => {
+        values.push({ value: restaurant.id, label: restaurant.name });
+      });
+      return values.map(option => (
+        `<option value="${escHtml(option.value)}" ${option.value === selectedTarget ? 'selected' : ''}>${escHtml(option.label)}</option>`
+      )).join('');
+    }
+
+    function renderRatingOptionsHtml(selectedValue) {
+      const rating = Number(selectedValue);
+      const normalized = Number.isFinite(rating) ? String(rating) : '';
+      const options = ['<option value="">Rating</option>'];
+      for (let value = 5; value >= 1; value -= 1) {
+        options.push(`<option value="${value}" ${normalized === String(value) ? 'selected' : ''}>${value} Stars</option>`);
+      }
+      return options.join('');
+    }
+
+    function formatLandingTimestampLabel(value) {
+      const timestamp = Number(value || 0);
+      if (!timestamp) return 'Not yet';
+      return new Intl.DateTimeFormat('en-US', {
+        month: 'short',
+        day: 'numeric',
+        year: 'numeric',
+        hour: 'numeric',
+        minute: '2-digit',
+      }).format(new Date(timestamp));
+    }
+
+    function getConstants() {
+      return {
+        APP_VERSION: appVersion,
+        RESTAURANTS: restaurants,
+        RESTAURANT_TIME_ZONE: restaurantTimeZone,
+        LANDING_PAGE_STATE_ID: landingPageStateId,
+        LANDING_PAGE_SECTION_ORDER: landingSectionOrder.slice(),
+        LANDING_DAY_ORDER: landingDayOrder.slice(),
+        LANDING_DAY_LABELS: cloneJsonCompatible(landingDayLabels, landingDayLabels),
+        LANDING_TARGET_BOTH: landingTargetBoth,
+        LANDING_IMPORT_STATUS_IDLE: landingImportStatusIdle,
+        LANDING_IMPORT_STATUS_IMPORTED: landingImportStatusImported,
+        LANDING_IMPORT_STATUS_PARTIAL: landingImportStatusPartial,
+        LANDING_IMPORT_STATUS_FAILED: landingImportStatusFailed,
+      };
+    }
+
+    return {
+      createDefaultRecord: createDefaultRecord,
+      createDefaultEventItem: createDefaultEventItem,
+      createDefaultNewsItem: createDefaultNewsItem,
+      createDefaultReviewItem: createDefaultReviewItem,
+      normalizeRecord: normalizeRecord,
+      normalizeTarget: normalizeTarget,
+      normalizeImportMeta: normalizeImportMeta,
+      normalizeTimeValue: normalizeTimeValue,
+      validateHoursSection: validateHoursSection,
+      validateEventsSection: validateEventsSection,
+      validateNewsSection: validateNewsSection,
+      validateReviewsSection: validateReviewsSection,
+      getSectionValidation: getSectionValidation,
+      getDraftDiffSectionIds: getDraftDiffSectionIds,
+      landingSectionHasDiff: landingSectionHasDiff,
+      applySectionPublish: applySectionPublish,
+      computeRestaurantStatus: computeRestaurantStatus,
+      getRenderableEvents: getRenderableEvents,
+      getRenderableNews: getRenderableNews,
+      getRenderableReviews: getRenderableReviews,
+      buildReviewPairs: buildReviewPairs,
+      renderHoursRowsHtml: renderHoursRowsHtml,
+      renderTargetOptionsHtml: renderTargetOptionsHtml,
+      renderRatingOptionsHtml: renderRatingOptionsHtml,
+      formatLandingTimestampLabel: formatLandingTimestampLabel,
+      getConstants: getConstants,
+    };
+  }
+
+  modules.createLandingModel = createLandingModel;
   globalScope.__HF_LANDING_MODULES__ = modules;
 })(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/core/landing/model.js
+++ b/core/landing/model.js
@@ -353,6 +353,20 @@
       return typeof value === 'string' && /^\d{4}-\d{2}-\d{2}$/.test(value);
     }
 
+    function formatDateLabel(value, options) {
+      const settings = options && typeof options === 'object' ? options : {};
+      if (!isIsoDate(value)) return value ? String(value) : '';
+      const [year, month, day] = String(value).split('-').map(Number);
+      const utcDate = new Date(Date.UTC(year, month - 1, day));
+      const formatter = new Intl.DateTimeFormat('en-US', {
+        month: settings.short ? 'short' : 'long',
+        day: 'numeric',
+        year: settings.year === false ? undefined : 'numeric',
+        timeZone: 'UTC',
+      });
+      return formatter.format(utcDate).replace(', ', settings.short && settings.year === false ? ' ' : ', ');
+    }
+
     function isAbsoluteUrl(value) {
       try {
         const url = new URL(String(value || '').trim());
@@ -395,6 +409,11 @@
 
     function getActiveItems(items) {
       return Array.isArray(items) ? items.filter(item => !item || !item.archived ? true : false) : [];
+    }
+
+    function getVisibleItems(items, showArchived) {
+      if (showArchived) return Array.isArray(items) ? items.slice() : [];
+      return getActiveItems(items);
     }
 
     function validateEventItem(item) {
@@ -536,6 +555,31 @@
       const suffix = hours24 >= 12 ? 'PM' : 'AM';
       const hours12 = hours24 % 12 || 12;
       return mins === 0 ? `${hours12} ${suffix}` : `${hours12}:${String(mins).padStart(2, '0')} ${suffix}`;
+    }
+
+    function getTargetLabel(target) {
+      if (target === landingTargetBoth) return 'Both';
+      const restaurant = knownLandingRestaurants().find(entry => entry.id === target);
+      return restaurant ? restaurant.name : 'Both';
+    }
+
+    function getTargetAccentClass(target) {
+      if (target === restaurants.LEROYS.id) return 'landing-tag--leroys';
+      if (target === restaurants.ELROYS.id) return 'landing-tag--elroys';
+      return 'landing-tag--both';
+    }
+
+    function formatImportStatusLabel(status) {
+      if (status === landingImportStatusImported) return 'Imported';
+      if (status === landingImportStatusPartial) return 'Partial';
+      if (status === landingImportStatusFailed) return 'Needs Repair';
+      return 'Waiting';
+    }
+
+    function formatImportTimestamp(meta) {
+      return meta && meta.lastSuccessTs
+        ? `Imported ${formatLandingTimestampLabel(meta.lastSuccessTs)}`
+        : (meta && meta.lastAttemptTs ? `Tried ${formatLandingTimestampLabel(meta.lastAttemptTs)}` : 'Not imported yet');
     }
 
     function formatHoursRange(day) {
@@ -875,6 +919,26 @@
       normalizeTarget: normalizeTarget,
       normalizeImportMeta: normalizeImportMeta,
       normalizeTimeValue: normalizeTimeValue,
+      parseTimeToMinutes: parseTimeToMinutes,
+      formatMinutes: formatMinutes,
+      getTimeSelectOptions: getTimeSelectOptions,
+      renderTimeSelectOptions: renderTimeSelectOptions,
+      isIsoDate: isIsoDate,
+      formatDateLabel: formatDateLabel,
+      getTargetLabel: getTargetLabel,
+      getTargetAccentClass: getTargetAccentClass,
+      formatImportStatusLabel: formatImportStatusLabel,
+      formatImportTimestamp: formatImportTimestamp,
+      isAbsoluteUrl: isAbsoluteUrl,
+      getEventDateRank: getEventDateRank,
+      sortEvents: sortEvents,
+      sortNews: sortNews,
+      sortReviews: sortReviews,
+      getActiveItems: getActiveItems,
+      getVisibleItems: getVisibleItems,
+      formatHoursRange: formatHoursRange,
+      getHoursForRestaurant: getHoursForRestaurant,
+      buildWeekRows: buildWeekRows,
       validateEventItem: validateEventItem,
       validateNewsItem: validateNewsItem,
       validateReviewItem: validateReviewItem,

--- a/core/landing/model.js
+++ b/core/landing/model.js
@@ -845,10 +845,16 @@
     }
 
     return {
+      createDefaultDay: createDefaultLandingDay,
+      createDefaultHoursRestaurant: createDefaultLandingHoursRestaurant,
+      createDefaultContent: createDefaultContent,
       createDefaultRecord: createDefaultRecord,
       createDefaultEventItem: createDefaultEventItem,
       createDefaultNewsItem: createDefaultNewsItem,
       createDefaultReviewItem: createDefaultReviewItem,
+      normalizeDay: normalizeDay,
+      normalizeHoursRestaurant: normalizeHoursRestaurant,
+      normalizeContent: normalizeContent,
       normalizeRecord: normalizeRecord,
       normalizeTarget: normalizeTarget,
       normalizeImportMeta: normalizeImportMeta,

--- a/core/landing/model.js
+++ b/core/landing/model.js
@@ -727,7 +727,9 @@
       return optionMarkup.join('');
     }
 
-    function renderHoursRowsHtml(section, restaurantId, restaurantLabel) {
+    function renderHoursRowsHtml(section, restaurantId, restaurantLabel, options) {
+      const settings = options && typeof options === 'object' ? options : {};
+      const setFieldHandlerName = settings.setFieldHandlerName ? String(settings.setFieldHandlerName) : '';
       const restaurantHours = getHoursForRestaurant(section, restaurantId);
       return `
     <article class="landing-admin-hours-card">
@@ -743,6 +745,15 @@
           const day = restaurantHours.days[dayKey];
           const safeRestaurantId = escAttrJs(restaurantId || '');
           const safeDayKey = escAttrJs(dayKey);
+          const openOnChange = setFieldHandlerName
+            ? `${setFieldHandlerName}(${safeRestaurantId}, ${safeDayKey}, 'open', this.value)`
+            : '';
+          const closeOnChange = setFieldHandlerName
+            ? `${setFieldHandlerName}(${safeRestaurantId}, ${safeDayKey}, 'close', this.value)`
+            : '';
+          const closedOnChange = setFieldHandlerName
+            ? `${setFieldHandlerName}(${safeRestaurantId}, ${safeDayKey}, 'closed', this.checked)`
+            : '';
           return `
             <div class="landing-hours-day-row">
               <div class="landing-hours-day-header">
@@ -756,7 +767,7 @@
                   data-landing-hours-day="${escHtml(dayKey)}"
                   aria-label="${escHtml(`${restaurantLabel || ''} ${landingDayLabels[dayKey]} open time`)}"
                   ${day.closed ? 'disabled' : ''}
-                  onchange="setLandingHoursField(${safeRestaurantId}, ${safeDayKey}, 'open', this.value)"
+                  ${openOnChange ? `onchange="${openOnChange}"` : ''}
                 >
                   ${renderTimeSelectOptions(day.open, 'Open time')}
                 </select>
@@ -767,7 +778,7 @@
                   data-landing-hours-day="${escHtml(dayKey)}"
                   aria-label="${escHtml(`${restaurantLabel || ''} ${landingDayLabels[dayKey]} close time`)}"
                   ${day.closed ? 'disabled' : ''}
-                  onchange="setLandingHoursField(${safeRestaurantId}, ${safeDayKey}, 'close', this.value)"
+                  ${closeOnChange ? `onchange="${closeOnChange}"` : ''}
                 >
                   ${renderTimeSelectOptions(day.close, 'Close time')}
                 </select>
@@ -781,7 +792,7 @@
                     data-landing-hours-restaurant="${escHtml(restaurantId || '')}"
                     data-landing-hours-day="${escHtml(dayKey)}"
                     ${day.closed ? 'checked' : ''}
-                    onchange="setLandingHoursField(${safeRestaurantId}, ${safeDayKey}, 'closed', this.checked)"
+                    ${closedOnChange ? `onchange="${closedOnChange}"` : ''}
                   >
                   Closed
                 </label>
@@ -845,20 +856,28 @@
     }
 
     return {
+      normalizeTimestamp: normalizeTimestamp,
       createDefaultDay: createDefaultLandingDay,
       createDefaultHoursRestaurant: createDefaultLandingHoursRestaurant,
-      createDefaultContent: createDefaultContent,
-      createDefaultRecord: createDefaultRecord,
+      createDefaultImportMeta: createDefaultImportMeta,
       createDefaultEventItem: createDefaultEventItem,
       createDefaultNewsItem: createDefaultNewsItem,
       createDefaultReviewItem: createDefaultReviewItem,
+      createDefaultContent: createDefaultContent,
+      createDefaultRecord: createDefaultRecord,
       normalizeDay: normalizeDay,
       normalizeHoursRestaurant: normalizeHoursRestaurant,
+      normalizeEventItem: normalizeEventItem,
+      normalizeNewsItem: normalizeNewsItem,
+      normalizeReviewItem: normalizeReviewItem,
       normalizeContent: normalizeContent,
       normalizeRecord: normalizeRecord,
       normalizeTarget: normalizeTarget,
       normalizeImportMeta: normalizeImportMeta,
       normalizeTimeValue: normalizeTimeValue,
+      validateEventItem: validateEventItem,
+      validateNewsItem: validateNewsItem,
+      validateReviewItem: validateReviewItem,
       validateHoursSection: validateHoursSection,
       validateEventsSection: validateEventsSection,
       validateNewsSection: validateNewsSection,

--- a/core/landing/root-renderer.js
+++ b/core/landing/root-renderer.js
@@ -1,0 +1,13 @@
+(function bootstrapLandingRootRendererModule(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+
+  modules.createLandingRootRendererService = function createLandingRootRendererService() {
+    return {};
+  };
+
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/core/landing/root-renderer.js
+++ b/core/landing/root-renderer.js
@@ -5,8 +5,246 @@
     ? globalScope.__HF_LANDING_MODULES__
     : {};
 
-  modules.createLandingRootRendererService = function createLandingRootRendererService() {
-    return {};
+  modules.createLandingRootRendererService = function createLandingRootRendererService(options = {}) {
+    const model = options.model && typeof options.model === 'object' ? options.model : null;
+    const store = options.store && typeof options.store === 'object' ? options.store : null;
+    const document = options.document || globalScope.document || null;
+    const escHtml = typeof options.escHtml === 'function' ? options.escHtml : (value => String(value || ''));
+    const restaurants = options.restaurants && typeof options.restaurants === 'object' ? options.restaurants : {};
+    const setReviewCarouselHandlerName = typeof options.setReviewCarouselHandlerName === 'string'
+      ? options.setReviewCarouselHandlerName.trim()
+      : '';
+    const hasRootShell = typeof options.hasRootShell === 'function' ? options.hasRootShell : (() => false);
+    const syncLegacyStateFromStore = typeof options.syncLegacyStateFromStore === 'function'
+      ? options.syncLegacyStateFromStore
+      : (() => (store && typeof store.getReviewCarouselIndex === 'function' ? store.getReviewCarouselIndex() : 0));
+
+    if (!model || !store || !document) {
+      return {};
+    }
+
+    function getRecord(record) {
+      return typeof model.normalizeRecord === 'function'
+        ? model.normalizeRecord(record || (store.getRecord ? store.getRecord() : null) || (model.createDefaultRecord ? model.createDefaultRecord() : {}))
+        : (record || {});
+    }
+
+    function setSectionVisible(sectionId = '', visible = true) {
+      const sectionEl = document.getElementById(sectionId);
+      if (sectionEl) sectionEl.hidden = !visible;
+      const dotEl = document.querySelector ? document.querySelector(`[data-landing-dot="${sectionId}"]`) : null;
+      if (dotEl) dotEl.hidden = !visible;
+    }
+
+    function formatEventScheduleLine(item = {}) {
+      const parts = [];
+      if (item.eventDate && typeof model.formatDateLabel === 'function') parts.push(model.formatDateLabel(item.eventDate));
+      const startMinutes = typeof model.parseTimeToMinutes === 'function' ? model.parseTimeToMinutes(item.startTime) : null;
+      if (startMinutes !== null && startMinutes !== undefined) {
+        let timeLabel = typeof model.formatMinutes === 'function' ? model.formatMinutes(startMinutes) : String(item.startTime || '');
+        const endMinutes = typeof model.parseTimeToMinutes === 'function' ? model.parseTimeToMinutes(item.endTime) : null;
+        if (endMinutes !== null && endMinutes !== undefined) {
+          timeLabel += ` - ${typeof model.formatMinutes === 'function' ? model.formatMinutes(endMinutes) : String(item.endTime || '')}`;
+        } else if (item.timingNote && String(item.timingNote).trim()) {
+          timeLabel += ` · ${String(item.timingNote).trim()}`;
+        }
+        parts.push(timeLabel);
+      } else if (item.timingNote && String(item.timingNote).trim()) {
+        parts.push(String(item.timingNote).trim());
+      }
+      return parts.filter(Boolean).join(' · ');
+    }
+
+    function renderRootEvents(section = {}) {
+      const listEl = document.getElementById('landing-events-list');
+      const emptyEl = document.getElementById('landing-events-empty');
+      if (!listEl || !emptyEl) return;
+      const items = typeof model.getRenderableEvents === 'function' ? model.getRenderableEvents(section) : [];
+      setSectionVisible('events', true);
+      if (!items.length) {
+        listEl.innerHTML = '';
+        emptyEl.hidden = false;
+        return;
+      }
+      emptyEl.hidden = true;
+      listEl.innerHTML = items.map(item => `
+    <article class="landing-story-card landing-story-card--event">
+      <p class="landing-card-kicker"><span class="landing-tag ${typeof model.getTargetAccentClass === 'function' ? model.getTargetAccentClass(item.target) : ''}">${escHtml(typeof model.getTargetLabel === 'function' ? model.getTargetLabel(item.target) : '')}</span></p>
+      <h3>${escHtml(item.title || 'Upcoming event')}</h3>
+      <p>${escHtml(item.body || '')}</p>
+      <p class="landing-card-kicker">${escHtml(formatEventScheduleLine(item))}</p>
+    </article>
+  `).join('');
+    }
+
+    function renderRootNews(section = {}) {
+      const listEl = document.getElementById('landing-news-list');
+      const emptyEl = document.getElementById('landing-news-empty');
+      if (!listEl || !emptyEl) return;
+      const items = typeof model.getRenderableNews === 'function' ? model.getRenderableNews(section) : [];
+      setSectionVisible('news', items.length > 0);
+      if (!items.length) {
+        listEl.innerHTML = '';
+        emptyEl.hidden = true;
+        return;
+      }
+      emptyEl.hidden = true;
+      listEl.innerHTML = items.map(item => `
+    <a class="landing-story-card landing-story-card--news ${item.imageUrl ? 'has-image' : 'is-text-only'}" href="${escHtml(item.href)}" target="_blank" rel="noreferrer">
+      ${item.imageUrl ? `<img class="landing-story-image" src="${escHtml(item.imageUrl)}" alt="${escHtml(item.title || item.source || 'News image')}">` : ''}
+      <div class="landing-story-copy">
+        <p class="landing-card-kicker">
+          <span class="landing-tag ${typeof model.getTargetAccentClass === 'function' ? model.getTargetAccentClass(item.target) : ''}">${escHtml(typeof model.getTargetLabel === 'function' ? model.getTargetLabel(item.target) : '')}</span>
+          <span>${escHtml([
+            item.source,
+            (item.publishedDate && typeof model.formatDateLabel === 'function')
+              ? model.formatDateLabel(item.publishedDate, { short: true, year: false })
+              : '',
+          ].filter(Boolean).join(' · '))}</span>
+        </p>
+        <h3>${escHtml(item.title || 'Imported story')}</h3>
+        ${item.body ? `<p>${escHtml(item.body)}</p>` : ''}
+        <span class="landing-story-link">Read Story ↗</span>
+      </div>
+    </a>
+  `).join('');
+    }
+
+    function renderRootReviews(section = {}) {
+      const listEl = document.getElementById('landing-reviews-list');
+      const emptyEl = document.getElementById('landing-reviews-empty');
+      const controlsEl = document.getElementById('landing-reviews-controls');
+      const dotsEl = document.getElementById('landing-reviews-dots');
+      if (!listEl || !emptyEl || !controlsEl || !dotsEl) return;
+      const pairs = typeof model.buildReviewPairs === 'function' ? model.buildReviewPairs(section) : [];
+      const visible = pairs.length > 0;
+      setSectionVisible('reviews', visible);
+      if (!visible) {
+        listEl.innerHTML = '';
+        emptyEl.hidden = true;
+        controlsEl.hidden = true;
+        dotsEl.innerHTML = '';
+        if (typeof store.setReviewCarouselIndex === 'function') store.setReviewCarouselIndex(0);
+        syncLegacyStateFromStore();
+        return;
+      }
+      emptyEl.hidden = true;
+      controlsEl.hidden = pairs.length <= 1;
+      const currentIndex = Math.max(0, Math.min(
+        typeof store.getReviewCarouselIndex === 'function' ? store.getReviewCarouselIndex() : 0,
+        pairs.length - 1
+      ));
+      if (typeof store.setReviewCarouselIndex === 'function') store.setReviewCarouselIndex(currentIndex);
+      syncLegacyStateFromStore();
+      listEl.innerHTML = pairs.map((pair, index) => `
+    <article class="landing-review-pair ${index === currentIndex ? 'is-active' : ''}" data-landing-review-pair="${index}">
+      <article class="landing-review-card landing-review-card--leroys">
+        <p class="landing-card-kicker">${escHtml(restaurants.LEROYS?.name || '')}</p>
+        <h3>${'★'.repeat(Math.max(1, Math.min(5, Number(pair.leroys.rating) || 5)))}</h3>
+        <p>${escHtml(pair.leroys.quote || '')}</p>
+        <p class="landing-card-kicker">${escHtml(pair.leroys.author || '')}${pair.leroys.source ? ` · ${escHtml(pair.leroys.source)}` : ''}</p>
+      </article>
+      <article class="landing-review-card landing-review-card--elroys">
+        <p class="landing-card-kicker">${escHtml(restaurants.ELROYS?.name || '')}</p>
+        <h3>${'★'.repeat(Math.max(1, Math.min(5, Number(pair.elroys.rating) || 5)))}</h3>
+        <p>${escHtml(pair.elroys.quote || '')}</p>
+        <p class="landing-card-kicker">${escHtml(pair.elroys.author || '')}${pair.elroys.source ? ` · ${escHtml(pair.elroys.source)}` : ''}</p>
+      </article>
+    </article>
+  `).join('');
+      dotsEl.innerHTML = pairs.map((pair, index) => {
+        const clickAttr = setReviewCarouselHandlerName
+          ? ` onclick="${setReviewCarouselHandlerName}(${index})"`
+          : '';
+        return `<button type="button" class="landing-review-dot ${index === currentIndex ? 'is-active' : ''}" aria-label="Review pair ${index + 1}"${clickAttr}></button>`;
+      }).join('');
+    }
+
+    function setReviewCarouselIndex(nextIndex = 0) {
+      const pairEls = Array.from(document.querySelectorAll ? document.querySelectorAll('[data-landing-review-pair]') : []);
+      if (!pairEls.length) return;
+      const bounded = Math.max(0, Math.min(Number(nextIndex) || 0, pairEls.length - 1));
+      if (typeof store.setReviewCarouselIndex === 'function') store.setReviewCarouselIndex(bounded);
+      syncLegacyStateFromStore();
+      pairEls.forEach((pairEl, index) => {
+        pairEl.classList.toggle('is-active', index === bounded);
+      });
+      Array.from(document.querySelectorAll ? document.querySelectorAll('.landing-review-dot') : []).forEach((dotEl, index) => {
+        dotEl.classList.toggle('is-active', index === bounded);
+      });
+    }
+
+    function stepReviewCarousel(direction = 1) {
+      const pairCount = Array.from(document.querySelectorAll ? document.querySelectorAll('[data-landing-review-pair]') : []).length;
+      if (!pairCount) return;
+      const currentIndex = typeof store.getReviewCarouselIndex === 'function' ? store.getReviewCarouselIndex() : 0;
+      const nextIndex = (currentIndex + direction + pairCount) % pairCount;
+      setReviewCarouselIndex(nextIndex);
+    }
+
+    function renderRootHours(section = {}) {
+      const restaurantPairs = [
+        { restaurant: restaurants.LEROYS, heroId: 'landing-hero-status-leroys', todayId: 'landing-hours-today-leroys', listId: 'landing-hours-list-leroys' },
+        { restaurant: restaurants.ELROYS, heroId: 'landing-hero-status-elroys', todayId: 'landing-hours-today-elroys', listId: 'landing-hours-list-elroys' },
+      ];
+      restaurantPairs.forEach(({ restaurant, heroId, todayId, listId }) => {
+        if (!restaurant) return;
+        const status = typeof model.computeRestaurantStatus === 'function'
+          ? model.computeRestaurantStatus(section, restaurant.id)
+          : { isOpen: false, label: '', todayRangeLabel: '', weekRows: [] };
+        const heroEl = document.getElementById(heroId);
+        const todayEl = document.getElementById(todayId);
+        const listEl = document.getElementById(listId);
+        if (heroEl) {
+          heroEl.textContent = status.label;
+          heroEl.classList.toggle('is-open', !!status.isOpen);
+          heroEl.classList.toggle('is-closed', !status.isOpen);
+        }
+        if (todayEl) {
+          todayEl.innerHTML = `<span>Today</span><strong>${escHtml(status.todayRangeLabel)}</strong>`;
+        }
+        if (listEl) {
+          listEl.innerHTML = (status.weekRows || []).map(row => (
+            `<div class="landing-hours-row">
+          <dt>${escHtml(row.label)}${row.isToday ? ' · Today' : ''}</dt>
+          <dd>${escHtml(row.rangeLabel)}</dd>
+        </div>`
+          )).join('');
+        }
+      });
+    }
+
+    function setFallbackVisible(visible) {
+      const shellEl = document.getElementById('landing-root-shell');
+      const fallbackEl = document.getElementById('landing-root-fallback');
+      const dotNavEl = document.querySelector ? document.querySelector('.landing-dot-nav') : null;
+      if (shellEl) shellEl.hidden = !!visible;
+      if (fallbackEl) fallbackEl.hidden = !visible;
+      if (dotNavEl) dotNavEl.hidden = !!visible;
+    }
+
+    function renderRootPage(record = store.getRecord()) {
+      if (!hasRootShell()) return;
+      const normalized = getRecord(record);
+      renderRootHours(normalized.liveContent.hours);
+      renderRootEvents(normalized.liveContent.events);
+      renderRootNews(normalized.liveContent.news);
+      renderRootReviews(normalized.liveContent.reviews);
+      setFallbackVisible(false);
+      return normalized;
+    }
+
+    return {
+      setSectionVisible: setSectionVisible,
+      renderRootEvents: renderRootEvents,
+      renderRootNews: renderRootNews,
+      renderRootReviews: renderRootReviews,
+      renderRootHours: renderRootHours,
+      setReviewCarouselIndex: setReviewCarouselIndex,
+      stepReviewCarousel: stepReviewCarousel,
+      setFallbackVisible: setFallbackVisible,
+      renderRootPage: renderRootPage,
+    };
   };
 
   globalScope.__HF_LANDING_MODULES__ = modules;

--- a/core/landing/store.js
+++ b/core/landing/store.js
@@ -21,44 +21,71 @@
       throw new Error('Landing store requires a landing model.');
     }
 
-    const defaultFilters = options.defaultFilters && typeof options.defaultFilters === 'object'
-      ? cloneJsonCompatible(options.defaultFilters, {})
-      : {};
+    const normalizeFilters = typeof model.normalizeFilters === 'function'
+      ? rawFilters => model.normalizeFilters(rawFilters)
+      : (rawFilters => cloneJsonCompatible(rawFilters, {}));
+    const defaultFilters = normalizeFilters(
+      options.defaultFilters && typeof options.defaultFilters === 'object'
+        ? options.defaultFilters
+        : (typeof model.getDefaultFilters === 'function' ? model.getDefaultFilters() : {})
+    );
     let state = {
       record: model.createDefaultRecord(),
       dirty: false,
-      hasLoaded: false,
+      loadScope: 'none',
       loadPromise: null,
+      loadPromiseScope: 'none',
       loadError: '',
       activePanel: options.defaultActivePanel ? String(options.defaultActivePanel) : 'landing-admin-panel-overview',
       filters: defaultFilters,
       reviewCarouselIndex: 0,
     };
 
+    function resolveLoadScope(settings = {}) {
+      if (settings && typeof settings.loadScope === 'string') return settings.loadScope;
+      if (settings && settings.loaded === false) return 'none';
+      return null;
+    }
+
+    function canServeScope(actualScope = 'none', requestedScope = 'live') {
+      if (requestedScope === 'draft') return actualScope === 'draft';
+      return actualScope === 'live' || actualScope === 'draft';
+    }
+
     function syncRecord(record, settings = {}) {
       state.record = model.normalizeRecord(record || model.createDefaultRecord());
       if (typeof settings.dirty === 'boolean') state.dirty = settings.dirty;
-      if (typeof settings.loaded === 'boolean') {
-        state.hasLoaded = settings.loaded;
-      } else if (record) {
-        state.hasLoaded = true;
+      const loadScope = resolveLoadScope(settings);
+      if (loadScope) {
+        state.loadScope = loadScope;
+      } else if (record && state.loadScope === 'none') {
+        state.loadScope = 'live';
       }
-      return state.record;
+      return cloneJsonCompatible(state.record, model.createDefaultRecord());
     }
 
     return {
       getRecord() {
-        return state.record;
+        return cloneJsonCompatible(state.record, model.createDefaultRecord());
       },
       setRecord(record, settings = {}) {
         return syncRecord(record, settings);
       },
-      hasLoaded() {
-        return state.hasLoaded;
+      updateRecord(mutator = () => {}, settings = {}) {
+        const nextRecord = cloneJsonCompatible(state.record, model.createDefaultRecord());
+        if (typeof mutator === 'function') mutator(nextRecord);
+        return syncRecord(nextRecord, settings);
       },
-      setLoaded(value) {
-        state.hasLoaded = !!value;
-        return state.hasLoaded;
+      hasLoaded(options = {}) {
+        const requestedScope = options.includeDraft === true ? 'draft' : 'live';
+        return canServeScope(state.loadScope, requestedScope);
+      },
+      setLoaded(value, settings = {}) {
+        state.loadScope = value ? (resolveLoadScope(settings) || 'live') : 'none';
+        return this.hasLoaded(settings);
+      },
+      getLoadScope() {
+        return state.loadScope;
       },
       isDirty() {
         return state.dirty;
@@ -67,11 +94,17 @@
         state.dirty = !!value;
         return state.dirty;
       },
-      getLoadPromise() {
-        return state.loadPromise;
+      getLoadPromise(options = {}) {
+        const requestedScope = options.includeDraft === true ? 'draft' : 'live';
+        return state.loadPromise && canServeScope(state.loadPromiseScope, requestedScope)
+          ? state.loadPromise
+          : null;
       },
-      setLoadPromise(promise) {
+      setLoadPromise(promise, options = {}) {
         state.loadPromise = promise || null;
+        state.loadPromiseScope = promise
+          ? (options.includeDraft === true ? 'draft' : 'live')
+          : 'none';
         return state.loadPromise;
       },
       getLoadError() {
@@ -93,10 +126,10 @@
       },
       setFilters(nextFilters = {}) {
         const incoming = nextFilters && typeof nextFilters === 'object' ? nextFilters : {};
-        state.filters = cloneJsonCompatible({
+        state.filters = normalizeFilters({
           ...state.filters,
           ...incoming,
-        }, defaultFilters);
+        });
         return this.getFilters();
       },
       getReviewCarouselIndex() {

--- a/core/landing/store.js
+++ b/core/landing/store.js
@@ -1,0 +1,13 @@
+(function bootstrapLandingStoreModule(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+
+  modules.createLandingStore = function createLandingStore() {
+    return {};
+  };
+
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);

--- a/core/landing/store.js
+++ b/core/landing/store.js
@@ -5,8 +5,109 @@
     ? globalScope.__HF_LANDING_MODULES__
     : {};
 
-  modules.createLandingStore = function createLandingStore() {
-    return {};
+  function cloneJsonCompatible(value, fallback) {
+    try {
+      return JSON.parse(JSON.stringify(value ?? fallback));
+    } catch (_) {
+      return JSON.parse(JSON.stringify(fallback));
+    }
+  }
+
+  modules.createLandingStore = function createLandingStore(options = {}) {
+    const model = (options.model && typeof options.model === 'object')
+      ? options.model
+      : (modules.createLandingModel ? modules.createLandingModel() : null);
+    if (!model || typeof model.createDefaultRecord !== 'function' || typeof model.normalizeRecord !== 'function') {
+      throw new Error('Landing store requires a landing model.');
+    }
+
+    const defaultFilters = options.defaultFilters && typeof options.defaultFilters === 'object'
+      ? cloneJsonCompatible(options.defaultFilters, {})
+      : {};
+    let state = {
+      record: model.createDefaultRecord(),
+      dirty: false,
+      hasLoaded: false,
+      loadPromise: null,
+      loadError: '',
+      activePanel: options.defaultActivePanel ? String(options.defaultActivePanel) : 'landing-admin-panel-overview',
+      filters: defaultFilters,
+      reviewCarouselIndex: 0,
+    };
+
+    function syncRecord(record, settings = {}) {
+      state.record = model.normalizeRecord(record || model.createDefaultRecord());
+      if (typeof settings.dirty === 'boolean') state.dirty = settings.dirty;
+      if (typeof settings.loaded === 'boolean') {
+        state.hasLoaded = settings.loaded;
+      } else if (record) {
+        state.hasLoaded = true;
+      }
+      return state.record;
+    }
+
+    return {
+      getRecord() {
+        return state.record;
+      },
+      setRecord(record, settings = {}) {
+        return syncRecord(record, settings);
+      },
+      hasLoaded() {
+        return state.hasLoaded;
+      },
+      setLoaded(value) {
+        state.hasLoaded = !!value;
+        return state.hasLoaded;
+      },
+      isDirty() {
+        return state.dirty;
+      },
+      setDirty(value) {
+        state.dirty = !!value;
+        return state.dirty;
+      },
+      getLoadPromise() {
+        return state.loadPromise;
+      },
+      setLoadPromise(promise) {
+        state.loadPromise = promise || null;
+        return state.loadPromise;
+      },
+      getLoadError() {
+        return state.loadError;
+      },
+      setLoadError(message) {
+        state.loadError = message ? String(message) : '';
+        return state.loadError;
+      },
+      getActivePanel() {
+        return state.activePanel;
+      },
+      setActivePanel(panelId) {
+        state.activePanel = panelId ? String(panelId) : state.activePanel;
+        return state.activePanel;
+      },
+      getFilters() {
+        return cloneJsonCompatible(state.filters, defaultFilters);
+      },
+      setFilters(nextFilters = {}) {
+        const incoming = nextFilters && typeof nextFilters === 'object' ? nextFilters : {};
+        state.filters = cloneJsonCompatible({
+          ...state.filters,
+          ...incoming,
+        }, defaultFilters);
+        return this.getFilters();
+      },
+      getReviewCarouselIndex() {
+        return state.reviewCarouselIndex;
+      },
+      setReviewCarouselIndex(nextIndex = 0) {
+        const numeric = Number(nextIndex);
+        state.reviewCarouselIndex = Number.isFinite(numeric) ? Math.max(0, Math.floor(numeric)) : 0;
+        return state.reviewCarouselIndex;
+      },
+    };
   };
 
   globalScope.__HF_LANDING_MODULES__ = modules;

--- a/docs/superpowers/plans/2026-04-21-appjs-auth-shell-navigation-split.md
+++ b/docs/superpowers/plans/2026-04-21-appjs-auth-shell-navigation-split.md
@@ -1,0 +1,1450 @@
+# App.js Auth And Shell Navigation Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move auth/session UI, settings-shell navigation, user-chip/dropdown behavior, and menu-picker runtime out of `app.js` so `app.js` becomes a thin browser wiring layer without changing current auth or shell behavior.
+
+**Architecture:** Reuse the existing `core/auth/*` boundary instead of adding more app-owned fallback code. Deepen auth around session refresh/teardown and form submission, add a dedicated routing boundary for manager/admin shell entry and settings-drawer behavior, and move user-header/menu-picker DOM logic into focused UI modules. `app.js` should keep only dependency builders, lazy service getters, and one-line wrappers that delegate into the new modules.
+
+**Tech Stack:** Plain browser JavaScript, HTML script tags, Node test runner (`node --test`), no bundler, no dependencies.
+
+---
+
+## File Structure
+
+- `app.js`
+  Keep only dependency assembly and thin wrappers for auth, settings-shell navigation, user header, dropdowns, and menu picker. Delete the large legacy auth/shell bodies at `app.js:3800-4037` and `app.js:9274-10630` once the shared modules own them.
+- `core/auth/auth-session-service.js`
+  Deepen the existing session boundary so it owns session restore, profile refresh, session clearing, and sign-out side effects through injected browser ports.
+- `core/auth/auth-overlay-controller.js`
+  Keep overlay rendering/focus/keyboard ownership here and add click-delegation bootstrapping so per-shell auth entry stays centralized.
+- `core/auth/auth-form-service.js`
+  New deep module for `handleSignIn()`, `handleSignUp()`, `handleForgotPassword()`, `handleResetPassword()`, preview-audit sign-in, and preview-audit button state.
+- `core/routing/settings-policy.js`
+  New boundary for `syncRequestedPageMode()`, `enterManager()`, `exitManager()`, `enterAdmin()`, `exitAdmin()`, `exitView()`, settings-drawer state, section hash syncing, and settings-shell route gating.
+- `core/ui/user-header.js`
+  New boundary for `renderUserHeader()`, `applyRole()`, user-chip hydration/visibility, route dropdown behavior, and global click/escape handlers.
+- `core/ui/menu-picker.js`
+  New boundary for focus-trapped menu picker behavior, `selectMenu()`, active-menu bar updates, and manager/public switch-menu flows.
+- `core/ui/public/footer-actions.js`
+  Keep footer staff actions as the public-facing auth entry surface, and add one helper so shell code does not reach into footer DOM details.
+- `index.html`
+- `manager/index.html`
+- `admin/index.html`
+- `leroyslounge/index.html`
+- `elroyscantina/index.html`
+  Load the new shared scripts before `app.js` without breaking route-first boot or auth overlay centralization.
+- `scripts/check-html-script-order.cjs`
+  Extend the enforced shared runtime order for the new modules.
+- `tests/helpers/runtime.cjs`
+  Add the new runtime scripts to the default in-test loading order.
+- `tests/phase15-auth-boundaries.test.cjs`
+  Guard auth module registration and auth-form/session delegation.
+- `tests/phase15-auth-unification-complete.test.cjs`
+  Guard shared script loading and footer-only staff sign-in behavior.
+- `tests/phase3-ui-boundaries.test.cjs`
+  Guard UI module registration and app-level delegation for user header, footer actions, and menu picker.
+- `tests/architecture-boundaries.test.cjs`
+  Guard routing boundary registration and app delegation for settings-shell policy.
+- `tests/user-chip-route-reimplementation.test.cjs`
+  Move source-level expectations for user-chip runtime out of `app.js` and into the new `core/ui/user-header.js` module.
+
+### Task 1: Lock The New Boundaries In Tests First
+
+**Files:**
+- Modify: `tests/phase15-auth-boundaries.test.cjs`
+- Modify: `tests/phase15-auth-unification-complete.test.cjs`
+- Modify: `tests/phase3-ui-boundaries.test.cjs`
+- Modify: `tests/architecture-boundaries.test.cjs`
+- Modify: `tests/user-chip-route-reimplementation.test.cjs`
+- Test: `tests/phase15-auth-boundaries.test.cjs`
+- Test: `tests/phase15-auth-unification-complete.test.cjs`
+- Test: `tests/phase3-ui-boundaries.test.cjs`
+- Test: `tests/architecture-boundaries.test.cjs`
+- Test: `tests/user-chip-route-reimplementation.test.cjs`
+
+- [ ] **Step 1: Add failing tests for the new auth, routing, and UI boundaries**
+
+```js
+test('auth module scripts register session, overlay, and form boundaries', () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/auth/auth-api.js',
+    'core/auth/auth-session-service.js',
+    'core/auth/auth-overlay-template.js',
+    'core/auth/auth-overlay-controller.js',
+    'core/auth/auth-form-service.js',
+  ]);
+
+  assert.equal(typeof sandbox.__HF_AUTH_MODULES__, 'object');
+  assert.equal(typeof sandbox.__HF_AUTH_MODULES__.createAccessSessionService, 'function');
+  assert.equal(typeof sandbox.__HF_AUTH_MODULES__.createAuthOverlayController, 'function');
+  assert.equal(typeof sandbox.__HF_AUTH_MODULES__.createAuthFormService, 'function');
+});
+
+test('routing module scripts register settings route policy boundary', () => {
+  const sandbox = loadSandboxWithScripts(['core/routing/settings-policy.js']);
+  assert.equal(typeof sandbox.__HF_ROUTING_MODULES__, 'object');
+  assert.equal(typeof sandbox.__HF_ROUTING_MODULES__.createSettingsRoutePolicyService, 'function');
+});
+
+test('ui module scripts register user header and menu picker boundaries', () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/ui/public/footer-actions.js',
+    'core/ui/user-header.js',
+    'core/ui/menu-picker.js',
+  ]);
+
+  assert.equal(typeof sandbox.__HF_UI_MODULES__, 'object');
+  assert.equal(typeof sandbox.__HF_UI_MODULES__.createPublicFooterActionsService, 'function');
+  assert.equal(typeof sandbox.__HF_UI_MODULES__.createUserHeaderService, 'function');
+  assert.equal(typeof sandbox.__HF_UI_MODULES__.createMenuPickerService, 'function');
+});
+```
+
+- [ ] **Step 2: Add failing shell-loading and source-location assertions**
+
+```js
+test('all entry shells load auth form, settings policy, user header, and menu picker before app.js', () => {
+  const entryFiles = [
+    'index.html',
+    'manager/index.html',
+    'admin/index.html',
+    'leroyslounge/index.html',
+    'elroyscantina/index.html',
+  ];
+
+  entryFiles.forEach(file => {
+    const html = read(file);
+    assert.equal(html.includes('/core/auth/auth-form-service.js'), true, `${file} must load auth form service`);
+    assert.equal(html.includes('/core/routing/settings-policy.js'), true, `${file} must load settings policy service`);
+    assert.equal(html.includes('/core/ui/user-header.js'), true, `${file} must load user header service`);
+    assert.equal(html.includes('/core/ui/menu-picker.js'), true, `${file} must load menu picker service`);
+  });
+});
+
+test('user chip runtime source lives in core/ui/user-header.js instead of app.js', () => {
+  const appSource = read('app.js');
+  const userHeaderSource = read('core/ui/user-header.js');
+
+  assert.doesNotMatch(appSource, /querySelectorAll\('\[data-user-chip\], \.user-chip, \[data-route-user-chip\]'\)/);
+  assert.match(userHeaderSource, /querySelectorAll\('\[data-user-chip\], \.user-chip, \[data-route-user-chip\]'\)/);
+  assert.match(userHeaderSource, /querySelector\('\[data-user-chip-name\]'\)/);
+  assert.match(userHeaderSource, /querySelector\('\[data-user-chip-role\]'\)/);
+  assert.match(userHeaderSource, /querySelector\('\[data-user-chip-initials\]'\)/);
+});
+```
+
+- [ ] **Step 3: Run the targeted tests to confirm the new assertions fail**
+
+Run: `node --test tests/phase15-auth-boundaries.test.cjs tests/phase15-auth-unification-complete.test.cjs tests/phase3-ui-boundaries.test.cjs tests/architecture-boundaries.test.cjs tests/user-chip-route-reimplementation.test.cjs`
+
+Expected: FAIL because `core/auth/auth-form-service.js`, `core/routing/settings-policy.js`, `core/ui/user-header.js`, and `core/ui/menu-picker.js` do not exist yet, the shells do not load them, and the user-chip source still lives in `app.js`.
+
+- [ ] **Step 4: Commit the red-test guardrail slice**
+
+```bash
+git add tests/phase15-auth-boundaries.test.cjs tests/phase15-auth-unification-complete.test.cjs tests/phase3-ui-boundaries.test.cjs tests/architecture-boundaries.test.cjs tests/user-chip-route-reimplementation.test.cjs
+git commit -m "test: lock auth shell split boundaries"
+```
+
+### Task 2: Deepen Auth Into Shared Session And Form Services
+
+**Files:**
+- Create: `core/auth/auth-form-service.js`
+- Modify: `core/auth/auth-session-service.js`
+- Modify: `core/auth/auth-overlay-controller.js`
+- Modify: `app.js:3664-3800`
+- Modify: `app.js:9274-10576`
+- Modify: `tests/phase15-auth-boundaries.test.cjs`
+- Test: `tests/phase15-auth-boundaries.test.cjs`
+
+- [ ] **Step 1: Add a failing delegation test for auth form handlers and session refresh**
+
+```js
+test('app auth form handlers and session refresh delegate through shared auth module boundaries', async () => {
+  const calls = [];
+  const sandbox = loadSandboxWithScripts(['app.js'], {
+    __HF_AUTH_MODULES__: {
+      createAccessSessionService: () => ({
+        refreshCurrentUserProfile: async () => {
+          calls.push('refreshCurrentUserProfile');
+          return { role: 'manager', name: 'Taylor Manager', accessibleMenuIds: ['menu-1'] };
+        },
+        signOut: () => calls.push('signOut'),
+      }),
+      createAuthFormService: () => ({
+        handleSignIn: async () => calls.push('handleSignIn'),
+        handleSignUp: async () => calls.push('handleSignUp'),
+        handleForgotPassword: async () => calls.push('handleForgotPassword'),
+        handleResetPassword: async () => calls.push('handleResetPassword'),
+      }),
+    },
+  });
+
+  await sandbox.refreshCurrentUserProfile();
+  await sandbox.handleSignIn();
+  await sandbox.handleSignUp();
+  await sandbox.handleForgotPassword();
+  await sandbox.handleResetPassword();
+  sandbox.signOut();
+
+  assert.deepEqual(calls, [
+    'refreshCurrentUserProfile',
+    'handleSignIn',
+    'handleSignUp',
+    'handleForgotPassword',
+    'handleResetPassword',
+    'signOut',
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the auth boundary test to verify it fails first**
+
+Run: `node --test tests/phase15-auth-boundaries.test.cjs`
+
+Expected: FAIL because `app.js` still owns `refreshCurrentUserProfile()`, the auth submit handlers, and `signOut()`.
+
+- [ ] **Step 3: Create `core/auth/auth-form-service.js` and move form submission plus preview-audit behavior there**
+
+```js
+(function bootstrapAuthFormService(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_AUTH_MODULES__ && typeof globalScope.__HF_AUTH_MODULES__ === 'object')
+    ? globalScope.__HF_AUTH_MODULES__
+    : {};
+
+  function createAuthFormServiceImpl(deps = {}) {
+    const getDocument = typeof deps.getDocument === 'function' ? deps.getDocument : (() => globalScope.document);
+    const signIn = typeof deps.signIn === 'function' ? deps.signIn : (async () => ({}));
+    const signUp = typeof deps.signUp === 'function' ? deps.signUp : (async () => ({}));
+    const resetPasswordForEmail = typeof deps.resetPasswordForEmail === 'function' ? deps.resetPasswordForEmail : (async () => null);
+    const updatePassword = typeof deps.updatePassword === 'function' ? deps.updatePassword : (async () => ({}));
+    const getRecoverySessionData = typeof deps.getRecoverySessionData === 'function' ? deps.getRecoverySessionData : (() => null);
+    const getAccessSessionService = typeof deps.getAccessSessionService === 'function' ? deps.getAccessSessionService : (() => null);
+    const closeAuthOverlay = typeof deps.closeAuthOverlay === 'function' ? deps.closeAuthOverlay : (() => {});
+    const syncRequestedPageMode = typeof deps.syncRequestedPageMode === 'function' ? deps.syncRequestedPageMode : (async () => {});
+    const showToast = typeof deps.showToast === 'function' ? deps.showToast : (() => {});
+    const isPreview = typeof deps.isPreview === 'function' ? deps.isPreview : (() => false);
+    const isSettingsPage = typeof deps.isSettingsPage === 'function' ? deps.isSettingsPage : (() => false);
+    const getRequestedMode = typeof deps.getRequestedMode === 'function' ? deps.getRequestedMode : (() => 'manager');
+    const fetchPreviewAuditAvailability = typeof deps.fetchPreviewAuditAvailability === 'function'
+      ? deps.fetchPreviewAuditAvailability
+      : (async () => ({ available: false }));
+    const signInToPreviewAuditSession = typeof deps.signInToPreviewAuditSession === 'function'
+      ? deps.signInToPreviewAuditSession
+      : (async () => ({ session: null }));
+    const setAuthScreen = typeof deps.setAuthScreen === 'function' ? deps.setAuthScreen : (() => {});
+    const getAuthScreen = typeof deps.getAuthScreen === 'function' ? deps.getAuthScreen : (() => 'signin');
+
+    function getFieldValue(id) {
+      return getDocument().getElementById(id)?.value?.trim?.() || '';
+    }
+
+    function setButtonState(id, disabled, label) {
+      const button = getDocument().getElementById(id);
+      if (!button) return;
+      button.disabled = !!disabled;
+      button.textContent = label;
+    }
+
+    function setError(id, message) {
+      const element = getDocument().getElementById(id);
+      if (element) element.textContent = message || '';
+    }
+
+    async function handleSignIn() {
+      const email = getFieldValue('signin-email');
+      const password = getDocument().getElementById('signin-password')?.value || '';
+      if (!email || !password) return setError('signin-error', 'Enter your email and password.');
+      setError('signin-error', '');
+      setButtonState('signin-submit-btn', true, 'Signing in…');
+      try {
+        const data = await signIn({ email, password });
+        const sessionService = getAccessSessionService();
+        const result = await sessionService.applyAuthenticatedSession(data, { closeOverlay: true });
+        await syncRequestedPageMode();
+        if (result?.profileUnavailable) showToast('Signed in, but your access could not be verified yet.', 'info');
+        else if (result?.role === 'none') showToast('Signed in. Contact admin to get manager access.', 'info');
+      } catch (error) {
+        setError('signin-error', error?.msg || error?.error_description || error?.message || 'Authentication failed.');
+      } finally {
+        setButtonState('signin-submit-btn', false, 'Sign In');
+      }
+    }
+
+    async function handleResetPassword() {
+      const password = getDocument().getElementById('reset-password')?.value || '';
+      const confirm = getDocument().getElementById('reset-confirm')?.value || '';
+      const recoveryData = getRecoverySessionData();
+      if (!password) return setError('reset-error', 'Enter a new password.');
+      if (password !== confirm) return setError('reset-error', 'Passwords do not match.');
+      if (password.length < 6) return setError('reset-error', 'Password must be at least 6 characters.');
+      if (!recoveryData) return setError('reset-error', 'Reset session expired. Please request a new link.');
+      setError('reset-error', '');
+      setButtonState('reset-submit-btn', true, 'Saving…');
+      try {
+        await updatePassword({ newPassword: password, accessToken: recoveryData.access_token });
+        await getAccessSessionService().applyAuthenticatedSession(recoveryData, { closeOverlay: true });
+        await syncRequestedPageMode();
+        showToast('Password updated. You are now signed in.', 'info');
+      } catch (error) {
+        setError('reset-error', error?.msg || error?.error_description || error?.message || 'Failed to update password.');
+      } finally {
+        setButtonState('reset-submit-btn', false, 'Set Password');
+      }
+    }
+
+    async function handleSignUp() {
+      const firstName = getFieldValue('signup-firstname');
+      const lastName = getFieldValue('signup-lastname');
+      const email = getFieldValue('signup-email');
+      const password = getDocument().getElementById('signup-password')?.value || '';
+      if (!email || !password) return setError('signup-error', 'Enter your email and password.');
+      setError('signup-error', '');
+      setButtonState('signup-submit-btn', true, 'Creating account…');
+      try {
+        await signUp({ email, password, name: [firstName, lastName].filter(Boolean).join(' ') });
+        closeAuthOverlay();
+        showToast('Account created. Contact admin to activate manager access.', 'info');
+      } catch (error) {
+        setError('signup-error', error?.msg || error?.error_description || error?.message || 'Sign-up failed.');
+      } finally {
+        setButtonState('signup-submit-btn', false, 'Create Account');
+      }
+    }
+
+    async function handleForgotPassword() {
+      const email = getFieldValue('forgot-email');
+      if (!email) return setError('forgot-error', 'Enter your email address.');
+      setError('forgot-error', '');
+      setButtonState('forgot-submit-btn', true, 'Sending…');
+      try {
+        await resetPasswordForEmail({ email });
+        closeAuthOverlay();
+        showToast('Check your email for a password reset link.', 'info');
+      } catch (error) {
+        setError('forgot-error', error?.msg || error?.error_description || error?.message || 'Failed to send reset email.');
+      } finally {
+        setButtonState('forgot-submit-btn', false, 'Send Reset Link');
+      }
+    }
+
+    async function handlePreviewAuditSignIn() {
+      if (!isPreview() || !isSettingsPage()) return;
+      setError('signin-error', '');
+      setButtonState('signin-submit-btn', true, 'Opening Preview Audit Session…');
+      try {
+        const payload = await signInToPreviewAuditSession({ mode: getRequestedMode() });
+        if (!payload?.session?.access_token) throw new Error(payload?.error || 'Preview audit session failed.');
+        const result = await getAccessSessionService().applyAuthenticatedSession(payload.session, { closeOverlay: true });
+        await syncRequestedPageMode();
+        if (result?.profileUnavailable) showToast('Preview audit session opened, but access could not be verified yet.', 'info');
+        else if (result?.role === 'none') showToast('Preview audit session opened, but no menu access is configured.', 'info');
+      } catch (error) {
+        setError('signin-error', error?.message || 'Preview audit session failed.');
+      } finally {
+        setButtonState('signin-submit-btn', false, 'Sign In');
+      }
+    }
+
+    return {
+      handleSignIn,
+      handleSignUp,
+      handleForgotPassword,
+      handleResetPassword,
+      handlePreviewAuditSignIn,
+      syncPreviewAuditButton: async function syncPreviewAuditButton() {
+        if (getAuthScreen() !== 'signin' || !isPreview() || !isSettingsPage()) return;
+        await fetchPreviewAuditAvailability({ mode: getRequestedMode() });
+      },
+      setAuthScreen,
+    };
+  }
+
+  modules.createAuthFormService = function createAuthFormServiceBoundary(deps = {}, options = {}) {
+    if (options && typeof options.fallback === 'function') return options.fallback();
+    return createAuthFormServiceImpl(deps);
+  };
+
+  globalScope.__HF_AUTH_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+- [ ] **Step 4: Extend `core/auth/auth-session-service.js` so the shared service owns profile refresh, session clearing, and sign-out**
+
+```js
+const getCurrentUser = typeof deps.getCurrentUser === 'function' ? deps.getCurrentUser : (() => null);
+const setCurrentUser = typeof deps.setCurrentUser === 'function' ? deps.setCurrentUser : (() => {});
+const normalizeAccessibleMenuIds = typeof deps.normalizeAccessibleMenuIds === 'function'
+  ? deps.normalizeAccessibleMenuIds
+  : (value => Array.isArray(value) ? value : []);
+const showToast = typeof deps.showToast === 'function' ? deps.showToast : (() => {});
+const renderUserHeader = typeof deps.renderUserHeader === 'function' ? deps.renderUserHeader : (() => {});
+const exitView = typeof deps.exitView === 'function' ? deps.exitView : (() => {});
+
+function updateCurrentUserProfile(profile = {}) {
+  const user = getCurrentUser();
+  if (!user) return profile;
+  user.name = profile.name || '';
+  user.role = profile.role || 'none';
+  user.accessibleMenuIds = normalizeAccessibleMenuIds(profile.accessibleMenuIds);
+  applyRole(user.role);
+  return profile;
+}
+
+async function refreshCurrentUserProfile() {
+  const user = getCurrentUser();
+  if (!user?.accessToken) return { role: 'none', name: '', accessibleMenuIds: [] };
+  try {
+    return updateCurrentUserProfile(await fetchProfile(user.accessToken));
+  } catch (error) {
+    if (isTerminalAuthSessionError(error)) {
+      showToast('Your session expired. Sign in again.', 'info');
+      service.clearCurrentSessionState({ syncRequestedPageMode: false, exitViewOnSettings: false });
+      return { role: 'none', name: '', accessibleMenuIds: [], authExpired: true };
+    }
+    showToast('Unable to refresh your access right now. Keeping your current session.', 'error');
+    return {
+      role: user?.role || 'none',
+      name: user?.name || '',
+      accessibleMenuIds: normalizeAccessibleMenuIds(user?.accessibleMenuIds),
+      staleProfile: true,
+    };
+  }
+}
+
+function clearCurrentSessionState(options = {}) {
+  const { syncRequestedPageMode = true, exitViewOnSettings = true } = options;
+  clearStoredSessionImpl({
+    clearExistingTimer: deps.clearExistingTimer,
+    setTimerRef: deps.setTimerRef,
+    setCurrentUser,
+    clearStorage: deps.clearStorage,
+  });
+  deps.clearManagerMenuPicked?.();
+  if (exitViewOnSettings && deps.isInSettingsView?.()) exitView();
+  renderUserHeader();
+  if (syncRequestedPageMode) return service.syncRequestedPageMode();
+  return null;
+}
+
+Object.assign(service, {
+  async refreshCurrentUserProfile() {
+    return refreshCurrentUserProfile();
+  },
+  clearCurrentSessionState,
+  signOut() {
+    return clearCurrentSessionState({ syncRequestedPageMode: true });
+  },
+});
+```
+
+- [ ] **Step 5: Make `app.js` delegate auth runtime through the shared services instead of carrying shadow implementations**
+
+```js
+// Extend the existing buildAccessSessionModuleDeps() return object with these new ports.
+getCurrentUser: () => currentUser,
+setCurrentUser: value => { currentUser = value; },
+normalizeAccessibleMenuIds: value => normalizeAccessibleMenuIds(value),
+showToast: (message, tone) => showToast(message, tone),
+renderUserHeader: options => renderUserHeader(options),
+exitView: () => exitView(),
+clearManagerMenuPicked: () => { _managerMenuPicked = false; },
+isInSettingsView: () => isManagerMode || isAdminMode,
+clearExistingTimer: () => {
+  if (_tokenRefreshTimer) clearTimeout(_tokenRefreshTimer);
+},
+setTimerRef: value => { _tokenRefreshTimer = value; },
+clearStorage: () => clearStoredAuthSessionKeys(),
+
+function buildAuthFormServiceDeps() {
+  return {
+    getDocument: () => document,
+    signIn: ({ email, password }) => sbSignIn(email, password),
+    signUp: ({ email, password, name }) => sbSignUp(email, password, name),
+    resetPasswordForEmail: ({ email }) => sbResetPasswordForEmail(email),
+    updatePassword: ({ newPassword, accessToken }) => sbUpdatePassword(newPassword, accessToken),
+    getRecoverySessionData: () => _recoverySessionData,
+    getAccessSessionService: () => getAccessSessionService(),
+    closeAuthOverlay: () => closeAuthOverlay(),
+    syncRequestedPageMode: () => _syncRequestedPageMode(),
+    showToast: (message, tone) => showToast(message, tone),
+    isPreview: () => IS_PREVIEW,
+    isSettingsPage: () => isSettingsPage(),
+    getRequestedMode: () => (_appPageMode === 'admin' ? 'admin' : 'manager'),
+    fetchPreviewAuditAvailability: options => fetchPreviewAuditAvailability(options),
+    signInToPreviewAuditSession: async payload => {
+      const response = await fetch(PREVIEW_AUDIT_SESSION_ENDPOINT, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ action: 'preview_audit_sign_in', mode: payload?.mode || 'manager' }),
+      });
+      return response.json().catch(() => ({}));
+    },
+    getAuthScreen: () => _authScreen,
+    setAuthScreen: value => { _authScreen = value; },
+  };
+}
+
+function getAuthFormService() {
+  if (_authFormService) return _authFormService;
+  const boundary = getAuthModuleBoundary();
+  if (typeof boundary?.createAuthFormService !== 'function') return null;
+  _authFormService = boundary.createAuthFormService(buildAuthFormServiceDeps());
+  return _authFormService;
+}
+
+function createAccessSessionService() {
+  const boundary = getAuthModuleBoundary();
+  if (typeof boundary?.createAccessSessionService !== 'function') return null;
+  return boundary.createAccessSessionService(buildAccessSessionModuleDeps());
+}
+
+async function refreshCurrentUserProfile() {
+  const service = getAccessSessionService();
+  return service?.refreshCurrentUserProfile ? service.refreshCurrentUserProfile() : { role: 'none', name: '', accessibleMenuIds: [] };
+}
+
+async function handleSignIn() {
+  return getAuthFormService()?.handleSignIn();
+}
+
+function signOut() {
+  return getAccessSessionService()?.signOut();
+}
+```
+
+- [ ] **Step 6: Re-run the auth boundary test and a syntax check**
+
+Run: `node --test tests/phase15-auth-boundaries.test.cjs && node --check app.js`
+
+Expected: PASS. `app.js` no longer owns the large auth handler bodies, and the shared auth module boundary now owns submit handling and session refresh/teardown.
+
+- [ ] **Step 7: Commit the auth extraction slice**
+
+```bash
+git add core/auth/auth-form-service.js core/auth/auth-session-service.js core/auth/auth-overlay-controller.js app.js tests/phase15-auth-boundaries.test.cjs
+git commit -m "refactor: move app auth flow behind shared auth services"
+```
+
+### Task 3: Move Settings-Shell Navigation Into A Routing Policy Module
+
+**Files:**
+- Create: `core/routing/settings-policy.js`
+- Modify: `app.js:3907-4025`
+- Modify: `app.js:9603-9777`
+- Modify: `tests/architecture-boundaries.test.cjs`
+- Test: `tests/architecture-boundaries.test.cjs`
+
+- [ ] **Step 1: Add a failing test that `app.js` delegates settings-shell behavior through a routing boundary**
+
+```js
+test('app settings shell functions delegate through shared routing policy boundary', async () => {
+  const calls = [];
+  const sandbox = loadSandboxWithScripts(['app.js'], {
+    __HF_ROUTING_MODULES__: {
+      createSettingsRoutePolicyService: () => ({
+        syncRequestedPageMode: async () => {
+          calls.push('syncRequestedPageMode');
+          return { handled: true, status: 'entered', pageMode: 'manager' };
+        },
+        toggleSettingsDrawer: () => calls.push('toggleSettingsDrawer'),
+        closeSettingsDrawer: options => calls.push(['closeSettingsDrawer', options]),
+        enterManager: () => calls.push('enterManager'),
+        exitManager: () => calls.push('exitManager'),
+        enterAdmin: () => calls.push('enterAdmin'),
+        exitAdmin: () => calls.push('exitAdmin'),
+      }),
+    },
+  });
+
+  await sandbox._syncRequestedPageMode();
+  sandbox.toggleSettingsDrawer();
+  sandbox.closeSettingsDrawer({ restoreFocus: false });
+  sandbox.enterManager();
+  sandbox.exitManager();
+  sandbox.enterAdmin();
+  sandbox.exitAdmin();
+
+  assert.deepEqual(calls, [
+    'syncRequestedPageMode',
+    'toggleSettingsDrawer',
+    ['closeSettingsDrawer', { restoreFocus: false }],
+    'enterManager',
+    'exitManager',
+    'enterAdmin',
+    'exitAdmin',
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the routing boundary test to verify it fails first**
+
+Run: `node --test tests/architecture-boundaries.test.cjs`
+
+Expected: FAIL because `core/routing/settings-policy.js` does not exist yet and `app.js` still owns the settings-shell runtime.
+
+- [ ] **Step 3: Create `core/routing/settings-policy.js` and move settings-shell routing, drawer state, and manager/admin entry there**
+
+```js
+(function bootstrapSettingsRoutePolicy(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_ROUTING_MODULES__ && typeof globalScope.__HF_ROUTING_MODULES__ === 'object')
+    ? globalScope.__HF_ROUTING_MODULES__
+    : {};
+
+  function createSettingsRoutePolicyServiceImpl(deps = {}) {
+    const getDocument = typeof deps.getDocument === 'function' ? deps.getDocument : (() => globalScope.document);
+    const getWindow = typeof deps.getWindow === 'function' ? deps.getWindow : (() => globalScope.window || globalScope);
+    const isSettingsPage = typeof deps.isSettingsPage === 'function' ? deps.isSettingsPage : (() => false);
+    const requestSignIn = typeof deps.requestSignIn === 'function' ? deps.requestSignIn : (() => {});
+    const refreshCurrentUserProfile = typeof deps.refreshCurrentUserProfile === 'function'
+      ? deps.refreshCurrentUserProfile
+      : (async () => ({ role: 'none', name: '', accessibleMenuIds: [] }));
+    const resolveRequestedSettingsRoute = typeof deps.resolveRequestedSettingsRoute === 'function'
+      ? deps.resolveRequestedSettingsRoute
+      : (() => ({ kind: 'auth-required' }));
+    const loadSettingsPageMenuContext = typeof deps.loadSettingsPageMenuContext === 'function'
+      ? deps.loadSettingsPageMenuContext
+      : (async () => false);
+    const renderUserHeader = typeof deps.renderUserHeader === 'function' ? deps.renderUserHeader : (() => {});
+    const renderManagerWorkspace = typeof deps.renderManagerWorkspace === 'function' ? deps.renderManagerWorkspace : (() => {});
+    const renderAdminWorkspace = typeof deps.renderAdminWorkspace === 'function' ? deps.renderAdminWorkspace : (() => {});
+
+    function getSettingsDrawerDom() {
+      const doc = getDocument();
+      const adminDrawer = doc.getElementById('admin-settings-rail');
+      const adminBackdrop = doc.getElementById('admin-settings-drawer-backdrop');
+      const adminToggle = doc.getElementById('admin-mobile-drawer-toggle');
+      const managerDrawer = doc.getElementById('manager-settings-rail');
+      const managerBackdrop = doc.getElementById('settings-drawer-backdrop');
+      const managerToggle = doc.getElementById('settings-drawer-toggle');
+      const managerMobileTrigger = doc.getElementById('manager-mobile-drawer-trigger');
+
+      if (deps.getAppPageMode?.() === 'admin' || (!managerDrawer && adminDrawer)) {
+        return {
+          drawer: adminDrawer,
+          backdrop: adminBackdrop,
+          toggle: adminToggle,
+          mobileTrigger: null,
+          mobileWidth: 900,
+          bodyOpenClass: 'admin-settings-drawer-open',
+        };
+      }
+
+      return {
+        drawer: managerDrawer,
+        backdrop: managerBackdrop,
+        toggle: managerToggle,
+        mobileTrigger: managerMobileTrigger,
+        mobileWidth: 920,
+        bodyOpenClass: 'settings-drawer-open',
+      };
+    }
+
+    async function syncRequestedPageMode() {
+      if (!isSettingsPage()) return { handled: false };
+      renderUserHeader();
+      if (!deps.getCurrentUser?.()) {
+        deps.resetSettingsModes?.();
+        deps.setLoadingMessage?.('Sign in to access settings.', { hideSpinner: true, showLockedState: true });
+        requestSignIn({ screen: 'signin', origin: 'settings-gate', reason: 'settings-auth-required' });
+        return { handled: true, status: 'auth-required', pageMode: deps.getAppPageMode?.() || 'public' };
+      }
+      if (deps.getAppPageMode?.() === 'manager') {
+        deps.setLoadingMessage?.('Checking manager access…');
+        const profile = await refreshCurrentUserProfile();
+        if (profile?.authExpired) return { handled: true, status: 'auth-required', pageMode: 'manager' };
+      }
+      const routeDecision = resolveRequestedSettingsRoute();
+      if (routeDecision.kind === 'admin') return enterAdmin(routeDecision.targetMenuId);
+      if (routeDecision.kind === 'manager') return enterManager(routeDecision.targetMenuId);
+      return { handled: true, status: routeDecision.kind, pageMode: deps.getAppPageMode?.() || 'public' };
+    }
+
+    function enterManager(targetMenuId) {
+      deps.prepareManagerShell?.(targetMenuId);
+      renderUserHeader();
+      renderManagerWorkspace();
+      deps.syncSettingsSectionFromLocation?.('manager-overview-section');
+      return { handled: true, status: 'entered', pageMode: 'manager', menuId: targetMenuId || deps.getMenuId?.() || '' };
+    }
+
+    function enterAdmin(targetMenuId) {
+      deps.prepareAdminShell?.(targetMenuId);
+      renderUserHeader();
+      renderAdminWorkspace();
+      deps.syncSettingsSectionFromLocation?.('admin-restaurants-section');
+      return { handled: true, status: 'entered', pageMode: 'admin', menuId: targetMenuId || deps.getMenuId?.() || '' };
+    }
+
+    return {
+      getSettingsDrawerDom,
+      setSettingsDrawerOpen: deps.setSettingsDrawerOpenImpl,
+      toggleSettingsDrawer() {
+        const drawer = getSettingsDrawerDom().drawer;
+        if (!drawer) return;
+        deps.setSettingsDrawerOpenImpl?.(!drawer.classList.contains('is-open'));
+      },
+      closeSettingsDrawer(options = {}) {
+        deps.setSettingsDrawerOpenImpl?.(false, options);
+      },
+      syncRequestedPageMode,
+      enterManager,
+      exitManager: deps.exitManagerImpl,
+      enterAdmin,
+      exitAdmin: deps.exitAdminImpl,
+      exitView: deps.exitViewImpl,
+      focusSettingsSection: deps.focusSettingsSectionImpl,
+    };
+  }
+
+  modules.createSettingsRoutePolicyService = function createSettingsRoutePolicyServiceBoundary(deps = {}, options = {}) {
+    if (options && typeof options.fallback === 'function') return options.fallback();
+    return createSettingsRoutePolicyServiceImpl(deps);
+  };
+
+  globalScope.__HF_ROUTING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+- [ ] **Step 4: Replace the big `app.js` settings-shell bodies with service getters and one-line wrappers**
+
+```js
+function getRoutingModuleBoundary() {
+  return globalThis.__HF_ROUTING_MODULES__ || null;
+}
+
+function buildSettingsRoutePolicyDeps() {
+  const setSettingsDrawerOpenImpl = (isOpen, options = {}) => {
+    const service = getSettingsRoutePolicyService();
+    if (!service) return;
+    const { drawer, backdrop, toggle, mobileTrigger, mobileWidth, bodyOpenClass } = service.getSettingsDrawerDom();
+    const isMobileDrawer = window.innerWidth <= mobileWidth;
+    const shouldRestoreToggleFocus = options.restoreFocus !== false;
+    if (!drawer || !backdrop) return;
+    drawer.classList.toggle('is-open', !!isOpen && isMobileDrawer);
+    drawer.setAttribute('aria-hidden', isMobileDrawer && !isOpen ? 'true' : 'false');
+    backdrop.hidden = !(isOpen && isMobileDrawer);
+    document.body.classList.remove('settings-drawer-open', 'admin-settings-drawer-open');
+    document.body.classList.toggle(bodyOpenClass, !!isOpen && isMobileDrawer);
+    if (toggle) toggle.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    if (mobileTrigger) mobileTrigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+    if (!isOpen && isMobileDrawer && shouldRestoreToggleFocus) (mobileTrigger || toggle)?.focus?.();
+  };
+
+  const focusSettingsSectionImpl = (sectionId, trigger, options = {}) => {
+    const section = document.getElementById(sectionId);
+    if (!section) return;
+    if (trigger) setActiveSettingsSection(trigger.dataset.target || sectionId);
+    else setActiveSettingsSection(sectionId);
+    setSettingsDrawerOpenImpl(false);
+    if (options.scroll !== false) section.scrollIntoView({ behavior: options.behavior || 'smooth', block: 'start' });
+  };
+
+  const syncSettingsSectionFromLocationImpl = defaultSectionId => {
+    requestAnimationFrame(() => focusSettingsSectionImpl(defaultSectionId, null, { behavior: 'auto', scroll: false, updateUrl: false }));
+  };
+
+  const exitManagerImpl = () => {
+    isManagerMode = false;
+    document.body.classList.remove('manager-mode');
+    _setDisplayById('manager-view', 'none');
+    _setRestaurantPublicMode(false);
+    setSettingsDrawerOpenImpl(false);
+    renderUserHeader();
+    if (isSettingsPage()) navigateToPage(getPublicHrefForCurrentMenu());
+    else showPublicView();
+  };
+
+  const exitAdminImpl = () => {
+    isAdminMode = false;
+    document.body.classList.remove('manager-mode');
+    _setDisplayById('manager-view', 'none');
+    _setRestaurantPublicMode(false);
+    setSettingsDrawerOpenImpl(false);
+    renderUserHeader();
+    if (isSettingsPage()) navigateToPage(getPublicHrefForCurrentMenu());
+    else showPublicView();
+  };
+
+  const exitViewImpl = () => {
+    if (isManagerMode) exitManagerImpl();
+    else if (isAdminMode) exitAdminImpl();
+  };
+
+  return {
+    getDocument: () => document,
+    getWindow: () => window,
+    getAppPageMode: () => _appPageMode,
+    getCurrentUser: () => currentUser,
+    getMenuId: () => MENU_ID,
+    isSettingsPage: () => isSettingsPage(),
+    requestSignIn: options => requestSignIn(options),
+    refreshCurrentUserProfile: () => refreshCurrentUserProfile(),
+    resolveRequestedSettingsRoute: () => resolveRequestedSettingsRoute(),
+    loadSettingsPageMenuContext: menuId => _loadSettingsPageMenuContext(menuId),
+    renderUserHeader: options => renderUserHeader(options),
+    renderManagerWorkspace: () => renderManagerWorkspace(),
+    renderAdminWorkspace: () => renderAdminWorkspace(),
+    setSettingsDrawerOpenImpl,
+    focusSettingsSectionImpl,
+    syncSettingsSectionFromLocation: syncSettingsSectionFromLocationImpl,
+    exitManagerImpl,
+    exitAdminImpl,
+    exitViewImpl,
+  };
+}
+
+function getSettingsRoutePolicyService() {
+  if (_settingsRoutePolicyService) return _settingsRoutePolicyService;
+  const boundary = getRoutingModuleBoundary();
+  if (typeof boundary?.createSettingsRoutePolicyService !== 'function') return null;
+  _settingsRoutePolicyService = boundary.createSettingsRoutePolicyService(buildSettingsRoutePolicyDeps());
+  return _settingsRoutePolicyService;
+}
+
+async function _syncRequestedPageMode() {
+  return getSettingsRoutePolicyService()?.syncRequestedPageMode();
+}
+
+function toggleSettingsDrawer() {
+  return getSettingsRoutePolicyService()?.toggleSettingsDrawer();
+}
+
+function enterManager() {
+  return getSettingsRoutePolicyService()?.enterManager();
+}
+```
+
+- [ ] **Step 5: Re-run the routing boundary test and a syntax check**
+
+Run: `node --test tests/architecture-boundaries.test.cjs && node --check app.js`
+
+Expected: PASS. `app.js` should stop carrying the long settings-shell route gate and manager/admin entry code.
+
+- [ ] **Step 6: Commit the routing extraction slice**
+
+```bash
+git add core/routing/settings-policy.js app.js tests/architecture-boundaries.test.cjs
+git commit -m "refactor: extract settings shell policy from app runtime"
+```
+
+### Task 4: Extract User Header, Footer Sync, And Dropdown Runtime
+
+**Files:**
+- Create: `core/ui/user-header.js`
+- Modify: `core/ui/public/footer-actions.js`
+- Modify: `app.js:9439-9595`
+- Modify: `app.js:9780-9877`
+- Modify: `tests/phase3-ui-boundaries.test.cjs`
+- Modify: `tests/user-chip-route-reimplementation.test.cjs`
+- Test: `tests/phase3-ui-boundaries.test.cjs`
+- Test: `tests/user-chip-route-reimplementation.test.cjs`
+
+- [ ] **Step 1: Add failing tests for user-header registration and app delegation**
+
+```js
+test('app user header functions delegate through shared ui module boundary', () => {
+  const calls = [];
+  const sandbox = loadSandboxWithScripts(['app.js'], {
+    __HF_UI_MODULES__: {
+      createUserHeaderService: () => ({
+        renderUserHeader: options => calls.push(['renderUserHeader', options]),
+        applyRole: role => calls.push(['applyRole', role]),
+        toggleUserDropdown: target => calls.push(['toggleUserDropdown', target]),
+        closeUserChips: () => calls.push('closeUserChips'),
+        toggleRouteDropdown: (triggerId, dropdownId) => calls.push(['toggleRouteDropdown', triggerId, dropdownId]),
+        closeRouteDropdowns: exceptId => calls.push(['closeRouteDropdowns', exceptId]),
+      }),
+    },
+  });
+
+  sandbox.renderUserHeader({ skipPublicRender: true });
+  sandbox.applyRole('admin');
+  sandbox.toggleUserDropdown('user-chip');
+  sandbox.closeUserChips();
+  sandbox.toggleRouteDropdown('route-trigger', 'route-panel');
+  sandbox.closeRouteDropdowns('route-panel');
+
+  assert.deepEqual(calls, [
+    ['renderUserHeader', { skipPublicRender: true }],
+    ['applyRole', 'admin'],
+    ['toggleUserDropdown', 'user-chip'],
+    'closeUserChips',
+    ['toggleRouteDropdown', 'route-trigger', 'route-panel'],
+    ['closeRouteDropdowns', 'route-panel'],
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the user-header tests to verify they fail first**
+
+Run: `node --test tests/phase3-ui-boundaries.test.cjs tests/user-chip-route-reimplementation.test.cjs`
+
+Expected: FAIL because `core/ui/user-header.js` does not exist and the user-chip/dropdown logic still lives inside `app.js`.
+
+- [ ] **Step 3: Create `core/ui/user-header.js` and move header rendering, user-chip hydration, and dropdown behavior there**
+
+```js
+(function bootstrapUserHeaderUi(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_UI_MODULES__ && typeof globalScope.__HF_UI_MODULES__ === 'object')
+    ? globalScope.__HF_UI_MODULES__
+    : {};
+
+  function createUserHeaderServiceImpl(deps = {}) {
+    const documentRef = deps.document || globalScope.document;
+    const getCurrentUser = typeof deps.getCurrentUser === 'function' ? deps.getCurrentUser : (() => null);
+    const isSettingsPage = typeof deps.isSettingsPage === 'function' ? deps.isSettingsPage : (() => false);
+    const currentUserCanManageMenu = typeof deps.currentUserCanManageMenu === 'function' ? deps.currentUserCanManageMenu : (() => false);
+    const syncPublicStaffFooterActionsForUser = typeof deps.syncPublicStaffFooterActionsForUser === 'function'
+      ? deps.syncPublicStaffFooterActionsForUser
+      : (() => {});
+
+    function getUserChipRoots() {
+      return Array.from(new Set(
+        Array.from(documentRef.querySelectorAll('[data-user-chip], .user-chip, [data-route-user-chip]')),
+      ));
+    }
+
+    function getUserChipParts(root) {
+      if (!root) return null;
+      return {
+        root,
+        trigger: root.querySelector('[data-user-chip-trigger]') || root,
+        panel: root.querySelector('[data-user-chip-panel]') || root.querySelector('.user-dropdown, .ll-site-userdropdown, .erc-userdropdown'),
+        initials: root.querySelector('[data-user-chip-initials]') || root.querySelector('[id$="user-initials"]'),
+        name: root.querySelector('[data-user-chip-name]') || root.querySelector('[id$="user-dropdown-name"]'),
+        role: root.querySelector('[data-user-chip-role]') || root.querySelector('[id$="user-dropdown-role"]'),
+      };
+    }
+
+    function renderUserHeader(options = {}) {
+      const user = getCurrentUser();
+      const signedIn = !!user;
+      const role = user?.role || 'none';
+      const name = user?.name || '';
+      const parts = name.trim().split(/\s+/).filter(Boolean);
+      const initials = parts.length >= 2 ? (parts[0][0] + parts[parts.length - 1][0]).toUpperCase() : (parts[0]?.[0] || '?').toUpperCase();
+      const roleLabel = { none: 'User', manager: 'Manager', admin: 'Admin' }[role] || 'User';
+
+      getUserChipRoots().forEach(root => {
+        const chip = getUserChipParts(root);
+        if (!chip) return;
+        root.style.display = signedIn ? '' : 'none';
+        if (chip.initials) chip.initials.textContent = initials;
+        if (chip.name) chip.name.textContent = name || user?.email || '';
+        if (chip.role) chip.role.textContent = roleLabel;
+        if (chip.trigger) chip.trigger.setAttribute('aria-expanded', root.classList.contains('open') ? 'true' : 'false');
+      });
+
+      syncPublicStaffFooterActionsForUser(user, {
+        skipPublicRender: !!options.skipPublicRender,
+        canManageCurrentMenu: currentUserCanManageMenu(),
+        isSettingsRoute: isSettingsPage(),
+      });
+    }
+
+    return {
+      getUserChipRoots,
+      getUserChipParts,
+      renderUserHeader,
+      applyRole(role) {
+        const pruneSection = documentRef.getElementById('prune-section');
+        if (pruneSection) pruneSection.style.display = role === 'admin' ? '' : 'none';
+        renderUserHeader();
+      },
+      toggleUserDropdown(targetOrId = null) {
+        const chip = typeof targetOrId === 'string'
+          ? documentRef.getElementById(targetOrId) || documentRef.querySelector(`[data-user-chip-id="${targetOrId}"]`)
+          : targetOrId?.closest?.('[data-user-chip], .user-chip, [data-route-user-chip]') || getUserChipRoots()[0] || null;
+        if (!chip) return;
+        this.closeRouteDropdowns();
+        this.closeUserChips(chip);
+        const isOpen = chip.classList.toggle('open');
+        const parts = getUserChipParts(chip);
+        if (parts?.trigger) parts.trigger.setAttribute('aria-expanded', isOpen ? 'true' : 'false');
+        if (isOpen && parts?.panel) parts.panel.querySelector('button, a')?.focus();
+      },
+      closeUserChips(exceptChip = null, target = null) {
+        getUserChipRoots().forEach(chip => {
+          if (exceptChip && chip === exceptChip) return;
+          if (target && chip.contains(target)) return;
+          chip.classList.remove('open');
+          getUserChipParts(chip)?.trigger?.setAttribute('aria-expanded', 'false');
+        });
+      },
+      toggleRouteDropdown(triggerId, dropdownId) {
+        const trigger = documentRef.getElementById(triggerId);
+        const dropdown = documentRef.getElementById(dropdownId);
+        if (!trigger || !dropdown) return;
+        const wrapper = trigger.closest('[data-route-dropdown]');
+        const shouldOpen = dropdown.hidden;
+        this.closeUserChips();
+        this.closeRouteDropdowns(shouldOpen ? dropdownId : '');
+        if (!wrapper) return;
+        wrapper.classList.toggle('open', shouldOpen);
+        dropdown.hidden = !shouldOpen;
+        trigger.setAttribute('aria-expanded', shouldOpen ? 'true' : 'false');
+        if (shouldOpen) dropdown.querySelector('button, [tabindex]:not([tabindex="-1"])')?.focus();
+      },
+      closeRouteDropdowns(exceptDropdownId = '') {
+        documentRef.querySelectorAll('[data-route-dropdown]').forEach(wrapper => {
+          const trigger = wrapper.querySelector('[data-route-dropdown-trigger], [aria-controls]');
+          const panel = wrapper.querySelector('[data-route-dropdown-panel]');
+          if (!trigger || !panel) return;
+          if (exceptDropdownId && panel.id === exceptDropdownId) return;
+          wrapper.classList.remove('open');
+          panel.hidden = true;
+          trigger.setAttribute('aria-expanded', 'false');
+        });
+      },
+      installGlobalHandlers() {
+        documentRef.addEventListener('click', event => {
+          this.closeUserChips(null, event.target);
+          documentRef.querySelectorAll('[data-route-dropdown]').forEach(wrapper => {
+            if (wrapper.contains(event.target)) return;
+            wrapper.classList.remove('open');
+            const trigger = wrapper.querySelector('[data-route-dropdown-trigger], [aria-controls]');
+            const panel = wrapper.querySelector('[data-route-dropdown-panel]');
+            if (panel) panel.hidden = true;
+            if (trigger) trigger.setAttribute('aria-expanded', 'false');
+          });
+        });
+      },
+    };
+  }
+
+  modules.createUserHeaderService = function createUserHeaderServiceBoundary(deps = {}) {
+    return createUserHeaderServiceImpl(deps);
+  };
+
+  globalScope.__HF_UI_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+- [ ] **Step 4: Deepen `core/ui/public/footer-actions.js` so shell code can sync footer staff actions without touching footer DOM directly**
+
+```js
+function syncPublicStaffFooterActionsForUser(user = getCurrentUser(), options = {}) {
+  const state = buildPublicStaffFooterState(user, options);
+  syncPublicStaffFooterActions(state);
+  return state;
+}
+
+return {
+  buildPublicStaffFooterState,
+  syncPublicStaffFooterActions,
+  syncPublicStaffFooterActionsForUser,
+};
+```
+
+- [ ] **Step 5: Replace the `app.js` header and dropdown bodies with wrappers to the new user-header service**
+
+```js
+function buildUserHeaderModuleDeps() {
+  const footerService = getPublicFooterActionsService();
+  return {
+    document,
+    getCurrentUser: () => currentUser,
+    isSettingsPage: () => isSettingsPage(),
+    currentUserCanManageMenu: () => currentUserCanManageMenu(),
+    syncPublicStaffFooterActionsForUser: (user, options) =>
+      footerService?.syncPublicStaffFooterActionsForUser
+        ? footerService.syncPublicStaffFooterActionsForUser(user, options)
+        : footerService?.syncPublicStaffFooterActions(footerService.buildPublicStaffFooterState(user, options)),
+  };
+}
+
+function getUserHeaderService() {
+  if (_userHeaderService) return _userHeaderService;
+  const boundary = getUiModuleBoundary();
+  if (typeof boundary?.createUserHeaderService !== 'function') return null;
+  _userHeaderService = boundary.createUserHeaderService(buildUserHeaderModuleDeps());
+  return _userHeaderService;
+}
+
+function renderUserHeader(options = {}) {
+  return getUserHeaderService()?.renderUserHeader(options);
+}
+
+function applyRole(role) {
+  return getUserHeaderService()?.applyRole(role);
+}
+```
+
+- [ ] **Step 6: Re-run the UI boundary tests**
+
+Run: `node --test tests/phase3-ui-boundaries.test.cjs tests/user-chip-route-reimplementation.test.cjs`
+
+Expected: PASS. `app.js` should stop being the source of truth for user-chip selectors, header hydration, and dropdown DOM behavior.
+
+- [ ] **Step 7: Commit the user-header slice**
+
+```bash
+git add core/ui/user-header.js core/ui/public/footer-actions.js app.js tests/phase3-ui-boundaries.test.cjs tests/user-chip-route-reimplementation.test.cjs
+git commit -m "refactor: extract user header and dropdown runtime"
+```
+
+### Task 5: Move Menu Picker Runtime Out Of App.js
+
+**Files:**
+- Create: `core/ui/menu-picker.js`
+- Modify: `app.js:9902-10095`
+- Modify: `tests/phase3-ui-boundaries.test.cjs`
+- Test: `tests/phase3-ui-boundaries.test.cjs`
+
+- [ ] **Step 1: Add a failing menu-picker delegation test**
+
+```js
+test('app menu picker functions delegate through shared ui module boundary', async () => {
+  const calls = [];
+  const sandbox = loadSandboxWithScripts(['app.js'], {
+    __HF_UI_MODULES__: {
+      createMenuPickerService: () => ({
+        showMenuPicker: async (...args) => calls.push(['showMenuPicker', args]),
+        closeMenuPicker: options => calls.push(['closeMenuPicker', options]),
+        selectMenu: (...args) => calls.push(['selectMenu', args]),
+        updateActiveMenuBar: () => calls.push('updateActiveMenuBar'),
+        onSwitchMenuClick: async () => calls.push('onSwitchMenuClick'),
+        onPublicSwitchMenuClick: async () => calls.push('onPublicSwitchMenuClick'),
+      }),
+    },
+  });
+
+  await sandbox.showMenuPicker(null, { managerOnly: true });
+  sandbox.closeMenuPicker({ skipOnClose: true });
+  sandbox.selectMenu('menu-1', 'leroys-lounge-drinks', 'Drinks', 'drinks', 'restaurant-1');
+  sandbox.updateActiveMenuBar();
+  await sandbox.onSwitchMenuClick();
+  await sandbox.onPublicSwitchMenuClick();
+
+  assert.deepEqual(calls, [
+    ['showMenuPicker', [null, { managerOnly: true }]],
+    ['closeMenuPicker', { skipOnClose: true }],
+    ['selectMenu', ['menu-1', 'leroys-lounge-drinks', 'Drinks', 'drinks', 'restaurant-1']],
+    'updateActiveMenuBar',
+    'onSwitchMenuClick',
+    'onPublicSwitchMenuClick',
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the UI boundary test to verify it fails first**
+
+Run: `node --test tests/phase3-ui-boundaries.test.cjs`
+
+Expected: FAIL because `core/ui/menu-picker.js` does not exist yet and `app.js` still owns picker focus-trap and selection behavior.
+
+- [ ] **Step 3: Create `core/ui/menu-picker.js` and move focus trapping, menu selection, and switch flows there**
+
+```js
+(function bootstrapMenuPickerUi(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_UI_MODULES__ && typeof globalScope.__HF_UI_MODULES__ === 'object')
+    ? globalScope.__HF_UI_MODULES__
+    : {};
+
+  function createMenuPickerServiceImpl(deps = {}) {
+    const documentRef = deps.document || globalScope.document;
+    const historyRef = deps.history || globalScope.history;
+    const getLocationHref = typeof deps.getLocationHref === 'function' ? deps.getLocationHref : (() => globalScope.location?.href || '');
+    const knownRestaurantList = typeof deps.knownRestaurantList === 'function' ? deps.knownRestaurantList : (() => []);
+    const knownMenuList = typeof deps.knownMenuList === 'function' ? deps.knownMenuList : (() => []);
+
+    let pickerFocusBefore = null;
+    let pickerOnSelect = null;
+    let pickerOnClose = null;
+
+    function showMenuPicker(afterSelect, options = {}) {
+      pickerFocusBefore = documentRef.activeElement;
+      pickerOnSelect = afterSelect || null;
+      pickerOnClose = typeof options.onClose === 'function' ? options.onClose : null;
+      documentRef.getElementById('menu-picker-overlay')?.classList.add('open');
+      return deps.loadMenusForPicker?.({
+        managerOnly: !!options.managerOnly,
+        menuIds: options.menuIds || [],
+        knownRestaurantList,
+        knownMenuList,
+      });
+    }
+
+    function closeMenuPicker(options = {}) {
+      documentRef.getElementById('menu-picker-overlay')?.classList.remove('open');
+      const onClose = options.skipOnClose ? null : pickerOnClose;
+      pickerOnClose = null;
+      if (pickerFocusBefore?.focus) pickerFocusBefore.focus();
+      pickerFocusBefore = null;
+      pickerOnSelect = null;
+      if (onClose) onClose();
+    }
+
+    function selectMenu(menuId, slug, menuName, menuType, restaurantId) {
+      deps.setActiveMenu?.({ menuId, slug, menuName, menuType, restaurantId });
+      const nextHref = deps.buildNextHref?.({ menuId, slug, restaurantId, currentHref: getLocationHref() });
+      if (nextHref) historyRef.replaceState({}, '', nextHref);
+      closeMenuPicker({ skipOnClose: true });
+      deps.afterMenuSelection?.({ menuId, slug, menuName, menuType, restaurantId, callback: pickerOnSelect });
+    }
+
+    return {
+      showMenuPicker,
+      closeMenuPicker,
+      selectMenu,
+      updateActiveMenuBar: deps.updateActiveMenuBarImpl,
+      onSwitchMenuClick: deps.onSwitchMenuClickImpl,
+      onPublicSwitchMenuClick: deps.onPublicSwitchMenuClickImpl,
+    };
+  }
+
+  modules.createMenuPickerService = function createMenuPickerServiceBoundary(deps = {}) {
+    return createMenuPickerServiceImpl(deps);
+  };
+
+  globalScope.__HF_UI_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+- [ ] **Step 4: Replace the `app.js` picker block with wrappers to the new service**
+
+```js
+function buildMenuPickerModuleDeps() {
+  const updateActiveMenuBarImpl = () => {
+    const bar = document.getElementById('active-menu-bar');
+    const nameEl = document.getElementById('active-menu-name');
+    const displayName = formatMenuDisplayName(_activeMenuName, MENU_TYPE, RESTAURANT_ID);
+    if (!bar || !nameEl) return;
+    nameEl.textContent = displayName || '';
+    bar.style.display = displayName ? '' : 'none';
+  };
+
+  const onSwitchMenuClickImpl = async () => {
+    await showMenuPicker(async () => {
+      _uncatCategoryUuid = null;
+      await ensureCurrentMenuSession().refresh();
+      applyDesign(currentDesign);
+      renderManagerWorkspace();
+      updateDraftIndicator();
+      updateSaveBtn();
+      updateManagerActionBar();
+    }, { managerOnly: true });
+  };
+
+  const onPublicSwitchMenuClickImpl = async () => {
+    await showMenuPicker(async () => {
+      const targetHref = getPublicHrefForCurrentMenu();
+      const currentHref = `${window.location.pathname}${window.location.search}`;
+      if (targetHref && targetHref !== currentHref) {
+        navigateToPage(targetHref);
+        return;
+      }
+      await ensureCurrentMenuSession().refresh();
+      applyDesign(currentDesign);
+      await renderPublicViews();
+    });
+  };
+
+  return {
+    document,
+    history,
+    getLocationHref: () => location.href,
+    knownRestaurantList: () => knownRestaurantList(),
+    knownMenuList: () => knownMenuList(),
+    setActiveMenu: ({ menuId, menuName, menuType, restaurantId }) => {
+      MENU_ID = menuId;
+      setActiveMenuContext(menuName || '', menuType || 'drinks', restaurantId || '');
+      lsSet(LS_KEYS.menuId, MENU_ID);
+    },
+    buildNextHref: ({ menuId, slug }) => _appPageMode === 'public' ? getPublicHrefForMenuId(menuId) : (() => {
+      const url = new URL(location.href);
+      url.searchParams.set('menu', slug);
+      return url.toString();
+    })(),
+    afterMenuSelection: ({ menuId, slug, restaurantId, callback }) => {
+      ensureCurrentMenuSession({ requestedMenuId: menuId, requestedMenuSlug: slug, siteRestaurantId: restaurantId || '' });
+      updateActiveMenuBar();
+      renderUserHeader({ skipPublicRender: !!callback });
+      if (callback) callback();
+    },
+    updateActiveMenuBarImpl,
+    onSwitchMenuClickImpl,
+    onPublicSwitchMenuClickImpl,
+  };
+}
+
+function getMenuPickerService() {
+  if (_menuPickerService) return _menuPickerService;
+  const boundary = getUiModuleBoundary();
+  if (typeof boundary?.createMenuPickerService !== 'function') return null;
+  _menuPickerService = boundary.createMenuPickerService(buildMenuPickerModuleDeps());
+  return _menuPickerService;
+}
+
+async function showMenuPicker(afterSelect, opts) {
+  return getMenuPickerService()?.showMenuPicker(afterSelect, opts);
+}
+
+function closeMenuPicker(opts = {}) {
+  return getMenuPickerService()?.closeMenuPicker(opts);
+}
+```
+
+- [ ] **Step 5: Re-run the UI boundary test and a syntax check**
+
+Run: `node --test tests/phase3-ui-boundaries.test.cjs && node --check app.js`
+
+Expected: PASS. `app.js` should no longer own the menu-picker focus trap, list rendering, and selection flow.
+
+- [ ] **Step 6: Commit the menu-picker slice**
+
+```bash
+git add core/ui/menu-picker.js app.js tests/phase3-ui-boundaries.test.cjs
+git commit -m "refactor: extract menu picker runtime"
+```
+
+### Task 6: Wire The New Scripts Into Every Shell And Run Final Verification
+
+**Files:**
+- Modify: `index.html`
+- Modify: `manager/index.html`
+- Modify: `admin/index.html`
+- Modify: `leroyslounge/index.html`
+- Modify: `elroyscantina/index.html`
+- Modify: `scripts/check-html-script-order.cjs`
+- Modify: `tests/helpers/runtime.cjs`
+- Modify: `tests/phase15-auth-unification-complete.test.cjs`
+- Modify: `app.js`
+- Test: `tests/phase15-auth-unification-complete.test.cjs`
+- Test: `tests/phase15-auth-boundaries.test.cjs`
+- Test: `tests/phase3-ui-boundaries.test.cjs`
+- Test: `tests/architecture-boundaries.test.cjs`
+- Test: `tests/user-chip-route-reimplementation.test.cjs`
+
+- [ ] **Step 1: Update the enforced shared runtime order**
+
+```js
+const SHARED_RUNTIME_SCRIPTS = [
+  '/core/domain/constants.js',
+  '/core/domain/category-defaults.js',
+  '/core/auth/auth-api.js',
+  '/core/auth/auth-session-service.js',
+  '/core/auth/auth-overlay-template.js',
+  '/core/auth/auth-overlay-controller.js',
+  '/core/auth/auth-form-service.js',
+  '/core/routing/settings-policy.js',
+  '/core/ui/user-header.js',
+  '/core/ui/menu-picker.js',
+  '/core/ui/manager/workspace.js',
+  '/core/ui/manager/sections.js',
+  '/core/ui/manager/editors.js',
+  '/core/ui/admin/workspace.js',
+  '/core/ui/admin/switcher.js',
+  '/core/ui/public/footer-actions.js',
+  '/core/ui/public/renderer-default.js',
+  '/core/session/publish-service.js',
+  '/core/session/menu-session.js',
+  '/core/data/menu-state-loader.js',
+  '/core/session/poll-scheduler.js',
+];
+```
+
+- [ ] **Step 2: Mirror the same order in the in-test runtime loader**
+
+```js
+const DEFAULT_RUNTIME_SCRIPTS = [
+  'core/domain/constants.js',
+  'core/domain/category-defaults.js',
+  'core/auth/auth-api.js',
+  'core/auth/auth-session-service.js',
+  'core/auth/auth-overlay-template.js',
+  'core/auth/auth-overlay-controller.js',
+  'core/auth/auth-form-service.js',
+  'core/routing/settings-policy.js',
+  'core/ui/user-header.js',
+  'core/ui/menu-picker.js',
+  'core/ui/manager/workspace.js',
+  'core/ui/manager/sections.js',
+  'core/ui/manager/editors.js',
+  'core/ui/manager/open-food-facts.js',
+  'core/ui/manager/untappd.js',
+  'core/ui/manager/barcode-scanner.js',
+  'core/ui/admin/workspace.js',
+  'core/ui/admin/switcher.js',
+  'core/ui/public/footer-actions.js',
+  'core/ui/public/renderer-default.js',
+  'core/session/menu-publish-workflow.js',
+  'core/session/menu-publish-facade.js',
+  'core/session/publish-service.js',
+  'core/session/menu-session.js',
+  'core/data/menu-state-loader.js',
+  'core/session/poll-scheduler.js',
+  'routes/shared/public-route-core.js',
+  'app.js',
+];
+```
+
+- [ ] **Step 3: Add the new shared scripts to every HTML shell before `app.js`**
+
+```html
+<script src="/core/auth/auth-api.js"></script>
+<script src="/core/auth/auth-session-service.js"></script>
+<script src="/core/auth/auth-overlay-template.js"></script>
+<script src="/core/auth/auth-overlay-controller.js"></script>
+<script src="/core/auth/auth-form-service.js"></script>
+<script src="/core/routing/settings-policy.js"></script>
+<script src="/core/ui/user-header.js"></script>
+<script src="/core/ui/menu-picker.js"></script>
+<script src="/core/ui/public/footer-actions.js"></script>
+<script src="/core/ui/public/renderer-default.js"></script>
+```
+
+- [ ] **Step 4: Run the full verification set for this slice**
+
+Run: `node --test tests/phase15-auth-boundaries.test.cjs tests/phase15-auth-unification-complete.test.cjs tests/phase3-ui-boundaries.test.cjs tests/architecture-boundaries.test.cjs tests/user-chip-route-reimplementation.test.cjs && node --check app.js && node scripts/check-html-script-order.cjs`
+
+Expected: PASS. The auth overlay remains centralized, footer staff actions remain the public auth entry, manager/admin shells still boot correctly, and the new scripts are loaded in a deterministic order everywhere.
+
+- [ ] **Step 5: Commit the integration and cleanup slice**
+
+```bash
+git add index.html manager/index.html admin/index.html leroyslounge/index.html elroyscantina/index.html scripts/check-html-script-order.cjs tests/helpers/runtime.cjs tests/phase15-auth-unification-complete.test.cjs app.js
+git commit -m "refactor: wire shared auth and shell modules across entry shells"
+```
+
+## Self-Review
+
+**1. Spec coverage**
+
+- `createAccessSessionService()`, `refreshCurrentUserProfile()`, auth submit handlers, and `signOut()` are covered in Task 2.
+- `requestSignIn()`, `openAuthOverlay()`, `closeAuthOverlay()`, and auth overlay keyboard/click support are covered in Task 2 through the deepened auth controller and new auth form service.
+- `renderUserHeader()`, `applyRole()`, dropdown keyboard/click handlers, and footer staff action sync are covered in Task 4.
+- `enterManager()/exitManager()`, `enterAdmin()/exitAdmin()`, settings drawer interactions, and settings route gating are covered in Task 3.
+- Menu picker functions and accessibility-preserving picker flow are covered in Task 5.
+- Script-order constraints, shell loading, and auth overlay centralization are covered in Task 6.
+- Memory-only recovery session behavior is preserved by keeping recovery data inside the shared auth services and never moving it into `localStorage`; that requirement is explicitly preserved in Tasks 2 and 6.
+
+**2. Placeholder scan**
+
+- No `TBD`, `TODO`, or “implement later” placeholders remain.
+- Every task includes concrete file paths, code snippets, commands, and expected results.
+
+**3. Type consistency**
+
+- Shared auth boundary names are consistent: `createAccessSessionService`, `createAuthOverlayController`, `createAuthFormService`.
+- Shared routing boundary name is consistent: `createSettingsRoutePolicyService`.
+- Shared UI boundary names are consistent: `createUserHeaderService`, `createMenuPickerService`, `createPublicFooterActionsService`.
+- App wrapper names match the service methods they delegate to: `refreshCurrentUserProfile`, `signOut`, `toggleSettingsDrawer`, `enterManager`, `renderUserHeader`, `showMenuPicker`.
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-21-appjs-auth-shell-navigation-split.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-04-21-appjs-landing-runtime-split.md
+++ b/docs/superpowers/plans/2026-04-21-appjs-landing-runtime-split.md
@@ -1,0 +1,1392 @@
+# App.js Landing Runtime Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the landing-page runtime out of `app.js` into deep owned modules so `app.js` becomes an orchestrator while the landing admin flow, selective publish behavior, and landing-root fallback behavior stay unchanged.
+
+**Architecture:** Introduce a dedicated `core/landing/*` runtime that mirrors the repo's existing extracted-module pattern: one model boundary for landing records and derived behavior, one state/data boundary for in-memory runtime state and API persistence, one admin workspace boundary, and one public-root renderer boundary. Keep every current global function name that tests and inline HTML handlers already call, but make those globals in `app.js` thin wrappers over the landing services instead of owning the implementation.
+
+**Tech Stack:** Plain browser JavaScript, shared runtime scripts loaded by HTML `<script>` tags, Node test runner (`node --test`), no bundler, no dependencies.
+
+---
+
+## File Structure
+
+- `app.js`
+  Keep landing orchestration only: instantiate landing services, expose the existing global function names as thin wrappers, and stop carrying the landing implementation body.
+- `core/landing/model.js`
+  Own landing defaults, normalization, validation, section diffing, publish copying, hours status derivation, renderable item filtering, and small HTML helpers used by both admin and public landing UI.
+- `core/landing/store.js`
+  Own in-memory landing runtime state: current record, dirty flag, load promise/error, active admin panel, filters, and review carousel index.
+- `core/landing/data-service.js`
+  Own landing fetch/save/publish persistence against `/api/public` and `/api/admin`, layered on top of the store and model.
+- `core/landing/admin-workspace.js`
+  Own `renderLandingAdminWorkspace()`, overview/hours/events/news/reviews panel rendering, field mutation handlers, import helpers, draft save flow, publish modal flow, and admin toolbar refresh behavior.
+- `core/landing/root-renderer.js`
+  Own `renderLandingRootPage()`, root fallback visibility, root hours/events/news/reviews rendering, and review carousel controls.
+- `index.html`
+  Load the new landing runtime scripts before `/app.js` so the shared landing module registry exists on the shared root page.
+- `manager/index.html`
+  Load the same landing runtime scripts before `/app.js` because the shared runtime still boots through the common shell even though manager does not render the landing workspace.
+- `admin/index.html`
+  Load the landing runtime scripts before `/app.js` so the admin landing workspace wrappers resolve immediately.
+- `leroyslounge/index.html`
+  Load the landing runtime scripts before `/app.js` to keep shared runtime ordering consistent on route-owned pages.
+- `elroyscantina/index.html`
+  Load the landing runtime scripts before `/app.js` to keep shared runtime ordering consistent on route-owned pages.
+- `scripts/check-html-script-order.cjs`
+  Extend the shared runtime script-order guardrail with the new `core/landing/*` files.
+- `tests/helpers/runtime.cjs`
+  Extend the test runtime script list so landing module files load before `app.js` in sandboxed tests.
+- `tests/runtime-helpers.test.cjs`
+  Update script-order expectations to include the new landing runtime files.
+- `tests/boundaries/landing.boundary.test.cjs`
+  Add a dedicated landing boundary suite for module registration and app-level delegation.
+- `tests/landing-page-hours.test.cjs`
+  Keep the current hours behavior coverage passing through the existing global function names after those names delegate into `core/landing/*`.
+- `tests/landing-page-content.test.cjs`
+  Keep the current content, fallback, and review-pair coverage passing through the existing global function names after those names delegate into `core/landing/*`.
+
+### Task 1: Lock The Landing Boundary And Script Order In Tests
+
+**Files:**
+- Create: `core/landing/model.js`
+- Create: `core/landing/store.js`
+- Create: `core/landing/data-service.js`
+- Create: `core/landing/admin-workspace.js`
+- Create: `core/landing/root-renderer.js`
+- Create: `tests/boundaries/landing.boundary.test.cjs`
+- Modify: `tests/helpers/runtime.cjs`
+- Modify: `tests/runtime-helpers.test.cjs`
+- Test: `tests/boundaries/landing.boundary.test.cjs`
+- Test: `tests/runtime-helpers.test.cjs`
+
+- [ ] **Step 1: Add failing boundary coverage for the landing module registry**
+
+```js
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { loadSandboxWithScripts } = require('../helpers/runtime.cjs');
+
+test('landing runtime scripts register landing factories', () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/landing/model.js',
+    'core/landing/store.js',
+    'core/landing/data-service.js',
+    'core/landing/admin-workspace.js',
+    'core/landing/root-renderer.js',
+  ]);
+
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__, 'object');
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingModel, 'function');
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingStore, 'function');
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingDataService, 'function');
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingAdminWorkspaceService, 'function');
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingRootRendererService, 'function');
+});
+```
+
+- [ ] **Step 2: Update the runtime helper expectations so the test harness demands the landing scripts**
+
+```js
+const DEFAULT_RUNTIME_SCRIPTS = [
+  'core/domain/constants.js',
+  'core/domain/category-defaults.js',
+  'core/auth/auth-api.js',
+  'core/auth/auth-session-service.js',
+  'core/auth/auth-overlay-template.js',
+  'core/auth/auth-overlay-controller.js',
+  'core/ui/manager/workspace.js',
+  'core/ui/manager/sections.js',
+  'core/ui/manager/editors.js',
+  'core/ui/manager/open-food-facts.js',
+  'core/ui/manager/untappd.js',
+  'core/ui/manager/barcode-scanner.js',
+  'core/ui/admin/workspace.js',
+  'core/ui/admin/switcher.js',
+  'core/ui/public/footer-actions.js',
+  'core/ui/public/renderer-default.js',
+  'core/session/menu-publish-workflow.js',
+  'core/session/menu-publish-facade.js',
+  'core/session/publish-service.js',
+  'core/session/menu-session.js',
+  'core/data/menu-state-loader.js',
+  'core/session/poll-scheduler.js',
+  'core/landing/model.js',
+  'core/landing/store.js',
+  'core/landing/data-service.js',
+  'core/landing/admin-workspace.js',
+  'core/landing/root-renderer.js',
+  'routes/shared/public-route-core.js',
+  'app.js',
+];
+```
+
+```js
+test('loadSandboxWithScripts evaluates runtime files in explicit order', () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/landing/model.js',
+    'core/landing/store.js',
+    'core/landing/data-service.js',
+    'core/landing/root-renderer.js',
+    'app.js',
+    'routes/shared/public-route-core.js',
+    'leroyslounge/app.js',
+  ]);
+  const restaurantId = getState(sandbox, 'window.__publicRouteRenderer?.restaurantId || ""');
+  assert.equal(restaurantId, '00000000-0000-0000-0000-000000000010');
+});
+```
+
+- [ ] **Step 3: Run the targeted tests to verify they fail before the new landing runtime exists**
+
+Run: `node --test tests/boundaries/landing.boundary.test.cjs tests/runtime-helpers.test.cjs`
+Expected: FAIL because `core/landing/*.js` files do not exist yet and `app.js` has no landing-module delegation path.
+
+- [ ] **Step 4: Create minimal stub landing modules so the registry and script-order tests go green**
+
+```js
+// core/landing/model.js
+(function bootstrapLandingModelModule(globalScope) {
+  if (!globalScope) return;
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+  modules.createLandingModel = function createLandingModelBoundary() {
+    return {};
+  };
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+
+// core/landing/store.js
+(function bootstrapLandingStoreModule(globalScope) {
+  if (!globalScope) return;
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+  modules.createLandingStore = function createLandingStoreBoundary() {
+    return {};
+  };
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+
+// core/landing/data-service.js
+(function bootstrapLandingDataServiceModule(globalScope) {
+  if (!globalScope) return;
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+  modules.createLandingDataService = function createLandingDataServiceBoundary() {
+    return {};
+  };
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+
+// core/landing/admin-workspace.js
+(function bootstrapLandingAdminWorkspaceModule(globalScope) {
+  if (!globalScope) return;
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+  modules.createLandingAdminWorkspaceService = function createLandingAdminWorkspaceServiceBoundary() {
+    return {};
+  };
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+
+// core/landing/root-renderer.js
+(function bootstrapLandingRootRendererModule(globalScope) {
+  if (!globalScope) return;
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+  modules.createLandingRootRendererService = function createLandingRootRendererServiceBoundary() {
+    return {};
+  };
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+- [ ] **Step 5: Run the bootstrap tests and commit the registry/script-order slice**
+
+Run: `node --test tests/boundaries/landing.boundary.test.cjs tests/runtime-helpers.test.cjs`
+Expected: PASS
+
+```bash
+git add core/landing/model.js core/landing/store.js core/landing/data-service.js core/landing/admin-workspace.js core/landing/root-renderer.js tests/boundaries/landing.boundary.test.cjs tests/helpers/runtime.cjs tests/runtime-helpers.test.cjs
+git commit -m "test: bootstrap landing runtime boundary"
+```
+
+### Task 2: Extract The Landing Model Boundary
+
+**Files:**
+- Create: `core/landing/model.js`
+- Modify: `app.js`
+- Test: `tests/landing-page-hours.test.cjs`
+- Test: `tests/landing-page-content.test.cjs`
+- Test: `tests/boundaries/landing.boundary.test.cjs`
+
+- [ ] **Step 1: Add a failing model-factory test that exercises the shared landing behavior without `app.js`**
+
+```js
+test('landing model factory owns record defaults, normalization, validation, and selective publish', () => {
+  const sandbox = loadSandboxWithScripts(['core/landing/model.js']);
+  const model = sandbox.__HF_LANDING_MODULES__.createLandingModel({
+    restaurants: [
+      { id: 'leroys', name: "Leroy's Lounge" },
+      { id: 'elroys', name: "El Roy's Cantina" },
+    ],
+    restaurantTimeZone: 'America/Detroit',
+    uid: () => 'generated-id',
+    cloneJsonCompatible: value => JSON.parse(JSON.stringify(value)),
+    escHtml: value => String(value),
+    escAttrJs: value => JSON.stringify(String(value)),
+    formatUpdatedAt: value => String(value),
+  });
+
+  const record = model.createDefaultRecord();
+  record.draftContent.news.items.push({
+    id: 'news-1',
+    target: 'both',
+    title: 'Draft story',
+    href: 'https://example.com/story',
+    source: 'Chronicle',
+    publishedDate: '2026-04-01',
+    body: 'Draft copy',
+    archived: false,
+    archivedAt: '',
+    updatedAt: '10',
+    importMeta: { sourceUrl: 'https://example.com/story', lastAttemptTs: '10', lastSuccessTs: '10', status: 'imported', messages: [] },
+  });
+
+  const published = model.applySectionPublish(record, ['news']);
+
+  assert.equal(record.liveContent.news.items.length, 0);
+  assert.equal(published.liveContent.news.items.length, 1);
+  assert.equal(model.validateNewsSection(published.liveContent.news).valid, true);
+});
+```
+
+- [ ] **Step 2: Run the model and landing behavior tests to verify they fail first**
+
+Run: `node --test tests/boundaries/landing.boundary.test.cjs tests/landing-page-hours.test.cjs tests/landing-page-content.test.cjs`
+Expected: FAIL because `createLandingModel()` is only a stub from Task 1 and does not yet implement landing defaults, normalization, validation, or selective publish behavior.
+
+- [ ] **Step 3: Implement `core/landing/model.js` as the deep landing record/model boundary**
+
+```js
+(function bootstrapLandingModelModule(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+
+  function createLandingModelImpl(deps = {}) {
+    const restaurants = Array.isArray(deps.restaurants) ? deps.restaurants.slice() : [];
+    const restaurantTimeZone = deps.restaurantTimeZone || 'America/Detroit';
+    const uid = typeof deps.uid === 'function' ? deps.uid : (() => `landing-${Date.now()}`);
+    const cloneJsonCompatible = typeof deps.cloneJsonCompatible === 'function'
+      ? deps.cloneJsonCompatible
+      : (value => JSON.parse(JSON.stringify(value)));
+    const escHtml = typeof deps.escHtml === 'function' ? deps.escHtml : (value => String(value));
+    const escAttrJs = typeof deps.escAttrJs === 'function' ? deps.escAttrJs : (value => JSON.stringify(String(value)));
+    const formatUpdatedAt = typeof deps.formatUpdatedAt === 'function' ? deps.formatUpdatedAt : (value => String(value || ''));
+
+    const STATE_ID = 'root';
+    const SECTION_ORDER = ['overview', 'hours', 'events', 'news', 'reviews'];
+    const SECTION_LABELS = { overview: 'Overview', hours: 'Hours', events: 'Events', news: 'News', reviews: 'Reviews' };
+    const DAY_ORDER = ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'];
+    const DAY_LABELS = { mon: 'Monday', tue: 'Tuesday', wed: 'Wednesday', thu: 'Thursday', fri: 'Friday', sat: 'Saturday', sun: 'Sunday' };
+    const TARGET_BOTH = 'both';
+
+    function createDefaultDay() { return { closed: true, open: '', close: '' }; }
+    function createDefaultHoursRestaurant() {
+      const days = {};
+      DAY_ORDER.forEach(dayKey => { days[dayKey] = createDefaultDay(); });
+      return { days };
+    }
+    function createDefaultImportMeta(sourceUrl = '') {
+      return { sourceUrl: sourceUrl ? String(sourceUrl) : '', lastAttemptTs: '', lastSuccessTs: '', status: 'idle', messages: [] };
+    }
+    function createDefaultEventItem() {
+      return { id: uid(), target: TARGET_BOTH, title: '', eventDate: '', startTime: '', endTime: '', timingNote: '', body: '', archived: false, archivedAt: '', updatedAt: '' };
+    }
+    function createDefaultNewsItem() {
+      return { id: uid(), target: TARGET_BOTH, title: '', body: '', href: '', source: '', publishedDate: '', imageUrl: '', archived: false, archivedAt: '', updatedAt: '', importMeta: createDefaultImportMeta() };
+    }
+    function createDefaultReviewItem() {
+      return { id: uid(), href: '', author: '', quote: '', source: 'Google Review', rating: '', archived: false, archivedAt: '', updatedAt: '', importMeta: createDefaultImportMeta() };
+    }
+    function createDefaultContent() {
+      const hoursRestaurants = {};
+      const reviewRestaurants = {};
+      restaurants.forEach(restaurant => {
+        hoursRestaurants[restaurant.id] = createDefaultHoursRestaurant();
+        reviewRestaurants[restaurant.id] = [];
+      });
+      return { overview: {}, hours: { restaurants: hoursRestaurants }, events: { items: [] }, news: { items: [] }, reviews: { restaurants: reviewRestaurants } };
+    }
+    function createDefaultRecord() {
+      const content = createDefaultContent();
+      return { id: STATE_ID, draftContent: cloneJsonCompatible(content), liveContent: cloneJsonCompatible(content), draftSavedTs: '', livePublishedTs: '' };
+    }
+
+    function normalizeRecord(rawRecord = {}) {
+      const defaults = createDefaultRecord();
+      return {
+        id: rawRecord?.id ? String(rawRecord.id) : defaults.id,
+        draftContent: normalizeContent(rawRecord?.draft_content || rawRecord?.draftContent || defaults.draftContent),
+        liveContent: normalizeContent(rawRecord?.live_content || rawRecord?.liveContent || defaults.liveContent),
+        draftSavedTs: normalizeTimestamp(rawRecord?.draft_saved_ts || rawRecord?.draftSavedTs),
+        livePublishedTs: normalizeTimestamp(rawRecord?.live_published_ts || rawRecord?.livePublishedTs),
+      };
+    }
+
+    function applySectionPublish(record = createDefaultRecord(), sectionIds = []) {
+      const nextRecord = normalizeRecord(record);
+      const draftContent = cloneJsonCompatible(nextRecord.draftContent);
+      const liveContent = cloneJsonCompatible(nextRecord.liveContent);
+      sectionIds.filter(sectionId => SECTION_ORDER.includes(sectionId)).forEach(sectionId => {
+        liveContent[sectionId] = cloneJsonCompatible(draftContent[sectionId]);
+      });
+      nextRecord.liveContent = normalizeContent(liveContent);
+      return nextRecord;
+    }
+
+    return {
+      createDefaultRecord,
+      createDefaultEventItem,
+      createDefaultNewsItem,
+      createDefaultReviewItem,
+      normalizeRecord,
+      normalizeTarget,
+      normalizeImportMeta,
+      normalizeTimeValue,
+      validateHoursSection,
+      validateEventsSection,
+      validateNewsSection,
+      validateReviewsSection,
+      getSectionValidation,
+      getDraftDiffSectionIds,
+      landingSectionHasDiff,
+      applySectionPublish,
+      computeRestaurantStatus,
+      getRenderableEvents,
+      getRenderableNews,
+      getRenderableReviews,
+      buildReviewPairs,
+      renderHoursRowsHtml,
+      renderTargetOptionsHtml,
+      renderRatingOptionsHtml,
+      formatLandingTimestampLabel(value) {
+        const ts = Number(value || 0);
+        return ts ? formatUpdatedAt(ts) : 'Not yet';
+      },
+      getConstants() {
+        return { STATE_ID, SECTION_ORDER, SECTION_LABELS, DAY_ORDER, DAY_LABELS, TARGET_BOTH, restaurantTimeZone };
+      },
+      _private: { createDefaultContent, createDefaultHoursRestaurant, createDefaultDay, createDefaultImportMeta, normalizeContent, normalizeTimestamp },
+    };
+  }
+
+  modules.createLandingModel = function createLandingModelBoundary(deps = {}) {
+    return createLandingModelImpl(deps);
+  };
+
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+```js
+// app.js: instantiate the model once and keep the old function names as thin proxies
+const LANDING_MODULES = (globalThis.__HF_LANDING_MODULES__ && typeof globalThis.__HF_LANDING_MODULES__ === 'object')
+  ? globalThis.__HF_LANDING_MODULES__
+  : {};
+const landingModel = typeof LANDING_MODULES.createLandingModel === 'function'
+  ? LANDING_MODULES.createLandingModel({
+      restaurants: knownLandingRestaurants(),
+      restaurantTimeZone: RESTAURANT_TIME_ZONE,
+      uid,
+      cloneJsonCompatible,
+      escHtml,
+      escAttrJs,
+      formatUpdatedAt,
+    })
+  : null;
+
+function createDefaultLandingPageRecord() { return landingModel.createDefaultRecord(); }
+function normalizeLandingPageRecord(rawRecord = {}) { return landingModel.normalizeRecord(rawRecord); }
+function normalizeLandingTarget(value = '', options = {}) { return landingModel.normalizeTarget(value, options); }
+function normalizeLandingImportMeta(rawMeta = {}) { return landingModel.normalizeImportMeta(rawMeta); }
+function normalizeLandingTimeValue(value = '') { return landingModel.normalizeTimeValue(value); }
+function validateLandingHoursSection(section = {}) { return landingModel.validateHoursSection(section); }
+function validateLandingEventsSection(section = {}) { return landingModel.validateEventsSection(section); }
+function validateLandingNewsSection(section = {}) { return landingModel.validateNewsSection(section); }
+function validateLandingReviewsSection(section = {}) { return landingModel.validateReviewsSection(section); }
+function getLandingSectionValidation(sectionId = '', record = _landingPageState) { return landingModel.getSectionValidation(sectionId, record); }
+function applyLandingSectionPublish(record = createDefaultLandingPageRecord(), sectionIds = []) { return landingModel.applySectionPublish(record, sectionIds); }
+function computeLandingStatusForRestaurant(section = {}, restaurantId = '', now = Date.now(), timeZone = RESTAURANT_TIME_ZONE) {
+  return landingModel.computeRestaurantStatus(section, restaurantId, now, timeZone);
+}
+function renderLandingHoursRowsHtml(section = {}, restaurantId = '', restaurantLabel = '') {
+  return landingModel.renderHoursRowsHtml(section, restaurantId, restaurantLabel);
+}
+function getLandingRenderableNews(section = {}) { return landingModel.getRenderableNews(section); }
+function buildLandingReviewPairs(section = {}) { return landingModel.buildReviewPairs(section); }
+```
+
+- [ ] **Step 4: Run the model and landing behavior tests again**
+
+Run: `node --test tests/boundaries/landing.boundary.test.cjs tests/landing-page-hours.test.cjs tests/landing-page-content.test.cjs`
+Expected: PASS, with the existing landing tests still green through the old global names and the new boundary suite proving the shared landing model exists outside `app.js`.
+
+- [ ] **Step 5: Commit the model extraction**
+
+```bash
+git add core/landing/model.js app.js tests/boundaries/landing.boundary.test.cjs
+git commit -m "refactor: extract landing model boundary"
+```
+
+### Task 3: Extract Landing Runtime State And Persistence
+
+**Files:**
+- Create: `core/landing/store.js`
+- Create: `core/landing/data-service.js`
+- Modify: `app.js`
+- Modify: `tests/boundaries/landing.boundary.test.cjs`
+- Test: `tests/boundaries/landing.boundary.test.cjs`
+- Test: `tests/landing-page-hours.test.cjs`
+- Test: `tests/landing-page-content.test.cjs`
+
+- [ ] **Step 1: Add failing boundary tests for the landing store and landing data service**
+
+```js
+test('landing store tracks record, dirty state, load status, filters, panel, and carousel state', () => {
+  const sandbox = loadSandboxWithScripts(['core/landing/store.js']);
+  const store = sandbox.__HF_LANDING_MODULES__.createLandingStore({
+    normalizeRecord: record => record || { id: 'root', draftContent: {}, liveContent: {}, draftSavedTs: '', livePublishedTs: '' },
+    createDefaultRecord: () => ({ id: 'root', draftContent: {}, liveContent: {}, draftSavedTs: '', livePublishedTs: '' }),
+    normalizeFilters: raw => ({ events: { showArchived: !!raw?.events?.showArchived }, news: { showArchived: false }, reviews: { showArchived: false } }),
+    getDefaultFilters: () => ({ events: { showArchived: false }, news: { showArchived: false }, reviews: { showArchived: false } }),
+  });
+
+  store.setRecord({ id: 'root' }, { dirty: true });
+  store.setLoadError('failed');
+  store.setActivePanel('landing-admin-panel-news');
+  store.setReviewCarouselIndex(2);
+  store.setFilters({ events: { showArchived: true }, news: { showArchived: false }, reviews: { showArchived: false } });
+
+  assert.equal(store.getRecord().id, 'root');
+  assert.equal(store.isDirty(), true);
+  assert.equal(store.getLoadError(), 'failed');
+  assert.equal(store.getActivePanel(), 'landing-admin-panel-news');
+  assert.equal(store.getReviewCarouselIndex(), 2);
+  assert.equal(store.getFilters().events.showArchived, true);
+});
+
+test('landing data service caches loads and persists draft and live state through its ports', async () => {
+  const sandbox = loadSandboxWithScripts(['core/landing/data-service.js']);
+  const calls = [];
+  const record = { id: 'root', draftContent: { news: { items: [] } }, liveContent: { news: { items: [] } }, draftSavedTs: '', livePublishedTs: '' };
+  const service = sandbox.__HF_LANDING_MODULES__.createLandingDataService({
+    store: {
+      getRecord: () => null,
+      getLoadPromise: () => null,
+      setLoadPromise: promise => promise,
+      setRecord: nextRecord => nextRecord,
+      setLoadError: error => error,
+      setDirty: value => value,
+    },
+    model: {
+      normalizeRecord: input => input,
+      applySectionPublish: (input, ids) => ({ ...input, livePublishedIds: ids }),
+      createDefaultRecord: () => record,
+    },
+    fetchRecord: async options => {
+      calls.push(['fetchRecord', options]);
+      return record;
+    },
+    upsertRecord: async (payload, action) => {
+      calls.push(['upsertRecord', action, payload]);
+      return { ...record, ...payload };
+    },
+  });
+
+  await service.ensureLoaded({ includeDraft: true });
+  await service.saveDraft(record, 123);
+  await service.publishSections(record, ['news'], 456);
+
+  assert.deepEqual(calls, [
+    ['fetchRecord', { includeDraft: true }],
+    ['upsertRecord', 'save_landing_page_draft', {
+      draft_content: record.draftContent,
+      live_content: record.liveContent,
+      draft_saved_ts: 123,
+      live_published_ts: null,
+    }],
+    ['upsertRecord', 'publish_landing_sections', {
+      draft_content: record.draftContent,
+      live_content: record.liveContent,
+      draft_saved_ts: null,
+      live_published_ts: 456,
+    }],
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the landing boundary tests to verify the new state/data expectations fail**
+
+Run: `node --test tests/boundaries/landing.boundary.test.cjs`
+Expected: FAIL because `createLandingStore()` and `createLandingDataService()` are still Task-1 stubs and do not yet implement record, dirty, promise, or persistence behavior.
+
+- [ ] **Step 3: Implement the store and persistence modules, then replace the app-owned state/load helpers with wrappers**
+
+```js
+// core/landing/store.js
+(function bootstrapLandingStoreModule(globalScope) {
+  if (!globalScope) return;
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+
+  function createLandingStoreImpl(deps = {}) {
+    const normalizeRecord = typeof deps.normalizeRecord === 'function' ? deps.normalizeRecord : (record => record);
+    const createDefaultRecord = typeof deps.createDefaultRecord === 'function' ? deps.createDefaultRecord : (() => ({ id: 'root' }));
+    const normalizeFilters = typeof deps.normalizeFilters === 'function' ? deps.normalizeFilters : (raw => raw || {});
+    const getDefaultFilters = typeof deps.getDefaultFilters === 'function' ? deps.getDefaultFilters : (() => ({}));
+
+    let record = null;
+    let dirty = false;
+    let loadPromise = null;
+    let loadError = '';
+    let activePanel = 'landing-admin-panel-overview';
+    let filters = null;
+    let reviewCarouselIndex = 0;
+
+    return {
+      getRecord() { return record; },
+      setRecord(nextRecord, options = {}) {
+        record = normalizeRecord(nextRecord || createDefaultRecord());
+        if (typeof options.dirty === 'boolean') dirty = options.dirty;
+        return record;
+      },
+      isDirty() { return dirty; },
+      setDirty(value = false) { dirty = !!value; return dirty; },
+      getLoadPromise() { return loadPromise; },
+      setLoadPromise(promise = null) { loadPromise = promise; return loadPromise; },
+      getLoadError() { return loadError; },
+      setLoadError(message = '') { loadError = message ? String(message) : ''; return loadError; },
+      getActivePanel() { return activePanel; },
+      setActivePanel(panelId = 'landing-admin-panel-overview') { activePanel = panelId || 'landing-admin-panel-overview'; return activePanel; },
+      getFilters() { return filters || getDefaultFilters(); },
+      setFilters(nextFilters = {}) { filters = normalizeFilters(nextFilters); return filters; },
+      getReviewCarouselIndex() { return reviewCarouselIndex; },
+      setReviewCarouselIndex(nextIndex = 0) { reviewCarouselIndex = Math.max(0, Number(nextIndex) || 0); return reviewCarouselIndex; },
+    };
+  }
+
+  modules.createLandingStore = function createLandingStoreBoundary(deps = {}) {
+    return createLandingStoreImpl(deps);
+  };
+
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+```js
+// core/landing/data-service.js
+(function bootstrapLandingDataServiceModule(globalScope) {
+  if (!globalScope) return;
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+
+  function createLandingDataServiceImpl(deps = {}) {
+    const store = deps.store;
+    const model = deps.model;
+    const fetchRecord = deps.fetchRecord;
+    const upsertRecord = deps.upsertRecord;
+
+    return {
+      async ensureLoaded(options = {}) {
+        const { force = false } = options;
+        if (store.getRecord() && !force) return store.getRecord();
+        if (store.getLoadPromise() && !force) return store.getLoadPromise();
+        const pending = (async () => {
+          try {
+            const record = await fetchRecord(options);
+            store.setLoadError('');
+            store.setRecord(record, { dirty: false });
+            store.setDirty(false);
+            return store.getRecord();
+          } catch (error) {
+            store.setLoadError(error?.message || 'Landing page state could not be loaded.');
+            throw error;
+          } finally {
+            store.setLoadPromise(null);
+          }
+        })();
+        store.setLoadPromise(pending);
+        return pending;
+      },
+      async saveDraft(record, timestamp) {
+        const normalized = model.normalizeRecord(record || store.getRecord() || model.createDefaultRecord());
+        const persisted = await upsertRecord({
+          draft_content: normalized.draftContent,
+          live_content: normalized.liveContent,
+          draft_saved_ts: timestamp,
+          live_published_ts: normalized.livePublishedTs ? Number(normalized.livePublishedTs) : null,
+        }, 'save_landing_page_draft');
+        store.setRecord(persisted, { dirty: false });
+        store.setDirty(false);
+        return store.getRecord();
+      },
+      async publishSections(record, selectedSectionIds = [], timestamp = Date.now()) {
+        const normalized = model.normalizeRecord(record || store.getRecord() || model.createDefaultRecord());
+        const nextLiveRecord = model.applySectionPublish(normalized, selectedSectionIds);
+        const persisted = await upsertRecord({
+          draft_content: normalized.draftContent,
+          live_content: nextLiveRecord.liveContent,
+          draft_saved_ts: normalized.draftSavedTs ? Number(normalized.draftSavedTs) : null,
+          live_published_ts: timestamp,
+        }, 'publish_landing_sections');
+        store.setRecord({
+          ...persisted,
+          liveContent: nextLiveRecord.liveContent,
+          livePublishedTs: String(timestamp),
+        }, { dirty: false });
+        store.setDirty(false);
+        return store.getRecord();
+      },
+    };
+  }
+
+  modules.createLandingDataService = function createLandingDataServiceBoundary(deps = {}) {
+    return createLandingDataServiceImpl(deps);
+  };
+
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+```js
+// app.js: replace app-owned landing state and persistence bodies with wrappers
+const landingStore = typeof LANDING_MODULES.createLandingStore === 'function'
+  ? LANDING_MODULES.createLandingStore({
+      normalizeRecord: record => landingModel.normalizeRecord(record),
+      createDefaultRecord: () => landingModel.createDefaultRecord(),
+      normalizeFilters: raw => landingModel.normalizeFilters ? landingModel.normalizeFilters(raw) : raw,
+      getDefaultFilters: () => landingModel.getDefaultFilters ? landingModel.getDefaultFilters() : { events: { showArchived: false }, news: { showArchived: false }, reviews: { showArchived: false } },
+    })
+  : null;
+
+const landingDataService = typeof LANDING_MODULES.createLandingDataService === 'function'
+  ? LANDING_MODULES.createLandingDataService({
+      store: landingStore,
+      model: landingModel,
+      fetchRecord: async ({ includeDraft = hasLandingAdminShell() } = {}) => {
+        const payload = await readApiJsonOrNull(getLandingPageEndpoint(includeDraft), {
+          headers: includeDraft ? getAuthorizedApiHeaders() : {},
+        });
+        if (!payload) throw new Error('Landing page state is missing.');
+        return landingModel.normalizeRecord(payload);
+      },
+      upsertRecord: async (payload = {}, action = 'save_landing_page_draft') => {
+        if (!currentUser?.accessToken) throw new Error('Sign in as an admin to edit the landing page.');
+        const result = await postApiJson('/api/admin', { action, ...payload }, { headers: getAuthorizedApiHeaders() });
+        if (!result.ok) throw new Error(result.payload?.error || 'Landing page save failed.');
+        return landingModel.normalizeRecord(result.payload?.record || result.payload);
+      },
+    })
+  : null;
+
+function setLandingPageState(record, options = {}) { return landingStore.setRecord(record, options); }
+function syncLandingDirtyFlag(value = false) { return landingStore.setDirty(value); }
+async function ensureLandingPageStateLoaded(options = {}) { return landingDataService.ensureLoaded(options); }
+```
+
+- [ ] **Step 4: Re-run the landing boundary and landing behavior tests**
+
+Run: `node --test tests/boundaries/landing.boundary.test.cjs tests/landing-page-hours.test.cjs tests/landing-page-content.test.cjs`
+Expected: PASS, with record state, load caching, and save/publish persistence now owned by `core/landing/store.js` and `core/landing/data-service.js`.
+
+- [ ] **Step 5: Commit the state/persistence extraction**
+
+```bash
+git add core/landing/store.js core/landing/data-service.js app.js tests/boundaries/landing.boundary.test.cjs
+git commit -m "refactor: extract landing store and data service"
+```
+
+### Task 4: Extract The Landing Admin Workspace Runtime
+
+**Files:**
+- Create: `core/landing/admin-workspace.js`
+- Modify: `app.js`
+- Modify: `tests/boundaries/landing.boundary.test.cjs`
+- Test: `tests/boundaries/landing.boundary.test.cjs`
+- Test: `tests/landing-page-hours.test.cjs`
+- Test: `tests/landing-page-content.test.cjs`
+
+- [ ] **Step 1: Add a failing boundary test for the admin workspace service**
+
+```js
+test('landing admin workspace service updates hours without full rerender and refreshes overview state', () => {
+  const sandbox = loadSandboxWithScripts(['core/landing/admin-workspace.js']);
+  const calls = [];
+  const service = sandbox.__HF_LANDING_MODULES__.createLandingAdminWorkspaceService({
+    model: {
+      createDefaultRecord: () => ({
+        id: 'root',
+        draftContent: { hours: { restaurants: { leroys: { days: { wed: { closed: true, open: '', close: '' } } } } }, events: { items: [] }, news: { items: [] }, reviews: { restaurants: {} } },
+        liveContent: { hours: { restaurants: { leroys: { days: { wed: { closed: true, open: '', close: '' } } } } }, events: { items: [] }, news: { items: [] }, reviews: { restaurants: {} } },
+        draftSavedTs: '',
+        livePublishedTs: '',
+      }),
+      normalizeRecord: record => record,
+      normalizeTimeValue: value => value,
+      getDraftDiffSectionIds: () => ['hours'],
+      validateHoursSection: () => ({ valid: true, issues: [] }),
+    },
+    store: {
+      getRecord: () => null,
+      setRecord: record => record,
+      isDirty: () => true,
+      setDirty: value => value,
+      getLoadError: () => '',
+      getActivePanel: () => 'landing-admin-panel-overview',
+      setActivePanel: panelId => panelId,
+    },
+    renderOverview: () => calls.push('renderOverview'),
+    renderHoursValidationState: () => calls.push('renderHoursValidationState'),
+    updateToolbar: () => calls.push('updateToolbar'),
+    rerenderWorkspace: () => calls.push('rerenderWorkspace'),
+  });
+
+  service.setHoursField('leroys', 'wed', 'open', '16:00');
+
+  assert.deepEqual(calls, ['renderOverview', 'renderHoursValidationState', 'updateToolbar']);
+});
+```
+
+- [ ] **Step 2: Run the targeted tests to confirm the admin service does not exist yet**
+
+Run: `node --test tests/boundaries/landing.boundary.test.cjs tests/landing-page-hours.test.cjs tests/landing-page-content.test.cjs`
+Expected: FAIL because `createLandingAdminWorkspaceService()` is still a stub and `app.js` still owns landing admin rendering and mutation logic.
+
+- [ ] **Step 3: Implement `core/landing/admin-workspace.js` and convert app globals into wrappers**
+
+```js
+(function bootstrapLandingAdminWorkspaceModule(globalScope) {
+  if (!globalScope) return;
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+
+  function createLandingAdminWorkspaceServiceImpl(deps = {}) {
+    const model = deps.model;
+    const store = deps.store;
+    const dataService = deps.dataService;
+    const document = deps.document;
+    const escHtml = typeof deps.escHtml === 'function' ? deps.escHtml : (value => String(value));
+    const showToast = typeof deps.showToast === 'function' ? deps.showToast : (() => {});
+    const hasAdminShell = typeof deps.hasAdminShell === 'function' ? deps.hasAdminShell : (() => false);
+    const focusAdminPanel = typeof deps.focusAdminPanel === 'function' ? deps.focusAdminPanel : (() => {});
+    const renderHoursPanel = typeof deps.renderHoursPanel === 'function' ? deps.renderHoursPanel : (() => {});
+    const renderEventsPanel = typeof deps.renderEventsPanel === 'function' ? deps.renderEventsPanel : (() => {});
+    const renderNewsPanel = typeof deps.renderNewsPanel === 'function' ? deps.renderNewsPanel : (() => {});
+    const renderReviewsPanel = typeof deps.renderReviewsPanel === 'function' ? deps.renderReviewsPanel : (() => {});
+
+    function renderOverview(record = store.getRecord()) {
+      const normalized = model.normalizeRecord(record || model.createDefaultRecord());
+      const diffSectionIds = model.getDraftDiffSectionIds(normalized);
+      const sectionValidations = ['hours', 'events', 'news', 'reviews'].map(sectionId => ({
+        sectionId,
+        validation: model.getSectionValidation(sectionId, normalized),
+      }));
+      const blockingIssues = sectionValidations.flatMap(entry => entry.validation.issues);
+      const allValid = sectionValidations.every(entry => entry.validation.valid);
+      const rootStatusEl = document.getElementById('landing-overview-root-status');
+      const draftCopyEl = document.getElementById('landing-overview-draft-copy');
+      const liveCopyEl = document.getElementById('landing-overview-live-copy');
+      const healthBadgeEl = document.getElementById('landing-overview-health-badge');
+      const issuesEl = document.getElementById('landing-overview-issues');
+
+      if (rootStatusEl) rootStatusEl.textContent = store.getLoadError() ? 'Fallback ready' : 'Live shell ready';
+      if (draftCopyEl) draftCopyEl.textContent = diffSectionIds.length
+        ? `${diffSectionIds.length} subsection draft${diffSectionIds.length === 1 ? '' : 's'} differ from live.`
+        : 'Draft and live are currently aligned.';
+      if (liveCopyEl) liveCopyEl.textContent = normalized.livePublishedTs
+        ? 'Publish promotes only the sections you select.'
+        : 'No landing-page sections have been published live yet.';
+      if (healthBadgeEl) {
+        healthBadgeEl.textContent = allValid ? 'Healthy' : 'Needs attention';
+        healthBadgeEl.className = `landing-admin-section-badge ${allValid ? 'is-ready' : 'is-blocked'}`;
+      }
+      if (issuesEl) {
+        issuesEl.innerHTML = allValid
+          ? ''
+          : blockingIssues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
+      }
+    }
+
+    function renderHoursValidationState(record = store.getRecord()) {
+      const normalized = model.normalizeRecord(record || model.createDefaultRecord());
+      const issuesEl = document.getElementById('landing-hours-issues');
+      const badgeEl = document.getElementById('landing-hours-panel-badge');
+      const validation = model.validateHoursSection(syncHoursDraftFromDom().draftContent.hours);
+      if (issuesEl) {
+        issuesEl.innerHTML = validation.valid
+          ? ''
+          : validation.issues.map(issue => `<div class="landing-admin-issue">${escHtml(issue)}</div>`).join('');
+      }
+      if (badgeEl) {
+        badgeEl.textContent = validation.valid ? 'Ready' : 'Blocked';
+        badgeEl.className = `landing-admin-section-badge ${validation.valid ? 'is-ready' : 'is-blocked'}`;
+      }
+      return normalized;
+    }
+
+    function updateToolbar(record = store.getRecord()) {
+      const normalized = model.normalizeRecord(record || model.createDefaultRecord());
+      const diffSectionIds = model.getDraftDiffSectionIds(normalized);
+      const draftButton = document.getElementById('landing-save-draft-btn');
+      const publishButton = document.getElementById('landing-publish-btn');
+      const noteEl = document.getElementById('landing-admin-toolbar-note');
+      if (draftButton) draftButton.disabled = !store.isDirty();
+      if (publishButton) publishButton.disabled = diffSectionIds.length === 0;
+      if (noteEl) {
+        noteEl.textContent = store.getLoadError()
+          ? store.getLoadError()
+          : (store.isDirty()
+              ? 'Save Draft stores the shared landing snapshot without changing the public root.'
+              : (diffSectionIds.length
+                  ? 'Publish Live promotes only the subsections you select.'
+                  : 'Landing-page draft and live snapshots are currently aligned.'));
+      }
+    }
+
+    function syncHoursDraftFromDom() {
+      const fields = Array.from(document.querySelectorAll('[data-landing-hours-field]'));
+      const record = store.setRecord(store.getRecord() || model.createDefaultRecord(), { dirty: store.isDirty() });
+      if (!fields.length) return record;
+      const groupedDays = new Map();
+      fields.forEach(fieldEl => {
+        const restaurantId = fieldEl.getAttribute('data-landing-hours-restaurant') || '';
+        const dayKey = fieldEl.getAttribute('data-landing-hours-day') || '';
+        const field = fieldEl.getAttribute('data-landing-hours-field') || '';
+        if (!restaurantId || !dayKey || !field) return;
+        const key = `${restaurantId}:${dayKey}`;
+        const entry = groupedDays.get(key) || { restaurantId, dayKey };
+        if (field === 'closed') entry.closed = !!fieldEl.checked;
+        if (field === 'open' || field === 'close') entry[field] = model.normalizeTimeValue(fieldEl.value);
+        groupedDays.set(key, entry);
+      });
+      groupedDays.forEach(({ restaurantId, dayKey, open, close, closed }) => {
+        const restaurantHours = record.draftContent.hours.restaurants[restaurantId] || { days: {} };
+        const currentDay = restaurantHours.days[dayKey] || { closed: true, open: '', close: '' };
+        restaurantHours.days[dayKey] = {
+          closed: !!closed,
+          open: closed ? '' : (typeof open === 'string' ? open : currentDay.open),
+          close: closed ? '' : (typeof close === 'string' ? close : currentDay.close),
+        };
+        record.draftContent.hours.restaurants[restaurantId] = restaurantHours;
+      });
+      return store.setRecord(record, { dirty: store.isDirty() });
+    }
+
+    function refreshHoursAdminState(record = store.getRecord()) {
+      renderOverview(record);
+      renderHoursValidationState(record);
+      updateToolbar(record);
+    }
+
+    function setHoursField(restaurantId, dayKey, field, value) {
+      const record = store.setRecord(store.getRecord() || model.createDefaultRecord(), { dirty: true });
+      if (!record.draftContent.hours.restaurants[restaurantId]) {
+        record.draftContent.hours.restaurants[restaurantId] = { days: {} };
+      }
+      const targetDay = record.draftContent.hours.restaurants[restaurantId].days[dayKey] || { closed: true, open: '', close: '' };
+      if (field === 'closed') {
+        targetDay.closed = !!value;
+        if (targetDay.closed) {
+          targetDay.open = '';
+          targetDay.close = '';
+        }
+      } else {
+        targetDay[field] = model.normalizeTimeValue(value);
+        if (targetDay[field]) targetDay.closed = false;
+      }
+      record.draftContent.hours.restaurants[restaurantId].days[dayKey] = targetDay;
+      store.setDirty(true);
+      if (field === 'closed') return renderWorkspace();
+      return refreshHoursAdminState(record);
+    }
+
+    function updateDraftRecord(mutator = () => {}, options = {}) {
+      const rerender = options.rerender !== false;
+      const record = store.setRecord(store.getRecord() || model.createDefaultRecord(), { dirty: true });
+      mutator(record);
+      store.setDirty(true);
+      if (rerender) renderWorkspace();
+      return record;
+    }
+
+    function updateEventField(itemId = '', field = '', value = '') {
+      updateDraftRecord(record => {
+        const item = (record.draftContent.events.items || []).find(entry => entry?.id === itemId);
+        if (!item) return;
+        if (field === 'target') item.target = model.normalizeTarget(value, { allowBoth: true });
+        else if (field === 'startTime' || field === 'endTime') item[field] = model.normalizeTimeValue(value);
+        else item[field] = typeof value === 'string' ? value : '';
+        item.updatedAt = String(Date.now());
+      });
+    }
+
+    function updateNewsField(itemId = '', field = '', value = '') {
+      updateDraftRecord(record => {
+        const item = (record.draftContent.news.items || []).find(entry => entry?.id === itemId);
+        if (!item) return;
+        if (field === 'target') item.target = model.normalizeTarget(value, { allowBoth: true });
+        else item[field] = typeof value === 'string' ? value : '';
+        if (field === 'href' && !item.importMeta?.sourceUrl) {
+          item.importMeta = model.normalizeImportMeta({ ...item.importMeta, sourceUrl: item.href });
+        }
+        item.updatedAt = String(Date.now());
+      });
+    }
+
+    function updateReviewField(restaurantId = '', itemId = '', field = '', value = '') {
+      updateDraftRecord(record => {
+        const items = record.draftContent.reviews.restaurants[restaurantId] || [];
+        const item = items.find(entry => entry?.id === itemId);
+        if (!item) return;
+        if (field === 'rating') item.rating = value ? String(Number(value)) : '';
+        else item[field] = typeof value === 'string' ? value : '';
+        if (field === 'href' && !item.importMeta?.sourceUrl) {
+          item.importMeta = model.normalizeImportMeta({ ...item.importMeta, sourceUrl: item.href });
+        }
+        item.updatedAt = String(Date.now());
+      });
+    }
+
+    function renderWorkspace(options = {}) {
+      if (!hasAdminShell()) return;
+      const { forceReload = false } = options;
+      const render = (record) => {
+        const normalized = store.setRecord(model.normalizeRecord(record || model.createDefaultRecord()), { dirty: store.isDirty() });
+        renderOverview(normalized);
+        renderHoursPanel(normalized);
+        renderEventsPanel(normalized);
+        renderNewsPanel(normalized);
+        renderReviewsPanel(normalized);
+        updateToolbar(normalized);
+        focusAdminPanel(store.getActivePanel());
+      };
+      if (store.getRecord() && !forceReload) return render(store.getRecord());
+      updateToolbar(model.createDefaultRecord());
+      return dataService.ensureLoaded({ force: forceReload, includeDraft: true }).then(render).catch(() => render(store.getRecord() || model.createDefaultRecord()));
+    }
+
+    async function saveDraft() {
+      try {
+        const record = model.normalizeRecord(syncHoursDraftFromDom() || await dataService.ensureLoaded({ includeDraft: true }));
+        await dataService.saveDraft(record, Date.now());
+        renderWorkspace();
+        showToast('✅ Landing page draft saved.', 'success');
+      } catch (error) {
+        showToast(`⚠️ ${error?.message || 'Landing page draft save failed.'}`, 'error');
+      }
+    }
+
+    async function publishSections() {
+      const selectedSectionIds = Array.from(document.querySelectorAll('[data-landing-publish-section]:checked'))
+        .map(input => input.getAttribute('data-landing-publish-section'))
+        .filter(Boolean);
+      if (!selectedSectionIds.length) {
+        showToast('Select at least one landing-page subsection to publish.', 'info');
+        return;
+      }
+      const currentRecord = model.normalizeRecord(syncHoursDraftFromDom() || await dataService.ensureLoaded({ includeDraft: true }));
+      const sectionLabels = (model.getConstants && model.getConstants().SECTION_LABELS) || {};
+      const blockedSection = selectedSectionIds
+        .map(sectionId => {
+          const validation = model.getSectionValidation(sectionId, currentRecord);
+          return {
+            sectionId,
+            label: sectionLabels[sectionId] || sectionId,
+            isValid: validation.valid,
+            issues: validation.issues,
+          };
+        })
+        .find(status => !status.isValid);
+      if (blockedSection) {
+        showToast(`⚠️ Fix ${blockedSection.label.toLowerCase()} before publishing it live.`, 'error');
+        return;
+      }
+      try {
+        await dataService.publishSections(currentRecord, selectedSectionIds, Date.now());
+        renderWorkspace();
+        if (deps.renderRootPage) deps.renderRootPage(store.getRecord());
+        if (deps.closePublishModal) deps.closePublishModal();
+        showToast(`✅ Published ${selectedSectionIds.length} landing-page section${selectedSectionIds.length === 1 ? '' : 's'} live.`, 'success');
+      } catch (error) {
+        showToast(`⚠️ ${error?.message || 'Landing page publish failed.'}`, 'error');
+      }
+    }
+
+    return {
+      renderWorkspace,
+      renderOverview,
+      renderHoursValidationState,
+      updateToolbar,
+      syncHoursDraftFromDom,
+      setHoursField,
+      updateEventField,
+      updateDraftRecord,
+      updateNewsField,
+      updateReviewField,
+      saveDraft,
+      publishSections,
+    };
+  }
+
+  modules.createLandingAdminWorkspaceService = function createLandingAdminWorkspaceServiceBoundary(deps = {}) {
+    return createLandingAdminWorkspaceServiceImpl(deps);
+  };
+
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+```js
+// app.js wrappers after wiring the admin service
+const landingAdminWorkspace = typeof LANDING_MODULES.createLandingAdminWorkspaceService === 'function'
+  ? LANDING_MODULES.createLandingAdminWorkspaceService({
+      model: landingModel,
+      store: landingStore,
+      dataService: landingDataService,
+      document,
+      escHtml,
+      showToast,
+      hasAdminShell: () => hasLandingAdminShell(),
+      focusAdminPanel: (panelId, trigger) => focusLandingAdminPanel(panelId, trigger),
+      renderHoursPanel: record => renderLandingHoursPanel(record),
+      renderEventsPanel: record => renderLandingEventsPanel(record),
+      renderNewsPanel: record => renderLandingNewsPanel(record),
+      renderReviewsPanel: record => renderLandingReviewsPanel(record),
+    })
+  : null;
+
+function renderLandingOverview(record = landingStore.getRecord()) { return landingAdminWorkspace.renderOverview(record); }
+function syncLandingHoursDraftFromDom() { return landingAdminWorkspace.syncHoursDraftFromDom(); }
+function renderLandingHoursValidationState(record = landingStore.getRecord()) { return landingAdminWorkspace.renderHoursValidationState(record); }
+function updateLandingAdminToolbar(record = landingStore.getRecord()) { return landingAdminWorkspace.updateToolbar(record); }
+function renderLandingAdminWorkspace(options = {}) { return landingAdminWorkspace.renderWorkspace(options); }
+function setLandingHoursField(restaurantId, dayKey, field, value) { return landingAdminWorkspace.setHoursField(restaurantId, dayKey, field, value); }
+function updateLandingEventField(itemId = '', field = '', value = '') { return landingAdminWorkspace.updateEventField(itemId, field, value); }
+function updateLandingNewsField(itemId = '', field = '', value = '') { return landingAdminWorkspace.updateNewsField(itemId, field, value); }
+function updateLandingReviewField(restaurantId = '', itemId = '', field = '', value = '') { return landingAdminWorkspace.updateReviewField(restaurantId, itemId, field, value); }
+function saveLandingPageDraft() { return landingAdminWorkspace.saveDraft(); }
+function publishLandingPageSections() { return landingAdminWorkspace.publishSections(); }
+```
+
+- [ ] **Step 4: Run the admin-focused landing tests and boundary suite**
+
+Run: `node --test tests/boundaries/landing.boundary.test.cjs tests/landing-page-hours.test.cjs tests/landing-page-content.test.cjs`
+Expected: PASS, with the existing hours/content tests still covering the same behavior through global wrappers while the implementation now lives in `core/landing/admin-workspace.js`.
+
+- [ ] **Step 5: Commit the admin-workspace extraction**
+
+```bash
+git add core/landing/admin-workspace.js app.js tests/boundaries/landing.boundary.test.cjs
+git commit -m "refactor: extract landing admin workspace"
+```
+
+### Task 5: Extract The Landing Root Renderer And Finish App.js Orchestration
+
+**Files:**
+- Create: `core/landing/root-renderer.js`
+- Modify: `app.js`
+- Modify: `index.html`
+- Modify: `manager/index.html`
+- Modify: `admin/index.html`
+- Modify: `leroyslounge/index.html`
+- Modify: `elroyscantina/index.html`
+- Modify: `scripts/check-html-script-order.cjs`
+- Modify: `tests/helpers/runtime.cjs`
+- Modify: `tests/runtime-helpers.test.cjs`
+- Test: `tests/landing-page-hours.test.cjs`
+- Test: `tests/landing-page-content.test.cjs`
+- Test: `tests/boundaries/landing.boundary.test.cjs`
+- Test: `tests/runtime-helpers.test.cjs`
+
+- [ ] **Step 1: Add a failing root-renderer boundary test, app-delegation test, and the final script-order expectation**
+
+```js
+test('landing root renderer service controls root fallback and review carousel state', () => {
+  const sandbox = loadSandboxWithScripts(['core/landing/root-renderer.js']);
+  const calls = [];
+  const service = sandbox.__HF_LANDING_MODULES__.createLandingRootRendererService({
+    model: {
+      normalizeRecord: record => record,
+      computeRestaurantStatus: () => ({ isOpen: false, label: 'Closed for now', todayRangeLabel: 'Closed', weekRows: [] }),
+      getRenderableEvents: () => [],
+      getRenderableNews: () => [],
+      buildReviewPairs: () => [],
+    },
+    store: {
+      getReviewCarouselIndex: () => 0,
+      setReviewCarouselIndex: value => value,
+    },
+    document: {
+      getElementById: () => ({ hidden: false, innerHTML: '', textContent: '', classList: { toggle() {} } }),
+      querySelector: () => ({ hidden: false }),
+      querySelectorAll: () => [],
+    },
+    hasRootShell: () => true,
+  });
+
+  service.setFallbackVisible(true);
+  service.renderRootPage({ id: 'root', liveContent: { hours: {}, events: {}, news: {}, reviews: {} } });
+
+  assert.equal(typeof service.stepReviewCarousel, 'function');
+});
+
+test('app landing globals delegate through the landing runtime boundary', async () => {
+  const calls = [];
+  const sandbox = loadSandboxWithScripts(['app.js'], {
+    __HF_LANDING_MODULES__: {
+      createLandingModel: () => ({
+        createDefaultRecord: () => ({ id: 'root', draftContent: {}, liveContent: {}, draftSavedTs: '', livePublishedTs: '' }),
+        normalizeRecord: record => record,
+        normalizeTarget: value => value,
+        normalizeImportMeta: value => value,
+        normalizeTimeValue: value => value,
+        validateHoursSection: () => ({ valid: true, issues: [] }),
+        validateEventsSection: () => ({ valid: true, issues: [] }),
+        validateNewsSection: () => ({ valid: true, issues: [] }),
+        validateReviewsSection: () => ({ valid: true, issues: [] }),
+        getSectionValidation: () => ({ valid: true, issues: [] }),
+        applySectionPublish: (record, ids) => ({ ...record, publishedIds: ids }),
+        computeRestaurantStatus: () => ({ isOpen: false, label: 'Closed for now', todayRangeLabel: 'Closed', weekRows: [] }),
+        getRenderableNews: section => section.items || [],
+        buildReviewPairs: () => [],
+        renderHoursRowsHtml: () => '<div>hours</div>',
+      }),
+      createLandingStore: () => ({ getRecord: () => null, isDirty: () => false, setDirty: () => false }),
+      createLandingDataService: () => ({
+        ensureLoaded: async options => {
+          calls.push(['ensureLoaded', options]);
+          return { id: 'root', draftContent: {}, liveContent: {}, draftSavedTs: '', livePublishedTs: '' };
+        },
+      }),
+      createLandingAdminWorkspaceService: () => ({
+        renderWorkspace: options => calls.push(['renderWorkspace', options]),
+        setHoursField: (...args) => calls.push(['setHoursField', ...args]),
+        saveDraft: async () => calls.push(['saveDraft']),
+        publishSections: async () => calls.push(['publishSections']),
+      }),
+      createLandingRootRendererService: () => ({
+        renderRootPage: record => calls.push(['renderRootPage', record]),
+        setFallbackVisible: visible => calls.push(['setFallbackVisible', visible]),
+        setReviewCarouselIndex: index => calls.push(['setReviewCarouselIndex', index]),
+        stepReviewCarousel: direction => calls.push(['stepReviewCarousel', direction]),
+      }),
+    },
+  });
+
+  await sandbox.ensureLandingPageStateLoaded({ force: true });
+  sandbox.renderLandingAdminWorkspace({ forceReload: true });
+  sandbox.setLandingHoursField('rest-1', 'fri', 'open', '16:00');
+  await sandbox.saveLandingPageDraft();
+  await sandbox.publishLandingPageSections();
+  sandbox.renderLandingRootPage({ id: 'root' });
+  sandbox.setLandingRootFallbackVisible(true);
+  sandbox.setLandingReviewCarouselIndex(1);
+  sandbox.stepLandingReviewCarousel(-1);
+
+  assert.deepEqual(calls, [
+    ['ensureLoaded', { force: true }],
+    ['renderWorkspace', { forceReload: true }],
+    ['setHoursField', 'rest-1', 'fri', 'open', '16:00'],
+    ['saveDraft'],
+    ['publishSections'],
+    ['renderRootPage', { id: 'root' }],
+    ['setFallbackVisible', true],
+    ['setReviewCarouselIndex', 1],
+    ['stepReviewCarousel', -1],
+  ]);
+});
+```
+
+```js
+const SHARED_RUNTIME_SCRIPTS = [
+  '/core/domain/constants.js',
+  '/core/domain/category-defaults.js',
+  '/core/auth/auth-api.js',
+  '/core/auth/auth-session-service.js',
+  '/core/auth/auth-overlay-template.js',
+  '/core/auth/auth-overlay-controller.js',
+  '/core/ui/manager/workspace.js',
+  '/core/ui/manager/sections.js',
+  '/core/ui/manager/editors.js',
+  '/core/ui/admin/workspace.js',
+  '/core/ui/admin/switcher.js',
+  '/core/ui/public/footer-actions.js',
+  '/core/ui/public/renderer-default.js',
+  '/core/session/publish-service.js',
+  '/core/session/menu-session.js',
+  '/core/data/menu-state-loader.js',
+  '/core/session/poll-scheduler.js',
+  '/core/landing/model.js',
+  '/core/landing/store.js',
+  '/core/landing/data-service.js',
+  '/core/landing/admin-workspace.js',
+  '/core/landing/root-renderer.js',
+];
+```
+
+- [ ] **Step 2: Run the full landing test set and script-order check to see the missing root boundary fail**
+
+Run: `node --test tests/boundaries/landing.boundary.test.cjs tests/landing-page-hours.test.cjs tests/landing-page-content.test.cjs tests/runtime-helpers.test.cjs`
+Expected: FAIL because `createLandingRootRendererService()` is still a stub, `app.js` is not delegating the root runtime yet, and the HTML/script-order expectations are not updated.
+
+- [ ] **Step 3: Implement `core/landing/root-renderer.js`, switch the last app-owned root functions to wrappers, and wire every shell**
+
+```js
+// core/landing/root-renderer.js
+(function bootstrapLandingRootRendererModule(globalScope) {
+  if (!globalScope) return;
+  const modules = (globalScope.__HF_LANDING_MODULES__ && typeof globalScope.__HF_LANDING_MODULES__ === 'object')
+    ? globalScope.__HF_LANDING_MODULES__
+    : {};
+
+  function createLandingRootRendererServiceImpl(deps = {}) {
+    const model = deps.model;
+    const store = deps.store;
+    const document = deps.document;
+    const hasRootShell = typeof deps.hasRootShell === 'function' ? deps.hasRootShell : (() => false);
+
+    function setSectionVisible(sectionId = '', visible = true) {
+      const sectionEl = document.getElementById(sectionId);
+      if (sectionEl) sectionEl.hidden = !visible;
+      const dotEl = document.querySelector(`[data-landing-dot="${sectionId}"]`);
+      if (dotEl) dotEl.hidden = !visible;
+    }
+
+    function setFallbackVisible(visible) {
+      const shellEl = document.getElementById('landing-root-shell');
+      const fallbackEl = document.getElementById('landing-root-fallback');
+      const dotNavEl = document.querySelector('.landing-dot-nav');
+      if (shellEl) shellEl.hidden = !!visible;
+      if (fallbackEl) fallbackEl.hidden = !visible;
+      if (dotNavEl) dotNavEl.hidden = !!visible;
+    }
+
+    function renderRootPage(record) {
+      if (!hasRootShell()) return;
+      const normalized = model.normalizeRecord(record);
+      renderRootHours(normalized.liveContent.hours);
+      renderRootEvents(normalized.liveContent.events);
+      renderRootNews(normalized.liveContent.news);
+      renderRootReviews(normalized.liveContent.reviews);
+      setFallbackVisible(false);
+    }
+
+    function setReviewCarouselIndex(nextIndex = 0) {
+      const pairEls = Array.from(document.querySelectorAll('[data-landing-review-pair]'));
+      if (!pairEls.length) return;
+      const bounded = Math.max(0, Math.min(Number(nextIndex) || 0, pairEls.length - 1));
+      store.setReviewCarouselIndex(bounded);
+      pairEls.forEach((pairEl, index) => pairEl.classList.toggle('is-active', index === bounded));
+      document.querySelectorAll('.landing-review-dot').forEach((dotEl, index) => dotEl.classList.toggle('is-active', index === bounded));
+    }
+
+    function stepReviewCarousel(direction = 1) {
+      const pairCount = document.querySelectorAll('[data-landing-review-pair]').length;
+      if (!pairCount) return;
+      const nextIndex = (store.getReviewCarouselIndex() + direction + pairCount) % pairCount;
+      setReviewCarouselIndex(nextIndex);
+    }
+
+    return {
+      setFallbackVisible,
+      renderRootPage,
+      renderRootHours,
+      renderRootEvents,
+      renderRootNews,
+      renderRootReviews,
+      setReviewCarouselIndex,
+      stepReviewCarousel,
+    };
+  }
+
+  modules.createLandingRootRendererService = function createLandingRootRendererServiceBoundary(deps = {}) {
+    return createLandingRootRendererServiceImpl(deps);
+  };
+
+  globalScope.__HF_LANDING_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+```js
+// app.js final landing wrappers
+const landingRootRenderer = typeof LANDING_MODULES.createLandingRootRendererService === 'function'
+  ? LANDING_MODULES.createLandingRootRendererService({
+      model: landingModel,
+      store: landingStore,
+      document,
+      hasRootShell: () => hasLandingRootShell(),
+    })
+  : null;
+
+function setLandingRootFallbackVisible(visible) { return landingRootRenderer.setFallbackVisible(visible); }
+function renderLandingRootPage(record = landingStore.getRecord()) { return landingRootRenderer.renderRootPage(record); }
+function setLandingReviewCarouselIndex(nextIndex = 0) { return landingRootRenderer.setReviewCarouselIndex(nextIndex); }
+function stepLandingReviewCarousel(direction = 1) { return landingRootRenderer.stepReviewCarousel(direction); }
+```
+
+```html
+<script src="/core/landing/model.js"></script>
+<script src="/core/landing/store.js"></script>
+<script src="/core/landing/data-service.js"></script>
+<script src="/core/landing/admin-workspace.js"></script>
+<script src="/core/landing/root-renderer.js"></script>
+<script src="/app.js"></script>
+```
+
+- [ ] **Step 4: Run the full verification set, including syntax and HTML ordering**
+
+Run: `node --test tests/boundaries/landing.boundary.test.cjs tests/landing-page-hours.test.cjs tests/landing-page-content.test.cjs tests/runtime-helpers.test.cjs`
+Expected: PASS
+
+Run: `node --check app.js`
+Expected: PASS
+
+Run: `node scripts/check-html-script-order.cjs`
+Expected: `HTML script order check passed.`
+
+- [ ] **Step 5: Commit the final landing split**
+
+```bash
+git add core/landing/root-renderer.js app.js index.html manager/index.html admin/index.html leroyslounge/index.html elroyscantina/index.html scripts/check-html-script-order.cjs tests/helpers/runtime.cjs tests/runtime-helpers.test.cjs
+git commit -m "refactor: move landing runtime out of app"
+```
+
+## Self-Review
+
+1. **Spec coverage:** The model task covers `createDefaultLandingPageRecord()`, the normalize helpers, validation helpers, hours/status helpers, `applyLandingSectionPublish()`, `getLandingRenderableNews()`, and `buildLandingReviewPairs()`. The state/data task covers `ensureLandingPageStateLoaded()`, app-owned landing state, draft/live persistence, and selective publish persistence. The admin task covers `renderLandingAdminWorkspace()`, `renderLandingOverview()`, field update handlers, draft save flow, publish flow, and draft-vs-live separation. The root task covers `renderLandingRootPage()`, landing root fallback behavior, and the review carousel. Existing landing tests remain the main regression suite all the way through.
+2. **Placeholder scan:** No step says `TODO`, `TBD`, or "handle later." Every task names exact files, commands, and concrete code shapes, and the admin-task code snippets now show real method bodies for the hours sync, field mutation, render orchestration, save flow, and publish flow.
+3. **Type consistency:** The plan uses one consistent registry (`__HF_LANDING_MODULES__`) and one consistent factory set: `createLandingModel`, `createLandingStore`, `createLandingDataService`, `createLandingAdminWorkspaceService`, and `createLandingRootRendererService`. App-level wrappers retain the current public names so existing tests and inline HTML handlers do not need API renames.
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-21-appjs-landing-runtime-split.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/docs/superpowers/plans/2026-04-21-appjs-manager-admin-runtime-split.md
+++ b/docs/superpowers/plans/2026-04-21-appjs-manager-admin-runtime-split.md
@@ -1,0 +1,1196 @@
+# App.js Manager/Admin Runtime Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Move the manager/admin editing runtime out of `app.js` and into deeper `core/ui/manager/*` and `core/ui/admin/*` modules so `app.js` becomes browser wiring plus compact delegation.
+
+**Architecture:** Keep `app.js` as the owner of browser globals, startup order, shared mutable runtime state, and module lookup/port construction. Move the large manager/admin UI bodies into cohesive boundaries: manager item editors in `core/ui/manager/editors.js`, manager workspace/section orchestration in `core/ui/manager/workspace.js` and `core/ui/manager/sections.js`, featured-item editing in a focused `core/ui/manager/featured.js`, and admin user/switcher/workspace behavior in `core/ui/admin/*`. Preserve current behavior by adding boundary tests before each extraction and by keeping inline handler names stable through thin delegate bindings.
+
+**Tech Stack:** Plain browser JavaScript, HTML script tags, Node test runner (`node --test`), no bundler, no dependencies.
+
+---
+
+## File Structure
+
+- `app.js`
+  Keep browser-owned state, module getters, and a compact `bindUiDelegates()` table. Delete the moved manager/admin function bodies after the shared modules own them.
+- `core/ui/manager/editors.js`
+  Own the item/category/pricing/description runtime: `renderManagerCategories()`, `renderManagerItems()`, `renderPricingSection()`, `renderDescriptionSection()`, add-item autocomplete, 86 toggles, swipe behavior, upcharges, recipe helpers, and related stale-section updates.
+- `core/ui/manager/workspace.js`
+  Own manager shell orchestration: `renderManagerWorkspace()`, `refreshManagerViews()`, `saveMenu()`, action-bar state syncing, overview stats, and `renderRecentChanges()`.
+- `core/ui/manager/sections.js`
+  Own active manager section state, stale-section invalidation, and `switchManagerTab()`.
+- `core/ui/manager/featured.js`
+  Own `renderFeaturedTab()` and the featured-item picker/edit flows so restaurant-special behavior is not buried in the workspace shell.
+- `core/ui/admin/workspace.js`
+  Own `renderAdminWorkspace()`, `renderMenusPanel()`, and `switchAdminTab()` while composing the users and switcher services.
+- `core/ui/admin/users.js`
+  Own `loadUsers()`, `renderUsersTab()`, `buildMenuAccessHTML()`, `renderMenuAccessForUser()`, `saveUserRole()`, `saveMenuAccess()`, and `saveUserName()`.
+- `core/ui/admin/switcher.js`
+  Own `loadAdminSwitcherData()`, `initAdminSwitcherTab()`, `onAdminSwitcherRestaurantChange()`, and `onAdminSwitcherMenuChange()`.
+- `index.html`
+  Load the new shared manager/admin module scripts before `app.js`.
+- `manager/index.html`
+  Load the new shared manager/admin module scripts before `app.js`.
+- `admin/index.html`
+  Load the new shared manager/admin module scripts before `app.js`.
+- `leroyslounge/index.html`
+  Load the new shared manager/admin module scripts before `routes/shared/public-route-core.js` and `app.js`.
+- `elroyscantina/index.html`
+  Load the new shared manager/admin module scripts before `routes/shared/public-route-core.js` and `app.js`.
+- `scripts/check-html-script-order.cjs`
+  Lock the shared runtime script order so the new modules always load before `app.js`.
+- `tests/helpers/runtime.cjs`
+  Mirror the HTML runtime script order inside the sandbox loader.
+- `tests/phase3-ui-boundaries.test.cjs`
+  App-to-boundary delegation coverage for manager/admin UI surfaces.
+- `tests/phase3-ui-deep-boundaries.test.cjs`
+  Deep-module behavior coverage for manager/admin services.
+- `tests/phase18-menu-history-boundaries.test.cjs`
+  Keep recent-changes history wiring pinned to the shared manager workspace boundary instead of `app.js`.
+- `tests/phase22-category-governance.test.cjs`
+  Regression guard for category/item editing behavior while the manager editor cluster moves.
+
+### Task 1: Create The New Module Loading Skeleton And Lock Boundary Contracts
+
+**Files:**
+- Create: `core/ui/manager/featured.js`
+- Create: `core/ui/admin/users.js`
+- Modify: `index.html`
+- Modify: `manager/index.html`
+- Modify: `admin/index.html`
+- Modify: `leroyslounge/index.html`
+- Modify: `elroyscantina/index.html`
+- Modify: `scripts/check-html-script-order.cjs`
+- Modify: `tests/helpers/runtime.cjs`
+- Modify: `tests/phase3-ui-boundaries.test.cjs`
+- Modify: `tests/phase3-ui-deep-boundaries.test.cjs`
+- Test: `tests/phase3-ui-boundaries.test.cjs`
+- Test: `tests/phase3-ui-deep-boundaries.test.cjs`
+
+- [ ] **Step 1: Add failing boundary tests for the new manager/admin module surface**
+
+```js
+test('ui module scripts register featured and admin-users factories', () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/ui/manager/workspace.js',
+    'core/ui/manager/sections.js',
+    'core/ui/manager/editors.js',
+    'core/ui/manager/featured.js',
+    'core/ui/admin/workspace.js',
+    'core/ui/admin/users.js',
+    'core/ui/admin/switcher.js',
+  ]);
+
+  assert.equal(typeof sandbox.__HF_UI_MODULES__.createManagerFeaturedService, 'function');
+  assert.equal(typeof sandbox.__HF_UI_MODULES__.createAdminUsersService, 'function');
+});
+
+test('app manager/admin helpers delegate through shared ui module boundaries', async () => {
+  const calls = [];
+  const sandbox = loadSandboxWithScripts(['app.js'], {
+    __HF_UI_MODULES__: {
+      createManagerWorkspaceService: () => ({
+        saveMenu: async () => calls.push('saveMenu'),
+        renderManagerWorkspace: () => calls.push('renderManagerWorkspace'),
+        renderRecentChanges: async () => calls.push('renderRecentChanges'),
+      }),
+      createManagerSectionService: () => ({
+        switchManagerTab: name => calls.push(['switchManagerTab', name]),
+      }),
+      createManagerFeaturedService: () => ({
+        renderFeaturedTab: () => calls.push('renderFeaturedTab'),
+      }),
+      createAdminWorkspaceService: () => ({
+        renderAdminWorkspace: () => calls.push('renderAdminWorkspace'),
+        renderMenusPanel: async () => calls.push('renderMenusPanel'),
+        switchAdminTab: name => calls.push(['switchAdminTab', name]),
+      }),
+      createAdminUsersService: () => ({
+        loadUsers: async () => calls.push('loadUsers'),
+      }),
+    },
+  });
+
+  await sandbox.saveMenu();
+  await sandbox.renderRecentChanges();
+  sandbox.renderFeaturedTab();
+  sandbox.switchManagerTab('edit-pricing');
+  await sandbox.renderMenusPanel();
+  await sandbox.loadUsers();
+  sandbox.switchAdminTab('admin-users');
+
+  assert.deepEqual(calls, [
+    'saveMenu',
+    'renderRecentChanges',
+    'renderFeaturedTab',
+    ['switchManagerTab', 'edit-pricing'],
+    'renderMenusPanel',
+    'loadUsers',
+    ['switchAdminTab', 'admin-users'],
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the boundary tests and confirm they fail before adding the new modules**
+
+Run: `node --test tests/phase3-ui-boundaries.test.cjs tests/phase3-ui-deep-boundaries.test.cjs`
+Expected: FAIL because `core/ui/manager/featured.js` and `core/ui/admin/users.js` do not exist yet, and `app.js` does not delegate `saveMenu()`, `renderRecentChanges()`, `renderFeaturedTab()`, `switchManagerTab()`, `renderMenusPanel()`, `loadUsers()`, or `switchAdminTab()` through shared UI services.
+
+- [ ] **Step 3: Add the new runtime skeleton files and wire them into script loading**
+
+Create `core/ui/manager/featured.js`:
+
+```js
+(function bootstrapManagerFeaturedUi(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_UI_MODULES__ && typeof globalScope.__HF_UI_MODULES__ === 'object')
+    ? globalScope.__HF_UI_MODULES__
+    : {};
+
+  function createManagerFeaturedServiceImpl(deps = {}) {
+    const renderFeaturedTab = typeof deps.renderFeaturedTab === 'function' ? deps.renderFeaturedTab : (() => {});
+    const filterFeaturedPicker = typeof deps.filterFeaturedPicker === 'function' ? deps.filterFeaturedPicker : (() => {});
+    const handleFeaturedAddKeydown = typeof deps.handleFeaturedAddKeydown === 'function' ? deps.handleFeaturedAddKeydown : (() => {});
+    const addFeaturedSlotFromInput = typeof deps.addFeaturedSlotFromInput === 'function' ? deps.addFeaturedSlotFromInput : (async () => {});
+    const addFeaturedSlot = typeof deps.addFeaturedSlot === 'function' ? deps.addFeaturedSlot : (async () => {});
+    const removeFeaturedSlot = typeof deps.removeFeaturedSlot === 'function' ? deps.removeFeaturedSlot : (async () => {});
+    const saveFeaturedSellNote = typeof deps.saveFeaturedSellNote === 'function' ? deps.saveFeaturedSellNote : (async () => {});
+    const moveFeaturedSlot = typeof deps.moveFeaturedSlot === 'function' ? deps.moveFeaturedSlot : (async () => {});
+    const focusFeaturedManagerCard = typeof deps.focusFeaturedManagerCard === 'function' ? deps.focusFeaturedManagerCard : (() => {});
+
+    return {
+      renderFeaturedTab,
+      filterFeaturedPicker,
+      handleFeaturedAddKeydown,
+      addFeaturedSlotFromInput,
+      addFeaturedSlot,
+      removeFeaturedSlot,
+      saveFeaturedSellNote,
+      moveFeaturedSlot,
+      focusFeaturedManagerCard,
+    };
+  }
+
+  modules.createManagerFeaturedService = function createManagerFeaturedServiceBoundary(deps = {}) {
+    return createManagerFeaturedServiceImpl(deps);
+  };
+
+  globalScope.__HF_UI_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+Create `core/ui/admin/users.js`:
+
+```js
+(function bootstrapAdminUsersUi(globalScope) {
+  if (!globalScope) return;
+
+  const modules = (globalScope.__HF_UI_MODULES__ && typeof globalScope.__HF_UI_MODULES__ === 'object')
+    ? globalScope.__HF_UI_MODULES__
+    : {};
+
+  function createAdminUsersServiceImpl(deps = {}) {
+    const loadUsers = typeof deps.loadUsers === 'function' ? deps.loadUsers : (async () => {});
+    const renderUsersTab = typeof deps.renderUsersTab === 'function' ? deps.renderUsersTab : (() => {});
+    const buildMenuAccessHTML = typeof deps.buildMenuAccessHTML === 'function' ? deps.buildMenuAccessHTML : (() => '');
+    const renderMenuAccessForUser = typeof deps.renderMenuAccessForUser === 'function' ? deps.renderMenuAccessForUser : (() => {});
+    const saveUserRole = typeof deps.saveUserRole === 'function' ? deps.saveUserRole : (async () => {});
+    const saveMenuAccess = typeof deps.saveMenuAccess === 'function' ? deps.saveMenuAccess : (async () => {});
+    const saveUserName = typeof deps.saveUserName === 'function' ? deps.saveUserName : (async () => {});
+
+    return {
+      loadUsers,
+      renderUsersTab,
+      buildMenuAccessHTML,
+      renderMenuAccessForUser,
+      saveUserRole,
+      saveMenuAccess,
+      saveUserName,
+    };
+  }
+
+  modules.createAdminUsersService = function createAdminUsersServiceBoundary(deps = {}) {
+    return createAdminUsersServiceImpl(deps);
+  };
+
+  globalScope.__HF_UI_MODULES__ = modules;
+})(typeof globalThis !== 'undefined' ? globalThis : this);
+```
+
+Update the shared script lists in both runtime guardrails:
+
+```js
+const SHARED_RUNTIME_SCRIPTS = [
+  '/core/domain/constants.js',
+  '/core/domain/category-defaults.js',
+  '/core/auth/auth-api.js',
+  '/core/auth/auth-session-service.js',
+  '/core/auth/auth-overlay-template.js',
+  '/core/auth/auth-overlay-controller.js',
+  '/core/ui/manager/workspace.js',
+  '/core/ui/manager/sections.js',
+  '/core/ui/manager/editors.js',
+  '/core/ui/manager/featured.js',
+  '/core/ui/admin/workspace.js',
+  '/core/ui/admin/users.js',
+  '/core/ui/admin/switcher.js',
+  '/core/ui/public/footer-actions.js',
+  '/core/ui/public/renderer-default.js',
+  '/core/session/publish-service.js',
+  '/core/session/menu-session.js',
+  '/core/data/menu-state-loader.js',
+  '/core/session/poll-scheduler.js',
+];
+```
+
+Insert the new script tags in every HTML shell immediately after the existing manager/admin UI tags:
+
+```html
+<script src="/core/ui/manager/workspace.js"></script>
+<script src="/core/ui/manager/sections.js"></script>
+<script src="/core/ui/manager/editors.js"></script>
+<script src="/core/ui/manager/featured.js"></script>
+<script src="/core/ui/admin/workspace.js"></script>
+<script src="/core/ui/admin/users.js"></script>
+<script src="/core/ui/admin/switcher.js"></script>
+```
+
+- [ ] **Step 4: Re-run the boundary tests and script-order check**
+
+Run: `node --test tests/phase3-ui-boundaries.test.cjs tests/phase3-ui-deep-boundaries.test.cjs`
+Expected: PASS
+
+Run: `node scripts/check-html-script-order.cjs`
+Expected: `HTML script order check passed.`
+
+- [ ] **Step 5: Commit the scaffolding**
+
+```bash
+git add core/ui/manager/featured.js core/ui/admin/users.js index.html manager/index.html admin/index.html leroyslounge/index.html elroyscantina/index.html scripts/check-html-script-order.cjs tests/helpers/runtime.cjs tests/phase3-ui-boundaries.test.cjs tests/phase3-ui-deep-boundaries.test.cjs
+git commit -m "test: lock manager admin ui module skeleton"
+```
+
+### Task 2: Move The Item/Pricing/Description Runtime Into `core/ui/manager/editors.js`
+
+**Files:**
+- Modify: `app.js:10999-12009`
+- Modify: `core/ui/manager/editors.js`
+- Modify: `tests/phase3-ui-deep-boundaries.test.cjs`
+- Test: `tests/phase3-ui-deep-boundaries.test.cjs`
+- Test: `tests/phase22-category-governance.test.cjs`
+
+- [ ] **Step 1: Add failing deep tests for the manager editor behaviors**
+
+```js
+test('manager editors service owns add-item, autocomplete, 86, pricing, and description flows', async () => {
+  const sandbox = loadSandboxWithScripts(['core/ui/manager/editors.js']);
+  const calls = [];
+  const menuState = {
+    beer: { items: [], lastSent: [] },
+    __uncategorized__: {
+      items: [{ id: 'pool-1', name: 'Pool Lager', onMenu: false, desc: '', recipe: [], price: '', upcharges: [], showDescription: true, showRecipe: false, eightySixed: false }],
+      lastSent: [],
+    },
+    _meta: {},
+  };
+
+  const service = sandbox.__HF_UI_MODULES__.createManagerEditorsService({
+    document: {
+      getElementById(id) {
+        if (id === 'new-input-beer') return { value: 'Pool Lager', focus() {}, blur() {} };
+        if (id === 'ac-beer') return { classList: { add() {}, remove() {} }, innerHTML: '' };
+        return null;
+      },
+      createElement() {
+        return {
+          className: '',
+          id: '',
+          dataset: {},
+          innerHTML: '',
+          appendChild() {},
+          querySelector() { return null; },
+          closest() { return null; },
+          addEventListener() {},
+        };
+      },
+    },
+    MENU_TYPE: 'drinks',
+    UNCATEGORIZED_ID: '__uncategorized__',
+    getMenuState: () => menuState,
+    getManagedCategoryDefs: () => [{ id: 'beer', title: 'Beer', icon: '🍺', color: '#eee', sub: '', placeholder: 'Add beer…' }],
+    getUncategorizedCategoryDef: () => ({ id: '__uncategorized__', title: 'Uncategorized', icon: '📦', color: '#ddd', sub: 'Pool', placeholder: '' }),
+    getRenderableCategoryItems: catId => (menuState[catId]?.items || []).filter(item => item.onMenu !== false),
+    findItem: (catId, itemId) => (menuState[catId]?.items || []).find(item => item.id === itemId) || null,
+    invalidateDiff: () => calls.push('invalidateDiff'),
+    updateDraftIndicator: () => calls.push('updateDraftIndicator'),
+    markSectionsStale: sectionId => calls.push(['markSectionsStale', sectionId]),
+    showToast: message => calls.push(['showToast', message]),
+  });
+
+  service.addItem('beer');
+  service.toggle86('beer', 'pool-1');
+
+  assert.equal(typeof service.renderPricingSection, 'function');
+  assert.equal(typeof service.renderDescriptionSection, 'function');
+  assert.equal(menuState.beer.items.length, 1);
+  assert.equal(menuState.__uncategorized__.items.length, 0);
+  assert.equal(menuState.beer.items[0].eightySixed, true);
+  assert.deepEqual(calls, [
+    'invalidateDiff',
+    ['markSectionsStale', undefined],
+    'updateDraftIndicator',
+    'invalidateDiff',
+    ['markSectionsStale', undefined],
+    'updateDraftIndicator',
+    ['showToast', "🚫 Marked 86'd — use Save & Send to notify channels"],
+  ]);
+});
+
+test('manager editors service hides recipe controls on food menus', () => {
+  const sandbox = loadSandboxWithScripts(['core/ui/manager/editors.js']);
+  const service = sandbox.__HF_UI_MODULES__.createManagerEditorsService({
+    MENU_TYPE: 'food',
+    getManagedCategoryDefs: () => [{ id: 'snacks', title: 'Snacks', icon: '🍟', color: '#eee', sub: '' }],
+    getRenderableCategoryItems: () => [{
+      id: 'fries-1',
+      name: 'Fries',
+      desc: 'Crispy fries',
+      recipe: ['Salt'],
+      upcharges: [],
+      eightySixed: false,
+      showDescription: true,
+      showRecipe: false,
+    }],
+    document: {
+      getElementById() { return { innerHTML: '' }; },
+      createElement() { return { className: '', id: '', innerHTML: '', appendChild() {} }; },
+    },
+  });
+
+  const html = service.buildDescriptionRowHtml({
+    id: 'fries-1',
+    name: 'Fries',
+    desc: 'Crispy fries',
+    recipe: ['Salt'],
+    upcharges: [],
+    eightySixed: false,
+    showDescription: true,
+    showRecipe: false,
+  }, 'snacks');
+
+  assert.doesNotMatch(html, /Recipe<\/label>/);
+  assert.doesNotMatch(html, /add-ingredient-btn/);
+});
+```
+
+- [ ] **Step 2: Run the manager editor tests and confirm they fail**
+
+Run: `node --test tests/phase3-ui-deep-boundaries.test.cjs tests/phase22-category-governance.test.cjs`
+Expected: FAIL because `createManagerEditorsService()` is still a shallow wrapper and does not own add-item, 86, autocomplete, pricing, or description behavior.
+
+- [ ] **Step 3: Deepen `core/ui/manager/editors.js` and replace the `app.js` item-editor bodies with service calls**
+
+Use `core/ui/manager/editors.js` as the owner of the moved code. Keep the existing factory name and add the concrete runtime methods:
+
+```js
+function createManagerEditorsServiceImpl(deps = {}) {
+  const documentRef = deps.document || globalScope.document;
+  const getMenuState = typeof deps.getMenuState === 'function' ? deps.getMenuState : (() => globalScope.menuState || {});
+  const getManagedCategoryDefs = typeof deps.getManagedCategoryDefs === 'function' ? deps.getManagedCategoryDefs : (() => globalScope.getManagedCategoryDefs?.() || []);
+  const getUncategorizedCategoryDef = typeof deps.getUncategorizedCategoryDef === 'function' ? deps.getUncategorizedCategoryDef : (() => globalScope.getUncategorizedCategoryDef?.());
+  const getRenderableCategoryItems = typeof deps.getRenderableCategoryItems === 'function' ? deps.getRenderableCategoryItems : (catId => globalScope.getRenderableCategoryItems?.(catId) || []);
+  const findItem = typeof deps.findItem === 'function' ? deps.findItem : ((catId, itemId) => globalScope.findItem?.(catId, itemId));
+  const invalidateDiff = typeof deps.invalidateDiff === 'function' ? deps.invalidateDiff : (() => globalScope.invalidateDiff?.());
+  const updateDraftIndicator = typeof deps.updateDraftIndicator === 'function' ? deps.updateDraftIndicator : (() => globalScope.updateDraftIndicator?.());
+  const markSectionsStale = typeof deps.markSectionsStale === 'function' ? deps.markSectionsStale : (sectionId => globalScope.markSectionsStale?.(sectionId));
+  const showToast = typeof deps.showToast === 'function' ? deps.showToast : ((message, tone) => globalScope.showToast?.(message, tone));
+  const MENU_TYPE = deps.MENU_TYPE || globalScope.MENU_TYPE || 'drinks';
+  const UNCATEGORIZED_ID = deps.UNCATEGORIZED_ID || globalScope.UNCATEGORIZED_ID || '__uncategorized__';
+
+  function recipeArray(recipe) {
+    if (Array.isArray(recipe)) return recipe.filter(Boolean);
+    if (typeof recipe === 'string' && recipe.trim()) return [recipe.trim()];
+    return [];
+  }
+
+  function itemUpchargeArray(upcharges) {
+    if (!Array.isArray(upcharges)) return [];
+    return upcharges
+      .filter(entry => entry && (entry.label || entry.price))
+      .map(entry => ({ label: String(entry.label || '').trim(), price: String(entry.price || '').trim() || '+$0' }));
+  }
+
+  function addItem(catId) {
+    const input = documentRef.getElementById('new-input-' + catId);
+    if (!input) return;
+    const name = String(input.value || '').trim();
+    if (!name) return;
+    const menuState = getMenuState();
+    if (!menuState[catId]) menuState[catId] = { items: [], lastSent: [] };
+
+    const pool = menuState[UNCATEGORIZED_ID]?.items || [];
+    const pooledIndex = pool.findIndex(item => item.name.toLowerCase() === name.toLowerCase());
+    if (pooledIndex !== -1 && catId !== UNCATEGORIZED_ID) {
+      const [pooledItem] = pool.splice(pooledIndex, 1);
+      menuState[catId].items.push({ ...pooledItem, onMenu: true });
+    } else {
+      menuState[catId].items.push({
+        id: globalScope.uid(),
+        name,
+        desc: '',
+        recipe: [],
+        price: '',
+        eightySixed: false,
+        onMenu: catId !== UNCATEGORIZED_ID,
+        upcharges: [],
+        showDescription: true,
+        showRecipe: false,
+      });
+    }
+
+    input.value = '';
+    hideAutocomplete(catId);
+    invalidateDiff();
+    renderManagerItems(catId);
+    if (catId !== UNCATEGORIZED_ID) renderManagerItems(UNCATEGORIZED_ID);
+    markSectionsStale(globalScope._activeManagerSection);
+    updateDraftIndicator();
+    input.focus();
+  }
+
+  function toggle86(catId, itemId) {
+    const item = findItem(catId, itemId);
+    if (!item) return;
+    item.eightySixed = !item.eightySixed;
+    invalidateDiff();
+    renderManagerItems(catId);
+    markSectionsStale(globalScope._activeManagerSection);
+    updateDraftIndicator();
+    showToast(item.eightySixed ? "🚫 Marked 86'd — use Save & Send to notify channels" : `↩ Marked ${globalScope.restoreLabel(catId)} — use Save & Send to notify channels`, 'info');
+  }
+
+  function renderPricingSection() { /* move app.js:11251-11285 here unchanged except for injected deps */ }
+  function renderDescriptionSection() { /* move app.js:11288-11322 here unchanged except for injected deps */ }
+  function renderManagerCategories() { /* move app.js:11000-11053 here unchanged except for injected deps */ }
+  function renderManagerItems(catId) { /* move app.js:11213-11248 here unchanged except for injected deps */ }
+  function showAutocomplete(catId) { /* move app.js:11538-11558 here unchanged */ }
+  function hideAutocomplete(catId) { /* move app.js:11560-11564 here unchanged */ }
+  function selectAutocomplete(event, catId, name) { /* move app.js:11566-11571 here unchanged */ }
+  function handleAddItemKeydown(event, catId) { /* move app.js:11573-11594 here unchanged */ }
+  function toggleUpcharges(catId, itemId) { /* move app.js:11616-11625 here unchanged */ }
+  function addUpcharge(catId, itemId) { /* move app.js:11627-11644 here unchanged */ }
+  function updateUpcharge(catId, itemId, index, field, value) { /* move app.js:11646-11653 here unchanged */ }
+  function removeUpcharge(catId, itemId, index) { /* move app.js:11655-11663 here unchanged */ }
+  function toggleDescriptionEditor(itemId) { /* move app.js:11797-11807 here unchanged */ }
+  function renderRecipeIngredients(catId, itemId) { /* move app.js:11846-11854 here unchanged */ }
+  async function addIngredient(catId, itemId) { /* move app.js:11856-11879 here unchanged */ }
+  async function removeIngredient(catId, itemId, index) { /* move app.js:11881-11898 here unchanged */ }
+  function handleIngredientKeydown(event, catId, itemId) { /* move app.js:11900-11902 here unchanged */ }
+  async function saveDesc(catId, itemId, value) { /* move app.js:11904-11927 here unchanged */ }
+
+  return {
+    recipeArray,
+    itemUpchargeArray,
+    renderManagerCategories,
+    renderManagerItems,
+    renderPricingSection,
+    renderDescriptionSection,
+    buildDescriptionRowHtml,
+    addItem,
+    showAutocomplete,
+    hideAutocomplete,
+    selectAutocomplete,
+    handleAddItemKeydown,
+    toggle86,
+    toggleUpcharges,
+    addUpcharge,
+    updateUpcharge,
+    removeUpcharge,
+    toggleDescriptionEditor,
+    renderRecipeIngredients,
+    addIngredient,
+    removeIngredient,
+    handleIngredientKeydown,
+    saveDesc,
+  };
+}
+```
+
+In `app.js`, replace the moved bodies with delegation entries inside the deep UI shim install:
+
+```js
+const MANAGER_EDITOR_METHODS = [
+  'renderManagerCategories',
+  'renderManagerItems',
+  'renderPricingSection',
+  'renderDescriptionSection',
+  'addItem',
+  'showAutocomplete',
+  'hideAutocomplete',
+  'selectAutocomplete',
+  'handleAddItemKeydown',
+  'toggle86',
+  'toggleUpcharges',
+  'addUpcharge',
+  'updateUpcharge',
+  'removeUpcharge',
+  'toggleDescriptionEditor',
+  'renderRecipeIngredients',
+  'addIngredient',
+  'removeIngredient',
+  'handleIngredientKeydown',
+  'saveDesc',
+];
+```
+
+- [ ] **Step 4: Run the deep manager tests and the category-governance regression**
+
+Run: `node --test tests/phase3-ui-deep-boundaries.test.cjs tests/phase22-category-governance.test.cjs`
+Expected: PASS
+
+- [ ] **Step 5: Commit the manager-editor extraction**
+
+```bash
+git add app.js core/ui/manager/editors.js tests/phase3-ui-deep-boundaries.test.cjs
+git commit -m "refactor: deepen manager editor runtime"
+```
+
+### Task 3: Move Manager Workspace/Sections/Featured Ownership Out Of `app.js`
+
+**Files:**
+- Modify: `app.js:7598-7660`
+- Modify: `app.js:11423-11433`
+- Modify: `app.js:12545-13093`
+- Modify: `core/ui/manager/workspace.js`
+- Modify: `core/ui/manager/sections.js`
+- Modify: `core/ui/manager/featured.js`
+- Modify: `tests/phase3-ui-boundaries.test.cjs`
+- Modify: `tests/phase18-menu-history-boundaries.test.cjs`
+- Test: `tests/phase3-ui-boundaries.test.cjs`
+- Test: `tests/phase18-menu-history-boundaries.test.cjs`
+
+- [ ] **Step 1: Add failing tests for manager workspace and section ownership**
+
+```js
+test('manager workspace boundary owns saveMenu, renderRecentChanges, and renderFeaturedTab', async () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/ui/manager/workspace.js',
+    'core/ui/manager/featured.js',
+  ]);
+
+  const calls = [];
+  const workspace = sandbox.__HF_UI_MODULES__.createManagerWorkspaceService({
+    flushFocusedManagerEditor: async () => calls.push('flushFocusedManagerEditor'),
+    getMenuActionState: () => ({ hasLocalDraft: true, hasPendingServerQueue: false }),
+    sendUpdate: async options => calls.push(['sendUpdate', options]),
+    readMenuHistoryThroughApi: async () => ({ history: { scope: 'menu' }, logs: [] }),
+    document: {
+      getElementById(id) {
+        if (id === 'recent-changes-wrap') return { innerHTML: '' };
+        return null;
+      },
+    },
+  });
+
+  await workspace.saveMenu();
+  await workspace.renderRecentChanges();
+
+  assert.deepEqual(calls, [
+    'flushFocusedManagerEditor',
+    ['sendUpdate', { notify: false }],
+  ]);
+});
+
+test('manager section boundary owns switchManagerTab and updates the active edit section', () => {
+  const sandbox = loadSandboxWithScripts(['core/ui/manager/sections.js']);
+  const calls = [];
+  const service = sandbox.__HF_UI_MODULES__.createManagerSectionService({
+    renderManagerCategories: () => calls.push('renderManagerCategories'),
+    renderPricingSection: () => calls.push('renderPricingSection'),
+    renderDescriptionSection: () => calls.push('renderDescriptionSection'),
+    renderCategoriesTab: () => calls.push('renderCategoriesTab'),
+    renderDatabaseTab: () => calls.push('renderDatabaseTab'),
+    renderPruneSection: () => calls.push('renderPruneSection'),
+    updateManagerToolsContext: () => calls.push('updateManagerToolsContext'),
+    focusSettingsSection: sectionId => calls.push(['focusSettingsSection', sectionId]),
+  });
+
+  service.switchManagerTab('edit-description');
+  service.switchManagerTab('database');
+
+  assert.deepEqual(calls, [
+    'renderDescriptionSection',
+    ['focusSettingsSection', 'manager-description-section'],
+    'renderDatabaseTab',
+    'renderPruneSection',
+    ['focusSettingsSection', 'manager-database-section'],
+  ]);
+});
+```
+
+Update `tests/phase18-menu-history-boundaries.test.cjs` so the source assertion follows the moved code:
+
+```js
+test('manager workspace boundary routes recent changes through the consolidated manager endpoint', () => {
+  const source = read('core/ui/manager/workspace.js');
+
+  assert.match(source, /readMenuHistoryThroughApi/);
+  assert.match(source, /\/api\/manager\?/);
+  assert.doesNotMatch(source, /rest\/v1\/update_log/);
+});
+```
+
+- [ ] **Step 2: Run the manager workspace tests and confirm they fail**
+
+Run: `node --test tests/phase3-ui-boundaries.test.cjs tests/phase18-menu-history-boundaries.test.cjs`
+Expected: FAIL because `saveMenu()`, `renderRecentChanges()`, `renderFeaturedTab()`, and `switchManagerTab()` are still owned by `app.js`.
+
+- [ ] **Step 3: Deepen the manager workspace, sections, and featured modules**
+
+Move the `app.js` bodies into the modules below and keep `app.js` as an injected-browser adapter only.
+
+In `core/ui/manager/workspace.js`:
+
+```js
+function createManagerWorkspaceServiceImpl(deps = {}) {
+  const documentRef = deps.document || globalScope.document;
+  const flushFocusedManagerEditor = typeof deps.flushFocusedManagerEditor === 'function' ? deps.flushFocusedManagerEditor : (() => globalScope.flushFocusedManagerEditor?.());
+  const getMenuActionState = typeof deps.getMenuActionState === 'function' ? deps.getMenuActionState : (() => globalScope.getMenuActionState?.() || {});
+  const openPreview = typeof deps.openPreview === 'function' ? deps.openPreview : (() => globalScope.openPreview?.());
+  const sendUpdate = typeof deps.sendUpdate === 'function' ? deps.sendUpdate : (options => globalScope.sendUpdate?.(options));
+  const readMenuHistoryThroughApi = typeof deps.readMenuHistoryThroughApi === 'function' ? deps.readMenuHistoryThroughApi : (options => globalScope.readMenuHistoryThroughApi?.(options));
+  const renderFeaturedTab = typeof deps.renderFeaturedTab === 'function' ? deps.renderFeaturedTab : (() => globalScope.renderFeaturedTab?.());
+
+  async function saveMenu() {
+    await flushFocusedManagerEditor();
+    const actionState = getMenuActionState();
+    if (!actionState.hasLocalDraft) {
+      if (actionState.hasPendingServerQueue) await openPreview();
+      return;
+    }
+    await sendUpdate({ notify: false });
+  }
+
+  function summarizeHistoryDiff(diff) { /* move app.js:12545-12556 here unchanged */ }
+  function buildHistoryDetailHtml(diff) { /* move app.js:12558-12566 here unchanged */ }
+  function buildHistoryMessageHtml(message) { /* move app.js:12568-12572 here unchanged */ }
+  function formatHistorySourceLabel(source) { /* move app.js:12574-12583 here unchanged */ }
+  function buildHistoryContextSummary(log) { /* move app.js:12585-12594 here unchanged */ }
+  function buildChangeFeedHtml(logs) { /* move app.js:12596-12632 here unchanged */ }
+
+  async function renderRecentChanges() {
+    const wrap = documentRef.getElementById('recent-changes-wrap');
+    if (!wrap) return;
+    if (!globalScope.currentUser?.accessToken) {
+      wrap.innerHTML = '<p class="db-empty">Recent changes are unavailable until you are signed in.</p>';
+      return;
+    }
+    if (!globalScope.MENU_ID) {
+      wrap.innerHTML = '<p class="db-empty">Select a menu to view recent changes.</p>';
+      return;
+    }
+
+    wrap.innerHTML = '<p class="db-empty">Loading…</p>';
+    const history = await readMenuHistoryThroughApi({ menuId: globalScope.MENU_ID, days: 7, limit: 25 });
+    const logs = Array.isArray(history?.logs) ? history.logs : [];
+    wrap.innerHTML = logs.length
+      ? buildChangeFeedHtml(logs)
+      : '<p class="db-empty">No sent updates for this menu in the last 7 days.</p>';
+  }
+
+  function renderManagerWorkspace(options = {}) {
+    deps.renderManagerCategories?.();
+    deps.renderPricingSection?.();
+    deps.renderDescriptionSection?.();
+    renderFeaturedTab();
+    deps.renderCategoriesTab?.();
+    deps.updateManagerToolsContext?.();
+    deps.renderDatabaseTab?.();
+    deps.renderPruneSection?.();
+    deps.updateActiveMenuBar?.();
+    renderManagerOverviewStats();
+    if (options.includeRecentChanges !== false) renderRecentChanges();
+    updateManagerActionBar();
+    deps.renderFooter?.();
+    deps.initManagerMobileDrawerTrigger?.();
+    deps.initDrawerSwipe?.();
+  }
+
+  return {
+    renderManagerOverviewStats,
+    syncManagerActionBarStatus,
+    updateManagerActionBar,
+    renderManagerWorkspace,
+    refreshManagerViews,
+    saveMenu,
+    renderRecentChanges,
+  };
+}
+```
+
+In `core/ui/manager/sections.js`:
+
+```js
+function createManagerSectionServiceImpl(deps = {}) {
+  const documentRef = deps.document || globalScope.document;
+  const focusSettingsSection = typeof deps.focusSettingsSection === 'function' ? deps.focusSettingsSection : (sectionId => globalScope.focusSettingsSection?.(sectionId));
+  const renderCategoriesTab = typeof deps.renderCategoriesTab === 'function' ? deps.renderCategoriesTab : (() => globalScope.renderCategoriesTab?.());
+  const renderDatabaseTab = typeof deps.renderDatabaseTab === 'function' ? deps.renderDatabaseTab : (() => globalScope.renderDatabaseTab?.());
+  const renderPruneSection = typeof deps.renderPruneSection === 'function' ? deps.renderPruneSection : (() => globalScope.renderPruneSection?.());
+  const updateManagerToolsContext = typeof deps.updateManagerToolsContext === 'function' ? deps.updateManagerToolsContext : (() => globalScope.updateManagerToolsContext?.());
+  let activeManagerSection = deps.initialActiveManagerSection || 'manager-items-section';
+
+  function switchManagerTab(name) {
+    if (name === 'edit-menu' || name === 'edit-items') {
+      activeManagerSection = 'manager-items-section';
+      renderManagerCategories();
+      focusSettingsSection('manager-items-section');
+      return;
+    }
+    if (name === 'edit-pricing') {
+      activeManagerSection = 'manager-pricing-section';
+      renderPricingSection();
+      focusSettingsSection('manager-pricing-section');
+      return;
+    }
+    if (name === 'edit-description') {
+      activeManagerSection = 'manager-description-section';
+      renderDescriptionSection();
+      focusSettingsSection('manager-description-section');
+      return;
+    }
+    if (name === 'categories') {
+      renderCategoriesTab();
+      updateManagerToolsContext();
+      focusSettingsSection('manager-categories-section');
+      return;
+    }
+    if (name === 'database') {
+      renderDatabaseTab();
+      renderPruneSection();
+      focusSettingsSection('manager-database-section');
+    }
+  }
+
+  return {
+    isManagerEditSection,
+    markSectionsStale,
+    refreshStaleSection,
+    setManagerEditSectionVisibility,
+    renderActiveManagerSection,
+    switchManagerTab,
+    getActiveManagerSection: () => activeManagerSection,
+  };
+}
+```
+
+In `core/ui/manager/featured.js`, replace the Task 1 skeleton with the full featured-item implementation moved from `app.js:12857-13064`, preserving:
+
+- `currentUserCanEditRestaurantSpecials()` access checks
+- the `Needs both menus` disabled state
+- off-menu and `86'D` badges
+- sell-note save behavior
+- picker filtering and keyboard support
+- `renderPublicView()` refreshes after add/remove/reorder
+
+- [ ] **Step 4: Run the manager workspace/history checks**
+
+Run: `node --test tests/phase3-ui-boundaries.test.cjs tests/phase18-menu-history-boundaries.test.cjs`
+Expected: PASS
+
+- [ ] **Step 5: Commit the manager workspace extraction**
+
+```bash
+git add app.js core/ui/manager/workspace.js core/ui/manager/sections.js core/ui/manager/featured.js tests/phase3-ui-boundaries.test.cjs tests/phase18-menu-history-boundaries.test.cjs
+git commit -m "refactor: move manager workspace runtime into shared modules"
+```
+
+### Task 4: Move Admin Users/Menus/Switcher Runtime Into `core/ui/admin/*`
+
+**Files:**
+- Modify: `app.js:10794-10843`
+- Modify: `app.js:12525-12823`
+- Modify: `app.js:13095-13337`
+- Modify: `core/ui/admin/workspace.js`
+- Modify: `core/ui/admin/users.js`
+- Modify: `core/ui/admin/switcher.js`
+- Modify: `tests/phase3-ui-boundaries.test.cjs`
+- Modify: `tests/phase3-ui-deep-boundaries.test.cjs`
+- Test: `tests/phase3-ui-boundaries.test.cjs`
+- Test: `tests/phase3-ui-deep-boundaries.test.cjs`
+
+- [ ] **Step 1: Add failing admin boundary tests for workspace, users, and switcher behavior**
+
+```js
+test('admin users boundary owns user list rendering and menu-access saves', async () => {
+  const sandbox = loadSandboxWithScripts(['core/ui/admin/users.js']);
+  const calls = [];
+  const service = sandbox.__HF_UI_MODULES__.createAdminUsersService({
+    readAdminCatalogThroughApi: async () => ({ allMenus: [{ id: 'menu-1', archived: false, name: 'Drinks', type: 'drinks', restaurant_id: 'rest-1' }] }),
+    fetchUsers: async () => [{ id: 'user-1', name: 'Taylor', email: 'taylor@example.com', role: 'manager', menuAccess: ['menu-1'] }],
+    patchUser: async payload => calls.push(['patchUser', payload]),
+    showToast: message => calls.push(['showToast', message]),
+    document: {
+      getElementById(id) {
+        if (id === 'users-list') return { innerHTML: '' };
+        if (id === 'user-role-user-1') return { value: 'admin', closest() { return { querySelector() { return { className: '', textContent: '' }; } }; } };
+        if (id === 'user-name-user-1') return { value: 'Taylor A.' };
+        return null;
+      },
+      querySelectorAll(selector) {
+        if (selector === '.user-menu-access-cb[data-user="user-1"]') {
+          return [{ checked: true, dataset: { menu: 'menu-1' } }];
+        }
+        return [];
+      },
+    },
+    currentUser: { uid: 'admin-1' },
+  });
+
+  await service.loadUsers();
+  await service.saveUserRole('user-1');
+  await service.saveMenuAccess('user-1');
+  await service.saveUserName('user-1');
+
+  assert.deepEqual(calls, [
+    ['patchUser', { userId: 'user-1', role: 'admin' }],
+    ['showToast', 'Role updated.'],
+    ['patchUser', { userId: 'user-1', menuAccess: ['menu-1'] }],
+    ['showToast', 'Menu access updated.'],
+    ['patchUser', { userId: 'user-1', name: 'Taylor A.' }],
+    ['showToast', 'Name updated.'],
+  ]);
+});
+
+test('admin workspace boundary owns renderMenusPanel and switchAdminTab', async () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/ui/admin/workspace.js',
+    'core/ui/admin/users.js',
+    'core/ui/admin/switcher.js',
+  ]);
+
+  const calls = [];
+  const service = sandbox.__HF_UI_MODULES__.createAdminWorkspaceService({
+    renderMenusPanel: async () => calls.push('renderMenusPanel'),
+    renderLandingWorkspace: () => calls.push('renderLandingWorkspace'),
+    initAdminSwitcherTab: async context => calls.push(['initAdminSwitcherTab', context]),
+    loadUsers: async () => calls.push('loadUsers'),
+    focusSettingsSection: sectionId => calls.push(['focusSettingsSection', sectionId]),
+  });
+
+  await service.renderAdminWorkspace();
+  await service.switchAdminTab('admin-users');
+
+  assert.deepEqual(calls, [
+    'renderMenusPanel',
+    ['initAdminSwitcherTab', 'notif'],
+    'loadUsers',
+    'renderLandingWorkspace',
+    'loadUsers',
+    ['focusSettingsSection', 'admin-users-section'],
+  ]);
+});
+```
+
+- [ ] **Step 2: Run the admin tests and confirm they fail**
+
+Run: `node --test tests/phase3-ui-boundaries.test.cjs tests/phase3-ui-deep-boundaries.test.cjs`
+Expected: FAIL because admin users/menu/switcher behavior is still implemented directly in `app.js`.
+
+- [ ] **Step 3: Deepen the admin modules and move the `app.js` logic into them**
+
+Replace the Task 1 `core/ui/admin/users.js` skeleton with the full user-management implementation moved from `app.js:12525-12823`:
+
+```js
+function createAdminUsersServiceImpl(deps = {}) {
+  const documentRef = deps.document || globalScope.document;
+  const readAdminCatalogThroughApi = typeof deps.readAdminCatalogThroughApi === 'function' ? deps.readAdminCatalogThroughApi : (() => globalScope.readAdminCatalogThroughApi?.());
+  const fetchUsers = typeof deps.fetchUsers === 'function'
+    ? deps.fetchUsers
+    : (async () => {
+        const response = await globalScope.fetch('/api/admin?action=users', {
+          headers: { Authorization: `Bearer ${globalScope.currentUser?.accessToken}` },
+        });
+        if (!response.ok) throw new Error(await response.text());
+        return response.json();
+      });
+  const postApiJson = typeof deps.postApiJson === 'function' ? deps.postApiJson : ((...args) => globalScope.postApiJson(...args));
+  const showToast = typeof deps.showToast === 'function' ? deps.showToast : ((message, tone) => globalScope.showToast?.(message, tone));
+
+  async function patchUser(payload) {
+    const result = await postApiJson('/api/admin', {
+      action: 'update_user',
+      ...payload,
+    }, {
+      headers: { Authorization: `Bearer ${globalScope.currentUser?.accessToken}` },
+    });
+    if (!result.ok) throw new Error(result.payload?.error || 'Request failed.');
+    return result;
+  }
+
+  async function loadUsers() { /* move app.js:12525-12543 here unchanged except for injected deps */ }
+  function renderUsersTab(users) { /* move app.js:12664-12730 here unchanged */ }
+  function buildMenuAccessHTML(user) { /* move app.js:12732-12753 here unchanged */ }
+  function renderMenuAccessForUser(userId) { /* move app.js:12755-12760 here unchanged */ }
+  async function saveUserRole(userId) { /* move app.js:12786-12799 here unchanged */ }
+  async function saveMenuAccess(userId) { /* move app.js:12801-12811 here unchanged */ }
+  async function saveUserName(userId) { /* move app.js:12813-12823 here unchanged */ }
+
+  return {
+    loadUsers,
+    renderUsersTab,
+    buildMenuAccessHTML,
+    renderMenuAccessForUser,
+    saveUserRole,
+    saveMenuAccess,
+    saveUserName,
+  };
+}
+```
+
+Deepen `core/ui/admin/workspace.js` with the restaurant/menu panel and tab switching moved from `app.js:13095-13337`:
+
+```js
+function createAdminWorkspaceServiceImpl(deps = {}) {
+  const documentRef = deps.document || globalScope.document;
+  const readAdminCatalogThroughApi = typeof deps.readAdminCatalogThroughApi === 'function' ? deps.readAdminCatalogThroughApi : (() => globalScope.readAdminCatalogThroughApi?.());
+  const sortKnownRestaurants = typeof deps.sortKnownRestaurants === 'function' ? deps.sortKnownRestaurants : (items => globalScope.sortKnownRestaurants(items));
+  const sortKnownMenus = typeof deps.sortKnownMenus === 'function' ? deps.sortKnownMenus : (items => globalScope.sortKnownMenus(items));
+  const knownRestaurantList = typeof deps.knownRestaurantList === 'function' ? deps.knownRestaurantList : (() => globalScope.knownRestaurantList());
+  const renderLandingWorkspace = typeof deps.renderLandingWorkspace === 'function' ? deps.renderLandingWorkspace : (() => globalScope.renderLandingAdminWorkspace?.());
+  const initAdminSwitcherTab = typeof deps.initAdminSwitcherTab === 'function' ? deps.initAdminSwitcherTab : (context => globalScope.initAdminSwitcherTab?.(context));
+  const loadUsers = typeof deps.loadUsers === 'function' ? deps.loadUsers : (() => globalScope.loadUsers?.());
+  const focusSettingsSection = typeof deps.focusSettingsSection === 'function' ? deps.focusSettingsSection : (sectionId => globalScope.focusSettingsSection?.(sectionId));
+
+  async function fetchRestaurantMenuIndex() { /* move app.js:13271-13279 here unchanged */ }
+  function groupMenusByRestaurant(allMenus) { /* move app.js:13281-13287 here unchanged */ }
+  function buildMenuChipHtml(menu) { /* move app.js:13289-13295 here unchanged */ }
+  function buildRestaurantRowHtml(restaurant, menus) { /* move app.js:13297-13311 here unchanged */ }
+  async function renderMenusPanel() { /* move app.js:13313-13337 here unchanged */ }
+
+  async function renderAdminWorkspace() {
+    await renderMenusPanel();
+    await initAdminSwitcherTab('notif');
+    await loadUsers();
+    renderLandingWorkspace();
+  }
+
+  async function switchAdminTab(name) {
+    if (name === 'admin-restaurants') {
+      await renderMenusPanel();
+      focusSettingsSection('admin-restaurants-section');
+      return;
+    }
+    if (name === 'admin-landing') {
+      renderLandingWorkspace();
+      focusSettingsSection('admin-landing-page-section');
+      return;
+    }
+    if (name === 'admin-notifications') {
+      await initAdminSwitcherTab('notif');
+      focusSettingsSection('admin-notifications-section');
+      return;
+    }
+    if (name === 'admin-users') {
+      await loadUsers();
+      focusSettingsSection('admin-users-section');
+    }
+  }
+
+  return {
+    renderAdminWorkspace,
+    renderMenusPanel,
+    switchAdminTab,
+  };
+}
+```
+
+Deepen `core/ui/admin/switcher.js` by moving the bodies from `app.js:10794-10843` so the switcher module owns its own data loading and select-change behavior instead of wrapping app functions.
+
+- [ ] **Step 4: Run the admin boundary tests**
+
+Run: `node --test tests/phase3-ui-boundaries.test.cjs tests/phase3-ui-deep-boundaries.test.cjs`
+Expected: PASS
+
+- [ ] **Step 5: Commit the admin extraction**
+
+```bash
+git add app.js core/ui/admin/workspace.js core/ui/admin/users.js core/ui/admin/switcher.js tests/phase3-ui-boundaries.test.cjs tests/phase3-ui-deep-boundaries.test.cjs
+git commit -m "refactor: move admin runtime into shared modules"
+```
+
+### Task 5: Thin `app.js` Down To Browser Wiring And Run Full Regression
+
+**Files:**
+- Modify: `app.js`
+- Modify: `tests/phase3-ui-deep-boundaries.test.cjs`
+- Test: `tests/phase3-ui-boundaries.test.cjs`
+- Test: `tests/phase3-ui-deep-boundaries.test.cjs`
+- Test: `tests/phase18-menu-history-boundaries.test.cjs`
+- Test: `tests/phase22-category-governance.test.cjs`
+
+- [ ] **Step 1: Add a failing guardrail test that `app.js` no longer owns the moved bodies**
+
+```js
+test('app runtime no longer carries large manager/admin shadow implementations', () => {
+  const app = read('app.js');
+
+  assert.doesNotMatch(app, /function renderManagerCategories\(\) \{/);
+  assert.doesNotMatch(app, /function renderManagerItems\(\) \{/);
+  assert.doesNotMatch(app, /function renderPricingSection\(\) \{/);
+  assert.doesNotMatch(app, /function renderDescriptionSection\(\) \{/);
+  assert.doesNotMatch(app, /async function saveMenu\(\) \{/);
+  assert.doesNotMatch(app, /async function loadUsers\(\) \{/);
+  assert.doesNotMatch(app, /async function renderMenusPanel\(\) \{/);
+  assert.match(app, /function bindUiDelegates\(/);
+  assert.match(app, /MANAGER_EDITOR_METHODS/);
+  assert.match(app, /MANAGER_WORKSPACE_METHODS/);
+  assert.match(app, /ADMIN_WORKSPACE_METHODS/);
+});
+```
+
+- [ ] **Step 2: Run the guardrail suite and confirm it fails**
+
+Run: `node --test tests/phase3-ui-deep-boundaries.test.cjs`
+Expected: FAIL because `app.js` still contains the original function bodies.
+
+- [ ] **Step 3: Replace the individual `app.js` bodies with table-driven delegates**
+
+Add one shared delegate helper near the existing UI module getter logic:
+
+```js
+function bindUiDelegates(target, getService, methodNames) {
+  methodNames.forEach(methodName => {
+    target[methodName] = function delegatedUiMethod(...args) {
+      if (_uiModuleDelegationStack.has(methodName)) return undefined;
+      const service = getService();
+      if (typeof service?.[methodName] !== 'function') {
+        throw new Error(`UI method unavailable: ${methodName}`);
+      }
+      _uiModuleDelegationStack.add(methodName);
+      try {
+        return service[methodName](...args);
+      } finally {
+        _uiModuleDelegationStack.delete(methodName);
+      }
+    };
+  });
+}
+
+const MANAGER_WORKSPACE_METHODS = [
+  'renderManagerWorkspace',
+  'refreshManagerViews',
+  'saveMenu',
+  'renderRecentChanges',
+];
+
+const MANAGER_SECTION_METHODS = [
+  'isManagerEditSection',
+  'markSectionsStale',
+  'refreshStaleSection',
+  'setManagerEditSectionVisibility',
+  'renderActiveManagerSection',
+  'switchManagerTab',
+];
+
+const MANAGER_FEATURED_METHODS = [
+  'renderFeaturedTab',
+  'filterFeaturedPicker',
+  'handleFeaturedAddKeydown',
+  'addFeaturedSlotFromInput',
+  'addFeaturedSlot',
+  'removeFeaturedSlot',
+  'saveFeaturedSellNote',
+  'moveFeaturedSlot',
+  'focusFeaturedManagerCard',
+];
+
+const ADMIN_WORKSPACE_METHODS = [
+  'renderAdminWorkspace',
+  'renderMenusPanel',
+  'switchAdminTab',
+];
+
+const ADMIN_USERS_METHODS = [
+  'loadUsers',
+  'saveUserRole',
+  'saveMenuAccess',
+  'saveUserName',
+  'renderMenuAccessForUser',
+];
+
+function installDeepUiDelegationShims() {
+  bindUiDelegates(globalThis, getManagerWorkspaceService, MANAGER_WORKSPACE_METHODS);
+  bindUiDelegates(globalThis, getManagerSectionService, MANAGER_SECTION_METHODS);
+  bindUiDelegates(globalThis, getManagerEditorsService, MANAGER_EDITOR_METHODS);
+  bindUiDelegates(globalThis, getManagerFeaturedService, MANAGER_FEATURED_METHODS);
+  bindUiDelegates(globalThis, getAdminWorkspaceService, ADMIN_WORKSPACE_METHODS);
+  bindUiDelegates(globalThis, getAdminUsersService, ADMIN_USERS_METHODS);
+  bindUiDelegates(globalThis, getAdminSwitcherService, [
+    'loadAdminSwitcherData',
+    'initAdminSwitcherTab',
+    'onAdminSwitcherRestaurantChange',
+    'onAdminSwitcherMenuChange',
+  ]);
+}
+```
+
+Delete the moved `app.js` bodies after the delegate binding is in place. Remove these exact functions from `app.js` once the delegate tables above are wired and passing tests:
+
+```js
+function renderManagerCategories() {}
+function renderManagerItems() {}
+function renderPricingSection() {}
+function renderDescriptionSection() {}
+async function saveMenu() {}
+async function loadUsers() {}
+async function renderMenusPanel() {}
+function renderFeaturedTab() {}
+function switchManagerTab() {}
+function switchAdminTab() {}
+```
+
+- [ ] **Step 4: Run the full regression stack and confirm `app.js` is materially smaller**
+
+Run: `node --test tests/phase3-ui-boundaries.test.cjs tests/phase3-ui-deep-boundaries.test.cjs tests/phase18-menu-history-boundaries.test.cjs tests/phase22-category-governance.test.cjs`
+Expected: PASS
+
+Run: `node --check app.js`
+Expected: no output
+
+Run: `node scripts/check-html-script-order.cjs`
+Expected: `HTML script order check passed.`
+
+Run: `wc -l app.js core/ui/manager/workspace.js core/ui/manager/sections.js core/ui/manager/editors.js core/ui/manager/featured.js core/ui/admin/workspace.js core/ui/admin/users.js core/ui/admin/switcher.js`
+Expected: `app.js` is below `11500` lines, with the removed lines now living under `core/ui/manager/*` and `core/ui/admin/*`.
+
+- [ ] **Step 5: Commit the final `app.js` thinning pass**
+
+```bash
+git add app.js core/ui/manager/workspace.js core/ui/manager/sections.js core/ui/manager/editors.js core/ui/manager/featured.js core/ui/admin/workspace.js core/ui/admin/users.js core/ui/admin/switcher.js tests/phase3-ui-boundaries.test.cjs tests/phase3-ui-deep-boundaries.test.cjs tests/phase18-menu-history-boundaries.test.cjs tests/phase22-category-governance.test.cjs
+git commit -m "refactor: thin app manager admin runtime"
+```
+
+## Self-Review
+
+### Spec coverage
+
+- Manager/admin runtime scope is covered: `renderManagerWorkspace()`, `renderAdminWorkspace()`, manager section tracking, `renderManagerCategories()`, `renderManagerItems()`, `renderPricingSection()`, `renderDescriptionSection()`, `saveMenu()`, autocomplete, 86 toggle, upcharge/recipe helpers, `loadUsers()`, `renderRecentChanges()`, `renderFeaturedTab()`, `renderMenusPanel()`, `switchManagerTab()`, `switchAdminTab()`, and the related helper clusters.
+- Existing modules are reused first: `core/ui/manager/workspace.js`, `core/ui/manager/sections.js`, `core/ui/manager/editors.js`, `core/ui/admin/workspace.js`, and `core/ui/admin/switcher.js` are all deepened rather than replaced.
+- New modules are justified and narrow: `core/ui/manager/featured.js` isolates restaurant-special editing, and `core/ui/admin/users.js` isolates user/access management.
+- Required behavior is preserved in the plan: save/send distinction, per-menu manager access, featured-item behavior, food-menu recipe hiding, admin switcher behavior, and current settings-shell accessibility.
+- Verification includes the requested boundary tests plus syntax and script-order checks.
+
+### Placeholder scan
+
+- No `TODO`, `TBD`, or “implement later” placeholders remain.
+- Every task names exact files and exact commands.
+- Every code-edit step includes concrete function names, factory names, and implementation shape.
+
+### Type consistency
+
+- Factory names are consistent throughout the plan: `createManagerWorkspaceService`, `createManagerSectionService`, `createManagerEditorsService`, `createManagerFeaturedService`, `createAdminWorkspaceService`, `createAdminUsersService`, and `createAdminSwitcherService`.
+- Delegated global method names stay stable for inline HTML handlers: `addItem`, `toggle86`, `saveMenu`, `loadUsers`, `saveUserRole`, `saveMenuAccess`, `switchManagerTab`, and `switchAdminTab`.
+- Manager section ids stay consistent: `manager-items-section`, `manager-pricing-section`, `manager-description-section`, `manager-categories-section`, and `manager-database-section`.

--- a/docs/superpowers/plans/2026-04-21-appjs-session-data-runtime-split.md
+++ b/docs/superpowers/plans/2026-04-21-appjs-session-data-runtime-split.md
@@ -1,0 +1,918 @@
+# App.js Session/Data Runtime Split Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Shrink `app.js` by moving the menu session lifecycle, quiet-save vs send-update behavior, draft rehydration, state loading, and polling runtime into the existing `core/session/*` and `core/data/*` deep modules without changing current behavior.
+
+**Architecture:** Treat `app.js` as the browser wiring layer, not the owner of session/data logic. Deepen `core/session/menu-session.js`, `core/session/publish-service.js`, `core/data/menu-state-loader.js`, and `core/session/poll-scheduler.js` until they own the real behavior, then replace the remaining `app.js` bodies with thin wrappers and compatibility shims. Keep `createRestaurantSpecialsService()` in `app.js` for now because it owns restaurant-specials CRUD and catalog composition, not generic session lifecycle; only `refreshFeaturedForActiveMenu()` should cross the session/data boundary as a dependency.
+
+**Tech Stack:** Plain browser JavaScript, `node --test`, `node --check`, no bundler, no dependencies.
+
+---
+
+## File Map
+
+| File | Responsibility after this plan |
+|---|---|
+| `app.js` | Thin browser adapters only for `getMenuSessionPorts()`, `createMenuSessionLifecycle()`, `ensureCurrentMenuSession()`, `createMenuStateLoaderService()`, `loadActiveMenuState()`, `startPolling()`, `stopPolling()`, and compatibility wrappers for `getMenuActionState()` / `updateSaveBtn()`. |
+| `core/session/menu-session.js` | Own the real session lifecycle implementation: request sync, route-first open/refresh, preview/save/send entrypoints, and unavailable-service behavior. |
+| `core/session/publish-service.js` | Own quiet-save vs send-update branching, preview/save no-op handling, and the shared publish service contract used by the session lifecycle. |
+| `core/data/menu-state-loader.js` | Own load/poll behavior, draft-envelope reapplication, featured refresh sequencing, default fallback resets, and dirty-state reconciliation. |
+| `core/session/poll-scheduler.js` | Own both the request de-duping scheduler and a new browser poll controller that starts/stops intervals and visibility listeners. |
+| `tests/boundaries/publish.boundary.test.cjs` | Boundary tests for shared publish behavior and session lifecycle publish entrypoints. |
+| `tests/boundaries/session.boundary.test.cjs` | Boundary tests for loader behavior, draft restoration, featured refresh sequencing, and poll behavior. |
+| `tests/phase2-session-boundaries.test.cjs` | Guardrail tests that `app.js` stays thin and delegates to `core/session/*` + `core/data/*` without carrying shadow implementations. |
+| `tests/architecture-boundaries.test.cjs` | Guardrail coverage for action-bar/draft-ledger behavior after `getMenuActionState()` and `updateSaveBtn()` become compatibility wrappers. |
+
+## Scope Notes
+
+- `app.js:2810-3451` is the main session/publish hotspot.
+- `app.js:6408-6670` is the main loader hotspot.
+- `app.js:8563-8714` is the main polling hotspot.
+- `app.js:1255-1337` is duplicate action-bar logic that should collapse to the existing draft-ledger boundary.
+- `app.js:6233-6405` should stay out of this refactor except for `refreshFeaturedForActiveMenu()` remaining an injected dependency.
+
+### Task 1: Add failing guardrail tests for the end-state split
+
+**Files:**
+- Modify: `tests/phase2-session-boundaries.test.cjs:6-125`
+- Modify: `tests/boundaries/session.boundary.test.cjs:70-286`
+- Modify: `tests/architecture-boundaries.test.cjs:618-770`
+- Test: `tests/phase2-session-boundaries.test.cjs`
+- Test: `tests/boundaries/session.boundary.test.cjs`
+- Test: `tests/architecture-boundaries.test.cjs`
+
+- [ ] **Step 1: Add a phase-2 source guardrail that fails while `app.js` still carries inline lifecycle, loader, and polling bodies**
+
+```js
+const fs = require('node:fs');
+const path = require('node:path');
+
+function readSource(relPath) {
+  return fs.readFileSync(path.join(__dirname, relPath), 'utf8');
+}
+
+test('app session/data wrappers stay thin after the runtime split', () => {
+  const source = readSource('../app.js');
+  const lifecycleStart = source.indexOf('function createMenuSessionLifecycle(');
+  const lifecycleEnd = source.indexOf('function ensureCurrentMenuSession(', lifecycleStart);
+  const lifecycleSource = source.slice(lifecycleStart, lifecycleEnd);
+  const loaderStart = source.indexOf('function createMenuStateLoaderService(');
+  const loaderEnd = source.indexOf('async function _loadActiveMenuStateInternal(', loaderStart);
+  const loaderSource = source.slice(loaderStart, loaderEnd);
+  const pollStart = source.indexOf('function createMenuPollScheduler(');
+  const pollEnd = source.indexOf('function getLastUpdatedTs(', pollStart);
+  const pollSource = source.slice(pollStart, pollEnd);
+  const actionStart = source.indexOf('function getMenuActionState(');
+  const actionEnd = source.indexOf('function getCachedDiff(', actionStart);
+  const actionSource = source.slice(actionStart, actionEnd);
+
+  assert.match(lifecycleSource, /boundary\\.createMenuSessionLifecycle/);
+  assert.doesNotMatch(lifecycleSource, /async open\\(/);
+  assert.match(loaderSource, /boundary\\.createMenuStateLoaderService/);
+  assert.doesNotMatch(loaderSource, /async load\\(/);
+  assert.match(pollSource, /createMenuPollController|boundary\\.createMenuPollScheduler/);
+  assert.doesNotMatch(pollSource, /let activeToken = 0/);
+  assert.match(actionSource, /createDraftLedgerService\\(\\)\\.getActionBarState/);
+  assert.doesNotMatch(actionSource, /countDiffLines\\(/);
+});
+```
+
+- [ ] **Step 2: Add a loader-boundary test for poll-time featured refresh and draft reconciliation**
+
+```js
+test('menu state loader boundary refreshes featured data only when poll detects new live data', async () => {
+  const sandbox = loadAppSandbox();
+  const refreshCalls = [];
+  const dirtyStates = [];
+  let currentTs = '1000';
+
+  const service = sandbox.createMenuStateLoaderService({
+    readState: async () => ({
+      cats: [{ key: 'beer', items: [{ id: 'lager' }] }],
+      meta: { lastUpdatedTs: currentTs },
+      restaurant: { id: 'restaurant-main', name: 'Main Restaurant' },
+      workspace: {
+        actor: { id: 'user-1', role: 'manager' },
+        permissions: { canManage: true },
+      },
+    }),
+    hydrateFromState: data => {
+      currentTs = String(data.meta.lastUpdatedTs);
+    },
+    getLastUpdatedTs: () => currentTs,
+    getCategorySnapshot: () => JSON.stringify([{ key: 'beer', items: [{ id: 'lager' }] }]),
+    getDesignSnapshot: () => JSON.stringify({ mode: 'default' }),
+    getFeaturedSnapshot: () => JSON.stringify([{ id: 'feature-1' }]),
+    readStoredLocalDraftEnvelope: () => null,
+    buildCurrentLocalDraftEnvelope: () => null,
+    alignLocalDraftEnvelope: envelope => envelope,
+    applyLocalDraftEnvelope: () => false,
+    clearCurrentLocalDraft: () => {},
+    syncLocalDraftDirtyState: () => false,
+    setDirty: value => {
+      dirtyStates.push(value);
+    },
+    clearDraftChanges: () => {},
+    writeMenuCache: () => {},
+    refreshFeatured: async () => {
+      refreshCalls.push(currentTs);
+    },
+    buildSnapshot: source => ({ source }),
+  });
+
+  currentTs = '1000';
+  const first = await service.poll({ request: { pageMode: 'public' } });
+  currentTs = '2000';
+  const second = await service.poll({ request: { pageMode: 'public' } });
+
+  assert.equal(first.changed, false);
+  assert.equal(second.changed, true);
+  assert.deepEqual(refreshCalls, ['2000']);
+  assert.deepEqual(dirtyStates, [false, false]);
+});
+```
+
+- [ ] **Step 3: Add an architecture guardrail proving the old action-button logic is only a compatibility shim**
+
+```js
+test('legacy action-button helpers collapse to the draft-ledger and manager-workspace boundaries', () => {
+  const source = read('app.js');
+  const getMenuActionStateStart = source.indexOf('function getMenuActionState(');
+  const getMenuActionStateEnd = source.indexOf('function updateSaveBtn(', getMenuActionStateStart);
+  const getMenuActionStateSource = source.slice(getMenuActionStateStart, getMenuActionStateEnd);
+  const updateSaveBtnStart = source.indexOf('function updateSaveBtn(');
+  const updateSaveBtnEnd = source.indexOf('function getCachedDiff(', updateSaveBtnStart);
+  const updateSaveBtnSource = source.slice(updateSaveBtnStart, updateSaveBtnEnd);
+
+  assert.match(getMenuActionStateSource, /createDraftLedgerService\\(\\)\\.getActionBarState/);
+  assert.doesNotMatch(getMenuActionStateSource, /saveLabel:\\s*'Save Quietly'/);
+  assert.match(updateSaveBtnSource, /updateManagerActionBar\\(/);
+  assert.doesNotMatch(updateSaveBtnSource, /document\\.getElementById\\('save-btn'\\)/);
+});
+```
+
+- [ ] **Step 4: Run the targeted tests to verify they fail before implementation**
+
+Run: `node --test tests/phase2-session-boundaries.test.cjs tests/boundaries/session.boundary.test.cjs tests/architecture-boundaries.test.cjs --test-name-pattern "runtime split|featured data only when poll detects new live data|legacy action-button helpers"`
+
+Expected: FAIL because `app.js` still contains inline lifecycle/loader/poll/action-state logic and the loader poll path does not yet have a dedicated regression test.
+
+- [ ] **Step 5: Commit the red-test checkpoint**
+
+```bash
+git add tests/phase2-session-boundaries.test.cjs tests/boundaries/session.boundary.test.cjs tests/architecture-boundaries.test.cjs
+git commit -m "test: add app session runtime split guardrails"
+```
+
+### Task 2: Move publish/session behavior fully behind `core/session/*`
+
+**Files:**
+- Modify: `core/session/publish-service.js:1-108`
+- Modify: `core/session/menu-session.js:1-197`
+- Modify: `app.js:2810-3451`
+- Modify: `tests/boundaries/publish.boundary.test.cjs:78-334`
+- Test: `tests/boundaries/publish.boundary.test.cjs`
+- Test: `tests/phase2-session-boundaries.test.cjs`
+
+- [ ] **Step 1: Deepen `core/session/publish-service.js` so it owns publish mode inference and save/send behavior instead of bouncing back into app-owned shadow code**
+
+```js
+function inferPublishIntent(options = {}, preview = {}) {
+  if (options.intent) return options.intent;
+  if (options.mode === 'save') return 'save';
+  if (options.mode === 'send') return 'send';
+  if (options.notify === false) return 'save';
+  if (preview.mode === 'send' || preview.mode === 'update-only') return 'send';
+  return 'save-and-send';
+}
+
+function createMenuPublishServiceImpl(sessionPorts, runtime = {}, options = {}) {
+  const moduleCreatePublishFacade = typeof modules.createMenuPublishFacade === 'function'
+    ? modules.createMenuPublishFacade
+    : null;
+  const globalCreatePublishFacade = typeof globalScope.createMenuPublishFacade === 'function'
+    ? globalScope.createMenuPublishFacade.bind(globalScope)
+    : null;
+  const createPublishFacade = typeof runtime.createPublishFacade === 'function'
+    ? runtime.createPublishFacade
+    : (moduleCreatePublishFacade || globalCreatePublishFacade);
+  const facade = typeof createPublishFacade === 'function'
+    ? createPublishFacade(sessionPorts, runtime)
+    : null;
+  let fallbackService = null;
+  const buildSnapshot = typeof runtime.buildSnapshot === 'function'
+    ? runtime.buildSnapshot
+    : (() => ({ source: 'unknown' }));
+  const buildPreview = typeof runtime.buildPreview === 'function'
+    ? runtime.buildPreview
+    : (() => sessionPorts.buildPreview?.(buildSnapshot('preview')));
+
+  function getFallbackService() {
+    if (fallbackService !== null) return fallbackService;
+    fallbackService = typeof options.fallback === 'function' ? options.fallback() : undefined;
+    return fallbackService;
+  }
+
+  function getUnavailableResult(message, preview = null) {
+    return {
+      ok: false,
+      userHandled: false,
+      userMessage: message,
+      preview: preview || buildPreview(),
+      snapshot: buildSnapshot('publish-unavailable'),
+    };
+  }
+
+  function buildSaveDraftNoop(preview, source = 'draft-noop') {
+    return {
+      ok: false,
+      noop: true,
+      preview,
+      snapshot: buildSnapshot(source),
+    };
+  }
+
+  async function prepare(opts = {}) {
+    if (facade && typeof facade.prepare === 'function') return facade.prepare(opts);
+    const fallback = getFallbackService();
+    if (fallback && typeof fallback.prepare === 'function') return fallback.prepare(opts);
+    return getUnavailableResult('Publish service is unavailable.');
+  }
+
+  async function saveDraft(opts = {}) {
+    const preview = opts.preview?.sections ? opts.preview : buildPreview();
+    const hasLocalDraft = !!buildSnapshot('draft')?.dirty || !!preview?.hasLocalDraft;
+    const hasChanges = !!preview?.hasChanges;
+    if (!hasLocalDraft || !hasChanges) return buildSaveDraftNoop(preview);
+
+    if (facade && typeof facade.commit === 'function') {
+      return facade.commit({ ...opts, intent: 'save' });
+    }
+    const fallback = getFallbackService();
+    if (fallback && typeof fallback.saveDraft === 'function') return fallback.saveDraft(opts);
+    return getUnavailableResult('Publish service is unavailable.', preview);
+  }
+
+  async function publishUpdate(opts = {}) {
+    const preview = opts.preview?.sections ? opts.preview : buildPreview();
+    const intent = inferPublishIntent(opts, preview);
+
+    if (facade && typeof facade.commit === 'function') {
+      return facade.commit({ ...opts, preview, intent });
+    }
+    const fallback = getFallbackService();
+    if (fallback && typeof fallback.publishUpdate === 'function') {
+      return fallback.publishUpdate({ ...opts, preview, intent });
+    }
+    return getUnavailableResult('Publish service is unavailable.', preview);
+  }
+
+  return {
+    prepare,
+    saveDraft,
+    publishUpdate,
+  };
+}
+```
+
+- [ ] **Step 2: Remove the inline lifecycle fallback from `app.js` and make `core/session/menu-session.js` the only owner of session behavior**
+
+```js
+function createMenuSessionLifecycle(ports) {
+  const sessionPorts = ports || getMenuSessionPorts();
+  const boundary = getSessionModuleBoundary();
+  if (typeof boundary?.createMenuSessionLifecycle !== 'function') {
+    throw new Error('createMenuSessionLifecycle boundary is unavailable');
+  }
+  return boundary.createMenuSessionLifecycle(sessionPorts, {
+    getMenuSessionPorts,
+    createPublishService,
+  });
+}
+
+function ensureCurrentMenuSession(overrides = {}) {
+  _currentMenuSession ??= createMenuSessionLifecycle();
+  _currentMenuSession.syncRequest(overrides);
+  return _currentMenuSession;
+}
+```
+
+Use this matching module-side session implementation in `core/session/menu-session.js` so the behavior previously duplicated in `app.js` still exists:
+
+```js
+modules.createMenuSessionLifecycle = function createMenuSessionLifecycleBoundary(ports, options = {}) {
+  if (options && typeof options.impl === 'function') {
+    return options.impl(ports, options);
+  }
+  return createMenuSessionLifecycleImpl(ports, options);
+};
+```
+
+Keep `createMenuSessionLifecycleImpl()` as the real owner of `open()`, `refresh()`, `preview()`, `preparePublish()`, `commitPublish()`, `saveDraft()`, and `publishUpdate()`.
+
+- [ ] **Step 3: Shrink `getMenuSessionPorts()` so it only exposes browser/runtime adapters, not session policy**
+
+```js
+function getMenuSessionPorts() {
+  return {
+    buildRequest(overrides = {}) {
+      return buildCurrentMenuPageRequest(overrides);
+    },
+    buildSnapshot(source = 'live', request = buildCurrentMenuPageRequest()) {
+      return buildMenuSessionSnapshot(source, request);
+    },
+    async resolveMenu() {
+      return sbResolveMenu();
+    },
+    canLoadFromNetwork() {
+      return !!MENU_ID;
+    },
+    restoreFallback({ expectedRestaurantId = '', request = {} } = {}) {
+      const requestedMenu = getMenuById(request.requestedMenuId) || getMenuBySlug(request.requestedMenuSlug || '');
+      const fallback = restoreMenuStateFromFallback({
+        menuId: request.requestedMenuId || requestedMenu?.id || MENU_ID,
+        menuSlug: request.requestedMenuSlug || requestedMenu?.slug || '',
+        restaurantId: expectedRestaurantId || requestedMenu?.restaurantId || request.siteRestaurantId || RESTAURANT_ID,
+        menuType: requestedMenu?.type || MENU_TYPE,
+      });
+      return {
+        source: fallback.source,
+        usedFallback: fallback.usedFallback,
+        snapshot: fallback.snapshot || buildMenuSessionSnapshot(fallback.source || 'fallback', request),
+      };
+    },
+    async loadState(options = {}) {
+      return _loadActiveMenuStateInternal(options);
+    },
+    async pollState(options = {}) {
+      return _pollActiveMenuStateInternal(options);
+    },
+    now() {
+      return Date.now();
+    },
+    async persistState(options = {}) {
+      return persistState(options);
+    },
+    async patchMenuMeta(update) {
+      return patchMenuMetaWithCompatibility(update);
+    },
+    async patchMenuMetaForMenu(menuId, update) {
+      return patchMenuMetaForMenuWithCompatibility(menuId, update);
+    },
+    async patchMenuDraftState(snapshot, savedAt) {
+      return patchMenuDraftState(snapshot, savedAt);
+    },
+    finalizePersistStatus(ok) {
+      finalizePersistStatus(ok);
+    },
+    commitDraft(ts) {
+      _dirty = false;
+      setSharedDraftState(ts);
+      updateManagerActionBar();
+    },
+    clearDraft() {
+      clearDraftSaveOnlyChanges();
+      clearSharedDraftState();
+      clearCurrentLocalDraft();
+      updateManagerActionBar();
+    },
+    commitLiveSave(ts) {
+      menuState._meta = { ...(menuState._meta || {}), lastUpdatedTs: String(ts) };
+      lsSet(LS_KEYS.lastUpdated, String(ts));
+      clearDraftSaveOnlyChanges();
+      clearSharedDraftState();
+      clearCurrentLocalDraft();
+      updateManagerActionBar();
+      updateLastUpdatedLabel();
+    },
+    buildPreview(snapshot) {
+      return buildMenuSessionPreview(snapshot);
+    },
+    getMenuId() {
+      return MENU_ID;
+    },
+    getRestaurantId() {
+      return RESTAURANT_ID;
+    },
+    getMenuName() {
+      return _activeMenuName;
+    },
+    snapshotCurrentItemsAsLastSent() {
+      return snapshotCurrentItemsAsLastSent();
+    },
+    getCurrentFeaturedIds() {
+      return getCurrentFeaturedIds();
+    },
+    canEditRestaurantSpecials(restaurantId) {
+      return currentUserCanEditRestaurantSpecials(restaurantId);
+    },
+    getRestaurantMenuIds(restaurantId) {
+      return getRestaurantSpecialConfig(restaurantId)?.menuIds || [];
+    },
+    async dispatchNotification(payload) {
+      return sendMenuNotificationThroughApi(payload);
+    },
+    collectNotificationWarnings(summary) {
+      return summarizeNotificationWarnings(summary);
+    },
+    syncLocalCache(options = {}) {
+      return syncLocalMenuCache(options);
+    },
+    commitPublished({ diff, ts, featuredIds }) {
+      _lastSentFeaturedIds = new Set(featuredIds);
+      applySentState(diff, ts);
+      clearDraftSaveOnlyChanges();
+      clearSharedDraftState();
+      clearCurrentLocalDraft();
+      updateManagerActionBar();
+      updateLastUpdatedLabel();
+    },
+    dedupeWarnings(warnings = []) {
+      return dedupeWarningMessages(warnings);
+    },
+  };
+}
+```
+
+Delete the old inline `createLegacyMenuPublishService()` block from `app.js` once the shared module behavior matches it. The key rule is that `getMenuSessionPorts()` may keep low-level browser hooks like persistence, notification, cache sync, and featured sync, but it must stop owning high-level publish policy or branching.
+
+- [ ] **Step 4: Extend the publish boundary tests to lock the new end-state**
+
+```js
+test('app createMenuSessionLifecycle is only a delegation wrapper after publish deepening', () => {
+  const source = require('node:fs').readFileSync(
+    require('node:path').join(__dirname, '..', '..', 'app.js'),
+    'utf8'
+  );
+  const start = source.indexOf('function createMenuSessionLifecycle(');
+  const end = source.indexOf('function ensureCurrentMenuSession(', start);
+  const fnSource = source.slice(start, end);
+
+  assert.match(fnSource, /boundary\\.createMenuSessionLifecycle/);
+  assert.doesNotMatch(fnSource, /async open\\(/);
+  assert.doesNotMatch(fnSource, /async refresh\\(/);
+  assert.doesNotMatch(fnSource, /preview\\(\\)/);
+});
+```
+
+- [ ] **Step 5: Run the publish-focused test slice**
+
+Run: `node --test tests/boundaries/publish.boundary.test.cjs tests/phase2-session-boundaries.test.cjs`
+
+Expected: PASS, with the session lifecycle and publish service behavior coming from `core/session/*`, not shadow code in `app.js`.
+
+- [ ] **Step 6: Commit the publish/session slice**
+
+```bash
+git add core/session/publish-service.js core/session/menu-session.js app.js tests/boundaries/publish.boundary.test.cjs tests/phase2-session-boundaries.test.cjs
+git commit -m "refactor: move session publish runtime behind shared modules"
+```
+
+### Task 3: Deepen `core/data/menu-state-loader.js` and keep specials outside the slice
+
+**Files:**
+- Modify: `core/data/menu-state-loader.js:1-220`
+- Modify: `app.js:6408-6670`
+- Modify: `tests/boundaries/session.boundary.test.cjs:92-286`
+- Modify: `tests/phase2-session-boundaries.test.cjs:6-125`
+- Test: `tests/boundaries/session.boundary.test.cjs`
+- Test: `tests/phase2-session-boundaries.test.cjs`
+
+- [ ] **Step 1: Add the missing dependencies to `core/data/menu-state-loader.js` so it can reach parity with the richer app-owned implementation**
+
+```js
+const applyPersistedDraftState = typeof deps.applyPersistedDraftState === 'function'
+  ? deps.applyPersistedDraftState
+  : (draftState => globalScope.applyPersistedDraftState?.(draftState));
+const getServerLiveSnapshot = typeof deps.getServerLiveSnapshot === 'function'
+  ? deps.getServerLiveSnapshot
+  : (() => globalScope.getServerLiveSnapshot?.());
+const setLocalDraftBaseSnapshot = typeof deps.setLocalDraftBaseSnapshot === 'function'
+  ? deps.setLocalDraftBaseSnapshot
+  : (snapshot => globalScope.setLocalDraftBaseSnapshot?.(snapshot));
+const setWorkspaceRestaurantToolsReadable = typeof deps.setWorkspaceRestaurantToolsReadable === 'function'
+  ? deps.setWorkspaceRestaurantToolsReadable
+  : (value => {
+      if (typeof globalScope.setWorkspaceRestaurantToolsReadable === 'function') {
+        globalScope.setWorkspaceRestaurantToolsReadable(value);
+      } else {
+        globalScope._workspaceRestaurantToolsReadable = !!value;
+      }
+    });
+```
+
+- [ ] **Step 2: Replace the inline `app.js` loader body with a thin dependency adapter**
+
+```js
+function createMenuStateLoaderService(deps = {}) {
+  const boundary = getSessionModuleBoundary();
+  if (typeof boundary?.createMenuStateLoaderService !== 'function') {
+    throw new Error('createMenuStateLoaderService boundary is unavailable');
+  }
+
+  return boundary.createMenuStateLoaderService({
+    readState: deps.readState || (async ({ request } = {}) => {
+      return readMenuStateThroughApi(request || buildCurrentMenuPageRequest());
+    }),
+    hydrateFromState: deps.hydrateFromState || hydrateState,
+    applyPersistedDraftState: deps.applyPersistedDraftState || applyPersistedDraftState,
+    setDefaultState: deps.setDefaultState || (() => {
+      menuState = defaultState();
+      currentDesign = { ...DESIGN_DEFAULTS };
+      _restaurantCustomDesignEnabled = true;
+    }),
+    setDirty: deps.setDirty || (value => { _dirty = !!value; }),
+    clearDraftChanges: deps.clearDraftChanges || (() => {
+      clearDraftSaveOnlyChanges();
+      clearSharedDraftState();
+      clearCurrentLocalDraft({ clearStorage: false });
+    }),
+    writeMenuCache: deps.writeMenuCache || (data => lsSet(LS_KEYS.menuCache, JSON.stringify(data))),
+    refreshFeatured: deps.refreshFeatured || refreshFeaturedForActiveMenu,
+    buildSnapshot: deps.buildSnapshot || (source => buildMenuSessionSnapshot(source)),
+    getLastUpdatedTs: deps.getLastUpdatedTs || (() => menuState._meta?.lastUpdatedTs),
+    getCategorySnapshot: deps.getCategorySnapshot || (() => getCategoryStateSnapshot()),
+    getDesignSnapshot: deps.getDesignSnapshot || (() => getDesignSnapshot()),
+    getFeaturedSnapshot: deps.getFeaturedSnapshot || (() => getFeaturedSnapshot()),
+    syncLocalDraftDirtyState: deps.syncLocalDraftDirtyState || (() => syncLocalDraftDirtyState()),
+    isDirty: deps.isDirty || (() => !!_dirty),
+    readStoredLocalDraftEnvelope: deps.readStoredLocalDraftEnvelope || (() => readStoredLocalDraftEnvelope()),
+    alignLocalDraftEnvelope: deps.alignLocalDraftEnvelope || ((envelope, liveSnapshot = getServerLiveSnapshot()) => (
+      alignLocalDraftEnvelopeWithLiveSnapshot(envelope, liveSnapshot)
+    )),
+    buildCurrentLocalDraftEnvelope: deps.buildCurrentLocalDraftEnvelope || (() => buildCurrentLocalDraftEnvelope()),
+    applyLocalDraftEnvelope: deps.applyLocalDraftEnvelope || ((envelope, options = {}) => applyLocalDraftEnvelope(envelope, options)),
+    clearCurrentLocalDraft: deps.clearCurrentLocalDraft || ((options = {}) => clearCurrentLocalDraft(options)),
+    applyWorkspaceRestaurantTools: deps.applyWorkspaceRestaurantTools || (data => applyWorkspaceRestaurantTools(data)),
+    syncServerLiveSnapshot: deps.syncServerLiveSnapshot || (() => syncServerLiveSnapshot()),
+    getServerLiveSnapshot: deps.getServerLiveSnapshot || (() => getServerLiveSnapshot()),
+    setLocalDraftBaseSnapshot: deps.setLocalDraftBaseSnapshot || (snapshot => setLocalDraftBaseSnapshot(snapshot)),
+    setWorkspaceRestaurantToolsReadable: deps.setWorkspaceRestaurantToolsReadable || (value => { _workspaceRestaurantToolsReadable = !!value; }),
+  });
+}
+
+async function _loadActiveMenuStateInternal(options = {}) {
+  return createMenuStateLoaderService().load(options);
+}
+
+async function _pollActiveMenuStateInternal(options = {}) {
+  return createMenuStateLoaderService().poll(options);
+}
+```
+
+- [ ] **Step 3: Keep `createRestaurantSpecialsService()` out of the refactor and lock that choice in the plan**
+
+```js
+// Do not move this service in the session/data runtime split.
+// The loader only depends on refreshFeaturedForActiveMenu(), not on the specials CRUD boundary.
+function getRestaurantSpecialsService() {
+  if (_restaurantSpecialsService) return _restaurantSpecialsService;
+  _restaurantSpecialsService = createRestaurantSpecialsService();
+  return _restaurantSpecialsService;
+}
+
+async function refreshFeaturedForActiveMenu() {
+  return getRestaurantSpecialsService().refreshForActiveMenu(RESTAURANT_ID);
+}
+```
+
+- [ ] **Step 4: Update the session boundary tests to reflect the deeper loader**
+
+```js
+test('app createMenuStateLoaderService delegates without carrying inline load or poll logic', () => {
+  const source = readSource('../app.js');
+  const start = source.indexOf('function createMenuStateLoaderService(');
+  const end = source.indexOf('async function _loadActiveMenuStateInternal(', start);
+  const fnSource = source.slice(start, end);
+
+  assert.match(fnSource, /boundary\\.createMenuStateLoaderService/);
+  assert.doesNotMatch(fnSource, /async load\\(/);
+  assert.doesNotMatch(fnSource, /async poll\\(/);
+});
+```
+
+- [ ] **Step 5: Run the loader-focused tests**
+
+Run: `node --test tests/boundaries/session.boundary.test.cjs tests/phase2-session-boundaries.test.cjs`
+
+Expected: PASS, including the new poll/featured-refresh regression and the app thin-wrapper guardrail.
+
+- [ ] **Step 6: Commit the loader slice**
+
+```bash
+git add core/data/menu-state-loader.js app.js tests/boundaries/session.boundary.test.cjs tests/phase2-session-boundaries.test.cjs
+git commit -m "refactor: move menu state loading behind shared data module"
+```
+
+### Task 4: Move polling start/stop into `core/session/poll-scheduler.js`
+
+**Files:**
+- Modify: `core/session/poll-scheduler.js:1-92`
+- Modify: `app.js:8563-8714`
+- Modify: `tests/phase2-session-boundaries.test.cjs:6-125`
+- Test: `tests/phase2-session-boundaries.test.cjs`
+
+- [ ] **Step 1: Add a new poll-controller boundary to `core/session/poll-scheduler.js`**
+
+```js
+function createMenuPollControllerImpl(config = {}, runtime = {}) {
+  const schedulerFactory = typeof config.schedulerFactory === 'function'
+    ? config.schedulerFactory
+    : (schedulerConfig => createMenuPollScheduler(schedulerConfig));
+  const scheduler = schedulerFactory(config.schedulerConfig || {});
+  const documentRef = runtime.document || globalScope.document;
+  const schedule = runtime.schedule || ((fn, ms) => globalScope.setInterval(fn, ms));
+  const unschedule = runtime.unschedule || (id => globalScope.clearInterval(id));
+  const intervalMs = Number(config.intervalMs || 10000);
+  const shouldPoll = typeof config.shouldPoll === 'function' ? config.shouldPoll : (() => true);
+  let intervalId = null;
+  let visibilityHandler = null;
+
+  function clearIntervalHandle() {
+    if (intervalId) {
+      unschedule(intervalId);
+      intervalId = null;
+    }
+  }
+
+  function startInterval() {
+    clearIntervalHandle();
+    intervalId = schedule(() => {
+      if (!shouldPoll()) return;
+      scheduler.tick();
+    }, intervalMs);
+  }
+
+  function stop() {
+    clearIntervalHandle();
+    if (visibilityHandler && documentRef) {
+      documentRef.removeEventListener('visibilitychange', visibilityHandler);
+      visibilityHandler = null;
+    }
+    scheduler.reset?.();
+  }
+
+  function start() {
+    stop();
+    if (!documentRef) return;
+    if (documentRef.visibilityState === 'visible') startInterval();
+    visibilityHandler = () => {
+      if (documentRef.visibilityState === 'visible') {
+        scheduler.resume();
+        startInterval();
+      } else {
+        clearIntervalHandle();
+      }
+    };
+    documentRef.addEventListener('visibilitychange', visibilityHandler);
+  }
+
+  return {
+    start,
+    stop,
+    scheduler,
+  };
+}
+
+modules.createMenuPollController = function createMenuPollControllerBoundary(config = {}, options = {}) {
+  if (options && typeof options.impl === 'function') {
+    return options.impl(config, options);
+  }
+  return createMenuPollControllerImpl(config, options);
+};
+```
+
+- [ ] **Step 2: Replace the app-owned polling body with a thin wrapper**
+
+```js
+function getMenuPollController() {
+  if (_menuPollController) return _menuPollController;
+  const boundary = getSessionModuleBoundary();
+  if (typeof boundary?.createMenuPollController !== 'function') {
+    throw new Error('createMenuPollController boundary is unavailable');
+  }
+
+  _menuPollController = boundary.createMenuPollController({
+    schedulerConfig: {
+      loader: async ({ requestContext }) => {
+        const [menuId, menuType, restaurantId] = requestContext.split('|');
+        return ensureCurrentMenuSession({
+          requestedMenuId: menuId,
+          requestedMenuSlug: getMenuById(menuId)?.slug || '',
+          siteRestaurantId: restaurantId || '',
+        }).refresh({
+          reason: 'poll',
+          requestedMenuId: menuId,
+          source: 'poll',
+          expectedMenuType: menuType,
+        });
+      },
+      onResult: async result => {
+        if (result?.changed) await renderPublicViews();
+        if (result?.designChanged) applyDesign(currentDesign);
+        return handlePollSuccess(result);
+      },
+      onError: () => {
+        handlePollError();
+      },
+      getContextKey: () => (MENU_ID ? `${MENU_ID}|${MENU_TYPE}|${RESTAURANT_ID || ''}` : ''),
+    },
+    intervalMs: 10000,
+    shouldPoll: () => !(isManagerMode || isAdminMode),
+  }, {
+    document,
+    schedule: (fn, ms) => setInterval(fn, ms),
+    unschedule: handle => clearInterval(handle),
+  });
+
+  return _menuPollController;
+}
+
+function startPolling() {
+  if (!SUPABASE_URL || !MENU_ID) return;
+  getMenuPollController().start();
+}
+
+function stopPolling() {
+  _menuPollController?.stop?.();
+}
+```
+
+- [ ] **Step 3: Add a phase-2 test that locks the new poll-controller boundary**
+
+```js
+test('session/data module scripts register a poll controller boundary', () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/session/poll-scheduler.js',
+  ]);
+
+  assert.equal(typeof sandbox.__HF_SESSION_MODULES__.createMenuPollController, 'function');
+});
+```
+
+- [ ] **Step 4: Run the polling-focused guardrails**
+
+Run: `node --test tests/phase2-session-boundaries.test.cjs --test-name-pattern "poll controller|runtime split"`
+
+Expected: PASS, proving polling interval and visibility wiring moved out of `app.js`.
+
+- [ ] **Step 5: Commit the polling slice**
+
+```bash
+git add core/session/poll-scheduler.js app.js tests/phase2-session-boundaries.test.cjs
+git commit -m "refactor: move poll control behind shared session module"
+```
+
+### Task 5: Collapse the remaining `app.js` action-state helpers into compatibility wrappers
+
+**Files:**
+- Modify: `app.js:1255-1337`
+- Modify: `tests/architecture-boundaries.test.cjs:618-770`
+- Test: `tests/architecture-boundaries.test.cjs`
+- Test: `tests/phase2-session-boundaries.test.cjs`
+
+- [ ] **Step 1: Replace `getMenuActionState()` and `updateSaveBtn()` with wrappers over existing boundaries**
+
+```js
+function getMenuActionState({ isCompactViewport = false } = {}) {
+  return createDraftLedgerService().getActionBarState({ isCompactViewport });
+}
+
+function updateSaveBtn() {
+  return updateManagerActionBar();
+}
+```
+
+- [ ] **Step 2: Keep the existing architecture-level action-bar assertions, but point them at the draft-ledger boundary rather than duplicate app logic**
+
+```js
+test('manager action bar stays visible and reflects idle and active draft states', () => {
+  const sandbox = loadAppSandbox();
+  const bar = sandbox.document._registerElement('manager-action-bar', createElement('div', 'manager-action-bar'));
+  const primaryGroup = sandbox.document._registerElement('manager-primary-action-group', createElement('div', 'manager-primary-action-group'));
+  const summary = sandbox.document._registerElement('manager-action-bar-summary', createElement('div', 'manager-action-bar-summary'));
+  sandbox.document._registerElement('sync-status', createElement('div', 'sync-status'));
+  const saveBtn = sandbox.document._registerElement('save-btn', createElement('button', 'save-btn'));
+  const sendBtn = sandbox.document._registerElement('send-btn', createElement('button', 'send-btn'));
+
+  sandbox.innerWidth = 960;
+  sandbox.window.innerWidth = 960;
+
+  setState(sandbox, {
+    _dirty: false,
+    _diffDirty: false,
+    _diffCache: [],
+  });
+
+  sandbox.updateManagerActionBar();
+
+  assert.equal(bar.hidden, false);
+  assert.equal(primaryGroup.hidden, false);
+  assert.equal(summary.textContent, 'No pending changes');
+  assert.equal(saveBtn.disabled, true);
+  assert.equal(sendBtn.disabled, true);
+});
+```
+
+- [ ] **Step 3: Run the action-bar verification slice**
+
+Run: `node --test tests/architecture-boundaries.test.cjs tests/phase2-session-boundaries.test.cjs --test-name-pattern "draft ledger service|manager action bar|legacy action-button helpers"`
+
+Expected: PASS, confirming the UI still shows the same copy and button states while `app.js` no longer owns the logic.
+
+- [ ] **Step 4: Commit the wrapper cleanup**
+
+```bash
+git add app.js tests/architecture-boundaries.test.cjs tests/phase2-session-boundaries.test.cjs
+git commit -m "refactor: collapse app action helpers to shared boundaries"
+```
+
+### Task 6: Final verification and cleanup pass
+
+**Files:**
+- Modify: `app.js`
+- Modify: `core/session/menu-session.js`
+- Modify: `core/session/publish-service.js`
+- Modify: `core/data/menu-state-loader.js`
+- Modify: `core/session/poll-scheduler.js`
+- Modify: `tests/boundaries/session.boundary.test.cjs`
+- Modify: `tests/boundaries/publish.boundary.test.cjs`
+- Modify: `tests/phase2-session-boundaries.test.cjs`
+- Modify: `tests/architecture-boundaries.test.cjs`
+- Test: `tests/boundaries/session.boundary.test.cjs`
+- Test: `tests/boundaries/publish.boundary.test.cjs`
+- Test: `tests/phase2-session-boundaries.test.cjs`
+- Test: `tests/architecture-boundaries.test.cjs`
+
+- [ ] **Step 1: Remove dead `app.js` helpers and confirm there is no remaining session/data shadow implementation**
+
+```js
+// Delete these app-owned bodies after the shared-module implementations are live:
+// - createLegacyMenuPublishService()
+// - the inline body previously inside createMenuSessionLifecycle()
+// - the inline body previously inside createMenuStateLoaderService()
+// - the inline body previously inside createMenuPollScheduler()
+//
+// Keep only:
+// - getMenuSessionPorts()
+// - createMenuPublishService()
+// - createMenuSessionLifecycle()
+// - ensureCurrentMenuSession()
+// - createMenuStateLoaderService()
+// - loadActiveMenuState()
+// - getMenuPollController()
+// - startPolling()
+// - stopPolling()
+// - compatibility wrappers for getMenuActionState() / updateSaveBtn()
+```
+
+- [ ] **Step 2: Run the full targeted verification suite**
+
+Run: `node --test tests/boundaries/session.boundary.test.cjs tests/boundaries/publish.boundary.test.cjs tests/phase2-session-boundaries.test.cjs tests/architecture-boundaries.test.cjs`
+
+Expected: PASS, with boundary tests covering route-first fallback, quiet save vs send-update, draft reload/reapply, featured refresh, polling, and action-bar compatibility.
+
+- [ ] **Step 3: Run syntax verification**
+
+Run: `node --check app.js`
+
+Expected: no output and exit code `0`.
+
+- [ ] **Step 4: Commit the finished slice**
+
+```bash
+git add app.js core/session/menu-session.js core/session/publish-service.js core/data/menu-state-loader.js core/session/poll-scheduler.js tests/boundaries/session.boundary.test.cjs tests/boundaries/publish.boundary.test.cjs tests/phase2-session-boundaries.test.cjs tests/architecture-boundaries.test.cjs
+git commit -m "refactor: split app session and data runtime into shared modules"
+```
+
+## Self-Review
+
+**1. Spec coverage**
+
+- `getMenuActionState()` / `updateSaveBtn()` are handled in Task 5 as compatibility wrappers over the existing draft-ledger and manager-workspace boundaries.
+- `getMenuSessionPorts()`, `createMenuSessionLifecycle()`, and `ensureCurrentMenuSession()` are covered in Task 2.
+- `createMenuStateLoaderService()`, `loadActiveMenuState()`, and draft/state loading behavior are covered in Task 3.
+- `createMenuPollScheduler()`, `startPolling()`, and `stopPolling()` are covered in Task 4 via the new `createMenuPollController` boundary.
+- Quiet save vs send-update behavior, draft handling, and publish entrypoints are covered in Task 2.
+- Featured/specials refresh behavior is preserved in Task 3, while `createRestaurantSpecialsService()` is intentionally kept out of scope except for `refreshFeaturedForActiveMenu()`.
+- Existing boundary tests are extended in Tasks 1, 2, 3, and 5, then re-run in Task 6.
+
+**2. Placeholder scan**
+
+- Checked for `TODO`, `TBD`, `implement later`, `appropriate error handling`, and `similar to Task`.
+- No placeholders remain.
+
+**3. Type consistency**
+
+- The plan consistently uses `createMenuSessionLifecycle`, `createMenuPublishService`, `createMenuStateLoaderService`, `createMenuPollController`, `preparePublish`, `commitPublish`, `saveDraft`, `publishUpdate`, `getActionBarState`, and `updateManagerActionBar`.
+- The new polling boundary is always named `createMenuPollController`.
+- The compatibility wrappers always point to `createDraftLedgerService().getActionBarState()` and `updateManagerActionBar()`.
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-21-appjs-session-data-runtime-split.md`. Two execution options:
+
+**1. Subagent-Driven (recommended)** - I dispatch a fresh subagent per task, review between tasks, fast iteration
+
+**2. Inline Execution** - Execute tasks in this session using executing-plans, batch execution with checkpoints
+
+**Which approach?**

--- a/elroyscantina/index.html
+++ b/elroyscantina/index.html
@@ -401,6 +401,11 @@
     <script src="/core/session/menu-session.js"></script>
     <script src="/core/data/menu-state-loader.js"></script>
     <script src="/core/session/poll-scheduler.js"></script>
+    <script src="/core/landing/model.js"></script>
+    <script src="/core/landing/store.js"></script>
+    <script src="/core/landing/data-service.js"></script>
+    <script src="/core/landing/admin-workspace.js"></script>
+    <script src="/core/landing/root-renderer.js"></script>
 <script src="/routes/shared/public-route-core.js"></script>
     <script src="/elroyscantina/app.js"></script>
     <script src="/app.js"></script>

--- a/index.html
+++ b/index.html
@@ -246,6 +246,11 @@
 <script src="/core/session/menu-session.js"></script>
 <script src="/core/data/menu-state-loader.js"></script>
 <script src="/core/session/poll-scheduler.js"></script>
+<script src="/core/landing/model.js"></script>
+<script src="/core/landing/store.js"></script>
+<script src="/core/landing/data-service.js"></script>
+<script src="/core/landing/admin-workspace.js"></script>
+<script src="/core/landing/root-renderer.js"></script>
 <script src="/app.js"></script>
 </body>
 </html>

--- a/leroyslounge/index.html
+++ b/leroyslounge/index.html
@@ -524,6 +524,11 @@
 <script src="/core/session/menu-session.js"></script>
 <script src="/core/data/menu-state-loader.js"></script>
 <script src="/core/session/poll-scheduler.js"></script>
+<script src="/core/landing/model.js"></script>
+<script src="/core/landing/store.js"></script>
+<script src="/core/landing/data-service.js"></script>
+<script src="/core/landing/admin-workspace.js"></script>
+<script src="/core/landing/root-renderer.js"></script>
 <script src="/routes/shared/public-route-core.js"></script>
 <script src="/leroyslounge/app.js"></script>
 <script src="/app.js"></script>

--- a/manager/index.html
+++ b/manager/index.html
@@ -421,6 +421,11 @@
 <script src="/core/session/menu-session.js"></script>
 <script src="/core/data/menu-state-loader.js"></script>
 <script src="/core/session/poll-scheduler.js"></script>
+<script src="/core/landing/model.js"></script>
+<script src="/core/landing/store.js"></script>
+<script src="/core/landing/data-service.js"></script>
+<script src="/core/landing/admin-workspace.js"></script>
+<script src="/core/landing/root-renderer.js"></script>
 <script src="/app.js"></script>
 </body>
 </html>

--- a/scripts/check-html-script-order.cjs
+++ b/scripts/check-html-script-order.cjs
@@ -21,6 +21,11 @@ const SHARED_RUNTIME_SCRIPTS = [
   '/core/session/menu-session.js',
   '/core/data/menu-state-loader.js',
   '/core/session/poll-scheduler.js',
+  '/core/landing/model.js',
+  '/core/landing/store.js',
+  '/core/landing/data-service.js',
+  '/core/landing/admin-workspace.js',
+  '/core/landing/root-renderer.js',
 ];
 
 const EXPECTED_SCRIPT_ORDER = {

--- a/tests/boundaries/landing.boundary.test.cjs
+++ b/tests/boundaries/landing.boundary.test.cjs
@@ -19,3 +19,28 @@ test('landing runtime scripts register landing factories', () => {
   assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingAdminWorkspaceService, 'function');
   assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingRootRendererService, 'function');
 });
+
+test('landing model factory publishes selected draft sections without mutating live state', () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/landing/model.js',
+  ]);
+  const model = sandbox.__HF_LANDING_MODULES__.createLandingModel();
+  const record = model.createDefaultRecord();
+
+  record.draftContent.news.items.push({
+    id: 'news-1',
+    title: 'Draft story',
+    body: 'Draft-only copy',
+    target: 'both',
+    href: 'https://example.com/story',
+    source: 'Local Press',
+    publishedAt: '2026-04-12',
+    importMeta: { lastAttemptTs: '1000', lastSuccessTs: '1000', status: 'imported' },
+  });
+
+  const published = model.applySectionPublish(record, ['news']);
+
+  assert.equal(record.liveContent.news.items.length, 0);
+  assert.equal(published.liveContent.news.items.length, 1);
+  assert.equal(model.validateNewsSection(published.liveContent.news).valid, true);
+});

--- a/tests/boundaries/landing.boundary.test.cjs
+++ b/tests/boundaries/landing.boundary.test.cjs
@@ -1,0 +1,21 @@
+const assert = require('node:assert/strict');
+const test = require('node:test');
+
+const { loadSandboxWithScripts } = require('../helpers/runtime.cjs');
+
+test('landing runtime scripts register landing factories', () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/landing/model.js',
+    'core/landing/store.js',
+    'core/landing/data-service.js',
+    'core/landing/admin-workspace.js',
+    'core/landing/root-renderer.js',
+  ]);
+
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__, 'object');
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingModel, 'function');
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingStore, 'function');
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingDataService, 'function');
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingAdminWorkspaceService, 'function');
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingRootRendererService, 'function');
+});

--- a/tests/boundaries/landing.boundary.test.cjs
+++ b/tests/boundaries/landing.boundary.test.cjs
@@ -160,6 +160,26 @@ test('landing model factory publishes selected draft sections without mutating l
   assert.equal(typeof model.normalizeNewsItem, 'function');
   assert.equal(typeof model.normalizeReviewItem, 'function');
   assert.equal(typeof model.normalizeContent, 'function');
+  assert.equal(typeof model.parseTimeToMinutes, 'function');
+  assert.equal(typeof model.formatMinutes, 'function');
+  assert.equal(typeof model.getTimeSelectOptions, 'function');
+  assert.equal(typeof model.renderTimeSelectOptions, 'function');
+  assert.equal(typeof model.isIsoDate, 'function');
+  assert.equal(typeof model.formatDateLabel, 'function');
+  assert.equal(typeof model.getTargetLabel, 'function');
+  assert.equal(typeof model.getTargetAccentClass, 'function');
+  assert.equal(typeof model.formatImportStatusLabel, 'function');
+  assert.equal(typeof model.formatImportTimestamp, 'function');
+  assert.equal(typeof model.isAbsoluteUrl, 'function');
+  assert.equal(typeof model.getEventDateRank, 'function');
+  assert.equal(typeof model.sortEvents, 'function');
+  assert.equal(typeof model.sortNews, 'function');
+  assert.equal(typeof model.sortReviews, 'function');
+  assert.equal(typeof model.getActiveItems, 'function');
+  assert.equal(typeof model.getVisibleItems, 'function');
+  assert.equal(typeof model.formatHoursRange, 'function');
+  assert.equal(typeof model.getHoursForRestaurant, 'function');
+  assert.equal(typeof model.buildWeekRows, 'function');
   assert.equal(typeof model.validateEventItem, 'function');
   assert.equal(typeof model.validateNewsItem, 'function');
   assert.equal(typeof model.validateReviewItem, 'function');
@@ -181,6 +201,61 @@ test('landing model factory publishes selected draft sections without mutating l
   assert.equal(record.liveContent.news.items.length, 0);
   assert.equal(published.liveContent.news.items.length, 1);
   assert.equal(model.validateNewsSection(published.liveContent.news).valid, true);
+
+  const restaurants = model.getConstants().RESTAURANTS;
+  const hours = model.createDefaultRecord().draftContent.hours;
+  hours.restaurants[restaurants.LEROYS.id].days.fri = {
+    closed: false,
+    open: '16:00',
+    close: '23:30',
+  };
+
+  assert.equal(model.parseTimeToMinutes('16:15'), 975);
+  assert.equal(model.formatMinutes(975), '4:15 PM');
+  assert.equal(model.getTimeSelectOptions()[0].value, '00:00');
+  assert.match(model.renderTimeSelectOptions('16:15', 'Start time'), /option value="16:15" selected/);
+  assert.equal(model.isIsoDate('2026-04-12'), true);
+  assert.equal(model.formatDateLabel('2026-04-12', { short: true, year: false }), 'Apr 12');
+  assert.equal(model.getTargetLabel(restaurants.LEROYS.id), "Leroy's Lounge");
+  assert.equal(model.getTargetAccentClass(restaurants.ELROYS.id), 'landing-tag--elroys');
+  assert.equal(model.formatImportStatusLabel('failed'), 'Needs Repair');
+  assert.equal(model.formatImportTimestamp({ lastAttemptTs: '1710000000000' }).startsWith('Tried '), true);
+  assert.equal(model.isAbsoluteUrl('https://example.com/story'), true);
+  assert.equal(model.getEventDateRank('not-a-date'), Number.MAX_SAFE_INTEGER);
+  assert.deepEqual(
+    model.sortEvents([
+      { title: 'B', eventDate: '2026-06-01', startTime: '18:00' },
+      { title: 'A', eventDate: '2026-05-01', startTime: '18:00' },
+    ]).map(item => item.title),
+    ['A', 'B']
+  );
+  assert.deepEqual(
+    model.sortNews([
+      { title: 'Older', publishedDate: '2026-04-01', updatedAt: '1' },
+      { title: 'Newer', publishedDate: '2026-04-02', updatedAt: '1' },
+    ]).map(item => item.title),
+    ['Newer', 'Older']
+  );
+  assert.deepEqual(
+    model.sortReviews([
+      { author: 'Older', updatedAt: '1', importMeta: { lastSuccessTs: '10' } },
+      { author: 'Newer', updatedAt: '1', importMeta: { lastSuccessTs: '20' } },
+    ]).map(item => item.author),
+    ['Newer', 'Older']
+  );
+  assert.equal(model.getActiveItems([{ archived: false }, { archived: true }]).length, 1);
+  assert.equal(model.getVisibleItems([{ archived: false }, { archived: true }], true).length, 2);
+  assert.equal(model.formatHoursRange(hours.restaurants[restaurants.LEROYS.id].days.fri), '4 PM - 11:30 PM');
+  assert.equal(model.getHoursForRestaurant(hours, restaurants.LEROYS.id).days.fri.open, '16:00');
+  assert.equal(
+    JSON.stringify(model.buildWeekRows(hours, restaurants.LEROYS.id, 'fri').find(row => row.dayKey === 'fri')),
+    JSON.stringify({
+      dayKey: 'fri',
+      label: 'Friday',
+      isToday: true,
+      rangeLabel: '4 PM - 11:30 PM',
+    })
+  );
 });
 
 test('landing model hours rows html uses injected handler names instead of app globals', () => {

--- a/tests/boundaries/landing.boundary.test.cjs
+++ b/tests/boundaries/landing.boundary.test.cjs
@@ -25,10 +25,18 @@ test('landing model factory publishes selected draft sections without mutating l
     'core/landing/model.js',
   ]);
   const model = sandbox.__HF_LANDING_MODULES__.createLandingModel();
+  assert.equal(typeof model.createDefaultImportMeta, 'function');
   assert.equal(typeof model.createDefaultContent, 'function');
+  assert.equal(typeof model.normalizeTimestamp, 'function');
   assert.equal(typeof model.normalizeDay, 'function');
   assert.equal(typeof model.normalizeHoursRestaurant, 'function');
+  assert.equal(typeof model.normalizeEventItem, 'function');
+  assert.equal(typeof model.normalizeNewsItem, 'function');
+  assert.equal(typeof model.normalizeReviewItem, 'function');
   assert.equal(typeof model.normalizeContent, 'function');
+  assert.equal(typeof model.validateEventItem, 'function');
+  assert.equal(typeof model.validateNewsItem, 'function');
+  assert.equal(typeof model.validateReviewItem, 'function');
   const record = model.createDefaultRecord();
 
   record.draftContent.news.items.push({
@@ -47,4 +55,35 @@ test('landing model factory publishes selected draft sections without mutating l
   assert.equal(record.liveContent.news.items.length, 0);
   assert.equal(published.liveContent.news.items.length, 1);
   assert.equal(model.validateNewsSection(published.liveContent.news).valid, true);
+});
+
+test('landing model hours rows html uses injected handler names instead of app globals', () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/landing/model.js',
+  ]);
+  const model = sandbox.__HF_LANDING_MODULES__.createLandingModel();
+  const restaurants = model.getConstants().RESTAURANTS;
+  const hours = model.createDefaultRecord().draftContent.hours;
+
+  hours.restaurants[restaurants.LEROYS.id].days.wed = {
+    closed: false,
+    open: '16:00',
+    close: '23:00',
+  };
+
+  const genericHtml = model.renderHoursRowsHtml(
+    hours,
+    restaurants.LEROYS.id,
+    restaurants.LEROYS.name,
+    { setFieldHandlerName: 'handleHourChange' }
+  );
+  const noHandlerHtml = model.renderHoursRowsHtml(
+    hours,
+    restaurants.LEROYS.id,
+    restaurants.LEROYS.name
+  );
+
+  assert.match(genericHtml, /onchange="handleHourChange\(/);
+  assert.doesNotMatch(genericHtml, /setLandingHoursField\(/);
+  assert.doesNotMatch(noHandlerHtml, /onchange="/);
 });

--- a/tests/boundaries/landing.boundary.test.cjs
+++ b/tests/boundaries/landing.boundary.test.cjs
@@ -1,7 +1,7 @@
 const assert = require('node:assert/strict');
 const test = require('node:test');
 
-const { loadSandboxWithScripts } = require('../helpers/runtime.cjs');
+const { createDocument, createElement, loadSandboxWithScripts } = require('../helpers/runtime.cjs');
 
 test('landing runtime scripts register landing factories', () => {
   const sandbox = loadSandboxWithScripts([
@@ -18,6 +18,165 @@ test('landing runtime scripts register landing factories', () => {
   assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingDataService, 'function');
   assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingAdminWorkspaceService, 'function');
   assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingRootRendererService, 'function');
+});
+
+test('landing root renderer service controls root fallback and review carousel state', () => {
+  const document = createDocument();
+  const shellEl = document._registerElement('landing-root-shell', createElement('main', 'landing-root-shell'));
+  const fallbackEl = document._registerElement('landing-root-fallback', createElement('div', 'landing-root-fallback'));
+  const dotNavEl = createElement('nav');
+  const eventsSectionEl = document._registerElement('events', createElement('section', 'events'));
+  const newsSectionEl = document._registerElement('news', createElement('section', 'news'));
+  const reviewsSectionEl = document._registerElement('reviews', createElement('section', 'reviews'));
+  const reviewsControlsEl = document._registerElement('landing-reviews-controls', createElement('div', 'landing-reviews-controls'));
+  const reviewsEmptyEl = document._registerElement('landing-reviews-empty', createElement('div', 'landing-reviews-empty'));
+  const eventsEmptyEl = document._registerElement('landing-events-empty', createElement('div', 'landing-events-empty'));
+  const newsEmptyEl = document._registerElement('landing-news-empty', createElement('div', 'landing-news-empty'));
+  const eventsListEl = document._registerElement('landing-events-list', createElement('div', 'landing-events-list'));
+  const newsListEl = document._registerElement('landing-news-list', createElement('div', 'landing-news-list'));
+  const reviewsDotsEl = document._registerElement('landing-reviews-dots', createElement('div', 'landing-reviews-dots'));
+  const leroysHeroStatusEl = document._registerElement('landing-hero-status-leroys', createElement('div', 'landing-hero-status-leroys'));
+  const leroysHoursListEl = document._registerElement('landing-hours-list-leroys', createElement('div', 'landing-hours-list-leroys'));
+  const reviewPairEls = [createElement('article'), createElement('article')];
+  const reviewDotEls = [createElement('button'), createElement('button')];
+  document._registerSelector('.landing-dot-nav', dotNavEl);
+  document._registerSelector('[data-landing-dot="events"]', createElement('button'));
+  document._registerSelector('[data-landing-dot="news"]', createElement('button'));
+  document._registerSelector('[data-landing-dot="reviews"]', createElement('button'));
+  document._registerElement('landing-reviews-list', createElement('div', 'landing-reviews-list'));
+  document._registerElement('landing-hours-today-leroys', createElement('div', 'landing-hours-today-leroys'));
+  document._registerElement('landing-hours-today-elroys', createElement('div', 'landing-hours-today-elroys'));
+  document._registerElement('landing-hero-status-elroys', createElement('div', 'landing-hero-status-elroys'));
+  document._registerElement('landing-hours-list-elroys', createElement('div', 'landing-hours-list-elroys'));
+  document._registerSelector('[data-landing-review-pair]', reviewPairEls);
+  document._registerSelector('.landing-review-dot', reviewDotEls);
+
+  const sandbox = loadSandboxWithScripts([
+    'core/landing/root-renderer.js',
+  ], { document });
+
+  const rootRecord = {
+    id: 'root',
+    liveContent: {
+      hours: { restaurants: {} },
+      events: { items: [] },
+      news: { items: [] },
+      reviews: { restaurants: {} },
+    },
+  };
+  let reviewIndex = 0;
+  const syncCalls = [];
+  const service = sandbox.__HF_LANDING_MODULES__.createLandingRootRendererService({
+    model: {
+      normalizeRecord: record => record,
+      computeRestaurantStatus: (_section, restaurantId) => ({
+        isOpen: restaurantId === 'leroys',
+        label: restaurantId === 'leroys' ? 'Open now' : 'Closed for now',
+        todayRangeLabel: restaurantId === 'leroys' ? '4 PM - 11 PM' : 'Closed',
+        weekRows: [{
+          dayKey: 'mon',
+          label: 'Monday',
+          isToday: true,
+          rangeLabel: restaurantId === 'leroys' ? '4 PM - 11 PM' : 'Closed',
+        }],
+      }),
+      getRenderableEvents: () => ([{
+        id: 'event-1',
+        target: 'both',
+        title: 'Trivia Night',
+        eventDate: '2026-04-25',
+        startTime: '19:00',
+        endTime: '21:00',
+        body: 'Weekly fun.',
+      }]),
+      getRenderableNews: () => ([{
+        id: 'news-1',
+        target: 'both',
+        title: 'Big Story',
+        href: 'https://example.com/story',
+        source: 'Chronicle',
+        publishedDate: '2026-04-20',
+        body: 'Fresh update.',
+      }]),
+      buildReviewPairs: () => ([
+        {
+          leroys: { author: 'Leroy 1', quote: 'Great room.', rating: 5, source: 'Google' },
+          elroys: { author: 'El Roy 1', quote: 'Great patio.', rating: 5, source: 'Google' },
+        },
+        {
+          leroys: { author: 'Leroy 2', quote: 'Love it.', rating: 4, source: 'Google' },
+          elroys: { author: 'El Roy 2', quote: 'Excellent.', rating: 5, source: 'Google' },
+        },
+      ]),
+      formatDateLabel: value => value === '2026-04-20' ? 'Apr 20' : 'Apr 25',
+      parseTimeToMinutes: value => {
+        const [hours, minutes] = String(value || '').split(':').map(Number);
+        return (hours * 60) + minutes;
+      },
+      formatMinutes: value => value === 1140 ? '7:00 PM' : '9:00 PM',
+      getTargetAccentClass: target => target === 'both' ? 'landing-tag--both' : '',
+      getTargetLabel: target => target === 'both' ? 'Both Locations' : target,
+    },
+    store: {
+      getRecord: () => rootRecord,
+      getReviewCarouselIndex: () => reviewIndex,
+      setReviewCarouselIndex: value => {
+        reviewIndex = value;
+        return value;
+      },
+    },
+    document,
+    restaurants: {
+      LEROYS: { id: 'leroys', name: "Leroy's Lounge" },
+      ELROYS: { id: 'elroys', name: "El Roy's Cantina" },
+    },
+    setReviewCarouselHandlerName: 'handleReviewDot',
+    hasRootShell: () => true,
+    syncLegacyStateFromStore: () => syncCalls.push(reviewIndex),
+  });
+
+  service.setFallbackVisible(true);
+  assert.equal(shellEl.hidden, true);
+  assert.equal(fallbackEl.hidden, false);
+  assert.equal(dotNavEl.hidden, true);
+
+  const renderedRecord = service.renderRootPage(rootRecord);
+
+  assert.equal(renderedRecord, rootRecord);
+  assert.equal(shellEl.hidden, false);
+  assert.equal(fallbackEl.hidden, true);
+  assert.equal(dotNavEl.hidden, false);
+  assert.equal(eventsSectionEl.hidden, false);
+  assert.equal(newsSectionEl.hidden, false);
+  assert.equal(reviewsSectionEl.hidden, false);
+  assert.equal(eventsEmptyEl.hidden, true);
+  assert.equal(newsEmptyEl.hidden, true);
+  assert.equal(reviewsEmptyEl.hidden, true);
+  assert.equal(reviewsControlsEl.hidden, false);
+  assert.equal(eventsListEl.innerHTML.includes('Trivia Night'), true);
+  assert.equal(eventsListEl.innerHTML.includes('Apr 25'), true);
+  assert.equal(eventsListEl.innerHTML.includes('7:00 PM - 9:00 PM'), true);
+  assert.equal(newsListEl.innerHTML.includes('Big Story'), true);
+  assert.equal(newsListEl.innerHTML.includes('Read Story'), true);
+  assert.equal(reviewsDotsEl.innerHTML.includes('onclick="handleReviewDot(1)"'), true);
+  assert.equal(leroysHeroStatusEl.textContent, 'Open now');
+  assert.equal(leroysHoursListEl.innerHTML.includes('4 PM - 11 PM'), true);
+  assert.equal(reviewIndex, 0);
+  assert.equal(syncCalls.length >= 1, true);
+
+  service.setReviewCarouselIndex(1);
+  assert.equal(reviewIndex, 1);
+  assert.equal(reviewPairEls[0].classList.contains('is-active'), false);
+  assert.equal(reviewPairEls[1].classList.contains('is-active'), true);
+  assert.equal(reviewDotEls[0].classList.contains('is-active'), false);
+  assert.equal(reviewDotEls[1].classList.contains('is-active'), true);
+
+  service.stepReviewCarousel(-1);
+  assert.equal(reviewIndex, 0);
+  assert.equal(reviewPairEls[0].classList.contains('is-active'), true);
+  assert.equal(reviewPairEls[1].classList.contains('is-active'), false);
+  assert.equal(reviewDotEls[0].classList.contains('is-active'), true);
+  assert.equal(reviewDotEls[1].classList.contains('is-active'), false);
 });
 
 test('landing store tracks record, dirty state, load status, filters, panel, and review carousel index', () => {
@@ -53,6 +212,16 @@ test('landing store tracks record, dirty state, load status, filters, panel, and
   store.setRecord(record, { dirty: true });
   assert.equal(JSON.stringify(store.getRecord()), JSON.stringify(record));
   assert.equal(store.isDirty(), true);
+  const leakedRecord = store.getRecord();
+  leakedRecord.draftContent.overview.heroTitle = 'leaked mutation';
+  assert.equal(store.getRecord().draftContent.overview.heroTitle || '', '');
+  const updatedRecord = store.updateRecord(nextRecord => {
+    nextRecord.draftContent.overview.heroTitle = 'owned mutation';
+  }, { dirty: true, loadScope: 'draft' });
+  assert.equal(updatedRecord.draftContent.overview.heroTitle, 'owned mutation');
+  assert.equal(store.getRecord().draftContent.overview.heroTitle, 'owned mutation');
+  assert.equal(store.hasLoaded({ includeDraft: true }), true);
+  assert.equal(store.getLoadScope(), 'draft');
   assert.equal(store.setDirty(false), false);
   assert.equal(store.setLoadPromise(loadPromise), loadPromise);
   assert.equal(store.getLoadPromise(), loadPromise);
@@ -129,6 +298,11 @@ test('landing data service caches loads and persists draft/live state through in
   assert.equal(fetchCalls, 1);
   assert.equal(cachedLoad.draftContent.overview.heroTitle, 'Loaded draft');
 
+  store.setRecord(model.createDefaultRecord(), { dirty: false, loaded: true, loadScope: 'live' });
+  const liveThenDraft = await service.ensureLoaded({ includeDraft: true });
+  assert.equal(fetchCalls, 2);
+  assert.equal(liveThenDraft.draftContent.overview.heroTitle, 'Loaded draft');
+
   const draftResult = await service.saveDraft(loadedRecord, 2000);
   assert.equal(upsertPorts[0].action, 'save_landing_page_draft');
   assert.equal(upsertPorts[0].payload.draft_saved_ts, 2000);
@@ -146,6 +320,309 @@ test('landing data service caches loads and persists draft/live state through in
   assert.equal(publishResult.livePublishedTs, '3000');
 });
 
+test('landing admin workspace service updates hours without full rerender and refreshes overview state', () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/landing/admin-workspace.js',
+  ]);
+  const accessLog = [];
+  let record = {
+    id: 'root',
+    draftContent: {
+      overview: {},
+      hours: { restaurants: { leroys: { days: { wed: { closed: true, open: '', close: '' } } } } },
+      events: { items: [] },
+      news: { items: [] },
+      reviews: { restaurants: {} },
+    },
+    liveContent: {
+      overview: {},
+      hours: { restaurants: { leroys: { days: { wed: { closed: true, open: '', close: '' } } } } },
+      events: { items: [] },
+      news: { items: [] },
+      reviews: { restaurants: {} },
+    },
+    draftSavedTs: '',
+    livePublishedTs: '',
+  };
+  const elements = new Map();
+  const document = {
+    getElementById(id) {
+      accessLog.push(id);
+      if (!elements.has(id)) elements.set(id, createElement('div', id));
+      return elements.get(id);
+    },
+    querySelectorAll() {
+      return [];
+    },
+  };
+  const service = sandbox.__HF_LANDING_MODULES__.createLandingAdminWorkspaceService({
+    model: {
+      normalizeTimeValue: value => value,
+    },
+    store: {
+      getRecord: () => record,
+      setRecord: nextRecord => {
+        record = nextRecord;
+        return record;
+      },
+      updateRecord: mutator => {
+        const nextRecord = JSON.parse(JSON.stringify(record));
+        mutator(nextRecord);
+        record = nextRecord;
+        return record;
+      },
+      isDirty: () => true,
+      getLoadError: () => '',
+      getActivePanel: () => 'landing-admin-panel-overview',
+      hasLoaded: () => true,
+    },
+    dataService: {
+      ensureLoaded: async () => record,
+      saveDraft: async () => record,
+      publishSections: async () => record,
+    },
+    document,
+    hasAdminShell: () => true,
+    syncLegacyStateFromStore: () => record,
+    getSectionFilter: () => ({ showArchived: false }),
+    getVisibleItems: items => items,
+    sortEvents: items => items,
+    sortNews: items => items,
+    sortReviews: items => items,
+    renderEventCardHtml: () => '',
+    renderNewsCardHtml: () => '',
+    renderReviewCardHtml: () => '',
+    renderHoursRowsHtml: () => '',
+    knownRestaurants: () => [],
+    restaurants: {},
+    getTargetAccentClass: () => '',
+    getSectionStatus: () => ({ sectionId: 'hours', label: 'Hours', hasDraftDiff: true, isValid: true, issues: [] }),
+    getDraftDiffSectionIds: () => ['hours'],
+    formatTimestampLabel: () => 'Now',
+    computeStatusForRestaurant: () => ({ label: 'Closed for now' }),
+    syncHoursDraftFromDom: currentRecord => currentRecord,
+    createDefaultRecord: () => record,
+    normalizeRecord: value => value,
+    validateEventsSection: () => ({ valid: true, issues: [] }),
+    validateNewsSection: () => ({ valid: true, issues: [] }),
+    validateReviewsSection: () => ({ valid: true, issues: [] }),
+    getHoursSectionValidation: () => ({ valid: true, issues: [] }),
+    sectionOrder: ['overview', 'hours', 'events', 'news', 'reviews'],
+    setPanelBadge: () => {},
+    createDefaultHoursRestaurant: () => ({ days: {} }),
+    createDefaultDay: () => ({ closed: true, open: '', close: '' }),
+    normalizeDay: day => day,
+  });
+
+  service.setHoursField('leroys', 'wed', 'open', '16:00');
+
+  assert.equal(record.draftContent.hours.restaurants.leroys.days.wed.open, '16:00');
+  assert.equal(accessLog.includes('landing-overview-root-status'), true);
+  assert.equal(accessLog.includes('landing-hours-issues'), true);
+  assert.equal(accessLog.includes('landing-save-draft-btn'), true);
+  assert.equal(accessLog.includes('landing-admin-hours-grid'), false);
+  assert.equal(accessLog.includes('landing-events-panel-body'), false);
+});
+
+test('landing admin workspace service imports news drafts through its request/import path', async () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/landing/admin-workspace.js',
+  ]);
+  let record = {
+    id: 'root',
+    draftContent: {
+      overview: {},
+      hours: { restaurants: {} },
+      events: { items: [] },
+      news: { items: [] },
+      reviews: { restaurants: {} },
+    },
+    liveContent: {
+      overview: {},
+      hours: { restaurants: {} },
+      events: { items: [] },
+      news: { items: [] },
+      reviews: { restaurants: {} },
+    },
+    draftSavedTs: '',
+    livePublishedTs: '',
+  };
+  const targetSelect = createElement('select', 'landing-news-import-target');
+  targetSelect.value = 'both';
+  const urlInput = createElement('input', 'landing-news-import-url');
+  urlInput.value = 'https://example.com/story';
+  const toastLog = [];
+  const service = sandbox.__HF_LANDING_MODULES__.createLandingAdminWorkspaceService({
+    model: {
+      createDefaultNewsItem: () => ({
+        id: 'news-1',
+        target: 'both',
+        title: '',
+        body: '',
+        href: '',
+        source: '',
+        publishedDate: '',
+        imageUrl: '',
+        importMeta: {},
+      }),
+      normalizeNewsItem: value => value,
+      normalizeImportMeta: value => value,
+      normalizeTarget: value => value,
+    },
+    store: {
+      getRecord: () => record,
+      setRecord: nextRecord => {
+        record = nextRecord;
+        return record;
+      },
+      updateRecord: mutator => {
+        const nextRecord = JSON.parse(JSON.stringify(record));
+        mutator(nextRecord);
+        record = nextRecord;
+        return record;
+      },
+      isDirty: () => true,
+      getLoadError: () => '',
+      getActivePanel: () => 'landing-admin-panel-overview',
+      hasLoaded: () => false,
+    },
+    dataService: {
+      ensureLoaded: async () => record,
+      saveDraft: async () => record,
+      publishSections: async () => record,
+    },
+    document: {
+      getElementById(id) {
+        if (id === 'landing-news-import-target') return targetSelect;
+        if (id === 'landing-news-import-url') return urlInput;
+        return createElement('div', id);
+      },
+      querySelectorAll() {
+        return [];
+      },
+    },
+    hasAdminShell: () => false,
+    syncLegacyStateFromStore: () => record,
+    createDefaultRecord: () => record,
+    normalizeRecord: value => value || record,
+    landingTargetBoth: 'both',
+    landingImportStatusImported: 'imported',
+    postApiJson: async () => ({
+      ok: true,
+      payload: {
+        status: 'imported',
+        sourceUrl: 'https://example.com/story',
+        href: 'https://example.com/story',
+        title: 'Story',
+        source: 'Chronicle',
+        publishedDate: '2026-04-01',
+      },
+    }),
+    getAuthorizedApiHeaders: () => ({}),
+    getCurrentUser: () => ({ accessToken: 'token' }),
+    showToast: (message, tone) => toastLog.push([message, tone]),
+  });
+
+  await service.importNewsDraft();
+
+  assert.equal(record.draftContent.news.items.length, 1);
+  assert.equal(record.draftContent.news.items[0].title, 'Story');
+  assert.equal(urlInput.value, '');
+  assert.equal(toastLog[0][1], 'success');
+});
+
+test('landing admin workspace service saves drafts and publishes selected sections', async () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/landing/admin-workspace.js',
+  ]);
+  let record = {
+    id: 'root',
+    draftContent: { overview: {}, hours: { restaurants: {} }, events: { items: [] }, news: { items: [] }, reviews: { restaurants: {} } },
+    liveContent: { overview: {}, hours: { restaurants: {} }, events: { items: [] }, news: { items: [] }, reviews: { restaurants: {} } },
+    draftSavedTs: '',
+    livePublishedTs: '',
+  };
+  const modalEl = createElement('div', 'landing-publish-modal');
+  modalEl.classList = { add() {}, remove() {} };
+  const listEl = createElement('div', 'landing-publish-list');
+  const issuesEl = createElement('div', 'landing-publish-issues');
+  const confirmButton = createElement('button', 'landing-publish-confirm-btn');
+  const calls = [];
+  const service = sandbox.__HF_LANDING_MODULES__.createLandingAdminWorkspaceService({
+    model: {},
+    store: {
+      getRecord: () => record,
+      setRecord: nextRecord => {
+        record = nextRecord;
+        return record;
+      },
+      updateRecord: mutator => {
+        const nextRecord = JSON.parse(JSON.stringify(record));
+        mutator(nextRecord);
+        record = nextRecord;
+        return record;
+      },
+      isDirty: () => false,
+      getLoadError: () => '',
+      getActivePanel: () => 'landing-admin-panel-overview',
+      hasLoaded: () => true,
+    },
+    dataService: {
+      ensureLoaded: async () => record,
+      saveDraft: async currentRecord => {
+        calls.push(['saveDraft', currentRecord.id]);
+        return currentRecord;
+      },
+      publishSections: async (currentRecord, sectionIds) => {
+        calls.push(['publishSections', sectionIds]);
+        return currentRecord;
+      },
+    },
+    document: {
+      getElementById(id) {
+        if (id === 'landing-publish-modal') return modalEl;
+        if (id === 'landing-publish-list') return listEl;
+        if (id === 'landing-publish-issues') return issuesEl;
+        if (id === 'landing-publish-confirm-btn') return confirmButton;
+        return createElement('div', id);
+      },
+      querySelectorAll(selector) {
+        if (selector === '[data-landing-publish-section]:checked') {
+          return [{
+            getAttribute(name) {
+              return name === 'data-landing-publish-section' ? 'hours' : '';
+            },
+          }];
+        }
+        return [];
+      },
+    },
+    hasAdminShell: () => true,
+    hasRootShell: () => true,
+    syncLegacyStateFromStore: () => record,
+    syncHoursDraftFromDom: currentRecord => currentRecord,
+    createDefaultRecord: () => record,
+    normalizeRecord: value => value || record,
+    getSectionStatus: () => ({ sectionId: 'hours', label: 'Hours', hasDraftDiff: true, isValid: true, issues: [] }),
+    getDraftDiffSectionIds: () => ['hours'],
+    formatTimestampLabel: () => 'Now',
+    computeStatusForRestaurant: () => ({ label: 'Closed for now' }),
+    sectionOrder: ['hours'],
+    renderRootPage: currentRecord => calls.push(['renderRootPage', currentRecord.id]),
+    showToast: (message, tone) => calls.push(['toast', tone, message]),
+  });
+
+  await service.saveDraft();
+  service.renderPublishModal();
+  await service.publishSections();
+
+  assert.equal(listEl.innerHTML.includes('Hours'), true);
+  assert.equal(confirmButton.disabled, false);
+  assert.equal(calls.some(entry => entry[0] === 'saveDraft'), true);
+  assert.equal(calls.some(entry => entry[0] === 'publishSections'), true);
+  assert.equal(calls.some(entry => entry[0] === 'renderRootPage'), true);
+});
+
 test('landing model factory publishes selected draft sections without mutating live state', () => {
   const sandbox = loadSandboxWithScripts([
     'core/landing/model.js',
@@ -154,12 +631,14 @@ test('landing model factory publishes selected draft sections without mutating l
   assert.equal(typeof model.createDefaultImportMeta, 'function');
   assert.equal(typeof model.createDefaultContent, 'function');
   assert.equal(typeof model.normalizeTimestamp, 'function');
+  assert.equal(typeof model.getDefaultFilters, 'function');
   assert.equal(typeof model.normalizeDay, 'function');
   assert.equal(typeof model.normalizeHoursRestaurant, 'function');
   assert.equal(typeof model.normalizeEventItem, 'function');
   assert.equal(typeof model.normalizeNewsItem, 'function');
   assert.equal(typeof model.normalizeReviewItem, 'function');
   assert.equal(typeof model.normalizeContent, 'function');
+  assert.equal(typeof model.normalizeFilters, 'function');
   assert.equal(typeof model.parseTimeToMinutes, 'function');
   assert.equal(typeof model.formatMinutes, 'function');
   assert.equal(typeof model.getTimeSelectOptions, 'function');
@@ -180,6 +659,9 @@ test('landing model factory publishes selected draft sections without mutating l
   assert.equal(typeof model.formatHoursRange, 'function');
   assert.equal(typeof model.getHoursForRestaurant, 'function');
   assert.equal(typeof model.buildWeekRows, 'function');
+  assert.equal(typeof model.getDayOffsetKey, 'function');
+  assert.equal(typeof model.getRestaurantLocalParts, 'function');
+  assert.equal(typeof model.applyHoursFieldDraft, 'function');
   assert.equal(typeof model.validateEventItem, 'function');
   assert.equal(typeof model.validateNewsItem, 'function');
   assert.equal(typeof model.validateReviewItem, 'function');
@@ -211,6 +693,16 @@ test('landing model factory publishes selected draft sections without mutating l
   };
 
   assert.equal(model.parseTimeToMinutes('16:15'), 975);
+  assert.equal(JSON.stringify(model.getDefaultFilters()), JSON.stringify({
+    events: { showArchived: false },
+    news: { showArchived: false },
+    reviews: { showArchived: false },
+  }));
+  assert.equal(JSON.stringify(model.normalizeFilters({ news: { showArchived: true } })), JSON.stringify({
+    events: { showArchived: false },
+    news: { showArchived: true },
+    reviews: { showArchived: false },
+  }));
   assert.equal(model.formatMinutes(975), '4:15 PM');
   assert.equal(model.getTimeSelectOptions()[0].value, '00:00');
   assert.match(model.renderTimeSelectOptions('16:15', 'Start time'), /option value="16:15" selected/);
@@ -247,6 +739,13 @@ test('landing model factory publishes selected draft sections without mutating l
   assert.equal(model.getVisibleItems([{ archived: false }, { archived: true }], true).length, 2);
   assert.equal(model.formatHoursRange(hours.restaurants[restaurants.LEROYS.id].days.fri), '4 PM - 11:30 PM');
   assert.equal(model.getHoursForRestaurant(hours, restaurants.LEROYS.id).days.fri.open, '16:00');
+  assert.equal(model.getDayOffsetKey('fri', 1), 'sat');
+  const hoursDraftRecord = model.applyHoursFieldDraft(model.createDefaultRecord(), [
+    { restaurantId: restaurants.LEROYS.id, dayKey: 'fri', field: 'open', value: '16:00' },
+    { restaurantId: restaurants.LEROYS.id, dayKey: 'fri', field: 'close', value: '23:30' },
+    { restaurantId: restaurants.LEROYS.id, dayKey: 'fri', field: 'closed', value: false },
+  ]);
+  assert.equal(hoursDraftRecord.draftContent.hours.restaurants[restaurants.LEROYS.id].days.fri.open, '16:00');
   assert.equal(
     JSON.stringify(model.buildWeekRows(hours, restaurants.LEROYS.id, 'fri').find(row => row.dayKey === 'fri')),
     JSON.stringify({
@@ -287,4 +786,446 @@ test('landing model hours rows html uses injected handler names instead of app g
   assert.match(genericHtml, /onchange="handleHourChange\(/);
   assert.doesNotMatch(genericHtml, /setLandingHoursField\(/);
   assert.doesNotMatch(noHandlerHtml, /onchange="/);
+});
+
+test('app landing helpers delegate through instantiated landing services', () => {
+  const delegationLog = [];
+  const defaultFilters = {
+    events: { showArchived: false },
+    news: { showArchived: true },
+    reviews: { showArchived: false },
+  };
+  const normalizedFilters = {
+    events: { showArchived: true },
+    news: { showArchived: false },
+    reviews: { showArchived: true },
+  };
+  const validationResult = { valid: false, issues: ['delegated validation'] };
+  const rootRecord = {
+    id: 'root',
+    draftContent: { hours: { restaurants: {} }, overview: {}, events: { items: [] }, news: { items: [] }, reviews: { restaurants: {} } },
+    liveContent: { hours: { restaurants: {} }, overview: {}, events: { items: [] }, news: { items: [] }, reviews: { restaurants: {} } },
+    draftSavedTs: '',
+    livePublishedTs: '',
+  };
+  const statusRecord = {
+    ...rootRecord,
+  };
+  const validationRecord = {
+    ...statusRecord,
+    draftContent: {
+      ...statusRecord.draftContent,
+      hours: {
+        restaurants: {
+          'restaurant-1': {
+            days: {
+              fri: { closed: false, open: '16:00', close: '23:30' },
+            },
+          },
+        },
+      },
+    },
+  };
+  const storeInstance = {
+    getRecord() { return statusRecord; },
+    isDirty() { return false; },
+    getLoadPromise() { return null; },
+    getLoadError() { return ''; },
+    getActivePanel() { return 'landing-admin-panel-overview'; },
+    getFilters() { delegationLog.push(['store.getFilters']); return defaultFilters; },
+    getReviewCarouselIndex() { return 0; },
+    setFilters(nextFilters) { delegationLog.push(['store.setFilters', nextFilters]); return nextFilters; },
+    setRecord() {},
+    setDirty() { return false; },
+    setLoadPromise() { return null; },
+    setLoadError() { return ''; },
+    setActivePanel() { return 'landing-admin-panel-overview'; },
+    setReviewCarouselIndex() { return 0; },
+  };
+  let modelInstance;
+  const rootRendererLog = [];
+  const sandbox = loadSandboxWithScripts(['app.js'], {
+    __HF_LANDING_MODULES__: {
+      createLandingModel(options) {
+        delegationLog.push(['createLandingModel', options]);
+        modelInstance = {
+          getConstants() {
+            delegationLog.push(['model.getConstants']);
+            return {
+              LANDING_PAGE_STATE_ID: 'root',
+              LANDING_PAGE_SECTION_ORDER: ['overview', 'hours', 'events', 'news', 'reviews'],
+              LANDING_PAGE_SECTION_LABELS: {
+                overview: 'Overview',
+                hours: 'Hours',
+                events: 'Events',
+                news: 'News',
+                reviews: 'Reviews',
+              },
+              LANDING_DAY_ORDER: ['mon', 'tue', 'wed', 'thu', 'fri', 'sat', 'sun'],
+              LANDING_DAY_LABELS: {
+                mon: 'Monday',
+                tue: 'Tuesday',
+                wed: 'Wednesday',
+                thu: 'Thursday',
+                fri: 'Friday',
+                sat: 'Saturday',
+                sun: 'Sunday',
+              },
+              LANDING_TARGET_BOTH: 'both',
+              LANDING_IMPORT_STATUS_IDLE: 'idle',
+              LANDING_IMPORT_STATUS_IMPORTED: 'imported',
+              LANDING_IMPORT_STATUS_PARTIAL: 'partial',
+              LANDING_IMPORT_STATUS_FAILED: 'failed',
+              LANDING_ITEM_STATUS_LIVE: 'Live',
+              LANDING_ITEM_STATUS_DRAFT: 'Draft',
+              LANDING_ITEM_STATUS_MISSING: 'Missing Fields',
+              LANDING_ITEM_STATUS_ARCHIVED: 'ARCHIVED',
+              LANDING_FILTER_STORAGE_KEY: 'hf_landing_admin_filters',
+            };
+          },
+          getDefaultFilters() {
+            delegationLog.push(['model.getDefaultFilters']);
+            return defaultFilters;
+          },
+          normalizeFilters(raw) {
+            delegationLog.push(['model.normalizeFilters', raw]);
+            return normalizedFilters;
+          },
+          getDayOffsetKey(dayKey, offset) {
+            delegationLog.push(['model.getDayOffsetKey', dayKey, offset]);
+            return `delegated-${dayKey}-${offset}`;
+          },
+          getRestaurantLocalParts(now, timeZone) {
+            delegationLog.push(['model.getRestaurantLocalParts', now, timeZone]);
+            return { dayKey: 'thu', minutes: 615 };
+          },
+          getSectionValidation(sectionId, record) {
+            delegationLog.push(['model.getSectionValidation', sectionId, record]);
+            return validationResult;
+          },
+          applyHoursFieldDraft(record, fieldStates) {
+            delegationLog.push(['model.applyHoursFieldDraft', record, fieldStates]);
+            return validationRecord;
+          },
+          createDefaultRecord() { return statusRecord; },
+          normalizeRecord(record) { return record || statusRecord; },
+          landingSectionHasDiff(sectionId, record) {
+            delegationLog.push(['model.landingSectionHasDiff', sectionId, record]);
+            return sectionId === 'hours';
+          },
+        };
+        return modelInstance;
+      },
+      createLandingStore(options) {
+        delegationLog.push(['createLandingStore', options]);
+        return storeInstance;
+      },
+      createLandingDataService(options) {
+        delegationLog.push(['createLandingDataService', options]);
+        return { options };
+      },
+      createLandingRootRendererService(options) {
+        rootRendererLog.push(['createLandingRootRendererService', options]);
+        return {
+          setSectionVisible(sectionId, visible) {
+            rootRendererLog.push(['root.setSectionVisible', sectionId, visible]);
+          },
+          renderRootEvents(section) {
+            rootRendererLog.push(['root.renderRootEvents', section]);
+          },
+          renderRootNews(section) {
+            rootRendererLog.push(['root.renderRootNews', section]);
+          },
+          renderRootReviews(section) {
+            rootRendererLog.push(['root.renderRootReviews', section]);
+          },
+          renderRootHours(section) {
+            rootRendererLog.push(['root.renderRootHours', section]);
+          },
+          setReviewCarouselIndex(nextIndex) {
+            rootRendererLog.push(['root.setReviewCarouselIndex', nextIndex]);
+            return nextIndex;
+          },
+          stepReviewCarousel(direction) {
+            rootRendererLog.push(['root.stepReviewCarousel', direction]);
+            return direction;
+          },
+          setFallbackVisible(visible) {
+            rootRendererLog.push(['root.setFallbackVisible', visible]);
+          },
+          renderRootPage(record) {
+            rootRendererLog.push(['root.renderRootPage', record]);
+            return record;
+          },
+        };
+      },
+      createLandingAdminWorkspaceService(options) {
+        delegationLog.push(['createLandingAdminWorkspaceService', options]);
+        return {
+          renderEventsPanel(record) { delegationLog.push(['admin.renderEventsPanel', record]); },
+          renderNewsPanel(record) { delegationLog.push(['admin.renderNewsPanel', record]); },
+          renderReviewsPanel(record) { delegationLog.push(['admin.renderReviewsPanel', record]); },
+          renderOverview(record) { delegationLog.push(['admin.renderOverview', record]); },
+          renderHoursValidationState(record) { delegationLog.push(['admin.renderHoursValidationState', record]); },
+          updateToolbar(record) { delegationLog.push(['admin.updateToolbar', record]); },
+          renderHoursPanel(record) { delegationLog.push(['admin.renderHoursPanel', record]); },
+          renderWorkspace(options) { delegationLog.push(['admin.renderWorkspace', options]); },
+          setHoursField(...args) { delegationLog.push(['admin.setHoursField', ...args]); },
+          updateDraftRecord(mutator, options) { delegationLog.push(['admin.updateDraftRecord', typeof mutator, options]); return statusRecord; },
+          addEventDraft() { delegationLog.push(['admin.addEventDraft']); },
+          updateEventField(...args) { delegationLog.push(['admin.updateEventField', ...args]); },
+          toggleEventArchived(...args) { delegationLog.push(['admin.toggleEventArchived', ...args]); },
+          updateNewsField(...args) { delegationLog.push(['admin.updateNewsField', ...args]); },
+          toggleNewsArchived(...args) { delegationLog.push(['admin.toggleNewsArchived', ...args]); },
+          updateReviewField(...args) { delegationLog.push(['admin.updateReviewField', ...args]); },
+          toggleReviewArchived(...args) { delegationLog.push(['admin.toggleReviewArchived', ...args]); },
+          toggleSectionArchivedFilter(...args) { delegationLog.push(['admin.toggleSectionArchivedFilter', ...args]); },
+          handleNewsImportPaste() { delegationLog.push(['admin.handleNewsImportPaste']); },
+          handleReviewImportPaste(...args) { delegationLog.push(['admin.handleReviewImportPaste', ...args]); },
+          importNewsDraft() { delegationLog.push(['admin.importNewsDraft']); },
+          refreshNewsItem(...args) { delegationLog.push(['admin.refreshNewsItem', ...args]); },
+          importReviewDraft(...args) { delegationLog.push(['admin.importReviewDraft', ...args]); },
+          refreshReviewItem(...args) { delegationLog.push(['admin.refreshReviewItem', ...args]); },
+          saveDraft() { delegationLog.push(['admin.saveDraft']); },
+          renderPublishModal() { delegationLog.push(['admin.renderPublishModal']); },
+          openPublishModal() { delegationLog.push(['admin.openPublishModal']); },
+          closePublishModal() { delegationLog.push(['admin.closePublishModal']); },
+          publishSections() { delegationLog.push(['admin.publishSections']); },
+        };
+      },
+    },
+  });
+  const openField = createElement('select');
+  openField.value = '16:00';
+  openField.setAttribute('data-landing-hours-field', 'open');
+  openField.setAttribute('data-landing-hours-restaurant', 'restaurant-1');
+  openField.setAttribute('data-landing-hours-day', 'fri');
+  const closeField = createElement('select');
+  closeField.value = '23:30';
+  closeField.setAttribute('data-landing-hours-field', 'close');
+  closeField.setAttribute('data-landing-hours-restaurant', 'restaurant-1');
+  closeField.setAttribute('data-landing-hours-day', 'fri');
+  sandbox.document._registerSelector('[data-landing-hours-field]', [openField, closeField]);
+
+  assert.deepEqual(sandbox.getLandingDefaultFilters(), defaultFilters);
+  assert.deepEqual(sandbox.normalizeLandingFilters({ events: { showArchived: true } }), normalizedFilters);
+  assert.equal(sandbox.getLandingDayOffsetKey('fri', 2), 'delegated-fri-2');
+  assert.deepEqual(sandbox.getRestaurantLocalParts(1234, 'America/Chicago'), { dayKey: 'thu', minutes: 615 });
+  assert.deepEqual(sandbox.getLandingSectionValidation('hours', statusRecord), validationResult);
+  assert.equal(JSON.stringify(sandbox.getLandingSectionStatus('hours', statusRecord)), JSON.stringify({
+    sectionId: 'hours',
+    label: 'Hours',
+    hasDraftDiff: true,
+    isValid: false,
+    issues: ['delegated validation'],
+  }));
+  sandbox.renderLandingEventsPanel(statusRecord);
+  sandbox.renderLandingNewsPanel(statusRecord);
+  sandbox.renderLandingReviewsPanel(statusRecord);
+  sandbox.renderLandingOverview(statusRecord);
+  sandbox.renderLandingHoursValidationState(statusRecord);
+  sandbox.updateLandingAdminToolbar(statusRecord);
+  sandbox.renderLandingHoursPanel(statusRecord);
+  sandbox.renderLandingAdminWorkspace({ forceReload: true });
+  sandbox.setLandingHoursField('leroys', 'fri', 'open', '16:00');
+  sandbox.updateLandingDraftRecord(() => {}, { rerender: false });
+  sandbox.addLandingEventDraft();
+  sandbox.updateLandingEventField('event-1', 'title', 'Trivia');
+  sandbox.toggleLandingEventArchived('event-1', true);
+  sandbox.updateLandingNewsField('news-1', 'title', 'Story');
+  sandbox.toggleLandingNewsArchived('news-1', true);
+  sandbox.updateLandingReviewField('leroys', 'review-1', 'quote', 'Great');
+  sandbox.toggleLandingReviewArchived('leroys', 'review-1', true);
+  sandbox.toggleLandingSectionArchivedFilter('news', true);
+  sandbox.handleLandingNewsImportPaste();
+  sandbox.handleLandingReviewImportPaste('leroys');
+  sandbox.importLandingNewsDraft();
+  sandbox.refreshLandingNewsItem('news-1');
+  sandbox.importLandingReviewDraft('leroys');
+  sandbox.refreshLandingReviewItem('leroys', 'review-1');
+  sandbox.saveLandingPageDraft();
+  sandbox.renderLandingPublishModal();
+  sandbox.openLandingPublishModal();
+  sandbox.closeLandingPublishModal();
+  sandbox.publishLandingPageSections();
+  sandbox.renderLandingRootEvents(rootRecord.liveContent.events);
+  sandbox.renderLandingRootNews(rootRecord.liveContent.news);
+  sandbox.renderLandingRootReviews(rootRecord.liveContent.reviews);
+  sandbox.renderLandingRootHours(rootRecord.liveContent.hours);
+  sandbox.setLandingRootSectionVisible('news', false);
+  sandbox.setLandingReviewCarouselIndex(2);
+  sandbox.stepLandingReviewCarousel(-1);
+  sandbox.setLandingRootFallbackVisible(true);
+  sandbox.renderLandingRootPage(rootRecord);
+
+  const createStoreCall = delegationLog.find(entry => entry[0] === 'createLandingStore');
+  assert.deepEqual(createStoreCall[1].model, modelInstance);
+  assert.deepEqual(createStoreCall[1].defaultFilters, defaultFilters);
+  const createRootRendererCall = rootRendererLog.find(entry => entry[0] === 'createLandingRootRendererService');
+  assert.deepEqual(createRootRendererCall[1].model, modelInstance);
+  assert.deepEqual(createRootRendererCall[1].store, storeInstance);
+  assert.equal(typeof createRootRendererCall[1].hasRootShell, 'function');
+  assert.equal(typeof createRootRendererCall[1].syncLegacyStateFromStore, 'function');
+  assert.equal(createRootRendererCall[1].setReviewCarouselHandlerName, 'setLandingReviewCarouselIndex');
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'createLandingAdminWorkspaceService'),
+    true
+  );
+  assert.equal(
+    delegationLog.filter(entry => entry[0] === 'model.getSectionValidation' && entry[1] === 'hours').length >= 2,
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.renderWorkspace' && entry[1].forceReload === true),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.setHoursField' && entry[1] === 'leroys' && entry[2] === 'fri' && entry[3] === 'open'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.updateDraftRecord' && entry[1] === 'function'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.addEventDraft'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.updateEventField' && entry[1] === 'event-1'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.toggleEventArchived' && entry[1] === 'event-1'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.updateNewsField' && entry[1] === 'news-1'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.toggleNewsArchived' && entry[1] === 'news-1'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.updateReviewField' && entry[1] === 'leroys' && entry[2] === 'review-1'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.toggleReviewArchived' && entry[1] === 'leroys' && entry[2] === 'review-1'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.toggleSectionArchivedFilter' && entry[1] === 'news'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.handleNewsImportPaste'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.handleReviewImportPaste' && entry[1] === 'leroys'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.importNewsDraft'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.refreshNewsItem' && entry[1] === 'news-1'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.importReviewDraft' && entry[1] === 'leroys'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.refreshReviewItem' && entry[1] === 'leroys' && entry[2] === 'review-1'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.saveDraft'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.renderPublishModal'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.openPublishModal'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.closePublishModal'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'admin.publishSections'),
+    true
+  );
+  assert.equal(
+    rootRendererLog.some(entry => entry[0] === 'root.renderRootEvents' && entry[1] === rootRecord.liveContent.events),
+    true
+  );
+  assert.equal(
+    rootRendererLog.some(entry => entry[0] === 'root.renderRootNews' && entry[1] === rootRecord.liveContent.news),
+    true
+  );
+  assert.equal(
+    rootRendererLog.some(entry => entry[0] === 'root.renderRootReviews' && entry[1] === rootRecord.liveContent.reviews),
+    true
+  );
+  assert.equal(
+    rootRendererLog.some(entry => entry[0] === 'root.renderRootHours' && entry[1] === rootRecord.liveContent.hours),
+    true
+  );
+  assert.equal(
+    rootRendererLog.some(entry => entry[0] === 'root.setSectionVisible' && entry[1] === 'news' && entry[2] === false),
+    true
+  );
+  assert.equal(
+    rootRendererLog.some(entry => entry[0] === 'root.setReviewCarouselIndex' && entry[1] === 2),
+    true
+  );
+  assert.equal(
+    rootRendererLog.some(entry => entry[0] === 'root.stepReviewCarousel' && entry[1] === -1),
+    true
+  );
+  assert.equal(
+    rootRendererLog.some(entry => entry[0] === 'root.setFallbackVisible' && entry[1] === true),
+    true
+  );
+  assert.equal(
+    rootRendererLog.some(entry => entry[0] === 'root.renderRootPage' && entry[1] === rootRecord),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => (
+      entry[0] === 'model.applyHoursFieldDraft' &&
+      entry[2].length === 2 &&
+      entry[2][0].restaurantId === 'restaurant-1' &&
+      entry[2][0].field === 'open'
+    )),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'model.getSectionValidation' && entry[1] === 'hours' && entry[2] === validationRecord),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'model.getDayOffsetKey' && entry[1] === 'fri' && entry[2] === 2),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'model.getRestaurantLocalParts' && entry[1] === 1234 && entry[2] === 'America/Chicago'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'model.getDefaultFilters'),
+    true
+  );
+  assert.equal(
+    delegationLog.some(entry => entry[0] === 'model.normalizeFilters'),
+    true
+  );
 });

--- a/tests/boundaries/landing.boundary.test.cjs
+++ b/tests/boundaries/landing.boundary.test.cjs
@@ -20,6 +20,132 @@ test('landing runtime scripts register landing factories', () => {
   assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingRootRendererService, 'function');
 });
 
+test('landing store tracks record, dirty state, load status, filters, panel, and review carousel index', () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/landing/model.js',
+    'core/landing/store.js',
+  ]);
+  const model = sandbox.__HF_LANDING_MODULES__.createLandingModel();
+  const store = sandbox.__HF_LANDING_MODULES__.createLandingStore({
+    model,
+    defaultActivePanel: 'landing-admin-panel-overview',
+    defaultFilters: {
+      events: { showArchived: false },
+      news: { showArchived: false },
+      reviews: { showArchived: false },
+    },
+  });
+  const record = model.createDefaultRecord();
+  const loadPromise = Promise.resolve(record);
+
+  assert.equal(JSON.stringify(store.getRecord()), JSON.stringify(model.createDefaultRecord()));
+  assert.equal(store.isDirty(), false);
+  assert.equal(store.getLoadPromise(), null);
+  assert.equal(store.getLoadError(), '');
+  assert.equal(store.getActivePanel(), 'landing-admin-panel-overview');
+  assert.equal(store.getReviewCarouselIndex(), 0);
+  assert.deepEqual(store.getFilters(), {
+    events: { showArchived: false },
+    news: { showArchived: false },
+    reviews: { showArchived: false },
+  });
+
+  store.setRecord(record, { dirty: true });
+  assert.equal(JSON.stringify(store.getRecord()), JSON.stringify(record));
+  assert.equal(store.isDirty(), true);
+  assert.equal(store.setDirty(false), false);
+  assert.equal(store.setLoadPromise(loadPromise), loadPromise);
+  assert.equal(store.getLoadPromise(), loadPromise);
+  assert.equal(store.setLoadError('network down'), 'network down');
+  assert.equal(store.getLoadError(), 'network down');
+  assert.equal(store.setActivePanel('landing-admin-panel-news'), 'landing-admin-panel-news');
+  assert.equal(store.getActivePanel(), 'landing-admin-panel-news');
+  assert.equal(store.setReviewCarouselIndex(3), 3);
+  assert.equal(store.getReviewCarouselIndex(), 3);
+  assert.deepEqual(
+    store.setFilters({ news: { showArchived: true } }),
+    {
+      events: { showArchived: false },
+      news: { showArchived: true },
+      reviews: { showArchived: false },
+    }
+  );
+});
+
+test('landing data service caches loads and persists draft/live state through injected ports', async () => {
+  const sandbox = loadSandboxWithScripts([
+    'core/landing/model.js',
+    'core/landing/store.js',
+    'core/landing/data-service.js',
+  ]);
+  const model = sandbox.__HF_LANDING_MODULES__.createLandingModel();
+  const store = sandbox.__HF_LANDING_MODULES__.createLandingStore({
+    model,
+    defaultActivePanel: 'landing-admin-panel-overview',
+    defaultFilters: {},
+  });
+  const fetchedRecord = model.createDefaultRecord();
+  fetchedRecord.draftContent.overview.heroTitle = 'Loaded draft';
+  const upsertedRecord = model.createDefaultRecord();
+  upsertedRecord.draftSavedTs = '2000';
+  upsertedRecord.livePublishedTs = '3000';
+  let fetchCalls = 0;
+  const fetchPorts = [];
+  const upsertPorts = [];
+  let releaseFetch;
+  const pendingFetch = new Promise(resolve => {
+    releaseFetch = () => resolve(fetchedRecord);
+  });
+  const service = sandbox.__HF_LANDING_MODULES__.createLandingDataService({
+    model,
+    store,
+    fetchRecord: async options => {
+      fetchCalls += 1;
+      fetchPorts.push(options);
+      return pendingFetch;
+    },
+    upsertRecord: async (payload, action) => {
+      upsertPorts.push({ payload, action });
+      return upsertedRecord;
+    },
+  });
+
+  const firstLoad = service.ensureLoaded({ includeDraft: true });
+  const secondLoad = service.ensureLoaded({ includeDraft: true });
+
+  assert.equal(firstLoad, secondLoad);
+  assert.equal(fetchCalls, 1);
+  assert.equal(store.getLoadPromise(), firstLoad);
+
+  releaseFetch();
+  const loadedRecord = await firstLoad;
+
+  assert.equal(fetchPorts[0].includeDraft, true);
+  assert.equal(store.getLoadPromise(), null);
+  assert.equal(store.isDirty(), false);
+  assert.equal(loadedRecord.draftContent.overview.heroTitle, 'Loaded draft');
+
+  const cachedLoad = await service.ensureLoaded({ includeDraft: true });
+  assert.equal(fetchCalls, 1);
+  assert.equal(cachedLoad.draftContent.overview.heroTitle, 'Loaded draft');
+
+  const draftResult = await service.saveDraft(loadedRecord, 2000);
+  assert.equal(upsertPorts[0].action, 'save_landing_page_draft');
+  assert.equal(upsertPorts[0].payload.draft_saved_ts, 2000);
+  assert.equal(store.isDirty(), false);
+  assert.equal(draftResult.draftSavedTs, '2000');
+
+  const publishResult = await service.publishSections(loadedRecord, ['news', 'reviews'], 3000);
+  assert.equal(upsertPorts[1].action, 'publish_landing_sections');
+  assert.equal(upsertPorts[1].payload.live_published_ts, 3000);
+  assert.deepEqual(
+    upsertPorts[1].payload.live_content,
+    model.applySectionPublish(loadedRecord, ['news', 'reviews']).liveContent
+  );
+  assert.equal(store.isDirty(), false);
+  assert.equal(publishResult.livePublishedTs, '3000');
+});
+
 test('landing model factory publishes selected draft sections without mutating live state', () => {
   const sandbox = loadSandboxWithScripts([
     'core/landing/model.js',

--- a/tests/boundaries/landing.boundary.test.cjs
+++ b/tests/boundaries/landing.boundary.test.cjs
@@ -25,6 +25,10 @@ test('landing model factory publishes selected draft sections without mutating l
     'core/landing/model.js',
   ]);
   const model = sandbox.__HF_LANDING_MODULES__.createLandingModel();
+  assert.equal(typeof model.createDefaultContent, 'function');
+  assert.equal(typeof model.normalizeDay, 'function');
+  assert.equal(typeof model.normalizeHoursRestaurant, 'function');
+  assert.equal(typeof model.normalizeContent, 'function');
   const record = model.createDefaultRecord();
 
   record.draftContent.news.items.push({

--- a/tests/helpers/runtime.cjs
+++ b/tests/helpers/runtime.cjs
@@ -26,6 +26,11 @@ const DEFAULT_RUNTIME_SCRIPTS = [
   'core/session/menu-session.js',
   'core/data/menu-state-loader.js',
   'core/session/poll-scheduler.js',
+  'core/landing/model.js',
+  'core/landing/store.js',
+  'core/landing/data-service.js',
+  'core/landing/admin-workspace.js',
+  'core/landing/root-renderer.js',
   'routes/shared/public-route-core.js',
   'app.js',
 ];

--- a/tests/helpers/runtime.cjs
+++ b/tests/helpers/runtime.cjs
@@ -3,6 +3,13 @@ const path = require('node:path');
 const vm = require('node:vm');
 const ROOT_DIR = path.join(__dirname, '..', '..');
 const ROOT_APP_PATH = path.join(ROOT_DIR, 'app.js');
+const LANDING_RUNTIME_SCRIPTS = [
+  'core/landing/model.js',
+  'core/landing/store.js',
+  'core/landing/data-service.js',
+  'core/landing/admin-workspace.js',
+  'core/landing/root-renderer.js',
+];
 const DEFAULT_RUNTIME_SCRIPTS = [
   'core/domain/constants.js',
   'core/domain/category-defaults.js',
@@ -26,11 +33,7 @@ const DEFAULT_RUNTIME_SCRIPTS = [
   'core/session/menu-session.js',
   'core/data/menu-state-loader.js',
   'core/session/poll-scheduler.js',
-  'core/landing/model.js',
-  'core/landing/store.js',
-  'core/landing/data-service.js',
-  'core/landing/admin-workspace.js',
-  'core/landing/root-renderer.js',
+  ...LANDING_RUNTIME_SCRIPTS,
   'routes/shared/public-route-core.js',
   'app.js',
 ];
@@ -352,6 +355,32 @@ function resolveRuntimeScriptPath(filePath) {
   return path.isAbsolute(filePath) ? filePath : path.join(ROOT_DIR, filePath);
 }
 
+function usesRootAppScript(scriptPath) {
+  return path.resolve(resolveRuntimeScriptPath(scriptPath)) === path.resolve(ROOT_APP_PATH);
+}
+
+function expandLandingRuntimeScripts(scriptPaths = [], overrides = {}) {
+  if (!Array.isArray(scriptPaths)) return scriptPaths;
+  if (Object.prototype.hasOwnProperty.call(overrides, '__HF_LANDING_MODULES__')) {
+    return scriptPaths.slice();
+  }
+
+  const appIndex = scriptPaths.findIndex(usesRootAppScript);
+  if (appIndex < 0) return scriptPaths.slice();
+
+  const resolvedScripts = new Set(scriptPaths.map(scriptPath => path.resolve(resolveRuntimeScriptPath(scriptPath))));
+  const missingLandingScripts = LANDING_RUNTIME_SCRIPTS.filter(scriptPath => (
+    !resolvedScripts.has(path.resolve(resolveRuntimeScriptPath(scriptPath)))
+  ));
+  if (!missingLandingScripts.length) return scriptPaths.slice();
+
+  return [
+    ...scriptPaths.slice(0, appIndex),
+    ...missingLandingScripts,
+    ...scriptPaths.slice(appIndex),
+  ];
+}
+
 function loadScriptsInOrder(scriptPaths = [], sandbox, options = {}) {
   const { stripInitRootApp = true } = options;
   if (!sandbox?.__vmContext) {
@@ -396,7 +425,7 @@ function loadRouteSandbox(routePath, overrides = {}) {
 
 function loadSandboxWithScripts(scriptPaths = [], overrides = {}, options = {}) {
   const sandbox = createSandbox(overrides);
-  return loadScriptsInOrder(scriptPaths, sandbox, options);
+  return loadScriptsInOrder(expandLandingRuntimeScripts(scriptPaths, overrides), sandbox, options);
 }
 
 module.exports = {

--- a/tests/landing-page-content.test.cjs
+++ b/tests/landing-page-content.test.cjs
@@ -148,3 +148,14 @@ test('landing safe fallback hides the section dot nav', () => {
   assert.equal(fallbackEl.hidden, true);
   assert.equal(dotNavEl.hidden, false);
 });
+
+test('landing restores saved archived filters after store sync', () => {
+  const sandbox = loadAppSandbox({ Intl });
+
+  sandbox.sessionStorage.setItem('hf_landing_admin_filters', JSON.stringify({
+    news: { showArchived: true },
+  }));
+  sandbox.syncLandingLegacyStateFromStore();
+
+  assert.equal(sandbox.getLandingSectionFilter('news').showArchived, true);
+});

--- a/tests/runtime-helpers.test.cjs
+++ b/tests/runtime-helpers.test.cjs
@@ -26,3 +26,13 @@ test('loadSandboxWithScripts evaluates runtime files in explicit order', () => {
   const restaurantId = getState(sandbox, 'window.__publicRouteRenderer?.restaurantId || ""');
   assert.equal(restaurantId, '00000000-0000-0000-0000-000000000010');
 });
+
+test('loadSandboxWithScripts preloads landing runtime before app.js when needed', () => {
+  const sandbox = loadSandboxWithScripts(['app.js']);
+  const record = getState(sandbox, 'createDefaultLandingPageRecord()');
+
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__, 'object');
+  assert.equal(typeof sandbox.__HF_LANDING_MODULES__.createLandingModel, 'function');
+  assert.equal(record.id, 'root');
+  assert.equal(Array.isArray(record.draftContent.news.items), true);
+});

--- a/tests/runtime-helpers.test.cjs
+++ b/tests/runtime-helpers.test.cjs
@@ -14,6 +14,10 @@ test('resolveRuntimeScriptPath resolves repo-relative script paths', () => {
 
 test('loadSandboxWithScripts evaluates runtime files in explicit order', () => {
   const sandbox = loadSandboxWithScripts([
+    'core/landing/model.js',
+    'core/landing/store.js',
+    'core/landing/data-service.js',
+    'core/landing/root-renderer.js',
     'app.js',
     'routes/shared/public-route-core.js',
     'leroyslounge/app.js',

--- a/tests/runtime-helpers.test.cjs
+++ b/tests/runtime-helpers.test.cjs
@@ -17,6 +17,7 @@ test('loadSandboxWithScripts evaluates runtime files in explicit order', () => {
     'core/landing/model.js',
     'core/landing/store.js',
     'core/landing/data-service.js',
+    'core/landing/admin-workspace.js',
     'core/landing/root-renderer.js',
     'app.js',
     'routes/shared/public-route-core.js',


### PR DESCRIPTION
## Summary
- continue the landing runtime extraction by moving more landing behavior into `core/landing/*` and shrinking `app.js`
- keep `app.js` aligned with the landing-module script contract while moving isolated sandbox bootstrapping into the test runtime helper instead of re-bloating the shared runtime
- fix landing admin archived-filter restoration so saved `showArchived` state survives the first store sync
- add four follow-up architecture plan docs for the landing, session/data, manager/admin, and auth/shell slices

## Why
The landing refactor is supposed to leave `app.js` as an orchestrator. A temporary fallback runtime inside `app.js` fixed a regression, but it pushed the architecture in the wrong direction. This change keeps the real behavior fix, restores the intended module boundary, and documents the next extraction slices.

## Impact
- `app.js` stays materially smaller and depends on the landing runtime modules that the HTML shells already preload
- isolated tests that load `app.js` directly now preload the landing runtime through the shared test helper unless they intentionally inject a custom landing boundary
- landing admin archived filters restore correctly from `sessionStorage`
- the repo now has concrete plan docs for the next `app.js` split phases

## Validation
- `node --test tests/runtime-helpers.test.cjs tests/phase1-domain-boundaries.test.cjs tests/phase2-session-boundaries.test.cjs tests/phase3-ui-boundaries.test.cjs tests/phase3-ui-deep-boundaries.test.cjs tests/phase15-auth-boundaries.test.cjs tests/phase15-auth-unification-complete.test.cjs tests/user-chip-route-reimplementation.test.cjs tests/boundaries/landing.boundary.test.cjs tests/landing-page-content.test.cjs tests/landing-page-hours.test.cjs`
- `node --check app.js`