### PR TITLE
[codex] Fix El Roy's Cantina logo sizing

### DIFF
--- a/elroyscantina/style.css
+++ b/elroyscantina/style.css
@@ -170,7 +170,7 @@ body.route-restaurant.route-restaurant--elroy {
 
 #restaurant-site-wrapper .erc-brand-logo {
   display: block;
-  width: clamp(11rem, 22vw, 16rem);
+  width: clamp(4.75rem, 9vw, 6.25rem);
   height: auto;
 }
 
@@ -1008,7 +1008,7 @@ body.route-restaurant.route-restaurant--elroy {
   }
 
   #restaurant-site-wrapper .erc-brand-logo {
-    width: clamp(9.5rem, 42vw, 12rem);
+    width: clamp(3.7rem, 18vw, 4.6rem);
   }
 
   #restaurant-site-wrapper .erc-sister-link {


### PR DESCRIPTION
## What changed
- reduced the `/elroyscantina` header logo clamp so the square El Roy's badge reads like a compact brand mark instead of a hero-sized element
- tightened the small-screen override so the mobile top bar stays balanced too

## Why
The route was sizing a square badge asset with a much larger wordmark-style width range, which made the El Roy's logo feel oversized in the header.

## Impact
The El Roy's Cantina route header should feel more proportionate on desktop and mobile without changing the rest of the page layout or route behavior.

## Validation
- `node --test tests/phase21-route-header-scroll-boundaries.test.cjs`
- local visual verification of `/elroyscantina` at desktop width and a `390x844` mobile viewport