### PR TITLE
[codex] Add app export compliance flag

### DIFF
--- a/ios/ElRoysManagerApp.xcodeproj/project.pbxproj
+++ b/ios/ElRoysManagerApp.xcodeproj/project.pbxproj
@@ -478,6 +478,7 @@
 				ENABLE_DEBUG_DYLIB = NO;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "El Roy's Manager";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Scan drink and food item barcodes to prefill add-item fields.";
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "Unlock the saved staff session before restoring manager access.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -586,6 +587,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "El Roy's Manager";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Scan drink and food item barcodes to prefill add-item fields.";
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "Unlock the saved staff session before restoring manager access.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -621,6 +623,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "El Roy's Manager";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Scan drink and food item barcodes to prefill add-item fields.";
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "Unlock the saved staff session before restoring manager access.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;
@@ -744,6 +747,7 @@
 				DEAD_CODE_STRIPPING = YES;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_KEY_CFBundleDisplayName = "El Roy's Manager";
+				INFOPLIST_KEY_ITSAppUsesNonExemptEncryption = NO;
 				INFOPLIST_KEY_NSCameraUsageDescription = "Scan drink and food item barcodes to prefill add-item fields.";
 				INFOPLIST_KEY_NSFaceIDUsageDescription = "Unlock the saved staff session before restoring manager access.";
 				INFOPLIST_KEY_UIApplicationSceneManifest_Generation = YES;

--- a/ios/scripts/generate_project.rb
+++ b/ios/scripts/generate_project.rb
@@ -111,6 +111,7 @@ app_target.build_configurations.each do |config|
   settings['INFOPLIST_KEY_NSCameraUsageDescription'] = 'Scan drink and food item barcodes to prefill add-item fields.'
   settings['INFOPLIST_KEY_NSFaceIDUsageDescription'] = 'Unlock the saved staff session before restoring manager access.'
   settings['INFOPLIST_KEY_CFBundleDisplayName'] = "El Roy's Manager"
+  settings['INFOPLIST_KEY_ITSAppUsesNonExemptEncryption'] = 'NO'
   settings['CODE_SIGN_STYLE'] = 'Automatic'
   settings['DEVELOPMENT_TEAM'] = ''
   settings['APPEnvironmentName'] = config.name == 'Release' ? 'Production' : 'Preview'


### PR DESCRIPTION
## Summary

Adds the App Store export compliance Info.plist declaration for the iOS app target by setting `ITSAppUsesNonExemptEncryption` to `NO`.

The checked-in Xcode project uses generated Info.plist build settings rather than a standalone plist file, so this updates both the committed `.pbxproj` and the project generator script to keep the setting durable.

## Impact

This should let App Store Connect read the encryption declaration from the app metadata during upload, avoiding the separate export compliance setup path for this app.

## Validation

- `ruby -c ios/scripts/generate_project.rb`
- `xcodebuild -list -project ios/ElRoysManagerApp.xcodeproj`