### PR TITLE
[codex] fix save publish contract

### DIFF
--- a/app.js
+++ b/app.js
@@ -2493,8 +2493,8 @@ function getMenuSessionPorts() {
     async patchMenuDraftState(snapshot, savedAt) {
       return patchMenuDraftState(snapshot, savedAt);
     },
-    async requestPublishPreview() {
-      return requestPublishPreviewThroughApi();
+    async requestPublishPreview(options = {}) {
+      return requestPublishPreviewThroughApi(options);
     },
     async publishMenuUpdate(options = {}) {
       const providedPreview = options.preview?.sections ? options.preview : null;
@@ -2760,6 +2760,33 @@ function createLegacyMenuPublishService(sessionPorts, runtime = {}) {
         mode: 'save',
         notify: false,
       });
+    },
+
+    async prepare(options = {}) {
+      if (typeof sessionPorts.requestPublishPreview === 'function') {
+        const result = await sessionPorts.requestPublishPreview(options);
+        if (result?.preview?.sections) return result;
+        if (result?.payload?.preview?.sections) {
+          return {
+            ...result.payload,
+            ok: result.ok !== false && result.payload.ok !== false,
+            status: result.status,
+            preview: result.payload.preview,
+          };
+        }
+        if (result?.ok === false) {
+          return {
+            ...result,
+            userHandled: result.userHandled === true,
+            userMessage: result.userMessage || result.payload?.error || 'Preview is unavailable right now.',
+          };
+        }
+        return result || { ok: false, userMessage: 'Preview is unavailable right now.' };
+      }
+      return {
+        ok: true,
+        preview: buildPreview(),
+      };
     },
 
     async publishUpdate(options = {}) {
@@ -4828,14 +4855,16 @@ function buildPublishSnapshotPayload() {
 }
 
 async function requestPublishPreviewThroughApi() {
+  const options = arguments[0] || {};
   if (!MENU_ID || !getAuthorizedApiHeaders().Authorization) return { ok: false, fallbackable: false };
   const draftEnvelope = buildCurrentLocalDraftEnvelope();
   return postApiJson('/api/manager', {
     action: 'preview_publish',
     menu_id: MENU_ID,
     snapshot: buildPublishSnapshotPayload(),
-    expected_live_revision: menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null,
-    expected_notification_revision: draftEnvelope?.baseLastSentRevision ?? null,
+    expected_live_revision: options.expectedLiveRevision ?? (menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null),
+    expected_draft_revision: options.expectedDraftRevision ?? null,
+    expected_notification_revision: options.expectedNotificationRevision ?? (draftEnvelope?.baseLastSentRevision ?? null),
   }, {
     headers: getAuthorizedApiHeaders(),
   });

--- a/core/session/publish-service.js
+++ b/core/session/publish-service.js
@@ -51,9 +51,33 @@
       };
     }
 
+    function normalizePreviewResult(result) {
+      if (!result) return getUnavailableResult('Preview is unavailable right now.');
+      if (result.preview?.sections) return result;
+      if (result.payload?.preview?.sections) {
+        return {
+          ...result.payload,
+          ok: result.ok !== false && result.payload.ok !== false,
+          status: result.status,
+          preview: result.payload.preview,
+        };
+      }
+      if (result.ok === false) {
+        return {
+          ...result,
+          userHandled: result.userHandled === true,
+          userMessage: result.userMessage || result.payload?.error || 'Preview is unavailable right now.',
+        };
+      }
+      return result;
+    }
+
     async function prepare(opts = {}) {
       if (facade && typeof facade.prepare === 'function') {
         return facade.prepare(opts);
+      }
+      if (typeof sessionPorts.requestPublishPreview === 'function') {
+        return normalizePreviewResult(await sessionPorts.requestPublishPreview(opts));
       }
       const fallback = getFallbackService();
       if (fallback && typeof fallback.prepare === 'function') {

--- a/server/_menu-live.js
+++ b/server/_menu-live.js
@@ -255,19 +255,13 @@ async function upsertCategories(menuId, normalizedCategories, categoriesByKey) {
   };
   rows.push(uncategorizedSeed);
 
-  const payload = rows.map(row => {
-    const existing = categoriesByKey.get(row.key);
-    const resolvedId = existing?.id;
-    return resolvedId ? { ...row, id: resolvedId } : row;
-  });
-
   const response = await fetch(`${sbUrl}/rest/v1/categories?on_conflict=menu_id,key`, {
     method: 'POST',
     headers: serviceHeaders({
       'Content-Type': 'application/json',
       Prefer: 'resolution=merge-duplicates,return=minimal',
     }),
-    body: JSON.stringify(payload),
+    body: JSON.stringify(rows),
   });
   if (!response.ok) {
     const errorPayload = await readJsonSafe(response);

--- a/server/_menu-publish.js
+++ b/server/_menu-publish.js
@@ -65,6 +65,19 @@ function snapshotLastSentState(snapshot = {}) {
   ]));
 }
 
+function collectCurrentFeaturedIds(snapshot = {}) {
+  const cats = Array.isArray(snapshot?.cats) ? snapshot.cats : [];
+  return cats
+    .filter(category => isFeaturedSpecialsSectionKey(category?.key))
+    .flatMap(category => Array.isArray(category?.items) ? category.items : [])
+    .filter(item => (item?.featured_enabled === true || item?.featuredEnabled === true)
+      && item?.on_menu !== false
+      && item?.onMenu !== false
+      && item?.visibility !== 'off_menu')
+    .map(item => normalizePersistentItemId(item?.id))
+    .filter(Boolean);
+}
+
 function readSnapshotPreviewContext(snapshot = {}) {
   const context = snapshot?.preview_context && typeof snapshot.preview_context === 'object'
     ? snapshot.preview_context
@@ -323,6 +336,7 @@ async function buildCanonicalPreviewForMenu({
     metadata: {
       serverOwned: true,
       contract: PREVIEW_CONTRACT,
+      currentFeaturedIds: collectCurrentFeaturedIds(queueSnapshot),
       unsentItemIds: queueState.unsentItemIds,
       lastSentState: snapshotHasFeaturedSpecials
         ? snapshotLastSentState(queueSnapshot)

--- a/tests/boundaries/publish.boundary.test.cjs
+++ b/tests/boundaries/publish.boundary.test.cjs
@@ -286,6 +286,39 @@ test('menu publish service honors an explicit global facade override for direct 
   assert.equal(calls[1].options.intent, 'save');
 });
 
+test('menu publish service prepares through the server preview port when no facade is loaded', async () => {
+  const sandbox = loadSandboxWithScripts(['core/session/publish-service.js']);
+  const previewCalls = [];
+  const service = sandbox.__HF_SESSION_MODULES__.createMenuPublishService(createMenuSessionPorts({
+    async requestPublishPreview(options = {}) {
+      previewCalls.push(options);
+      return {
+        ok: true,
+        status: 200,
+        payload: {
+          ok: true,
+          preview: {
+            hasChanges: true,
+            hasLocalDraft: true,
+            sections: [{ id: 'beer', changes: [] }],
+            notificationChanges: [{ id: 'beer::added::lager' }],
+          },
+          current_revisions: { live: 10 },
+        },
+      };
+    },
+  }), {});
+
+  const result = await service.prepare({ expectedLiveRevision: 10 });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 200);
+  assert.equal(result.current_revisions.live, 10);
+  assert.equal(result.preview.sections[0].id, 'beer');
+  assert.equal(previewCalls.length, 1);
+  assert.equal(previewCalls[0].expectedLiveRevision, 10);
+});
+
 test('menu publish service keeps fallback methods explicit for quiet-save and publish paths', async () => {
   const sandbox = loadSandboxWithScripts(['core/session/publish-service.js']);
   const quietSaveCalls = [];

--- a/tests/phase8-server-write-boundaries.test.cjs
+++ b/tests/phase8-server-write-boundaries.test.cjs
@@ -522,8 +522,9 @@ test('saveLiveMenuCommand resolves DB category ids and persists featured_enabled
   const categoryPayload = JSON.parse(categoryPersistCall.options.body);
   assert.equal(categoryPayload.length, 2);
   assert.equal(categoryPayload[0].key, 'featured_specials');
-  assert.equal(categoryPayload[0].id, 'category-uuid-1');
-  assert.notEqual(categoryPayload[0].id, 'featured_specials');
+  assert.equal(Object.prototype.hasOwnProperty.call(categoryPayload[0], 'id'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(categoryPayload[1], 'id'), false);
+  assert.deepEqual(Object.keys(categoryPayload[0]).sort(), Object.keys(categoryPayload[1]).sort());
 
   const itemPersistCall = fetchCalls.find(call => call.url.endsWith('/rest/v1/items'));
   assert.ok(itemPersistCall, 'expected item persistence request');

--- a/tests/phase9-publish-specials-boundaries.test.cjs
+++ b/tests/phase9-publish-specials-boundaries.test.cjs
@@ -123,6 +123,8 @@ test('server preview does not invent featured_specials diffs when legacy feature
     assert.equal(result.ok, true);
     assert.equal(result.preview.hasNotificationChanges, false);
     assert.deepEqual(result.preview.diff, []);
+    assert.equal(capturedPreview.metadata.currentFeaturedIds.length, 1);
+    assert.match(capturedPreview.metadata.currentFeaturedIds[0], /^[0-9a-f-]{36}$/i);
     assert.equal(capturedPreview.metadata.lastSentState.featured_specials.length, 1);
     assert.notEqual(capturedPreview.metadata.lastSentState.featured_specials[0].id, sharedItemId);
     assert.match(capturedPreview.metadata.lastSentState.featured_specials[0].id, /^[0-9a-f-]{36}$/i);


### PR DESCRIPTION
## What changed

- Restored the web publish preview preparation path so Save and Save & Send can call the server preview boundary instead of falling through to an unavailable publish service.
- Passed expected revision values through the web preview API request.
- Added `currentFeaturedIds` to the server preview metadata expected by the iOS client.
- Adjusted legacy `save_live` category upserts to send uniform category row shapes, avoiding PostgREST's `All object keys must match` failure.
- Added boundary coverage for the web publish service fallback, iOS preview metadata, and uniform category upsert payloads.

## Why

Web saves were showing `Publish service is unavailable` because the extracted publish service did not know how to prepare a preview without a facade. iOS was also hitting shared API contract gaps: preview responses lacked the metadata field the native decoder requires, and quiet saves could fail when category upsert rows mixed objects with and without `id`.

## Impact

Managers should be able to save quietly and build Save & Send previews from both web and the iOS app once this branch is deployed. No iOS app binary changes are required for the server-side fixes.

## Validation

- `node --test tests/boundaries/publish.boundary.test.cjs tests/phase8-server-write-boundaries.test.cjs tests/phase9-publish-specials-boundaries.test.cjs tests/phase19-menu-preview-boundaries.test.cjs`
- `node --check app.js`
- `node --check core/session/publish-service.js`
- `node --check server/_menu-live.js`
- `node --check server/_menu-publish.js`

## Notes

Attempted iOS `MenuDocumentTests`, but the Xcode scheme built Release simulator products while attempting to launch the Debug simulator app path, so the runner failed before tests executed.