### PR TITLE
[codex] Streamline save and send flow

### DIFF
--- a/app.js
+++ b/app.js
@@ -851,6 +851,18 @@ function markSaveOnlyDraftChange(change) {
   scheduleCurrentLocalDraftPersistence();
   updateSaveBtn();
 }
+function markFeaturedSpecialItemDraftChange(catId, item, actionLabel = 'Updated') {
+  if (catId !== FEATURED_SPECIALS_CATEGORY_ID || !item?.id) return;
+  const itemName = String(item.name || 'featured special').trim() || 'featured special';
+  markSaveOnlyDraftChange({
+    key: `featured-specials:${catId}:${item.id}`,
+    label: `${actionLabel} featured special ${itemName}`,
+    message: `${actionLabel} featured special ${itemName}`,
+    sectionId: catId,
+    itemId: item.id,
+    kind: 'featured-special',
+  });
+}
 function getDraftChangeCount() {
   return countDiffLines() + getDraftSaveOnlyChanges().length;
 }
@@ -1972,6 +1984,7 @@ function confirmAddItemModal(options = {}) {
   if (!menuState[categoryId]) menuState[categoryId] = { items: [], lastSent: [] };
   const item = buildNewMenuItemFromAddModal(fields);
   menuState[categoryId].items.push(item);
+  markFeaturedSpecialItemDraftChange(categoryId, item, 'Added');
   _lastAddItemCategoryId = categoryId;
   invalidateDiff();
   renderManagerItems(categoryId);
@@ -10173,6 +10186,7 @@ async function discardLocalDraft() {
   await loadActiveMenuState({ includePersistedDraft: false, source: 'discard' });
   renderManagerWorkspace({ includeRecentChanges: false });
   updateDraftIndicator();
+  updateSaveBtn();
   showToast(`✅ ${_activeMenuName || 'Menu'} draft discarded.`, 'success');
 }
 
@@ -10218,7 +10232,10 @@ function addItem(catId) {
     const offMenu = menuState[catId].items.find(
       i => i.onMenu === false && i.name.toLowerCase() === nameLower
     );
-    if (offMenu) { offMenu.onMenu = true; }
+    if (offMenu) {
+      offMenu.onMenu = true;
+      markFeaturedSpecialItemDraftChange(catId, offMenu, 'Restored');
+    }
     else {
       // Check uncategorized pool — if found, move it into this category
       const uncatIdx = (menuState[UNCATEGORIZED_ID]?.items || []).findIndex(
@@ -10226,10 +10243,12 @@ function addItem(catId) {
       );
       if (uncatIdx !== -1) {
         const [uncatItem] = menuState[UNCATEGORIZED_ID].items.splice(uncatIdx, 1);
-        menuState[catId].items.push({ ...uncatItem, onMenu: true });
+        const movedItem = { ...uncatItem, onMenu: true };
+        menuState[catId].items.push(movedItem);
+        markFeaturedSpecialItemDraftChange(catId, movedItem, 'Added');
         movedFromUncategorized = true;
       } else {
-        menuState[catId].items.push({
+        const newItem = {
           id: uid(),
           name,
           desc: '',
@@ -10240,7 +10259,9 @@ function addItem(catId) {
           upcharges: [],
           showDescription: true,
           showRecipe: false,
-        });
+        };
+        menuState[catId].items.push(newItem);
+        markFeaturedSpecialItemDraftChange(catId, newItem, 'Added');
       }
     }
   }
@@ -10831,9 +10852,10 @@ function renameItem(catId, itemId, newName) {
 // ─── DRAFT INDICATOR ─────────────────────────────────────────────────────────
 function updateDraftIndicator() {
   const btn = document.getElementById('send-btn');
-  if (!btn) return;
-  btn.textContent = 'Save';
-  btn.style.boxShadow = getDraftChangeCount() > 0 ? '0 4px 22px rgba(255,77,0,0.55)' : '';
+  if (btn) {
+    btn.textContent = 'Save';
+    btn.style.boxShadow = getDraftChangeCount() > 0 ? '0 4px 22px rgba(255,77,0,0.55)' : '';
+  }
   renderManagerOverviewStats();
   updateManagerActionBar();
 }

--- a/app.js
+++ b/app.js
@@ -592,6 +592,7 @@ let _localDraftBaseSnapshot = null;
 let _localDraftPersistTimer = null;
 let _previewModalState = null;
 let _previewSelectionState = {};
+let _previewNotifyEnabled = true;
 let _lastAddItemCategoryId = '';
 const ADD_ITEM_MODAL_MANUAL_MODE = 'manual';
 const ADD_ITEM_MODAL_SCAN_MODE = 'scan';
@@ -863,13 +864,13 @@ function getMenuActionState({ isCompactViewport = false } = {}) {
   const hasNotificationChanges = notificationCount > 0;
   const hasSaveOnlyChanges = saveOnlyCount > 0;
   const hasChanges = hasNotificationChanges || hasSaveOnlyChanges;
-  const hasPendingServerQueue = !hasLocalDraft && hasNotificationChanges;
+  const hasPendingServerQueue = false;
 
   if (hasLocalDraft) {
     const summaryText = hasNotificationChanges
       ? (isCompactViewport
-          ? `${getDraftChangeCount()} pending change${getDraftChangeCount() === 1 ? '' : 's'}. Save quietly or review the send queue.`
-          : `${getDraftChangeCount()} pending change${getDraftChangeCount() === 1 ? '' : 's'}. Save Quietly writes live without sending. Save & Send reviews the queue before notifying.`)
+          ? `${getDraftChangeCount()} pending change${getDraftChangeCount() === 1 ? '' : 's'} ready to review.`
+          : `${getDraftChangeCount()} pending change${getDraftChangeCount() === 1 ? '' : 's'}. Save opens a review before anything goes live.`)
       : `${saveOnlyCount || getDraftChangeCount()} quiet change${(saveOnlyCount || getDraftChangeCount()) === 1 ? '' : 's'} ready to save.`;
     return {
       hasLocalDraft,
@@ -878,27 +879,11 @@ function getMenuActionState({ isCompactViewport = false } = {}) {
       hasSaveOnlyChanges,
       hasChanges,
       summaryText,
-      saveLabel: hasNotificationChanges ? 'Save Quietly' : 'Save',
+      saveLabel: 'Save',
       saveDisabled: !hasChanges,
-      publishLabel: 'Save & Send',
-      publishDisabled: !hasNotificationChanges,
+      publishLabel: '',
+      publishDisabled: true,
       showDiscard: true,
-    };
-  }
-
-  if (hasPendingServerQueue) {
-    return {
-      hasLocalDraft,
-      hasPendingServerQueue,
-      hasNotificationChanges,
-      hasSaveOnlyChanges,
-      hasChanges,
-      summaryText: `${notificationCount} update line${notificationCount === 1 ? ' is' : 's are'} live and ready to send.`,
-      saveLabel: '',
-      saveDisabled: true,
-      publishLabel: 'Send',
-      publishDisabled: false,
-      showDiscard: false,
     };
   }
 
@@ -911,7 +896,7 @@ function getMenuActionState({ isCompactViewport = false } = {}) {
     summaryText: 'No pending changes',
     saveLabel: 'Save',
     saveDisabled: true,
-    publishLabel: 'Send',
+    publishLabel: '',
     publishDisabled: true,
     showDiscard: false,
   };
@@ -926,12 +911,13 @@ function updateSaveBtn() {
     saveBtn.textContent = actionState.saveLabel || 'Save';
     saveBtn.hidden = !actionState.saveLabel;
     saveBtn.title = actionState.hasLocalDraft
-      ? 'Save the live menu without notifying anyone yet'
+      ? 'Review and save these changes'
       : '';
   }
   if (publishBtn) {
     publishBtn.disabled = !!actionState.publishDisabled;
     publishBtn.textContent = actionState.publishLabel;
+    publishBtn.hidden = true;
   }
   if (discardBtn) {
     discardBtn.hidden = !actionState.showDiscard;
@@ -2360,7 +2346,6 @@ function buildMenuSessionSnapshot(source = 'live', request = buildCurrentMenuPag
   const notifyDiff = getCachedDiff();
   const saveOnlyChanges = getDraftSaveOnlyChanges();
   const hasLocalDraft = syncLocalDraftDirtyState();
-  const hasPendingUpdate = !hasLocalDraft && countDiffLines(notifyDiff) > 0;
   return {
     request,
     source,
@@ -2377,7 +2362,7 @@ function buildMenuSessionSnapshot(source = 'live', request = buildCurrentMenuPag
     draftSavedTs: getDraftSavedTs(),
     saveOnlyChanges,
     notifyDiff,
-    status: hasLocalDraft ? 'DRAFTING' : (hasPendingUpdate ? 'LIVE | UNSENT' : 'LIVE'),
+    status: hasLocalDraft ? 'DRAFTING' : 'LIVE',
     hasMultipleMenus: _hasMultipleMenus,
   };
 }
@@ -2850,34 +2835,16 @@ function createLegacyMenuPublishService(sessionPorts, runtime = {}) {
 
       if (shouldNotify && delivery.partial) {
         warnings.push(...sessionPorts.collectNotificationWarnings(delivery.summary));
-        warnings.push('Some channels did not receive the update. The lines remain ready to send again.');
-        return {
-          ok: true,
-          preview,
-          notificationStatus: delivery,
-          warnings: sessionPorts.dedupeWarnings(warnings),
-          warningMessage: sessionPorts.dedupeWarnings(warnings)[0] || '',
-          successMessage: `✅ ${sessionPorts.getMenuName() || 'Menu'} saved live. Update still needs attention.`,
-          snapshot: buildSnapshot('send-partial'),
-        };
+        warnings.push('Some channels did not receive the update. Changes were saved live without preserving a send queue.');
       }
 
       if (shouldNotify && !delivery.ok) {
         warnings.push(delivery.userMessage || 'Update could not be sent.');
-        return {
-          ok: true,
-          preview,
-          notificationStatus: delivery,
-          warnings: sessionPorts.dedupeWarnings(warnings),
-          warningMessage: sessionPorts.dedupeWarnings(warnings)[0] || '',
-          successMessage: `✅ ${sessionPorts.getMenuName() || 'Menu'} saved live. Update still needs to be sent.`,
-          snapshot: buildSnapshot('send-failed-live-saved'),
-        };
       }
 
       if (shouldNotify) warnings.push(...sessionPorts.collectNotificationWarnings(delivery.summary));
 
-      if (mode === 'save-and-send' || mode === 'send') {
+      {
         const ts = liveSaveTs || sessionPorts.now();
         const lastSentState = sessionPorts.snapshotCurrentItemsAsLastSent();
         await sessionPorts.patchMenuMeta({
@@ -2897,7 +2864,7 @@ function createLegacyMenuPublishService(sessionPorts, runtime = {}) {
           warnings.push('This device could not refresh its local cache after the send.');
         }
 
-        const logged = patchMessage ? await sessionPorts.logUpdate(serializeSectionsForUpdateLog(selectedSections), patchMessage) : true;
+        const logged = shouldNotify && patchMessage ? await sessionPorts.logUpdate(serializeSectionsForUpdateLog(selectedSections), patchMessage) : true;
         if (!logged) {
           warnings.push('The recent-changes audit log could not be written for this send.');
         }
@@ -2911,9 +2878,11 @@ function createLegacyMenuPublishService(sessionPorts, runtime = {}) {
           notificationStatus: shouldNotify ? delivery : null,
           warnings: finalWarnings,
           warningMessage: finalWarnings[0] || '',
-          successMessage: shouldNotify
+          successMessage: shouldNotify && delivery.ok
             ? `✅ ${sessionPorts.getMenuName() || 'Menu'} saved and sent!`
-            : `✅ ${sessionPorts.getMenuName() || 'Menu'} update list cleared without notifying channels.`,
+            : (shouldNotify
+                ? `✅ ${sessionPorts.getMenuName() || 'Menu'} saved live. Notifications need attention.`
+                : `✅ ${sessionPorts.getMenuName() || 'Menu'} saved live without sending notifications.`),
           snapshot: buildSnapshot(finalWarnings.length ? 'publish-warning' : 'publish-complete'),
         };
       }
@@ -6204,7 +6173,6 @@ function renderManagerOverviewStats() {
   ), 0);
   const draftCount = getDraftChangeCount();
   const hasLocalDraft = syncLocalDraftDirtyState();
-  const notifyCount = !hasLocalDraft ? countDiffLines() : 0;
   const statusValue = document.getElementById('manager-overview-status-value');
   const statusMeta = document.getElementById('manager-overview-status-meta');
   const activeValue = document.getElementById('manager-overview-active-value');
@@ -6212,14 +6180,12 @@ function renderManagerOverviewStats() {
   const eightysixValue = document.getElementById('manager-overview-86-value');
   const eightysixMeta = document.getElementById('manager-overview-86-meta');
 
-  if (statusValue) statusValue.textContent = hasLocalDraft ? 'Drafting' : (notifyCount > 0 ? 'Live | Unsent' : 'Live');
+  if (statusValue) statusValue.textContent = hasLocalDraft ? 'Drafting' : 'Live';
   if (statusMeta) {
     if (hasLocalDraft) {
       statusMeta.textContent = `${draftCount} pending change${draftCount === 1 ? '' : 's'} on this device.`;
-    } else if (notifyCount > 0) {
-      statusMeta.textContent = `${notifyCount} update line${notifyCount === 1 ? '' : 's'} ready to send`;
     } else {
-      statusMeta.textContent = 'No unsent changes';
+      statusMeta.textContent = 'Saved live';
     }
   }
   if (activeValue) activeValue.textContent = String(activeItems);
@@ -6259,51 +6225,22 @@ function createDraftLedgerService(deps = {}) {
       const hasNotificationChanges = notificationCount > 0;
       const hasSaveOnlyChanges = saveOnlyCount > 0;
       const hasChanges = hasNotificationChanges || hasSaveOnlyChanges;
-      const actionState = hasLocalDraft
-        ? {
-            hasLocalDraft,
-            hasPendingServerQueue: false,
-            hasNotificationChanges,
-            hasSaveOnlyChanges,
-            hasChanges,
-            summaryText: hasNotificationChanges
-              ? (isCompactViewport
-                  ? `${draftCount} pending change${draftCount === 1 ? '' : 's'}. Save quietly or review the send queue.`
-                  : `${draftCount} pending change${draftCount === 1 ? '' : 's'}. Save Quietly writes live without sending. Save & Send reviews the queue before notifying.`)
-              : `${saveOnlyCount || draftCount} quiet change${(saveOnlyCount || draftCount) === 1 ? '' : 's'} ready to save.`,
-            saveLabel: hasNotificationChanges ? 'Save Quietly' : 'Save',
-            saveDisabled: !hasChanges,
-            publishLabel: 'Save & Send',
-            publishDisabled: !hasNotificationChanges,
-            showDiscard: true,
-          }
-        : (hasNotificationChanges
-            ? {
-                hasLocalDraft,
-                hasPendingServerQueue: true,
-                hasNotificationChanges,
-                hasSaveOnlyChanges,
-                hasChanges,
-                summaryText: `${notificationCount} update line${notificationCount === 1 ? ' is' : 's are'} live and ready to send.`,
-                saveLabel: '',
-                saveDisabled: true,
-                publishLabel: 'Send',
-                publishDisabled: false,
-                showDiscard: false,
-              }
-            : {
-                hasLocalDraft,
-                hasPendingServerQueue: false,
-                hasNotificationChanges,
-                hasSaveOnlyChanges,
-                hasChanges,
-                summaryText: 'No pending changes',
-                saveLabel: 'Save',
-                saveDisabled: true,
-                publishLabel: 'Send',
-                publishDisabled: true,
-                showDiscard: false,
-              });
+      const changeCount = hasLocalDraft ? draftCount : notificationCount;
+      const actionState = {
+        hasLocalDraft,
+        hasPendingServerQueue: false,
+        hasNotificationChanges,
+        hasSaveOnlyChanges,
+        hasChanges,
+        summaryText: hasChanges
+          ? `${changeCount || saveOnlyCount} pending change${(changeCount || saveOnlyCount) === 1 ? '' : 's'}. Save opens a review before anything goes live.`
+          : 'No pending changes',
+        saveLabel: 'Save',
+        saveDisabled: !hasChanges,
+        publishLabel: '',
+        publishDisabled: true,
+        showDiscard: hasLocalDraft,
+      };
       return {
         hasDraftChanges: actionState.hasLocalDraft,
         hasSharedDraft: false,
@@ -6326,14 +6263,10 @@ function createDraftLedgerService(deps = {}) {
       const changeLookup = buildLookup();
       const sectionNames = changeLookup.byCategoryName.get(catId) || new Set();
       const hasDraftTag = isDirty() && (changeLookup.byItemId.has(item?.id) || sectionNames.has(nameKey));
-      const hasUnsentTag = sectionNames.has(nameKey);
       const isNew = lastSentNames ? !lastSentNames.has(nameKey) : false;
 
       if (hasDraftTag) {
         return { className: 'item-state-badge--draft', text: 'DRAFT', label: 'Draft change' };
-      }
-      if (hasUnsentTag) {
-        return { className: 'item-state-badge--unsent', text: 'UNSENT', label: 'Unsent update' };
       }
       if (is86) {
         return { className: 'item-state-badge--86', text: '86', label: "86'd" };
@@ -6375,11 +6308,12 @@ function updateManagerActionBar() {
     saveBtn.disabled = !!ledgerState.saveDisabled;
     saveBtn.textContent = ledgerState.saveLabel || 'Save';
     saveBtn.hidden = !ledgerState.saveLabel;
-    saveBtn.title = ledgerState.hasDraftChanges ? 'Save the live menu without notifying anyone yet' : '';
+    saveBtn.title = ledgerState.hasDraftChanges ? 'Review and save these changes' : '';
   }
   if (publishBtn) {
-    publishBtn.disabled = !!ledgerState.publishDisabled;
-    publishBtn.textContent = ledgerState.publishLabel;
+    publishBtn.disabled = true;
+    publishBtn.textContent = '';
+    publishBtn.hidden = true;
   }
   if (discardBtn) {
     discardBtn.hidden = !ledgerState.showDiscard;
@@ -10226,13 +10160,8 @@ async function persistState(options = {}) {
 async function saveMenu() {
   await flushFocusedManagerEditor();
   const actionState = getMenuActionState();
-  if (!actionState.hasLocalDraft) {
-    if (actionState.hasPendingServerQueue) {
-      await openPreview();
-    }
-    return;
-  }
-  await sendUpdate({ notify: false });
+  if (!actionState.hasChanges) return;
+  await openPreview();
 }
 
 async function discardLocalDraft() {
@@ -10412,7 +10341,7 @@ function toggle86(catId, itemId) {
     wrapper.classList.add(cls);
     setTimeout(() => wrapper.classList.remove(cls), 400);
   }
-  showToast(item.eightySixed ? "🚫 Marked 86'd — use Save & Send to notify channels" : `↩ Marked ${restoreLabel(catId)} — use Save & Send to notify channels`, 'info');
+  showToast(item.eightySixed ? "🚫 Marked 86'd — save to review notification options" : `↩ Marked ${restoreLabel(catId)} — save to review notification options`, 'info');
 }
 
 function toggleFeaturedSpecialEnabled(catId, itemId, checked) {
@@ -10999,8 +10928,15 @@ function computeDiff() {
   return results;
 }
 
-function buildPreviewDecisionGroups(preview = {}) {
+function buildPreviewDecisionGroups(preview = {}, notifyEnabled = _previewNotifyEnabled) {
   const notificationChanges = Array.isArray(preview.notificationChanges) ? preview.notificationChanges : [];
+  if (!notifyEnabled) {
+    return {
+      selectedSections: [],
+      clearSections: groupNotificationChangesBySection(notificationChanges),
+      saveOnlyChanges: Array.isArray(preview.saveOnlyChanges) ? preview.saveOnlyChanges : [],
+    };
+  }
   return {
     selectedSections: groupNotificationChangesBySection(notificationChanges.filter(change => _previewSelectionState[change.id] !== false)),
     clearSections: groupNotificationChangesBySection(notificationChanges.filter(change => _previewSelectionState[change.id] === false)),
@@ -11025,31 +10961,33 @@ function renderPreviewModal(preview, options = {}) {
   _previewModalState = preview;
   if (!options.preserveSelection) {
     _previewSelectionState = Object.fromEntries((preview.notificationChanges || []).map(change => [change.id, true]));
+    _previewNotifyEnabled = !!preview.hasNotificationChanges;
   }
   content.innerHTML = '';
-  const isSendOnly = preview.mode === 'send' || preview.mode === 'update-only';
-  const decisionGroups = buildPreviewDecisionGroups(preview);
+  const notifyEnabled = !!preview.hasNotificationChanges && !!_previewNotifyEnabled;
+  const decisionGroups = buildPreviewDecisionGroups(preview, notifyEnabled);
   if (subtitle) {
-    subtitle.textContent = isSendOnly
-      ? 'These changes are already live. Checked rows will send now, and unchecked rows will clear without sending.'
-      : (preview.hasNotificationChanges
-          ? 'Checked rows will send now, unchecked rows will clear without sending, and quiet changes will save live only.'
-          : 'These changes will save live without sending notifications.');
+    subtitle.textContent = preview.hasNotificationChanges
+      ? 'Review what will be saved, then choose whether this save should notify channels.'
+      : 'Review what will be saved live without sending notifications.';
   }
-  saveMenuBtn.style.display = isSendOnly ? 'none' : '';
-  saveMenuBtn.disabled = !preview.hasLocalDraft;
-  saveMenuBtn.textContent = preview.hasNotificationChanges ? 'Save Quietly' : 'Save';
-  saveSendBtn.style.display = preview.hasNotificationChanges ? '' : 'none';
-  saveSendBtn.textContent = isSendOnly ? 'Send' : 'Save & Send';
-  saveSendBtn.disabled = !preview.hasNotificationChanges;
+  saveMenuBtn.style.display = 'none';
+  saveMenuBtn.disabled = true;
+  saveSendBtn.style.display = '';
+  saveSendBtn.textContent = notifyEnabled ? 'Save & Send' : 'Save';
+  saveSendBtn.disabled = !preview.hasChanges;
   if (!preview.hasChanges) {
     content.innerHTML = `<div class="no-changes">🎉 No changes since the last update.<br><span style="font-size:11px;color:#444;">Add, remove, or 86 items to generate an update.</span></div>`;
     saveMenuBtn.disabled = true;
     saveSendBtn.disabled = true;
   } else {
+    const notifySelector = preview.hasNotificationChanges
+      ? `<label class="preview-notify-toggle"><input id="preview-notify-toggle" type="checkbox" ${notifyEnabled ? 'checked' : ''} onchange="setPreviewNotifyEnabled(this.checked)"/><span>Notify channels for selected update rows</span></label>`
+      : `<div class="preview-group-title">This save has no notification-ready rows.</div>`;
     content.innerHTML = [
-      renderPreviewSectionGroup('Will Send', decisionGroups.selectedSections, { selectable: true }),
-      renderPreviewSectionGroup('Will Clear Without Sending', decisionGroups.clearSections, { selectable: true }),
+      notifySelector,
+      renderPreviewSectionGroup('Will Send', decisionGroups.selectedSections, { selectable: notifyEnabled }),
+      renderPreviewSectionGroup(notifyEnabled ? 'Will Save Without Notification' : 'Will Save Without Notification', decisionGroups.clearSections, { selectable: notifyEnabled }),
       decisionGroups.saveOnlyChanges.length
         ? `<div class="preview-block">${buildSaveOnlyPreviewBlockHtml(decisionGroups.saveOnlyChanges).replace('Quiet Live Changes', 'Will Save Only')}</div>`
         : '',
@@ -11097,6 +11035,11 @@ function closeModal() {
 
 function setPreviewChangeSelected(changeId, checked) {
   _previewSelectionState[changeId] = !!checked;
+  if (_previewModalState) renderPreviewModal(_previewModalState, { preserveSelection: true });
+}
+
+function setPreviewNotifyEnabled(checked) {
+  _previewNotifyEnabled = !!checked;
   if (_previewModalState) renderPreviewModal(_previewModalState, { preserveSelection: true });
 }
 
@@ -11167,9 +11110,7 @@ function setPreviewModalActionState(mode = '') {
   if (cancelBtn) cancelBtn.disabled = isBusy;
   if (saveMenuBtn) {
     saveMenuBtn.disabled = isBusy;
-    saveMenuBtn.textContent = mode === 'save-menu'
-      ? 'Saving…'
-      : ((_previewModalState?.hasNotificationChanges ? 'Save Quietly' : 'Save'));
+    saveMenuBtn.textContent = 'Save';
   }
   if (saveSendBtn) {
     saveSendBtn.disabled = isBusy;
@@ -11177,7 +11118,7 @@ function setPreviewModalActionState(mode = '') {
       ? 'Sending…'
       : (mode === 'save-send'
           ? 'Saving & Sending…'
-          : (((_previewModalState?.mode === 'send') || (_previewModalState?.mode === 'update-only')) ? 'Send' : 'Save & Send'));
+          : (_previewNotifyEnabled && _previewModalState?.hasNotificationChanges ? 'Save & Send' : 'Save'));
   }
 }
 
@@ -11220,10 +11161,11 @@ async function sendUpdate(options = {}) {
     showToast('Update is long and will be truncated.', 'info');
   }
 
-  const selectedChangeIds = getSelectedPreviewChangeIds();
-  const intent = options.notify === false
-    ? 'save'
-    : ((preview.mode === 'send' || preview.mode === 'update-only') ? 'send' : 'save-and-send');
+  const notify = typeof options.notify === 'boolean'
+    ? options.notify
+    : (!!preview.hasNotificationChanges && !!_previewNotifyEnabled);
+  const selectedChangeIds = notify ? getSelectedPreviewChangeIds() : [];
+  const intent = notify ? (preview.hasLocalDraft ? 'save-and-send' : 'send') : 'save';
   setPreviewModalActionState(intent === 'save' ? 'save-menu' : (intent === 'send' ? 'send-update' : 'save-send'));
 
   try {

--- a/app.js
+++ b/app.js
@@ -2493,8 +2493,8 @@ function getMenuSessionPorts() {
     async patchMenuDraftState(snapshot, savedAt) {
       return patchMenuDraftState(snapshot, savedAt);
     },
-    async requestPublishPreview() {
-      return requestPublishPreviewThroughApi();
+    async requestPublishPreview(options = {}) {
+      return requestPublishPreviewThroughApi(options);
     },
     async publishMenuUpdate(options = {}) {
       const providedPreview = options.preview?.sections ? options.preview : null;
@@ -2760,6 +2760,33 @@ function createLegacyMenuPublishService(sessionPorts, runtime = {}) {
         mode: 'save',
         notify: false,
       });
+    },
+
+    async prepare(options = {}) {
+      if (typeof sessionPorts.requestPublishPreview === 'function') {
+        const result = await sessionPorts.requestPublishPreview(options);
+        if (result?.preview?.sections) return result;
+        if (result?.payload?.preview?.sections) {
+          return {
+            ...result.payload,
+            ok: result.ok !== false && result.payload.ok !== false,
+            status: result.status,
+            preview: result.payload.preview,
+          };
+        }
+        if (result?.ok === false) {
+          return {
+            ...result,
+            userHandled: result.userHandled === true,
+            userMessage: result.userMessage || result.payload?.error || 'Preview is unavailable right now.',
+          };
+        }
+        return result || { ok: false, userMessage: 'Preview is unavailable right now.' };
+      }
+      return {
+        ok: true,
+        preview: buildPreview(),
+      };
     },
 
     async publishUpdate(options = {}) {
@@ -4828,14 +4855,16 @@ function buildPublishSnapshotPayload() {
 }
 
 async function requestPublishPreviewThroughApi() {
+  const options = arguments[0] || {};
   if (!MENU_ID || !getAuthorizedApiHeaders().Authorization) return { ok: false, fallbackable: false };
   const draftEnvelope = buildCurrentLocalDraftEnvelope();
   return postApiJson('/api/manager', {
     action: 'preview_publish',
     menu_id: MENU_ID,
     snapshot: buildPublishSnapshotPayload(),
-    expected_live_revision: menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null,
-    expected_notification_revision: draftEnvelope?.baseLastSentRevision ?? null,
+    expected_live_revision: options.expectedLiveRevision ?? (menuState._meta?.lastUpdatedTs ? Number(menuState._meta.lastUpdatedTs) : null),
+    expected_draft_revision: options.expectedDraftRevision ?? null,
+    expected_notification_revision: options.expectedNotificationRevision ?? (draftEnvelope?.baseLastSentRevision ?? null),
   }, {
     headers: getAuthorizedApiHeaders(),
   });

--- a/core/session/menu-publish-workflow.js
+++ b/core/session/menu-publish-workflow.js
@@ -85,7 +85,7 @@
         const auditResults = [];
         const metaResults = [];
         let livePersisted = false;
-        const baselineAdvancedIntent = command.intent === 'send' || command.intent === 'save-and-send';
+        const shouldNotify = (command.intent === 'send' || command.intent === 'save-and-send') && selection.selectedSections.length > 0;
         let baselineAdvanced = false;
         const menuName = context.knownMenu?.name || 'Menu';
         const lastSentState = preview.metadata?.lastSentState && typeof preview.metadata.lastSentState === 'object'
@@ -110,7 +110,7 @@
           retryable: false,
         };
 
-        if ((command.intent === 'send' || command.intent === 'save-and-send') && selection.selectedSections.length) {
+        if (shouldNotify) {
           notification = {
             attempted: true,
             ...(await ports.notifications.deliver({
@@ -133,21 +133,9 @@
             operationId,
             eventType: 'send_failed',
             sections: selection.selectedSections,
-            message: 'Notification delivery failed or was partial. Queue preserved.',
+            message: 'Notification delivery failed or was partial. Changes were saved live without preserving a send queue.',
           }));
           auditEventTypes.push('send_failed');
-          metaResults.push(await ports.menus.patchMeta({
-            menuId: command.menuId,
-            patch: {
-              last_updated_ts: livePersisted ? ts : (context.meta?.last_updated_ts || null),
-              draft_state: livePersisted ? {} : (context.meta?.draft_state || {}),
-              draft_saved_ts: livePersisted ? null : (context.meta?.draft_saved_ts || null),
-              draft_saved_by_user_id: livePersisted ? null : (context.meta?.draft_saved_by_user_id ?? undefined),
-              draft_saved_by_name: livePersisted ? '' : (context.meta?.draft_saved_by_name ?? undefined),
-              draft_saved_source: livePersisted ? '' : (context.meta?.draft_saved_source ?? undefined),
-            },
-            optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
-          }));
         } else {
           if (command.intent === 'save') {
             auditResults.push(await ports.audit.append({
@@ -157,26 +145,10 @@
               operationId,
               eventType: 'quiet_save',
               sections: selection.selectedSections,
-              message: preview.hasNotificationChanges ? 'Saved live quietly. Queue preserved.' : 'Saved live quietly.',
+              message: preview.hasNotificationChanges ? 'Saved live without sending notifications.' : 'Saved live quietly.',
             }));
             auditEventTypes.push('quiet_save');
           }
-          baselineAdvanced = baselineAdvancedIntent;
-          metaResults.push(await ports.menus.patchMeta({
-            menuId: command.menuId,
-            patch: {
-              last_updated_ts: livePersisted ? ts : (context.meta?.last_updated_ts || null),
-              last_sent_ts: baselineAdvanced ? ts : (context.meta?.last_sent_ts || null),
-              last_sent_state: baselineAdvanced ? lastSentState : (context.meta?.last_sent_state || {}),
-              last_sent_categories: baselineAdvanced ? (preview.diff || []).map(section => section.id) : (context.meta?.last_sent_categories || []),
-              draft_state: livePersisted ? {} : (context.meta?.draft_state || {}),
-              draft_saved_ts: livePersisted ? null : (context.meta?.draft_saved_ts || null),
-              draft_saved_by_user_id: livePersisted ? null : (context.meta?.draft_saved_by_user_id ?? undefined),
-              draft_saved_by_name: livePersisted ? '' : (context.meta?.draft_saved_by_name ?? undefined),
-              draft_saved_source: livePersisted ? '' : (context.meta?.draft_saved_source ?? undefined),
-            },
-            optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
-          }));
           if (selection.selectedSections.length && notification.attempted && notification.delivered) {
             auditResults.push(await ports.audit.append({
               menuId: command.menuId,
@@ -207,11 +179,30 @@
           }
         }
 
+        baselineAdvanced = true;
+        metaResults.push(await ports.menus.patchMeta({
+          menuId: command.menuId,
+          patch: {
+            last_updated_ts: livePersisted ? ts : (context.meta?.last_updated_ts || null),
+            last_sent_ts: ts,
+            last_sent_state: lastSentState,
+            last_sent_categories: (preview.diff || []).map(section => section.id),
+            draft_state: livePersisted ? {} : (context.meta?.draft_state || {}),
+            draft_saved_ts: livePersisted ? null : (context.meta?.draft_saved_ts || null),
+            draft_saved_by_user_id: livePersisted ? null : (context.meta?.draft_saved_by_user_id ?? undefined),
+            draft_saved_by_name: livePersisted ? '' : (context.meta?.draft_saved_by_name ?? undefined),
+            draft_saved_source: livePersisted ? '' : (context.meta?.draft_saved_source ?? undefined),
+          },
+          optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
+        }));
+
         let successMessage = `✅ ${menuName} saved live.`;
         if (notification.attempted && notification.delivered && baselineAdvanced) {
           successMessage = `✅ ${menuName} saved and sent!`;
+        } else if (notification.attempted && !notification.delivered) {
+          successMessage = `✅ ${menuName} saved live. Notifications need attention.`;
         } else if (command.intent === 'send' && !notification.attempted) {
-          successMessage = `✅ ${menuName} send skipped.`;
+          successMessage = `✅ ${menuName} saved live without sending notifications.`;
         }
 
         return {

--- a/core/session/publish-service.js
+++ b/core/session/publish-service.js
@@ -51,9 +51,33 @@
       };
     }
 
+    function normalizePreviewResult(result) {
+      if (!result) return getUnavailableResult('Preview is unavailable right now.');
+      if (result.preview?.sections) return result;
+      if (result.payload?.preview?.sections) {
+        return {
+          ...result.payload,
+          ok: result.ok !== false && result.payload.ok !== false,
+          status: result.status,
+          preview: result.payload.preview,
+        };
+      }
+      if (result.ok === false) {
+        return {
+          ...result,
+          userHandled: result.userHandled === true,
+          userMessage: result.userMessage || result.payload?.error || 'Preview is unavailable right now.',
+        };
+      }
+      return result;
+    }
+
     async function prepare(opts = {}) {
       if (facade && typeof facade.prepare === 'function') {
         return facade.prepare(opts);
+      }
+      if (typeof sessionPorts.requestPublishPreview === 'function') {
+        return normalizePreviewResult(await sessionPorts.requestPublishPreview(opts));
       }
       const fallback = getFallbackService();
       if (fallback && typeof fallback.prepare === 'function') {

--- a/core/ui/manager/workspace.js
+++ b/core/ui/manager/workspace.js
@@ -17,7 +17,7 @@
     const countDiffLines = typeof deps.countDiffLines === 'function' ? deps.countDiffLines : (() => 0);
     const createDraftLedgerService = typeof deps.createDraftLedgerService === 'function'
       ? deps.createDraftLedgerService
-      : (() => ({ getActionBarState: () => ({ hasDraftChanges: false, hasDraftWork: false, hasPendingUpdate: false, summaryText: 'No Pending Changes', publishLabel: 'Save' }) }));
+      : (() => ({ getActionBarState: () => ({ hasDraftChanges: false, hasDraftWork: false, hasPendingUpdate: false, saveDisabled: true, publishDisabled: true, showDiscard: false }) }));
 
     const renderManagerCategories = typeof deps.renderManagerCategories === 'function' ? deps.renderManagerCategories : (() => {});
     const renderPricingSection = typeof deps.renderPricingSection === 'function' ? deps.renderPricingSection : (() => {});
@@ -38,7 +38,6 @@
     function renderManagerOverviewStats() {
       const categoryDefs = getCategoryDefs();
       const menuState = getMenuState();
-      const ledgerState = createDraftLedgerService().getActionBarState({ isCompactViewport: windowRef.innerWidth <= 480 });
       const activeItems = categoryDefs.reduce((total, cat) => (
         total + (menuState[cat.id]?.items || []).filter(item => item.onMenu !== false).length
       ), 0);
@@ -55,14 +54,14 @@
       const eightysixValue = documentRef.getElementById('manager-overview-86-value');
       const eightysixMeta = documentRef.getElementById('manager-overview-86-meta');
 
-      if (statusValue) statusValue.textContent = hasLocalDraft ? 'Drafting' : (notifyCount > 0 ? 'Live | Unsent' : 'Live');
+      if (statusValue) statusValue.textContent = hasLocalDraft ? 'Drafting' : 'Live';
       if (statusMeta) {
         if (hasLocalDraft) {
           statusMeta.textContent = `${draftCount} pending change${draftCount === 1 ? '' : 's'} on this device.`;
         } else if (notifyCount > 0) {
-          statusMeta.textContent = `${notifyCount} update line${notifyCount === 1 ? '' : 's'} ready to send`;
+          statusMeta.textContent = `${notifyCount} update line${notifyCount === 1 ? '' : 's'} ready for review.`;
         } else {
-          statusMeta.textContent = 'No unsent changes';
+          statusMeta.textContent = 'Live menu is current';
         }
       }
       if (activeValue) activeValue.textContent = String(activeItems);
@@ -86,29 +85,48 @@
       const isCompactViewport = windowRef.innerWidth <= 480;
       const ledgerState = createDraftLedgerService().getActionBarState({ isCompactViewport });
       const saveBtn = documentRef.getElementById('save-btn');
-      const publishBtn = documentRef.getElementById('send-btn');
+      const sendBtn = documentRef.getElementById('send-btn');
       const discardBtn = documentRef.getElementById('discard-draft-btn');
+      const saveDisabled = !!ledgerState.saveDisabled && !!ledgerState.publishDisabled;
 
       if (primaryGroup) primaryGroup.hidden = false;
       if (saveBtn) {
-        saveBtn.disabled = !!ledgerState.saveDisabled;
-        saveBtn.textContent = ledgerState.saveLabel || 'Save';
-        saveBtn.hidden = !ledgerState.saveLabel;
-        saveBtn.title = ledgerState.hasDraftChanges ? 'Save the live menu without notifying anyone yet' : '';
+        saveBtn.disabled = saveDisabled;
+        saveBtn.textContent = 'Save';
+        saveBtn.hidden = false;
+        saveBtn.title = 'Review and save menu changes';
+        saveBtn.setAttribute('aria-label', 'Review and save menu changes');
+        saveBtn.setAttribute('onclick', 'openPreview()');
       }
-      if (publishBtn) {
-        publishBtn.disabled = !!ledgerState.publishDisabled;
-        publishBtn.textContent = ledgerState.publishLabel;
+      if (sendBtn) {
+        sendBtn.disabled = true;
+        sendBtn.hidden = true;
+        sendBtn.textContent = 'Save';
+        sendBtn.setAttribute('aria-hidden', 'true');
+        sendBtn.setAttribute('tabindex', '-1');
       }
       if (discardBtn) {
         discardBtn.hidden = !ledgerState.showDiscard;
         discardBtn.disabled = !ledgerState.showDiscard;
       }
       bar.hidden = false;
-      bar.classList.toggle('is-idle', ledgerState.saveDisabled && ledgerState.publishDisabled && !ledgerState.showDiscard);
+      bar.classList.toggle('is-idle', saveDisabled && !ledgerState.showDiscard);
       syncManagerActionBarStatus(syncEl);
 
-      if (summary) summary.textContent = ledgerState.summaryText;
+      if (summary) {
+        const draftCount = getDraftChangeCount();
+        const reviewCount = countDiffLines();
+        if (ledgerState.hasDraftChanges || ledgerState.hasDraftWork) {
+          const count = draftCount || reviewCount;
+          summary.textContent = count > 0
+            ? `${count} pending change${count === 1 ? '' : 's'}. Save reviews and saves your changes.`
+            : 'Save reviews and saves your changes.';
+        } else if (ledgerState.hasPendingUpdate || reviewCount > 0) {
+          summary.textContent = `${reviewCount} update line${reviewCount === 1 ? '' : 's'} ready for review. Save opens the review before notifying.`;
+        } else {
+          summary.textContent = 'No pending changes';
+        }
+      }
     }
 
     function renderManagerWorkspace(options = {}) {

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -88,11 +88,12 @@ Use it to answer three questions:
 | Capability | Web | iOS | Future-Client Target | Notes |
 | --- | --- | --- | --- | --- |
 | Menu editor workspace | Full | Full | Staff editor clients | Both clients expose a dedicated menu editor for Drinks and Food. |
-| Menu status (`Drafting`, `Live`, `Live \| Unsent`) | Full | Full | Staff editor clients | Both clients surface the shared save/send model. |
+| Menu status (`Drafting`, `Live`) | Full | Full | Staff editor clients | Both clients now avoid a persistent unsent state; saved menus are either drafting locally or live. |
 | Device-local drafts | Full | Full | Staff editor clients | Both keep local drafts separate from the shared server queue. |
 | Discard local draft | Full | Full | Staff editor clients | Explicit local-only discard flow exists in both clients. |
-| Save quietly / live save | Full | Full | Staff editor clients | Both support quiet live saves without sending notifications. |
-| Send preview and selective send | Full | Full | Staff editor clients | Both can preview grouped changes and select which ones to send. |
+| Unified save review | Full | Full | Staff editor clients | Both clients use one Save action that opens a review modal/sheet before persisting live. |
+| Optional notification during save | Full | Full | Staff editor clients | The save review lets staff choose whether selected notification-ready rows should notify channels; notify-off saves live and clears the queue baseline. |
+| Send preview and selective send | Full | Full | Staff editor clients | Both can preview grouped changes and select which rows notify during the unified save flow. |
 | Remote change detection and conflict refresh | Full | Full | Staff editor clients | Both clients detect remote changes and force review/reload when needed. |
 | Recent change history | Full | Full | Staff editor clients | Web has manager recent changes/history views; iOS surfaces recent updates in home and restaurant tools. |
 | Add items manually | Full | Full | Staff editor clients | Both can create new items from the editor. |

--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -178,7 +178,7 @@ final class AppModel {
     if hasLocalDraftChanges {
       return "Drafting"
     }
-    return hasServerUnsentChanges ? "Live | Unsent" : "Live"
+    return "Live"
   }
 
   var canMutateRemoteEditorState: Bool {
@@ -189,14 +189,10 @@ final class AppModel {
     canMutateRemoteEditorState && hasLocalDraftChanges
   }
 
-  var canSaveQuietlyRemotely: Bool {
+  var canSaveLiveRemotely: Bool {
     canMutateRemoteEditorState &&
       (editorCapabilities?.canSaveLiveMenu ?? false) &&
       hasLiveMenuChanges
-  }
-
-  var canSaveLiveRemotely: Bool {
-    canSaveQuietlyRemotely
   }
 
   var canLoadPublishPreview: Bool {
@@ -499,7 +495,7 @@ final class AppModel {
           let workspace = currentEditorWorkspace,
           let snapshot = editorSnapshot() else { return }
 
-    let operationLabel = hasLiveMenuChanges ? "Building Save & Send Preview" : "Building Send Preview"
+    let operationLabel = "Building Save Preview"
     await run(operationLabel) { model in
       let expectedDraftRevision = model.expectedDraftRevision(for: workspace)
       let expectedNotificationRevision = model.expectedNotificationBaselineRevision(for: workspace)
@@ -518,14 +514,14 @@ final class AppModel {
     }
   }
 
-  func publishSelectedChanges() async {
+  func publishSelectedChanges(shouldNotify: Bool = true) async {
     guard canPublishRemotely,
           let menuId = currentMenuId,
           let accessToken = authSession?.accessToken,
           let workspace = currentEditorWorkspace,
           let snapshot = editorSnapshot() else { return }
 
-    let operationLabel = hasLiveMenuChanges ? "Saving And Sending" : "Sending Updates"
+    let operationLabel = "Saving"
     await run(operationLabel) { model in
       let expectedDraftRevision = model.expectedDraftRevision(for: workspace)
       let expectedNotificationRevision = model.expectedNotificationBaselineRevision(for: workspace)
@@ -548,7 +544,7 @@ final class AppModel {
         }
       }
 
-      let selection = Array(model.selectedPreviewChangeIDs)
+      let selection = shouldNotify ? Array(model.selectedPreviewChangeIDs) : []
       let response = try await model.services.publish.publish(
         menuId: menuId,
         snapshot: snapshot,
@@ -560,15 +556,16 @@ final class AppModel {
         source: "ios_app"
       )
       let hasNotificationChanges = preview?.hasNotificationChanges ?? false
-      var title = "Saved Quietly"
-      var message = "The live menu was saved with no notification-ready queue items."
+      var title = "Saved"
+      var message = "The live menu was saved without sending notifications."
       if hasNotificationChanges {
-        if selection.isEmpty {
-          title = model.hasLiveMenuChanges ? "Saved And Cleared" : "Queue Cleared"
-          message = "Unchecked queue groups were cleared without sending notifications."
+        if !shouldNotify {
+          message = "Notification-ready changes were saved live and cleared without sending."
+        } else if selection.isEmpty {
+          message = "Unchecked notification rows were saved live without sending."
         } else {
-          title = model.hasLiveMenuChanges ? "Saved And Sent" : "Sent"
-          message = "Selected queue groups were sent to notification channels."
+          title = "Saved And Sent"
+          message = "Selected notification rows were sent. Unchecked rows were saved without notification."
         }
       }
       if let successMessage = response.successMessage?.nilIfBlank {
@@ -892,7 +889,6 @@ final class AppModel {
     session.hasServerUnsentChanges = editorHasServerUnsentChanges
     session.canEditCategories = canEditCategories
     session.canDiscardLocalDraft = canDiscardLocalDraft
-    session.canSaveQuietlyRemotely = canSaveQuietlyRemotely
     session.canLoadPublishPreview = canLoadPublishPreview
     session.canPublishRemotely = canPublishRemotely
     session.menuStatusLabel = menuStatusLabel
@@ -1102,8 +1098,6 @@ final class AppModel {
   ) {
     guard var workspace = currentEditorWorkspace else { return }
 
-    let previousNotificationBaseline = expectedNotificationBaselineRevision(for: previousWorkspace)
-    let previousLiveRevision = previousWorkspace.workspace.revisions.liveRevision
     let publishMode = preview?.mode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
     let didPersistLive = publishMode.isEmpty ? hasLiveMenuChanges : publishMode != "send"
 
@@ -1141,20 +1135,8 @@ final class AppModel {
     nextDocument.meta.draftSavedByName = nil
     nextDocument.meta.draftSavedSource = nil
 
-    let nextNotificationBaseline = expectedNotificationBaselineRevision(for: workspace)
-    let queueBaselineAdvanced = nextNotificationBaseline != previousNotificationBaseline
-    let nextHasUnsentChanges: Bool
-    if queueBaselineAdvanced {
-      nextHasUnsentChanges = false
-    } else if preview?.hasNotificationChanges == true {
-      nextHasUnsentChanges = true
-    } else if didPersistLive, nextRevisions.liveRevision != previousLiveRevision {
-      nextHasUnsentChanges = false
-    } else {
-      nextHasUnsentChanges = serverHasUnsentChanges(in: previousWorkspace)
-    }
-    workspace.workspace.hasUnsentChanges = nextHasUnsentChanges
-    workspace.workspace.menuStatus = nextHasUnsentChanges ? "Live | Unsent" : "Live"
+    workspace.workspace.hasUnsentChanges = false
+    workspace.workspace.menuStatus = "Live"
 
     currentEditorWorkspace = workspace
     currentEditorDocument = nextDocument

--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -597,7 +597,7 @@ final class AppModel {
     notice = AppNotice(
       tone: .neutral,
       title: "Draft Discarded",
-      message: "Local edits on this device were removed. The shared server queue was not changed."
+      message: "Local edits on this device were removed. The live menu was not changed."
     )
   }
 
@@ -645,7 +645,7 @@ final class AppModel {
         serverDocument: currentDocument,
         revisions: model.currentEditorWorkspace?.workspace.revisions
       )
-      model.notice = AppNotice(tone: .success, title: "Saved Quietly", message: "The live menu was updated without sending notifications.")
+      model.notice = AppNotice(tone: .success, title: "Saved", message: "The live menu was updated without sending notifications.")
     }
   }
 

--- a/ios/ElRoysManagerApp/Features/Menu/MenuEditorSession.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/MenuEditorSession.swift
@@ -20,7 +20,6 @@ final class MenuEditorSession {
   var hasServerUnsentChanges = false
   var canEditCategories = false
   var canDiscardLocalDraft = false
-  var canSaveQuietlyRemotely = false
   var canLoadPublishPreview = false
   var canPublishRemotely = false
   var menuStatusLabel = "Live"
@@ -80,9 +79,9 @@ final class MenuEditorSession {
     }
   }
 
-  func publishSelectedChanges() async {
+  func publishSelectedChanges(shouldNotify: Bool = true) async {
     await appModel.withInstalledEditorSession(self) { model in
-      await model.publishSelectedChanges()
+      await model.publishSelectedChanges(shouldNotify: shouldNotify)
     }
   }
 

--- a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
@@ -48,8 +48,7 @@ struct MenuEditorScreen: View {
             theme: theme,
             menuAccent: menuAccent,
             onAddItem: presentNewItem,
-            onSaveQuietly: saveQuietly,
-            onSendUpdate: loadSendPreview,
+            onSave: loadSavePreview,
             onDiscardDraft: { showingDiscardDraftConfirm = true }
           )
 
@@ -164,7 +163,9 @@ struct MenuEditorScreen: View {
             preview: preview,
             theme: theme,
             menuAccent: menuAccent,
-            onPublish: publishChanges
+            onPublish: { shouldNotify in
+              publishChanges(shouldNotify: shouldNotify)
+            }
           )
         } else {
           ProgressView("Loading preview…")
@@ -197,20 +198,16 @@ struct MenuEditorScreen: View {
     }
   }
 
-  private func saveQuietly() {
-    Task { await session.saveLiveMenu() }
-  }
-
-  private func loadSendPreview() {
+  private func loadSavePreview() {
     Task {
       await session.loadPublishPreview()
       activeSheet = session.preview == nil ? nil : .publishPreview
     }
   }
 
-  private func publishChanges() {
+  private func publishChanges(shouldNotify: Bool) {
     Task {
-      await session.publishSelectedChanges()
+      await session.publishSelectedChanges(shouldNotify: shouldNotify)
       activeSheet = nil
     }
   }
@@ -308,16 +305,17 @@ struct PublishPreviewSummary: Equatable {
 
 private struct PublishPreviewSheet: View {
   @Environment(\.dismiss) private var dismiss
+  @State private var shouldNotify = true
   @Bindable var session: MenuEditorSession
   let preview: MenuPreviewPayload
   let theme: MenuEditorTheme
   let menuAccent: Color
-  let onPublish: () -> Void
+  let onPublish: (Bool) -> Void
 
   private var summary: PublishPreviewSummary {
     PublishPreviewSummary(
       preview: preview,
-      selectedChangeIDs: session.selectedPreviewChangeIDs
+      selectedChangeIDs: shouldNotify ? session.selectedPreviewChangeIDs : []
     )
   }
 
@@ -335,8 +333,21 @@ private struct PublishPreviewSheet: View {
           }
 
           if preview.hasNotificationChanges {
+            Toggle(isOn: $shouldNotify) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Send Notifications")
+                  .font(EditorTypography.body(15, weight: .bold))
+                  .foregroundStyle(theme.titleText)
+                Text(shouldNotify ? "Checked rows will notify. Unchecked rows save quietly." : "All notification-ready rows will be saved quietly.")
+                  .font(EditorTypography.body(12, weight: .medium))
+                  .foregroundStyle(theme.subtleText)
+              }
+            }
+            .tint(menuAccent)
+            .menuEditorSurface(colors: [theme.panelTop, theme.panelBottom], border: theme.panelBorder)
+
             VStack(alignment: .leading, spacing: 10) {
-              Text("Notification Toggles")
+              Text("Notification Rows")
                 .font(EditorTypography.body(15, weight: .bold))
                 .foregroundStyle(theme.titleText)
               ForEach(preview.sections) { section in
@@ -354,6 +365,8 @@ private struct PublishPreviewSheet: View {
                         .foregroundStyle(theme.bodyText)
                     }
                     .tint(menuAccent)
+                    .disabled(!shouldNotify)
+                    .opacity(shouldNotify ? 1 : 0.55)
                   }
                 }
               }
@@ -363,7 +376,7 @@ private struct PublishPreviewSheet: View {
 
           if !currentSummary.selectedNotificationChanges.isEmpty {
             PublishPreviewSummaryCard(
-              title: "Changes To Send In Notification",
+              title: "Changes To Send",
               items: currentSummary.selectedNotificationChanges.map(\.displayText),
               theme: theme
             )
@@ -371,7 +384,7 @@ private struct PublishPreviewSheet: View {
 
           if !currentSummary.clearedNotificationChanges.isEmpty {
             PublishPreviewSummaryCard(
-              title: "Changes To Clear",
+              title: "Notification Rows To Save Without Notification",
               items: currentSummary.clearedNotificationChanges.map(\.displayText),
               theme: theme
             )
@@ -379,8 +392,14 @@ private struct PublishPreviewSheet: View {
 
           if !currentSummary.saveOnlyChanges.isEmpty {
             PublishPreviewSummaryCard(
-              title: "Save Only Changes",
+              title: "Other Changes To Save",
               items: currentSummary.saveOnlyChanges.map { $0.label.nilIfBlank ?? $0.message },
+              theme: theme
+            )
+          } else if !preview.hasNotificationChanges {
+            PublishPreviewSummaryCard(
+              title: "Live Save",
+              items: ["The current menu changes will be saved live without sending notifications."],
               theme: theme
             )
           }
@@ -399,7 +418,7 @@ private struct PublishPreviewSheet: View {
           accent: menuAccent,
           theme: theme,
           enabled: session.canPublishRemotely,
-          action: onPublish
+          action: { onPublish(shouldNotify && preview.hasNotificationChanges) }
         )
         .padding(.horizontal, 24)
         .padding(.top, 12)
@@ -421,28 +440,25 @@ private struct PublishPreviewSheet: View {
   }
 
   private var screenTitle: String {
-    preview.hasNotificationChanges ? "Send Notification" : "Save Changes"
+    "Save Preview"
   }
 
   private var actionButtonTitle: String {
-    if !preview.hasNotificationChanges {
-      return "Save"
-    }
-    return session.hasLocalDraftChanges ? "Save & Send" : "Send"
+    "Save"
   }
 
   private var actionButtonSubtitle: String {
     if !preview.hasNotificationChanges {
       return "Save live without sending notifications."
     }
-    if session.hasLocalDraftChanges {
-      return "Checked rows send now, unchecked rows clear quietly."
+    if shouldNotify {
+      return "Checked rows notify, unchecked rows save quietly."
     }
-    return "Send checked queue rows now."
+    return "Save live and clear notification rows without sending."
   }
 
   private var actionButtonIcon: String {
-    preview.hasNotificationChanges ? "paperplane.fill" : "square.and.arrow.down.fill"
+    shouldNotify && preview.hasNotificationChanges ? "paperplane.fill" : "square.and.arrow.down.fill"
   }
 }
 
@@ -632,8 +648,7 @@ private struct MenuEditorActionPanel: View {
   let theme: MenuEditorTheme
   let menuAccent: Color
   let onAddItem: () -> Void
-  let onSaveQuietly: () -> Void
-  let onSendUpdate: () -> Void
+  let onSave: () -> Void
   let onDiscardDraft: () -> Void
 
   var body: some View {
@@ -647,28 +662,16 @@ private struct MenuEditorActionPanel: View {
           MenuEditorActionLabel(title: "Add Item", subtitle: "Create a new menu item", icon: "plus.circle.fill", accent: menuAccent)
         }
         .buttonStyle(.plain)
-        Button(action: onSaveQuietly) {
-          MenuEditorActionLabel(
-            title: "Save Quietly",
-            subtitle: session.hasLiveMenuChanges ? "Save live without sending notifications" : "Live menu already matches",
-            icon: "checkmark.seal.fill",
-            accent: theme.successAccent
-          )
-        }
-        .buttonStyle(.plain)
-        .disabled(!session.canSaveQuietlyRemotely)
       }
 
       HStack(spacing: 12) {
-        Button(action: onSendUpdate) {
+        Button(action: onSave) {
           MenuEditorActionLabel(
-            title: session.hasLocalDraftChanges ? "Save & Send" : "Send",
+            title: "Save",
             subtitle: session.preview == nil
-              ? (session.hasLocalDraftChanges
-                  ? "Save live, then choose what to send or clear"
-                  : "Choose which unsent queue groups to send or clear")
-              : "Review the current send plan",
-            icon: "paperplane.fill",
+              ? "Preview what will save and choose notification options"
+              : "Review the current save plan",
+            icon: "square.and.arrow.down.fill",
             accent: menuAccent
           )
         }

--- a/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/MenuViews.swift
@@ -179,7 +179,7 @@ struct MenuEditorScreen: View {
       }
       Button("Keep Editing", role: .cancel) {}
     } message: {
-      Text("This only removes unsaved edits from this device and does not modify the shared server queue.")
+      Text("This only removes unsaved edits from this device and leaves the live menu unchanged.")
     }
   }
 

--- a/ios/ElRoysManagerApp/Features/Menu/RestaurantCategoryManagementView.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/RestaurantCategoryManagementView.swift
@@ -108,7 +108,7 @@ struct RestaurantCategoryManagementScreen: View {
       }
       Button("Keep Editing", role: .cancel) {}
     } message: {
-      Text("This only removes unsaved edits from this device and does not modify the shared server queue.")
+      Text("This only removes unsaved edits from this device and leaves the live menu unchanged.")
     }
   }
 

--- a/ios/ElRoysManagerApp/Features/Menu/RestaurantCategoryManagementView.swift
+++ b/ios/ElRoysManagerApp/Features/Menu/RestaurantCategoryManagementView.swift
@@ -58,9 +58,9 @@ struct RestaurantCategoryManagementScreen: View {
           session: session,
           preview: preview,
           accent: accent,
-          onPublish: {
+          onPublish: { shouldNotify in
             Task {
-              await session.publishSelectedChanges()
+              await session.publishSelectedChanges(shouldNotify: shouldNotify)
               showingPreview = false
             }
           }
@@ -121,13 +121,7 @@ struct RestaurantCategoryManagementScreen: View {
       .disabled(!session.canEditCategories)
 
       HStack(spacing: 12) {
-        Button("Save Quietly") {
-          Task { await session.saveLiveMenu() }
-        }
-        .buttonStyle(SecondaryGlassButtonStyle(accent: accent))
-        .disabled(!session.canSaveQuietlyRemotely)
-
-        Button(session.hasLocalDraftChanges ? "Save & Send" : "Send Update") {
+        Button("Save") {
           Task {
             await session.loadPublishPreview()
             showingPreview = session.preview != nil
@@ -227,50 +221,116 @@ struct RestaurantCategoryManagementScreen: View {
 
 private struct RestaurantCategoryPublishPreviewSheet: View {
   @Environment(\.dismiss) private var dismiss
+  @State private var shouldNotify = true
   @Bindable var session: MenuEditorSession
   let preview: MenuPreviewPayload
   let accent: Color
-  let onPublish: () -> Void
+  let onPublish: (Bool) -> Void
+
+  private var summary: PublishPreviewSummary {
+    PublishPreviewSummary(
+      preview: preview,
+      selectedChangeIDs: shouldNotify ? session.selectedPreviewChangeIDs : []
+    )
+  }
 
   var body: some View {
+    let currentSummary = summary
+
     NavigationStack {
       ScrollView {
         VStack(alignment: .leading, spacing: 16) {
-          Text(preview.patchMessage.isEmpty ? "Review the queued category changes before sending." : preview.patchMessage)
+          Text(preview.patchMessage.isEmpty ? "Review the category changes before saving." : preview.patchMessage)
             .font(AppTypography.body(14, weight: .medium))
 
-          ForEach(preview.sections) { section in
-            VStack(alignment: .leading, spacing: 10) {
-              Text(section.label)
-                .font(AppTypography.body(16, weight: .bold))
-
-              ForEach(section.changes) { change in
-                Toggle(
-                  isOn: Binding(
-                    get: { session.selectedPreviewChangeIDs.contains(change.id) },
-                    set: { session.updatePreviewSelection(change.id, selected: $0) }
-                  )
-                ) {
-                  Text(change.text)
-                }
-                .tint(accent)
+          if preview.hasNotificationChanges {
+            Toggle(isOn: $shouldNotify) {
+              VStack(alignment: .leading, spacing: 4) {
+                Text("Send Notifications")
+                  .font(AppTypography.body(15, weight: .bold))
+                Text(shouldNotify ? "Checked rows will notify. Unchecked rows save quietly." : "All notification-ready rows will save quietly.")
+                  .font(AppTypography.body(12, weight: .medium))
+                  .foregroundStyle(.secondary)
               }
             }
+            .tint(accent)
             .appFieldChrome(tint: accent, cornerRadius: 20)
+
+            ForEach(preview.sections) { section in
+              VStack(alignment: .leading, spacing: 10) {
+                Text(section.label)
+                  .font(AppTypography.body(16, weight: .bold))
+
+                ForEach(section.changes) { change in
+                  Toggle(
+                    isOn: Binding(
+                      get: { session.selectedPreviewChangeIDs.contains(change.id) },
+                      set: { session.updatePreviewSelection(change.id, selected: $0) }
+                    )
+                  ) {
+                    Text(change.text)
+                  }
+                  .tint(accent)
+                  .disabled(!shouldNotify)
+                  .opacity(shouldNotify ? 1 : 0.55)
+                }
+              }
+              .appFieldChrome(tint: accent, cornerRadius: 20)
+            }
+          }
+
+          if !currentSummary.selectedNotificationChanges.isEmpty {
+            categorySummaryCard(
+              title: "Changes To Send",
+              items: currentSummary.selectedNotificationChanges.map(\.displayText)
+            )
+          }
+
+          if !currentSummary.clearedNotificationChanges.isEmpty {
+            categorySummaryCard(
+              title: "Notification Rows To Save Without Notification",
+              items: currentSummary.clearedNotificationChanges.map(\.displayText)
+            )
+          }
+
+          if !currentSummary.saveOnlyChanges.isEmpty {
+            categorySummaryCard(
+              title: "Other Changes To Save",
+              items: currentSummary.saveOnlyChanges.map { $0.label.nilIfBlank ?? $0.message }
+            )
+          } else if !preview.hasNotificationChanges {
+            categorySummaryCard(
+              title: "Live Save",
+              items: ["The current category changes will be saved live without sending notifications."]
+            )
           }
         }
         .padding(24)
       }
-      .navigationTitle("Send Preview")
+      .navigationTitle("Save Preview")
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
           Button("Close") { dismiss() }
         }
         ToolbarItem(placement: .confirmationAction) {
-          Button(preview.hasNotificationChanges ? "Send Update" : "Save Changes", action: onPublish)
+          Button("Save") {
+            onPublish(shouldNotify && preview.hasNotificationChanges)
+          }
             .disabled(!session.canPublishRemotely)
         }
       }
     }
+  }
+
+  private func categorySummaryCard(title: String, items: [String]) -> some View {
+    VStack(alignment: .leading, spacing: 8) {
+      Text(title)
+        .font(AppTypography.body(15, weight: .bold))
+      ForEach(Array(items.enumerated()), id: \.offset) { _, item in
+        Text(item)
+          .font(AppTypography.body(13, weight: .medium))
+      }
+    }
+    .appFieldChrome(tint: accent, cornerRadius: 20)
   }
 }

--- a/ios/ElRoysManagerApp/Models/AppModels.swift
+++ b/ios/ElRoysManagerApp/Models/AppModels.swift
@@ -455,19 +455,12 @@ struct WorkspaceState: Codable, Equatable {
       SharedDraftInfo.self,
       forKey: .sharedDraft
     ) ?? SharedDraftInfo(exists: false, savedAt: nil, savedBy: nil, source: "")
-    let menuStatusPrimary = try container.decodeIfPresent(String.self, forKey: .menuStatus)
-    let menuStatusLegacy = try container.decodeIfPresent(String.self, forKey: .publishStatus)
-    let menuStatusFallback = try container.decodeIfPresent(String.self, forKey: .status)
-    let menuStatus = menuStatusPrimary ?? menuStatusLegacy ?? menuStatusFallback ?? ""
-    let unsentPrimary = try container.decodeIfPresent(Bool.self, forKey: .hasUnsentChanges)
-    let unsentLegacy = try container.decodeIfPresent(Bool.self, forKey: .hasPendingUpdate)
-    let unsentFallback = try container.decodeIfPresent(Bool.self, forKey: .hasNotificationQueue)
-    let hasUnsentChanges = unsentPrimary ?? unsentLegacy ?? unsentFallback
+    let hasUnsentChanges = false
     self.actor = try container.decodeIfPresent(ActorProfile.self, forKey: .actor)
     self.accessibleMenuIds = (try? container.decode([String].self, forKey: .accessibleMenuIds)) ?? []
     self.hasSharedDraft = try container.decodeIfPresent(Bool.self, forKey: .hasSharedDraft) ?? sharedDraft.exists
     self.sharedDraft = sharedDraft
-    self.menuStatus = menuStatus
+    self.menuStatus = sharedDraft.exists ? "Drafting" : "Live"
     self.hasUnsentChanges = hasUnsentChanges
     self.permissions = try container.decodeIfPresent(
       WorkspacePermissions.self,
@@ -1445,9 +1438,7 @@ struct MenuPreviewPayload: Codable, Equatable {
     self.hasChanges = try container.decodeBool(forKey: .hasChanges)
     self.hasLocalDraft = try container.decodeBool(forKey: .hasLocalDraft)
     let sharedDraftFallback = try container.decodeBool(forKey: .hasSharedDraft)
-    let unsentPrimary = try container.decodeIfPresent(Bool.self, forKey: .hasUnsentChanges)
-    let unsentFallback = try container.decodeIfPresent(Bool.self, forKey: .hasPendingUpdate)
-    self.hasUnsentChanges = unsentPrimary ?? unsentFallback ?? sharedDraftFallback
+    self.hasUnsentChanges = false
     self.hasSharedDraft = sharedDraftFallback
     self.hasNotificationChanges = try container.decodeBool(forKey: .hasNotificationChanges)
     self.hasSaveOnlyChanges = try container.decodeBool(forKey: .hasSaveOnlyChanges)
@@ -1460,11 +1451,7 @@ struct MenuPreviewPayload: Codable, Equatable {
     self.selectionDefaults = try container.decodeArray([String].self, forKey: .selectionDefaults)
     self.metadata = try container.decodeIfPresent(PreviewMetadata.self, forKey: .metadata)
       ?? PreviewMetadata(serverOwned: false, contract: "", currentFeaturedIds: [])
-    let decodedStatus = try container.decodeIfPresent(String.self, forKey: .menuStatus)?
-      .trimmingCharacters(in: .whitespacesAndNewlines)
-    self.menuStatus = (decodedStatus?.isEmpty == false)
-      ? (decodedStatus ?? "")
-      : (self.hasUnsentChanges ? "Live | Unsent" : "Live")
+    self.menuStatus = self.hasLocalDraft || self.hasSharedDraft ? "Drafting" : "Live"
   }
 
   func encode(to encoder: Encoder) throws {
@@ -1561,9 +1548,7 @@ struct SnapshotPreviewContext: Codable, Equatable {
     let container = try decoder.container(keyedBy: CodingKeys.self)
     let hasSharedDraft = try container.decodeBool(forKey: .hasSharedDraft)
     self.dirty = try container.decodeBool(forKey: .dirty)
-    let unsentPrimary = try container.decodeIfPresent(Bool.self, forKey: .hasUnsentChanges)
-    let unsentFallback = try container.decodeIfPresent(Bool.self, forKey: .hasPendingUpdate)
-    self.hasUnsentChanges = unsentPrimary ?? unsentFallback ?? hasSharedDraft
+    self.hasUnsentChanges = false
     self.hasSharedDraft = hasSharedDraft
     self.saveOnlyChanges = try container.decodeArray([SaveOnlyChange].self, forKey: .saveOnlyChanges)
   }

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -1780,7 +1780,7 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(liveSaveClient.lastExpectedDraftRevision, 22)
     XCTAssertEqual(model.currentEditorWorkspace?.workspace.revisions.liveRevision, 44)
     XCTAssertNil(offlineStore.draft)
-    XCTAssertEqual(model.notice?.title, "Saved Quietly")
+    XCTAssertEqual(model.notice?.title, "Saved")
   }
 
   @MainActor

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -1071,8 +1071,8 @@ final class MenuDocumentTests: XCTestCase {
         }
       },
       "workspace": {
-        "menu_status": "Live | Unsent",
-        "has_unsent_changes": true,
+        "menu_status": "Live",
+        "has_unsent_changes": false,
         "accessible_menu_ids": ["menu"],
         "shared_draft": { "exists": false },
         "permissions": { "can_manage": true },
@@ -1091,8 +1091,8 @@ final class MenuDocumentTests: XCTestCase {
 
     let payload = try JSONDecoder.backend.decode(MenuWorkspacePayload.self, from: data)
 
-    XCTAssertEqual(payload.workspace.menuStatus, "Live | Unsent")
-    XCTAssertEqual(payload.workspace.hasUnsentChanges, true)
+    XCTAssertEqual(payload.workspace.menuStatus, "Live")
+    XCTAssertEqual(payload.workspace.hasUnsentChanges, false)
     XCTAssertEqual(payload.workspace.revisions.liveRevision, 200)
     XCTAssertEqual(payload.workspace.revisions.notificationBaselineRevision, 150)
   }
@@ -1527,8 +1527,8 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(payload.selectedChangeIds, ["beer::added::ipa"])
     XCTAssertEqual(payload.preview?.metadata.contract, "menu-publish-preview.v1")
     XCTAssertEqual(payload.preview?.metadata.currentFeaturedIds, ["item-1"])
-    XCTAssertEqual(payload.preview?.menuStatus, "Live | Unsent")
-    XCTAssertEqual(payload.preview?.hasUnsentChanges, true)
+    XCTAssertEqual(payload.preview?.menuStatus, "Drafting")
+    XCTAssertEqual(payload.preview?.hasUnsentChanges, false)
     XCTAssertEqual(payload.preview?.diff.first?.displayOrder, 0)
   }
 
@@ -1693,7 +1693,7 @@ final class MenuDocumentTests: XCTestCase {
   }
 
   @MainActor
-  func testSaveQuietlyRebaselinesAndKeepsQueueStateForLaterSend() async throws {
+  func testLiveSaveRebaselinesAndAdvancesQueueState() async throws {
     let offlineStore = TestOfflineDraftStore()
     let sessionStore = TestSessionStore()
     let baseWorkspace = makeWorkspace(categories: [
@@ -1784,7 +1784,7 @@ final class MenuDocumentTests: XCTestCase {
   }
 
   @MainActor
-  func testSaveQuietlyIgnoresStaleDraftRevisionWhenNoSharedDraftExists() async throws {
+  func testLiveSaveIgnoresStaleDraftRevisionWhenNoSharedDraftExists() async throws {
     let sessionStore = TestSessionStore()
     let workspace = makeWorkspace(
       categories: [
@@ -1860,7 +1860,7 @@ final class MenuDocumentTests: XCTestCase {
     beer.name = "House Pilsner"
     model.upsertItem(beer, categoryKey: "beer", originalCategoryKey: "beer")
 
-    XCTAssertTrue(model.canSaveQuietlyRemotely)
+    XCTAssertTrue(model.canSaveLiveRemotely)
 
     await model.saveLiveMenu()
 
@@ -1870,7 +1870,7 @@ final class MenuDocumentTests: XCTestCase {
   }
 
   @MainActor
-  func testSaveQuietlyRefreshesLocalLiveRevisionWhenServerOnlyReturnsTimestamp() async throws {
+  func testLiveSaveRefreshesLocalLiveRevisionWhenServerOnlyReturnsTimestamp() async throws {
     let sessionStore = TestSessionStore()
     let initialWorkspace = makeWorkspace(
       categories: [
@@ -1912,8 +1912,8 @@ final class MenuDocumentTests: XCTestCase {
         lastSentRevision: 10,
         notificationBaselineRevision: 10
       ),
-      menuStatus: "Live | Unsent",
-      hasUnsentChanges: true
+      menuStatus: "Live",
+      hasUnsentChanges: false
     )
     let liveSaveClient = StubLiveSaveClient(
       response: PublishResponse(
@@ -2116,7 +2116,7 @@ final class MenuDocumentTests: XCTestCase {
   }
 
   @MainActor
-  func testLiveUnsentStatusEnablesSendWithoutLocalDraft() async throws {
+  func testLiveStatusDoesNotEnableSendWithoutLocalDraft() async throws {
     let workspace = makeWorkspace(
       categories: [
         MenuCategoryPayload(
@@ -2138,8 +2138,8 @@ final class MenuDocumentTests: XCTestCase {
         lastSentRevision: 20,
         notificationBaselineRevision: 20
       ),
-      menuStatus: "Live | Unsent",
-      hasUnsentChanges: true
+      menuStatus: "Live",
+      hasUnsentChanges: false
     )
     let model = AppModel(
       environment: AppEnvironment(
@@ -2161,14 +2161,14 @@ final class MenuDocumentTests: XCTestCase {
 
     XCTAssertFalse(model.hasLocalDraftChanges)
     XCTAssertFalse(model.hasLiveMenuChanges)
-    XCTAssertTrue(model.hasServerUnsentChanges)
-    XCTAssertEqual(model.menuStatusLabel, "Live | Unsent")
-    XCTAssertTrue(model.canLoadPublishPreview)
-    XCTAssertFalse(model.canSaveQuietlyRemotely)
+    XCTAssertFalse(model.hasServerUnsentChanges)
+    XCTAssertEqual(model.menuStatusLabel, "Live")
+    XCTAssertFalse(model.canLoadPublishPreview)
+    XCTAssertFalse(model.canSaveLiveRemotely)
   }
 
   @MainActor
-  func testSendOnlyPublishRebaselinesStatusWithoutDependingOnImmediateReload() async throws {
+  func testLiveMenuWithoutDraftDoesNotPublishSendOnlyChanges() async throws {
     let notificationChangeIDs = ["beer::added::ipa"]
     let initialWorkspace = makeWorkspace(
       categories: [
@@ -2191,8 +2191,8 @@ final class MenuDocumentTests: XCTestCase {
         lastSentRevision: 20,
         notificationBaselineRevision: 20
       ),
-      menuStatus: "Live | Unsent",
-      hasUnsentChanges: true
+      menuStatus: "Live",
+      hasUnsentChanges: false
     )
     let publishClient = StubPublishClient(
       previewResponse: PublishResponse(
@@ -2261,20 +2261,131 @@ final class MenuDocumentTests: XCTestCase {
     await model.loadEditor(menuId: "menu")
     await model.loadPublishPreview()
 
-    XCTAssertTrue(model.hasServerUnsentChanges)
-    XCTAssertEqual(model.menuStatusLabel, "Live | Unsent")
+    XCTAssertFalse(model.hasServerUnsentChanges)
+    XCTAssertEqual(model.menuStatusLabel, "Live")
 
     await model.publishSelectedChanges()
 
-    XCTAssertEqual(publishClient.publishCallCount, 1)
-    XCTAssertEqual(publishClient.lastPublishExpectedLiveRevision, 30)
-    XCTAssertEqual(publishClient.lastPublishExpectedNotificationRevision, 20)
+    XCTAssertEqual(publishClient.publishCallCount, 0)
+    XCTAssertNil(publishClient.lastPublishExpectedLiveRevision)
+    XCTAssertNil(publishClient.lastPublishExpectedNotificationRevision)
     XCTAssertFalse(model.hasServerUnsentChanges)
     XCTAssertEqual(model.menuStatusLabel, "Live")
     XCTAssertNil(model.currentEditorPreview)
     XCTAssertTrue(model.selectedPreviewChangeIDs.isEmpty)
     XCTAssertFalse(model.canLoadPublishPreview)
-    XCTAssertEqual(model.notice?.message, "Sent successfully.")
+    XCTAssertNil(model.notice?.message)
+  }
+
+  @MainActor
+  func testPublishWithNotificationsDisabledSavesAndClearsWithoutSelectedRows() async throws {
+    let notificationChangeIDs = ["beer::added::ipa"]
+    let initialWorkspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      revisions: WorkspaceRevisions(
+        liveRevision: 30,
+        draftRevision: nil,
+        lastSentRevision: 20,
+        notificationBaselineRevision: 20
+      ),
+      menuStatus: "Live",
+      hasUnsentChanges: false
+    )
+    let publishClient = StubPublishClient(
+      previewResponse: PublishResponse(
+        ok: true,
+        action: "preview",
+        ts: nil,
+        preview: try makePreviewPayload(
+          mode: "send",
+          selectionDefaults: notificationChangeIDs,
+          notificationChangeIDs: notificationChangeIDs
+        ),
+        currentRevisions: WorkspaceRevisions(
+          liveRevision: 30,
+          draftRevision: nil,
+          lastSentRevision: 20,
+          notificationBaselineRevision: 20
+        ),
+        notificationStatus: nil,
+        warnings: nil,
+        warningMessage: nil,
+        successMessage: nil,
+        selectedChangeIds: nil
+      ),
+      publishResponse: PublishResponse(
+        ok: true,
+        action: "publish",
+        ts: 40,
+        preview: nil,
+        currentRevisions: WorkspaceRevisions(
+          liveRevision: 30,
+          draftRevision: nil,
+          lastSentRevision: 40,
+          notificationBaselineRevision: 40
+        ),
+        notificationStatus: NotificationStatus(
+          ok: true,
+          skipped: true,
+          partial: false,
+          statusCode: nil,
+          summary: nil,
+          results: nil
+        ),
+        warnings: nil,
+        warningMessage: nil,
+        successMessage: nil,
+        selectedChangeIds: []
+      )
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [initialWorkspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload()),
+        publishClient: publishClient
+      ),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+    guard var beer = model.currentEditorDocument?.itemRecord(for: "item-1")?.item else {
+      XCTFail("Expected seeded item")
+      return
+    }
+    beer.name = "House Pilsner"
+    model.upsertItem(beer, categoryKey: "beer", originalCategoryKey: "beer")
+    await model.loadPublishPreview()
+
+    XCTAssertEqual(model.selectedPreviewChangeIDs, Set(notificationChangeIDs))
+
+    await model.publishSelectedChanges(shouldNotify: false)
+
+    XCTAssertEqual(publishClient.publishCallCount, 1)
+    XCTAssertEqual(publishClient.lastPublishSelectedChangeIds, [])
+    XCTAssertFalse(model.hasServerUnsentChanges)
+    XCTAssertEqual(model.menuStatusLabel, "Live")
+    XCTAssertEqual(model.notice?.title, "Saved")
   }
 
   @MainActor
@@ -3385,6 +3496,7 @@ private final class StubPublishClient: PublishClienting {
   private(set) var lastPublishExpectedLiveRevision: Int?
   private(set) var lastPublishExpectedDraftRevision: Int?
   private(set) var lastPublishExpectedNotificationRevision: Int?
+  private(set) var lastPublishSelectedChangeIds: [String]?
 
   init(previewResponse: PublishResponse? = nil, publishResponse: PublishResponse? = nil) {
     self.previewResponse = previewResponse
@@ -3406,6 +3518,7 @@ private final class StubPublishClient: PublishClienting {
   func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
     publishCallCount += 1
     lastPublishSnapshot = snapshot
+    lastPublishSelectedChangeIds = selectedChangeIds
     lastPublishExpectedLiveRevision = expectedLiveRevision
     lastPublishExpectedDraftRevision = expectedDraftRevision
     lastPublishExpectedNotificationRevision = expectedNotificationRevision

--- a/manager/index.html
+++ b/manager/index.html
@@ -363,7 +363,6 @@
       <div class="manager-shell-actionbar-groups">
         <div class="btn-row manager-shell-actionbar-primary" id="manager-primary-action-group">
           <button class="save-btn" id="save-btn" onclick="openPreview()" title="Review and save menu changes">Save</button>
-          <button class="send-btn" id="send-btn" onclick="openPreview()" title="Compatibility action for review and save" hidden aria-hidden="true" tabindex="-1">Save</button>
           <button class="btn-small" id="discard-draft-btn" onclick="discardLocalDraft()" hidden>Discard Draft</button>
         </div>
       </div>

--- a/manager/index.html
+++ b/manager/index.html
@@ -154,8 +154,8 @@
             <div class="manager-shell-overview-hero manager-dossier-hero">
               <div class="manager-shell-overview-hero-copy">
                 <p class="manager-shell-overview-hero-kicker">Where to start</p>
-                <h3>Draft it. Polish it. Send it live.</h3>
-                <p class="manager-shell-overview-hero-text">Every edit sits as a draft until you hit the dock. Jump into a record, make your passes, come back here to publish.</p>
+                <h3>Draft it. Polish it. Save it live.</h3>
+                <p class="manager-shell-overview-hero-text">Every edit sits as a draft until you hit the dock. Jump into a record, make your passes, come back here to review and save.</p>
               </div>
               <div class="manager-shell-overview-hero-actions" role="group" aria-label="Quick manager actions">
                 <button type="button" class="btn-small manager-shell-overview-chip" onclick="focusSettingsSection('manager-items-section')">Edit Items</button>
@@ -169,7 +169,7 @@
               <article class="manager-shell-stat-card">
                 <p class="manager-shell-stat-label">Menu Status</p>
                 <strong class="manager-shell-stat-value" id="manager-overview-status-value">Live</strong>
-                <span class="manager-shell-stat-meta" id="manager-overview-status-meta">No unsent changes</span>
+                <span class="manager-shell-stat-meta" id="manager-overview-status-meta">Live menu is current</span>
               </article>
               <article class="manager-shell-stat-card">
                 <p class="manager-shell-stat-label">Active Items</p>
@@ -214,7 +214,7 @@
                 <h2>Shape tonight's lineup.</h2>
               </div>
               <div class="manager-shell-section-actions">
-                <p class="manager-shell-section-copy">Swipe left to 86, right to bring it back. Nothing hits the floor until you send from the dock.</p>
+                <p class="manager-shell-section-copy">Swipe left to 86, right to bring it back. Review and save changes from the dock.</p>
                 <button type="button" class="btn-small manager-add-item-launch" id="manager-add-item-btn" onclick="openAddItemModal({ mode: 'manual' })" style="display:none">Add Item(s)</button>
               </div>
             </div>
@@ -341,8 +341,8 @@
         <footer class="manager-shell-footer manager-dossier-footer">
           <div class="manager-shell-footer-copy manager-dossier-footer-panel">
             <p class="manager-shell-footer-kicker">Behind the Pass</p>
-            <h3>Drafts stay here. Service sees the send.</h3>
-            <p class="manager-shell-footer-note">Publish from the dock whenever the line is ready.</p>
+            <h3>Drafts stay here until you save.</h3>
+            <p class="manager-shell-footer-note">Review and save from the dock whenever the line is ready.</p>
           </div>
           <div class="manager-shell-footer-meta manager-dossier-footer-panel">
             <div class="manager-shell-footer-pills manager-dossier-footer-pills">
@@ -362,8 +362,8 @@
       </div>
       <div class="manager-shell-actionbar-groups">
         <div class="btn-row manager-shell-actionbar-primary" id="manager-primary-action-group">
-          <button class="save-btn" id="save-btn" onclick="saveMenu()" title="Save changes without notifying anyone">Save Quietly</button>
-          <button class="send-btn" id="send-btn" onclick="openPreview()" title="Review changes before publishing them live">Save &amp; Send</button>
+          <button class="save-btn" id="save-btn" onclick="openPreview()" title="Review and save menu changes">Save</button>
+          <button class="send-btn" id="send-btn" onclick="openPreview()" title="Compatibility action for review and save" hidden aria-hidden="true" tabindex="-1">Save</button>
           <button class="btn-small" id="discard-draft-btn" onclick="discardLocalDraft()" hidden>Discard Draft</button>
         </div>
       </div>
@@ -377,13 +377,13 @@
 
 <div class="modal-bg" id="modal-bg" hidden aria-hidden="true">
   <div class="modal" role="dialog" aria-modal="true" aria-labelledby="modal-title">
-    <h2 id="modal-title">Send Preview</h2>
-    <div class="modal-sub" id="modal-subtitle">Review how these changes will save, send, or clear.</div>
+    <h2 id="modal-title">Save Preview</h2>
+    <div class="modal-sub" id="modal-subtitle">Review how these changes will save or clear.</div>
     <div id="preview-content"></div>
     <div class="modal-actions">
       <button class="btn-cancel" id="cancel-preview-btn" onclick="closeModal()">Cancel</button>
-      <button class="btn-secondary" id="save-menu-btn" onclick="sendUpdate({ notify: false })">Save Menu</button>
-      <button class="btn-confirm" id="save-send-btn" onclick="sendUpdate({ notify: true })">Save &amp; Send</button>
+      <button class="btn-secondary" id="save-menu-btn" onclick="sendUpdate({ notify: false })">Save</button>
+      <button class="btn-confirm" id="save-send-btn" onclick="sendUpdate()">Save</button>
     </div>
   </div>
 </div>

--- a/server/_menu-live.js
+++ b/server/_menu-live.js
@@ -255,19 +255,13 @@ async function upsertCategories(menuId, normalizedCategories, categoriesByKey) {
   };
   rows.push(uncategorizedSeed);
 
-  const payload = rows.map(row => {
-    const existing = categoriesByKey.get(row.key);
-    const resolvedId = existing?.id;
-    return resolvedId ? { ...row, id: resolvedId } : row;
-  });
-
   const response = await fetch(`${sbUrl}/rest/v1/categories?on_conflict=menu_id,key`, {
     method: 'POST',
     headers: serviceHeaders({
       'Content-Type': 'application/json',
       Prefer: 'resolution=merge-duplicates,return=minimal',
     }),
-    body: JSON.stringify(payload),
+    body: JSON.stringify(rows),
   });
   if (!response.ok) {
     const errorPayload = await readJsonSafe(response);

--- a/server/_menu-publish.js
+++ b/server/_menu-publish.js
@@ -65,6 +65,19 @@ function snapshotLastSentState(snapshot = {}) {
   ]));
 }
 
+function collectCurrentFeaturedIds(snapshot = {}) {
+  const cats = Array.isArray(snapshot?.cats) ? snapshot.cats : [];
+  return cats
+    .filter(category => isFeaturedSpecialsSectionKey(category?.key))
+    .flatMap(category => Array.isArray(category?.items) ? category.items : [])
+    .filter(item => (item?.featured_enabled === true || item?.featuredEnabled === true)
+      && item?.on_menu !== false
+      && item?.onMenu !== false
+      && item?.visibility !== 'off_menu')
+    .map(item => normalizePersistentItemId(item?.id))
+    .filter(Boolean);
+}
+
 function readSnapshotPreviewContext(snapshot = {}) {
   const context = snapshot?.preview_context && typeof snapshot.preview_context === 'object'
     ? snapshot.preview_context
@@ -323,6 +336,7 @@ async function buildCanonicalPreviewForMenu({
     metadata: {
       serverOwned: true,
       contract: PREVIEW_CONTRACT,
+      currentFeaturedIds: collectCurrentFeaturedIds(queueSnapshot),
       unsentItemIds: queueState.unsentItemIds,
       lastSentState: snapshotHasFeaturedSpecials
         ? snapshotLastSentState(queueSnapshot)

--- a/server/_menu-read.js
+++ b/server/_menu-read.js
@@ -436,16 +436,14 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
     ...draftMeta,
     last_sent_state: lastSentState,
   };
-  const unsentItemIds = Array.from(new Set(queueState.unsentItemIds));
-  const hasUnsentChanges = queueState.hasNotificationChanges;
-  const publishStatus = hasUnsentChanges ? 'live_unsent' : 'live';
+  const hasUnsentChanges = false;
+  const publishStatus = 'live';
   const liveRevision = bundle?.meta?.last_updated_ts || null;
   const draftRevision = bundle?.meta?.draft_saved_ts || null;
   const lastSentRevision = bundle?.meta?.last_sent_ts || null;
   const workspaceCapabilities = {
     canSaveDraft: canManage,
     canSaveLiveMenu: canManage,
-    canSaveQuietly: canManage,
     canPublishUpdates: canManage,
     canManageRestaurantSpecials: canEditRestaurantSpecials,
     canReadRestaurantTools: canEditRestaurantSpecials,
@@ -470,7 +468,7 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
       sharedDraft,
       publishState: {
         status: publishStatus,
-        statusLabel: hasUnsentChanges ? 'Live | Unsent' : 'Live',
+        statusLabel: 'Live',
         hasUnsentChanges,
         revisions: {
           liveRevision,
@@ -478,10 +476,10 @@ export function createMenuWorkspacePayload(bundle, { actor = null, restaurantToo
         },
         queue: {
           contract: 'menu-queue.v1',
-          unsentItemIds,
+          unsentItemIds: [],
           unsentFeaturedIds: [],
-          sections: queueState.diff,
-          selectableGroupIds: queueState.groups.map(group => group.id),
+          sections: [],
+          selectableGroupIds: [],
         },
       },
       permissions: {

--- a/tests/architecture-boundaries.test.cjs
+++ b/tests/architecture-boundaries.test.cjs
@@ -253,34 +253,16 @@ function installPublishFacadeStub(sandbox, overrides = {}) {
 
       if (shouldNotify && delivery.partial) {
         warnings.push(...sessionPorts.collectNotificationWarnings(delivery.summary));
-        warnings.push('Some channels did not receive the update. The lines remain ready to send again.');
-        return {
-          ok: true,
-          preview,
-          notificationStatus: delivery,
-          warnings: sessionPorts.dedupeWarnings(warnings),
-          warningMessage: sessionPorts.dedupeWarnings(warnings)[0] || '',
-          successMessage: `✅ ${sessionPorts.getMenuName() || 'Menu'} saved live. Update still needs attention.`,
-          snapshot: buildSnapshot('send-partial'),
-        };
+        warnings.push('Some channels did not receive the update. Changes were saved live without preserving a send queue.');
       }
 
       if (shouldNotify && !delivery.ok) {
         warnings.push(delivery.userMessage || 'Update could not be sent.');
-        return {
-          ok: true,
-          preview,
-          notificationStatus: delivery,
-          warnings: sessionPorts.dedupeWarnings(warnings),
-          warningMessage: sessionPorts.dedupeWarnings(warnings)[0] || '',
-          successMessage: `✅ ${sessionPorts.getMenuName() || 'Menu'} saved live. Update still needs to be sent.`,
-          snapshot: buildSnapshot('send-failed-live-saved'),
-        };
       }
 
       if (shouldNotify) warnings.push(...sessionPorts.collectNotificationWarnings(delivery.summary));
 
-      if (mode === 'save-and-send' || mode === 'send') {
+      {
         const ts = liveSaveTs || sessionPorts.now();
         const currentFeaturedIds = sessionPorts.getCurrentFeaturedIds();
         const restaurantId = sessionPorts.getRestaurantId();
@@ -314,7 +296,7 @@ function installPublishFacadeStub(sandbox, overrides = {}) {
         const cacheSynced = sessionPorts.syncLocalCache({ silent: true });
         if (!cacheSynced) warnings.push('This device could not refresh its local cache after the send.');
 
-        const logged = patchMessage
+        const logged = shouldNotify && patchMessage
           ? await sessionPorts.logUpdate(
             typeof sandbox.serializeNotificationSectionsForLog === 'function'
               ? sandbox.serializeNotificationSectionsForLog(selectedSections)
@@ -333,9 +315,11 @@ function installPublishFacadeStub(sandbox, overrides = {}) {
           notificationStatus: shouldNotify ? delivery : null,
           warnings: finalWarnings,
           warningMessage: finalWarnings[0] || '',
-          successMessage: shouldNotify
+          successMessage: shouldNotify && delivery.ok
             ? `✅ ${sessionPorts.getMenuName() || 'Menu'} saved and sent!`
-            : `✅ ${sessionPorts.getMenuName() || 'Menu'} update list cleared without notifying channels.`,
+            : (shouldNotify
+                ? `✅ ${sessionPorts.getMenuName() || 'Menu'} saved live. Notifications need attention.`
+                : `✅ ${sessionPorts.getMenuName() || 'Menu'} saved live without sending notifications.`),
           snapshot: buildSnapshot(finalWarnings.length ? 'publish-warning' : 'publish-complete'),
         };
       }
@@ -574,9 +558,9 @@ test('menu session lifecycle publishes updates through one preview-aware boundar
   assert.equal(result.ok, true);
   assert.equal(result.notificationStatus.statusCode, 207);
   assert.equal(result.preview, preview);
-  assert.equal(patchCalls.length, 0);
+  assert.ok(patchCalls.length > 0);
   assert.ok(result.warnings.some(message => message.includes('Some notification channels failed: SMS.')));
-  assert.ok(result.warnings.some(message => message.includes('remain ready to send again')));
+  assert.ok(result.warnings.some(message => message.includes('without preserving a send queue')));
 });
 
 test('menu session lifecycle can publish without firing notifications', async () => {
@@ -601,7 +585,7 @@ test('menu session lifecycle can publish without firing notifications', async ()
   assert.equal(result.notificationStatus, null);
   assert.equal(notificationCalls, 0);
   assert.equal(result.warnings.length, 0);
-  assert.match(result.successMessage, /saved to the live menu/i);
+  assert.match(result.successMessage, /saved live without sending notifications/i);
 });
 
 test('app runtime delegates preview and commit through the session publish facade', () => {
@@ -640,9 +624,9 @@ test('draft ledger service provides action-bar and item badge state through one 
   const actionBarState = service.getActionBarState({ isCompactViewport: false });
   assert.equal(actionBarState.hasDraftChanges, true);
   assert.equal(actionBarState.hasPendingUpdate, false);
-  assert.equal(actionBarState.saveLabel, 'Save Quietly');
-  assert.equal(actionBarState.publishLabel, 'Save & Send');
-  assert.equal(actionBarState.summaryText, '2 pending changes. Save Quietly writes live without sending. Save & Send reviews the queue before notifying.');
+  assert.equal(actionBarState.saveLabel, 'Save');
+  assert.equal(actionBarState.publishLabel, '');
+  assert.equal(actionBarState.summaryText, '2 pending changes. Save opens a review before anything goes live.');
 
   const draftBadge = service.getItemBadge({
     item: { id: 'item-1', name: 'Lager', eightySixed: false },
@@ -670,8 +654,8 @@ test('draft ledger service provides action-bar and item badge state through one 
     catId: 'beer',
     lastSentNames: new Set(['lager']),
   });
-  assert.equal(unsentBadge.text, 'UNSENT');
-  assert.equal(unsentBadge.className, 'item-state-badge--unsent');
+  assert.equal(unsentBadge.text, '');
+  assert.equal(unsentBadge.className, 'item-state-badge--active');
 });
 
 test('manager action bar stays visible and reflects idle and active draft states', () => {
@@ -700,7 +684,8 @@ test('manager action bar stays visible and reflects idle and active draft states
   assert.equal(saveBtn.disabled, true);
   assert.equal(saveBtn.textContent, 'Save');
   assert.equal(sendBtn.disabled, true);
-  assert.equal(sendBtn.textContent, 'Send');
+  assert.equal(sendBtn.textContent, 'Save');
+  assert.equal(sendBtn.hidden, true);
   assert.equal(bar.classList.contains('is-idle'), true);
 
   setState(sandbox, {
@@ -721,11 +706,12 @@ test('manager action bar stays visible and reflects idle and active draft states
 
   sandbox.updateManagerActionBar();
 
-  assert.equal(summary.textContent, '2 pending changes. Save Quietly writes live without sending. Save & Send reviews the queue before notifying.');
+  assert.equal(summary.textContent, '2 pending changes. Save reviews and saves your changes.');
   assert.equal(saveBtn.disabled, false);
-  assert.equal(saveBtn.textContent, 'Save Quietly');
-  assert.equal(sendBtn.disabled, false);
-  assert.equal(sendBtn.textContent, 'Save & Send');
+  assert.equal(saveBtn.textContent, 'Save');
+  assert.equal(sendBtn.disabled, true);
+  assert.equal(sendBtn.textContent, 'Save');
+  assert.equal(sendBtn.hidden, true);
   assert.equal(bar.classList.contains('is-idle'), false);
 
   setState(sandbox, {
@@ -746,11 +732,12 @@ test('manager action bar stays visible and reflects idle and active draft states
 
   sandbox.updateManagerActionBar();
 
-  assert.equal(summary.textContent, '1 update line is live and ready to send.');
-  assert.equal(saveBtn.disabled, true);
-  assert.equal(saveBtn.hidden, true);
-  assert.equal(sendBtn.disabled, false);
-  assert.equal(sendBtn.textContent, 'Send');
+  assert.equal(summary.textContent, '1 update line ready for review. Save opens the review before notifying.');
+  assert.equal(saveBtn.disabled, false);
+  assert.equal(saveBtn.hidden, false);
+  assert.equal(sendBtn.disabled, true);
+  assert.equal(sendBtn.textContent, 'Save');
+  assert.equal(sendBtn.hidden, true);
 });
 
 test('manager action bar reconciles stale dirty flags against the actual local draft state', () => {
@@ -775,7 +762,8 @@ test('manager action bar reconciles stale dirty flags against the actual local d
   assert.equal(saveBtn.disabled, true);
   assert.equal(saveBtn.textContent, 'Save');
   assert.equal(sendBtn.disabled, true);
-  assert.equal(sendBtn.textContent, 'Send');
+  assert.equal(sendBtn.textContent, 'Save');
+  assert.equal(sendBtn.hidden, true);
   assert.equal(bar.classList.contains('is-idle'), true);
   assert.equal(getState(sandbox, '_dirty'), false);
 });
@@ -855,7 +843,7 @@ test('save actions blur the focused editor before publishing workspace changes',
   await sandbox.saveMenu();
 
   assert.equal(blurred, true);
-  assert.deepEqual(requests.slice(0, 2), ['preview_publish', 'publish']);
+  assert.deepEqual(requests.slice(0, 2), ['preview_publish']);
 });
 
 test('save-only menu edits stay in the draft session until save', async () => {
@@ -891,7 +879,7 @@ test('save-only menu edits stay in the draft session until save', async () => {
   assert.equal(getState(sandbox, 'getDraftSaveOnlyChanges().length'), 1);
 });
 
-test('save draft routes a quiet live save through the publish boundary and leaves the queue unsent', async () => {
+test('save draft routes a quiet live save through the publish boundary and advances the baseline', async () => {
   const sandbox = loadAppSandbox();
   const requests = [];
   installPublishFacadeStub(sandbox);
@@ -941,10 +929,10 @@ test('save draft routes a quiet live save through the publish boundary and leave
   assert.ok(Array.isArray(requests[0][1].snapshot.cats));
   assert.equal(getState(sandbox, '_dirty'), false);
   assert.equal(getState(sandbox, 'hasSharedDraftState()'), false);
-  assert.equal(getState(sandbox, "buildMenuSessionSnapshot('test').status"), 'LIVE | UNSENT');
+  assert.equal(getState(sandbox, "buildMenuSessionSnapshot('test').status"), 'LIVE');
 });
 
-test('save menu quietly writes a local draft to live and leaves unsent changes behind', async () => {
+test('save menu quietly writes a local draft to live and advances the baseline', async () => {
   const sandbox = loadAppSandbox();
   const requests = [];
   installPublishFacadeStub(sandbox);
@@ -989,11 +977,11 @@ test('save menu quietly writes a local draft to live and leaves unsent changes b
   assert.equal(Object.prototype.hasOwnProperty.call(requests[0][1], 'selected_sections'), false);
   assert.equal(Object.prototype.hasOwnProperty.call(requests[0][1], 'patch_message'), false);
   assert.equal(getState(sandbox, '_hasSharedDraft'), false);
-  assert.equal(getState(sandbox, "buildMenuSessionSnapshot('after-save').status"), 'LIVE | UNSENT');
+  assert.equal(getState(sandbox, "buildMenuSessionSnapshot('after-save').status"), 'LIVE');
   assert.match(result.successMessage, /saved to the live menu/i);
 });
 
-test('manager item badges mark live unsent changes distinctly from drafts', () => {
+test('manager item badges do not mark live changes as unsent', () => {
   const sandbox = loadAppSandbox();
 
   setState(sandbox, {
@@ -1014,8 +1002,8 @@ test('manager item badges mark live unsent changes distinctly from drafts', () =
   });
 
   const badge = sandbox.getItemStateBadge({ id: 'item-1', name: 'Lager', eightySixed: false }, 'beer', new Set());
-  assert.equal(badge.text, 'UNSENT');
-  assert.equal(badge.className, 'item-state-badge--unsent');
+  assert.equal(badge.text, 'NEW');
+  assert.equal(badge.className, 'item-state-badge--new');
 });
 
 test('access session service restores sessions and resolves settings access', async () => {
@@ -1802,10 +1790,10 @@ test('manager user header no longer depends on a header return button', () => {
 test('manager shell header stays minimal and action-focused', () => {
   const managerHtml = fs.readFileSync(path.join(__dirname, '..', 'manager', 'index.html'), 'utf8');
 
-  assert.match(managerHtml, /Manager Workspace/);
-  assert.match(managerHtml, /id="switch-menu-btn"[\s\S]*Menu Switcher/);
+  assert.match(managerHtml, /Revision Dock/);
+  assert.match(managerHtml, /id="switch-menu-btn"[\s\S]*Switch Menu/);
   assert.match(managerHtml, /id="admin-btn"[\s\S]*Admin Console/);
-  assert.match(managerHtml, /manager-shell-legacy-hooks/);
+  assert.doesNotMatch(managerHtml, /manager-shell-legacy-hooks/);
   assert.doesNotMatch(managerHtml, /Current Menu Control Room/);
   assert.doesNotMatch(managerHtml, /manager-shell-header-summary/);
 });

--- a/tests/boundaries/menu-publish-workflow.boundary.test.cjs
+++ b/tests/boundaries/menu-publish-workflow.boundary.test.cjs
@@ -200,7 +200,7 @@ test('workflow execute advances queue baseline after successful send', async () 
   assert.ok(result.audit.loggedEvents.includes('send_notification'));
 });
 
-test('workflow preserves queue when notification delivery is partial', async () => {
+test('workflow advances queue baseline when notification delivery is partial', async () => {
   const patchCalls = [];
   const { createMenuPublishWorkflow } = await importWorkflow();
   const workflow = createMenuPublishWorkflow({
@@ -233,10 +233,13 @@ test('workflow preserves queue when notification delivery is partial', async () 
 
   assert.equal(result.ok, true);
   assert.equal(result.notification.partial, true);
-  assert.equal(result.queue.baselineAdvanced, false);
+  assert.equal(result.queue.baselineAdvanced, true);
   assert.ok(result.userOutcome.warnings.some(message => message.includes('failed')));
   assert.deepEqual(patchCalls[0].patch, {
     last_updated_ts: 1000,
+    last_sent_ts: 1000,
+    last_sent_state: DEFAULT_LAST_SENT_STATE,
+    last_sent_categories: ['beer'],
     draft_state: {},
     draft_saved_ts: null,
     draft_saved_by_user_id: null,
@@ -292,7 +295,7 @@ test('workflow send without selected sections does not claim it sent notificatio
 
   assert.equal(result.ok, true);
   assert.equal(result.notification.attempted, false);
-  assert.equal(result.userOutcome.successMessage, '✅ Main Menu send skipped.');
+  assert.equal(result.userOutcome.successMessage, '✅ Main Menu saved live without sending notifications.');
 });
 
 test('workflow forwards legacy selected sections into preview selection resolution', async () => {

--- a/tests/boundaries/publish.boundary.test.cjs
+++ b/tests/boundaries/publish.boundary.test.cjs
@@ -286,6 +286,39 @@ test('menu publish service honors an explicit global facade override for direct 
   assert.equal(calls[1].options.intent, 'save');
 });
 
+test('menu publish service prepares through the server preview port when no facade is loaded', async () => {
+  const sandbox = loadSandboxWithScripts(['core/session/publish-service.js']);
+  const previewCalls = [];
+  const service = sandbox.__HF_SESSION_MODULES__.createMenuPublishService(createMenuSessionPorts({
+    async requestPublishPreview(options = {}) {
+      previewCalls.push(options);
+      return {
+        ok: true,
+        status: 200,
+        payload: {
+          ok: true,
+          preview: {
+            hasChanges: true,
+            hasLocalDraft: true,
+            sections: [{ id: 'beer', changes: [] }],
+            notificationChanges: [{ id: 'beer::added::lager' }],
+          },
+          current_revisions: { live: 10 },
+        },
+      };
+    },
+  }), {});
+
+  const result = await service.prepare({ expectedLiveRevision: 10 });
+
+  assert.equal(result.ok, true);
+  assert.equal(result.status, 200);
+  assert.equal(result.current_revisions.live, 10);
+  assert.equal(result.preview.sections[0].id, 'beer');
+  assert.equal(previewCalls.length, 1);
+  assert.equal(previewCalls[0].expectedLiveRevision, 10);
+});
+
 test('menu publish service keeps fallback methods explicit for quiet-save and publish paths', async () => {
   const sandbox = loadSandboxWithScripts(['core/session/publish-service.js']);
   const quietSaveCalls = [];

--- a/tests/phase16-add-item-modal.test.cjs
+++ b/tests/phase16-add-item-modal.test.cjs
@@ -204,6 +204,38 @@ test('add item modal includes Featured Specials as a standard category option', 
   assert.equal(Array.from(options).slice(0, 2).join(','), 'featured_specials,cocktails');
 });
 
+test('adding a featured specials item hydrates the unified save action', () => {
+  const sandbox = loadAppSandbox();
+  setupManagerAddItemDom(sandbox);
+  seedManagerMenuState(sandbox, {
+    CATEGORY_DEFS: [
+      { id: 'featured_specials', title: 'Featured Specials', icon: '⭐', color: '', sub: '', placeholder: '', untappdEnabled: false },
+      { id: 'cocktails', title: 'Cocktails', icon: '🍹', color: '', sub: '', placeholder: '', untappdEnabled: false },
+    ],
+    menuState: {
+      featured_specials: { items: [], lastSent: [] },
+      cocktails: { items: [], lastSent: [] },
+      __uncategorized__: { items: [], lastSent: [] },
+    },
+  });
+  sandbox.setServerLiveSnapshot(sandbox.buildPersistedDraftStateSnapshot());
+
+  sandbox.openAddItemModal();
+  sandbox.updateAddItemModalField('name', 'Burger Special');
+  sandbox.updateAddItemModalField('categoryId', 'featured_specials');
+
+  const result = sandbox.confirmAddItemModal();
+  const actionState = sandbox.getMenuActionState();
+  const saveOnlyChanges = sandbox.getDraftSaveOnlyChanges();
+
+  assert.equal(result.ok, true);
+  assert.equal(saveOnlyChanges.length, 1);
+  assert.equal(saveOnlyChanges[0].sectionId, 'featured_specials');
+  assert.equal(actionState.saveLabel, 'Save');
+  assert.equal(actionState.saveDisabled, false);
+  assert.equal(actionState.showDiscard, true);
+});
+
 test('add item modal defaults to the first normal category before Featured Specials', () => {
   const sandbox = loadAppSandbox();
   setState(sandbox, {

--- a/tests/phase7-server-read-boundaries.test.cjs
+++ b/tests/phase7-server-read-boundaries.test.cjs
@@ -157,13 +157,13 @@ test('workspace payload preserves the live menu snapshot shape and adds staff co
   assert.equal(payload.workspace.revisions.notificationBaselineRevision, 1712705100000);
   assert.equal(payload.workspace.capabilities.includesDraftAuthorship, true);
   assert.equal(payload.workspace.capabilities.includesRestaurantTools, true);
-  assert.equal(payload.workspace.capabilities.canSaveQuietly, true);
+  assert.equal(payload.workspace.capabilities.canSaveLiveMenu, true);
   assert.equal(payload.restaurantTools.restaurantId, '00000000-0000-0000-0000-000000000010');
   assert.equal(payload.context.kind, 'menu-workspace');
   assert.equal(payload.compatibility.contract, 'menu-workspace.v4');
 });
 
-test('workspace payload projects server-owned Live | Unsent queue state from stable item IDs', async () => {
+test('workspace payload does not expose server-owned unsent queue state', async () => {
   const helper = await importApiModule('server/_menu-read.js');
   const payload = helper.createMenuWorkspacePayload({
     menu: {
@@ -188,16 +188,16 @@ test('workspace payload projects server-owned Live | Unsent queue state from sta
     actor: { id: 'user-1', name: 'Alex', role: 'manager', accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'] },
   });
 
-  assert.equal(payload.workspace.publishState.status, 'live_unsent');
-  assert.equal(payload.workspace.publishState.statusLabel, 'Live | Unsent');
-  assert.equal(payload.workspace.publishState.hasUnsentChanges, true);
+  assert.equal(payload.workspace.publishState.status, 'live');
+  assert.equal(payload.workspace.publishState.statusLabel, 'Live');
+  assert.equal(payload.workspace.publishState.hasUnsentChanges, false);
   assert.equal(payload.workspace.publishState.revisions.notificationRevision, 1712705100000);
-  assert.deepEqual(payload.workspace.publishState.queue.unsentItemIds, ['item-1']);
+  assert.deepEqual(payload.workspace.publishState.queue.unsentItemIds, []);
   assert.equal(payload.workspace.revisions.liveRevision, 1712705300000);
   assert.equal(payload.workspace.revisions.draftRevision, null);
   assert.equal(payload.workspace.revisions.lastSentRevision, 1712705100000);
   assert.equal(payload.workspace.revisions.notificationBaselineRevision, 1712705100000);
-  assert.ok(payload.workspace.publishState.queue.selectableGroupIds.some(groupId => groupId.includes('rename')));
+  assert.deepEqual(payload.workspace.publishState.queue.selectableGroupIds, []);
 });
 
 test('workspace payload treats legacy last_sent_featured as the featured_specials baseline during migration', async () => {
@@ -590,7 +590,7 @@ test('legacy featured objects prefer item_id over wrapper id during migration', 
   assert.deepEqual(queueState.unsentItemIds, []);
 });
 
-test('workspace payload keeps rename, 86, and restore queue lines for enabled featured_specials items', async () => {
+test('workspace payload hides rename, 86, and restore queue lines for enabled featured_specials items', async () => {
   const helper = await importApiModule('server/_menu-read.js');
   const payload = helper.createMenuWorkspacePayload({
     menu: {
@@ -629,27 +629,10 @@ test('workspace payload keeps rename, 86, and restore queue lines for enabled fe
     actor: { id: 'user-1', name: 'Alex', role: 'manager', accessibleMenuIds: ['00000000-0000-0000-0000-000000000020'] },
   });
 
-  assert.equal(payload.workspace.publishState.status, 'live_unsent');
-  assert.deepEqual(payload.workspace.publishState.queue.unsentItemIds, [
-    'special-rename',
-    'special-86',
-    'special-restore',
-    'special-hidden-eighty',
-  ]);
-  assert.deepEqual(payload.workspace.publishState.queue.sections, [{
-    id: 'featured_specials',
-    icon: '⭐',
-    label: 'Featured Specials',
-    displayOrder: 0,
-    added: ['Dormant Frozen Pour', 'After Party Marg'],
-    removed: ['Before Party Marg'],
-    eightySixed: ['Back Bar Deal'],
-    restored: ['Night Cap Shot'],
-  }]);
-  assert.ok(payload.workspace.publishState.queue.selectableGroupIds.some(groupId => groupId.includes('rename')));
-  assert.ok(payload.workspace.publishState.queue.selectableGroupIds.some(groupId => groupId.includes('eightySixed')));
-  assert.ok(payload.workspace.publishState.queue.selectableGroupIds.some(groupId => groupId.includes('restored')));
-  assert.ok(payload.workspace.publishState.queue.selectableGroupIds.some(groupId => groupId.includes('added')));
+  assert.equal(payload.workspace.publishState.status, 'live');
+  assert.deepEqual(payload.workspace.publishState.queue.unsentItemIds, []);
+  assert.deepEqual(payload.workspace.publishState.queue.sections, []);
+  assert.deepEqual(payload.workspace.publishState.queue.selectableGroupIds, []);
 });
 
 test('normal categories do not treat hidden eighty-sixed items as added queue lines', async () => {

--- a/tests/phase8-server-write-boundaries.test.cjs
+++ b/tests/phase8-server-write-boundaries.test.cjs
@@ -522,8 +522,9 @@ test('saveLiveMenuCommand resolves DB category ids and persists featured_enabled
   const categoryPayload = JSON.parse(categoryPersistCall.options.body);
   assert.equal(categoryPayload.length, 2);
   assert.equal(categoryPayload[0].key, 'featured_specials');
-  assert.equal(categoryPayload[0].id, 'category-uuid-1');
-  assert.notEqual(categoryPayload[0].id, 'featured_specials');
+  assert.equal(Object.prototype.hasOwnProperty.call(categoryPayload[0], 'id'), false);
+  assert.equal(Object.prototype.hasOwnProperty.call(categoryPayload[1], 'id'), false);
+  assert.deepEqual(Object.keys(categoryPayload[0]).sort(), Object.keys(categoryPayload[1]).sort());
 
   const itemPersistCall = fetchCalls.find(call => call.url.endsWith('/rest/v1/items'));
   assert.ok(itemPersistCall, 'expected item persistence request');

--- a/tests/phase9-publish-specials-boundaries.test.cjs
+++ b/tests/phase9-publish-specials-boundaries.test.cjs
@@ -123,6 +123,8 @@ test('server preview does not invent featured_specials diffs when legacy feature
     assert.equal(result.ok, true);
     assert.equal(result.preview.hasNotificationChanges, false);
     assert.deepEqual(result.preview.diff, []);
+    assert.equal(capturedPreview.metadata.currentFeaturedIds.length, 1);
+    assert.match(capturedPreview.metadata.currentFeaturedIds[0], /^[0-9a-f-]{36}$/i);
     assert.equal(capturedPreview.metadata.lastSentState.featured_specials.length, 1);
     assert.notEqual(capturedPreview.metadata.lastSentState.featured_specials[0].id, sharedItemId);
     assert.match(capturedPreview.metadata.lastSentState.featured_specials[0].id, /^[0-9a-f-]{36}$/i);


### PR DESCRIPTION
## Summary

This reworks the menu save/send flow into a single Save review path across the web manager and iOS manager app. The review modal/sheet now owns the notification decision, including the option to save notification-ready rows without sending.

## What Changed

- Replaced separate Save / Save & Send surface behavior with one Save entry point on web and iOS.
- Updated shared publish workflow handling so save operations advance the notification baseline instead of preserving a saved-but-unsent queue.
- Reduced menu status language to Drafting or Live and removed Live | Unsent behavior from shared payloads and clients.
- Added shared publish service compatibility and server command coverage for the new save/publish contract.
- Fixed follow-up web regressions where Featured Specials item additions did not hydrate Save, draft discard did not dehydrate Save, and the dock could show two Save buttons.
- Updated iOS wording and tests to align with the new no-queue model.
- Updated docs/FEATURES.md to describe the unified save review flow.

## Root Cause

The old flow split quiet saves, send previews, and persisted unsent state across separate client actions and server assumptions. Featured Specials also had category-owned behavior that could produce save-only changes without registering as draft work in the web action dock. This PR moves the user-facing decision back into one review step and makes the backend baseline behavior match that model.

## Impact

Staff now sees one Save path. Changes are either Drafting or Live, and choosing not to notify in the review step saves live without leaving a persistent unsent state. Web and iOS consume the same publish/preview contract, reducing future drift.

## Validation

- `node --check app.js`
- `node --check core/session/menu-publish-workflow.js`
- `node --check core/ui/manager/workspace.js`
- `node scripts/check-html-script-order.cjs`
- Focused Node boundary/regression tests: 102 passing after follow-up dock fixes
- Broader Node boundary suite: 111 passing during the main flow refactor
- iOS `MenuDocumentTests`: 62 passing in Release configuration on iPhone 16 simulator