### PR TITLE
Close launch readiness P1 gaps

### DIFF
--- a/404.html
+++ b/404.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Page Not Found | El Roy's Drink Menu</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body class="error-page">
+  <main class="error-shell">
+    <h1>Page Not Found</h1>
+    <p>Choose a menu from the landing page.</p>
+    <p><a href="/">Back to menus</a></p>
+  </main>
+</body>
+</html>

--- a/500.html
+++ b/500.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Service Unavailable | El Roy's Drink Menu</title>
+  <link rel="stylesheet" href="/style.css">
+</head>
+<body class="error-page">
+  <main class="error-shell">
+    <h1>Service Unavailable</h1>
+    <p>The menu service is having trouble. Please try again shortly.</p>
+    <p><a href="/">Back to menus</a></p>
+  </main>
+</body>
+</html>

--- a/admin/index.html
+++ b/admin/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex,nofollow">
 <title>Admin Console</title>
 <link rel="icon" type="image/png" href="/ELROYSTEMPLOGO.png">
 <link href="/api/public?action=font_css&amp;set=admin-shell" rel="stylesheet">

--- a/api/admin.js
+++ b/api/admin.js
@@ -51,7 +51,7 @@ export default async function handler(req, res) {
       }
     }
 
-    const body = parseRequestBody(req);
+    const body = await parseRequestBody(req);
     const action = readAction(req, body);
 
     switch (action) {

--- a/api/manager.js
+++ b/api/manager.js
@@ -22,8 +22,8 @@ import { lookupProductByBarcode } from '../server/_product-lookup.js';
 import { previewUntappdBeerImport, searchUntappdBeers } from '../server/_untappd.js';
 import { parseRequestBody, readAction } from '../server/_request.js';
 
-function parsePublishBody(req) {
-  const body = parseRequestBody(req);
+async function parsePublishBody(req) {
+  const body = await parseRequestBody(req);
   return {
     body,
     menuId: String(body?.menu_id || parseMenuId(req) || '').trim(),
@@ -35,7 +35,7 @@ export default async function handler(req, res) {
   if (req.method !== 'GET' && req.method !== 'POST') return res.status(405).end();
 
   try {
-    const body = req.method === 'POST' ? parseRequestBody(req) : null;
+    const body = req.method === 'POST' ? await parseRequestBody(req) : null;
     const action = readAction(req, body) || (req.method === 'GET' ? 'workspace' : '');
 
     if (req.method === 'GET') {
@@ -79,7 +79,7 @@ export default async function handler(req, res) {
       case 'save_quietly':
       case 'preview_publish':
       case 'publish': {
-        const { body: publishBody, menuId, action: bodyAction } = parsePublishBody(req);
+        const { body: publishBody, menuId, action: bodyAction } = await parsePublishBody(req);
         if (!menuId) return res.status(400).json({ error: 'Missing menu_id' });
         const hasLegacySelectedSections = Object.prototype.hasOwnProperty.call(publishBody || {}, 'selected_sections');
         const actor = await readAuthorizedMenuActor(req, menuId);

--- a/elroyscantina/index.html
+++ b/elroyscantina/index.html
@@ -6,6 +6,13 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
+    <meta name="description" content="View current food and drink menus for El Roy's Cantina." />
+    <link rel="canonical" href="https://el-roys-drink-menu.vercel.app/elroyscantina" />
+    <meta property="og:title" content="Current Menu | El Roy's Cantina" />
+    <meta property="og:description" content="See the current El Roy's Cantina food and drink menus." />
+    <meta property="og:type" content="website" />
+    <meta property="og:url" content="https://el-roys-drink-menu.vercel.app/elroyscantina" />
+    <meta name="twitter:card" content="summary" />
     <meta name="theme-color" content="#fcf6e8" />
 <title>Current Menu | El Roy's Cantina</title>
     <link rel="icon" type="image/png" href="/ELROYSTEMPLOGO.png" />

--- a/index.html
+++ b/index.html
@@ -3,6 +3,13 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="description" content="View current menus for Leroy's Lounge and El Roy's Cantina.">
+<link rel="canonical" href="https://el-roys-drink-menu.vercel.app/">
+<meta property="og:title" content="El Roy's Drink Menu">
+<meta property="og:description" content="Choose Leroy's Lounge or El Roy's Cantina to view current menus.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://el-roys-drink-menu.vercel.app/">
+<meta name="twitter:card" content="summary">
 <title>Leroy's Lounge &amp; El Roy's Cantina | Menus</title>
 <link rel="icon" type="image/png" href="/ELROYSTEMPLOGO.png">
     <link href="/api/public?action=font_css&amp;set=root" rel="stylesheet">

--- a/ios/ElRoysManagerApp/Storage/OfflineDraftStore.swift
+++ b/ios/ElRoysManagerApp/Storage/OfflineDraftStore.swift
@@ -28,8 +28,7 @@ final class OfflineDraftStore: OfflineDraftStoring {
     decoder.dateDecodingStrategy = .iso8601
     encoder.dateEncodingStrategy = .iso8601
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    try? fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true, attributes: nil)
-    try? Self.protectItem(at: rootURL, fileManager: fileManager)
+    try? Self.createProtectedDirectory(at: rootURL, fileManager: fileManager)
   }
 
   init(
@@ -43,8 +42,7 @@ final class OfflineDraftStore: OfflineDraftStoring {
     decoder.dateDecodingStrategy = .iso8601
     encoder.dateEncodingStrategy = .iso8601
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
-    try? fileManager.createDirectory(at: self.rootURL, withIntermediateDirectories: true, attributes: nil)
-    try? Self.protectItem(at: self.rootURL, fileManager: fileManager)
+    try? Self.createProtectedDirectory(at: self.rootURL, fileManager: fileManager)
   }
 
   func loadDraft(userId: String, menuId: String) throws -> LocalDraftEnvelope? {
@@ -115,6 +113,32 @@ final class OfflineDraftStore: OfflineDraftStoring {
       [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
       ofItemAtPath: url.path
     )
+  }
+
+  private static func createProtectedDirectory(at url: URL, fileManager: FileManager) throws {
+    let protectionAttributes: [FileAttributeKey: Any] = [
+      .protectionKey: FileProtectionType.completeUntilFirstUserAuthentication
+    ]
+    var missingDirectories: [URL] = []
+    var currentURL = url
+
+    while !fileManager.fileExists(atPath: currentURL.path) {
+      missingDirectories.append(currentURL)
+      let parentURL = currentURL.deletingLastPathComponent()
+      guard parentURL.path != currentURL.path else { break }
+      currentURL = parentURL
+    }
+
+    for directoryURL in missingDirectories.reversed() {
+      try fileManager.createDirectory(
+        at: directoryURL,
+        withIntermediateDirectories: false,
+        attributes: protectionAttributes
+      )
+      try protectItem(at: directoryURL, fileManager: fileManager)
+    }
+
+    try protectItem(at: url, fileManager: fileManager)
   }
 
   private static func resolveClientScopeId(

--- a/ios/ElRoysManagerApp/Storage/OfflineDraftStore.swift
+++ b/ios/ElRoysManagerApp/Storage/OfflineDraftStore.swift
@@ -29,6 +29,7 @@ final class OfflineDraftStore: OfflineDraftStoring {
     encoder.dateEncodingStrategy = .iso8601
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     try? fileManager.createDirectory(at: rootURL, withIntermediateDirectories: true, attributes: nil)
+    try? Self.protectItem(at: rootURL, fileManager: fileManager)
   }
 
   init(
@@ -43,6 +44,7 @@ final class OfflineDraftStore: OfflineDraftStoring {
     encoder.dateEncodingStrategy = .iso8601
     encoder.outputFormatting = [.prettyPrinted, .sortedKeys]
     try? fileManager.createDirectory(at: self.rootURL, withIntermediateDirectories: true, attributes: nil)
+    try? Self.protectItem(at: self.rootURL, fileManager: fileManager)
   }
 
   func loadDraft(userId: String, menuId: String) throws -> LocalDraftEnvelope? {
@@ -71,7 +73,9 @@ final class OfflineDraftStore: OfflineDraftStoring {
     var scoped = envelope
     scoped.clientScopeId = clientScopeId
     let data = try encoder.encode(scoped)
-    try data.write(to: draftURL(userId: scoped.userId, menuId: scoped.menuId, clientScopeId: clientScopeId), options: .atomic)
+    let fileURL = draftURL(userId: scoped.userId, menuId: scoped.menuId, clientScopeId: clientScopeId)
+    try data.write(to: fileURL, options: .atomic)
+    try Self.protectItem(at: fileURL)
     try? FileManager.default.removeItem(at: legacyDraftURL(userId: scoped.userId, menuId: scoped.menuId))
   }
 
@@ -104,6 +108,13 @@ final class OfflineDraftStore: OfflineDraftStoring {
 
   private func sanitize(_ value: String) -> String {
     value.replacingOccurrences(of: "/", with: "_")
+  }
+
+  private static func protectItem(at url: URL, fileManager: FileManager = .default) throws {
+    try fileManager.setAttributes(
+      [.protectionKey: FileProtectionType.completeUntilFirstUserAuthentication],
+      ofItemAtPath: url.path
+    )
   }
 
   private static func resolveClientScopeId(

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -874,6 +874,25 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertEqual(protection, .completeUntilFirstUserAuthentication)
   }
 
+  func testOfflineDraftStoreProtectsCreatedNestedDraftDirectories() throws {
+    let baseURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let rootURL = baseURL
+      .appendingPathComponent("nested", isDirectory: true)
+      .appendingPathComponent("drafts", isDirectory: true)
+    let fileManager = RecordingDirectoryProtectionFileManager(
+      existingPaths: [FileManager.default.temporaryDirectory.path]
+    )
+
+    _ = OfflineDraftStore(rootURL: rootURL, fileManager: fileManager, clientScopeId: "ios-phone")
+
+    let nestedURL = baseURL.appendingPathComponent("nested", isDirectory: true)
+    XCTAssertEqual(fileManager.createdDirectoryPaths, [baseURL.path, nestedURL.path, rootURL.path])
+    XCTAssertTrue(fileManager.protectedPaths.contains(baseURL.path))
+    XCTAssertTrue(fileManager.protectedPaths.contains(nestedURL.path))
+    XCTAssertTrue(fileManager.protectedPaths.contains(rootURL.path))
+  }
+
   func testCompactFeaturedItemProjectionDecodesWithDefaults() throws {
     let data = Data("""
     {
@@ -3333,6 +3352,43 @@ private enum TestError: LocalizedError {
     case .message(let value):
       return value
     }
+  }
+}
+
+private final class RecordingDirectoryProtectionFileManager: FileManager {
+  private var existingPaths: Set<String>
+  private(set) var createdDirectoryPaths: [String] = []
+  private(set) var protectedPaths: [String] = []
+
+  init(existingPaths: Set<String>) {
+    self.existingPaths = existingPaths
+    super.init()
+  }
+
+  override func fileExists(atPath path: String) -> Bool {
+    existingPaths.contains(path)
+  }
+
+  override func createDirectory(
+    at url: URL,
+    withIntermediateDirectories createIntermediates: Bool,
+    attributes: [FileAttributeKey: Any]? = nil
+  ) throws {
+    XCTAssertFalse(createIntermediates)
+    XCTAssertEqual(
+      attributes?[.protectionKey] as? FileProtectionType,
+      .completeUntilFirstUserAuthentication
+    )
+    existingPaths.insert(url.path)
+    createdDirectoryPaths.append(url.path)
+  }
+
+  override func setAttributes(_ attributes: [FileAttributeKey: Any], ofItemAtPath path: String) throws {
+    XCTAssertEqual(
+      attributes[.protectionKey] as? FileProtectionType,
+      .completeUntilFirstUserAuthentication
+    )
+    protectedPaths.append(path)
   }
 }
 

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -847,6 +847,33 @@ final class MenuDocumentTests: XCTestCase {
     XCTAssertNil(try tabletStore.loadDraft(userId: "staff-1", menuId: "menu-drinks"))
   }
 
+  func testOfflineDraftStoreProtectsSavedDraftFilesUntilFirstUnlock() throws {
+    let rootURL = FileManager.default.temporaryDirectory
+      .appendingPathComponent(UUID().uuidString, isDirectory: true)
+    let store = OfflineDraftStore(rootURL: rootURL, clientScopeId: "ios-phone")
+    let envelope = LocalDraftEnvelope(
+      userId: "staff-1",
+      menuId: "menu-drinks",
+      clientScopeId: "ios-phone",
+      restaurantId: "leroys-lounge",
+      menuName: "Drinks",
+      savedAt: Date(timeIntervalSince1970: 1234),
+      baseLiveRevision: 8,
+      baseDraftRevision: 9,
+      baseNotificationBaselineRevision: 7,
+      baseDocument: EditableMenuDocument(workspace: makeWorkspace()),
+      document: EditableMenuDocument(workspace: makeWorkspace())
+    )
+
+    try store.saveDraft(envelope)
+
+    let fileURL = rootURL.appendingPathComponent("staff-1__menu-drinks__ios-phone.json")
+    let protection = try fileURL
+      .resourceValues(forKeys: [.fileProtectionKey])
+      .fileProtection
+    XCTAssertEqual(protection, .completeUntilFirstUserAuthentication)
+  }
+
   func testCompactFeaturedItemProjectionDecodesWithDefaults() throws {
     let data = Data("""
     {

--- a/leroyslounge/index.html
+++ b/leroyslounge/index.html
@@ -3,6 +3,13 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover">
+<meta name="description" content="View current food and drink menus for Leroy's Lounge.">
+<link rel="canonical" href="https://el-roys-drink-menu.vercel.app/leroyslounge">
+<meta property="og:title" content="Current Menu | Leroy's Lounge">
+<meta property="og:description" content="See the current Leroy's Lounge food and drink menus.">
+<meta property="og:type" content="website">
+<meta property="og:url" content="https://el-roys-drink-menu.vercel.app/leroyslounge">
+<meta name="twitter:card" content="summary">
 <meta name="theme-color" content="#d30b0b">
 <title>Current Menu | Leroy's Lounge</title>
 <link rel="icon" type="image/png" href="/ELROYSTEMPLOGO.png">

--- a/manager/index.html
+++ b/manager/index.html
@@ -3,6 +3,7 @@
 <head>
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="robots" content="noindex,nofollow">
 <title>Manager Console</title>
 <link rel="icon" type="image/png" href="/ELROYSTEMPLOGO.png">
 <link href="/api/public?action=font_css&amp;set=manager-shell" rel="stylesheet">

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://el-roys-drink-menu.vercel.app/sitemap.xml

--- a/server/_auth-proxy.js
+++ b/server/_auth-proxy.js
@@ -188,7 +188,7 @@ export async function signInPreviewAuditUser(req) {
   if (!isPreviewRuntime()) {
     throw { status: 403, message: 'Preview audit session is only available on preview deployments.' };
   }
-  const body = parseRequestBody(req);
+  const body = await parseRequestBody(req);
   const requestedMode = normalizeAuditMode(body?.mode || readQueryValue(req, 'mode') || 'manager');
   const config = getLoopAuditConfig(requestedMode);
   if (!config.available) {
@@ -231,7 +231,7 @@ export async function signInPreviewAuditUser(req) {
 }
 
 export async function executeAuthAction(req) {
-  const body = parseRequestBody(req);
+  const body = await parseRequestBody(req);
   const action = readAction(req, body);
 
   switch (action) {

--- a/server/_fetch.js
+++ b/server/_fetch.js
@@ -2,29 +2,55 @@ async function fetchWithTimeout(url, options = {}, config = {}) {
   const timeoutMs = Number(config.timeoutMs || 8000);
   const fetchImpl = config.fetchImpl || fetch;
   const controller = new AbortController();
+  const callerSignal = options.signal;
   let timeoutId;
+  let timedOut = false;
+  let callerAbortHandler = null;
+
+  const timeoutError = () => new Error(`Request timed out after ${timeoutMs}ms`);
 
   const timeoutPromise = new Promise((_, reject) => {
     timeoutId = setTimeout(() => {
+      timedOut = true;
       controller.abort();
-      reject(new Error(`Request timed out after ${timeoutMs}ms`));
+      reject(timeoutError());
     }, timeoutMs);
   });
 
+  const callerAbortPromise = callerSignal ? new Promise((_, reject) => {
+    callerAbortHandler = () => {
+      if (!controller.signal.aborted) controller.abort(callerSignal.reason);
+      if (callerSignal.reason instanceof Error) reject(callerSignal.reason);
+      else {
+        const error = new Error('Request aborted');
+        error.name = 'AbortError';
+        reject(error);
+      }
+    };
+
+    if (callerSignal.aborted) callerAbortHandler();
+    else callerSignal.addEventListener('abort', callerAbortHandler, { once: true });
+  }) : null;
+
   const fetchPromise = fetchImpl(url, {
     ...options,
-    signal: options.signal || controller.signal,
+    signal: controller.signal,
   }).catch(error => {
-    if (error?.name === 'AbortError') {
-      throw new Error(`Request timed out after ${timeoutMs}ms`);
+    if (timedOut && error?.name === 'AbortError') {
+      throw timeoutError();
     }
     throw error;
   });
 
   try {
-    return await Promise.race([fetchPromise, timeoutPromise]);
+    return await Promise.race(
+      callerAbortPromise ? [fetchPromise, timeoutPromise, callerAbortPromise] : [fetchPromise, timeoutPromise]
+    );
   } finally {
     clearTimeout(timeoutId);
+    if (callerSignal && callerAbortHandler) {
+      callerSignal.removeEventListener('abort', callerAbortHandler);
+    }
   }
 }
 

--- a/server/_fetch.js
+++ b/server/_fetch.js
@@ -1,0 +1,31 @@
+async function fetchWithTimeout(url, options = {}, config = {}) {
+  const timeoutMs = Number(config.timeoutMs || 8000);
+  const fetchImpl = config.fetchImpl || fetch;
+  const controller = new AbortController();
+  let timeoutId;
+
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
+      controller.abort();
+      reject(new Error(`Request timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+  });
+
+  const fetchPromise = fetchImpl(url, {
+    ...options,
+    signal: options.signal || controller.signal,
+  }).catch(error => {
+    if (error?.name === 'AbortError') {
+      throw new Error(`Request timed out after ${timeoutMs}ms`);
+    }
+    throw error;
+  });
+
+  try {
+    return await Promise.race([fetchPromise, timeoutPromise]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+module.exports = { fetchWithTimeout };

--- a/server/_fetch.js
+++ b/server/_fetch.js
@@ -69,6 +69,39 @@ async function readStreamText(reader) {
   }
 }
 
+async function readStreamArrayBuffer(reader) {
+  const chunks = [];
+  let totalLength = 0;
+
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk?.done) break;
+      const value = chunk?.value;
+      if (value === undefined || value === null) continue;
+      const bytes = value instanceof Uint8Array
+        ? value
+        : new Uint8Array(value);
+      chunks.push(bytes);
+      totalLength += bytes.byteLength;
+    }
+  } finally {
+    try {
+      reader.releaseLock?.();
+    } catch (_) {
+      // Releasing can fail after cancellation; the reader has still been canceled.
+    }
+  }
+
+  const combined = new Uint8Array(totalLength);
+  let offset = 0;
+  chunks.forEach(chunk => {
+    combined.set(chunk, offset);
+    offset += chunk.byteLength;
+  });
+  return combined.buffer;
+}
+
 async function fetchWithTimeout(url, options = {}, config = {}) {
   const timeoutMs = Number(config.timeoutMs || 8000);
   const fetchImpl = config.fetchImpl || fetch;
@@ -166,8 +199,32 @@ async function readResponseJsonWithTimeout(response, config = {}) {
   );
 }
 
+function readResponseArrayBufferWithTimeout(response, config = {}) {
+  const reader = response?.body?.getReader?.();
+  if (reader) {
+    return runWithTimeout(
+      () => readStreamArrayBuffer(reader),
+      {
+        ...config,
+        label: config.label || 'Response body',
+        onTimeout: () => cancelReader(reader),
+      }
+    );
+  }
+
+  return runWithTimeout(
+    () => response.arrayBuffer(),
+    {
+      ...config,
+      label: config.label || 'Response body',
+      onTimeout: () => cancelResponseBody(response),
+    }
+  );
+}
+
 module.exports = {
   fetchWithTimeout,
+  readResponseArrayBufferWithTimeout,
   readResponseJsonWithTimeout,
   readResponseTextWithTimeout,
 };

--- a/server/_fetch.js
+++ b/server/_fetch.js
@@ -13,6 +13,17 @@ function cancelResponseBody(response) {
   }
 }
 
+function cancelReader(reader) {
+  try {
+    const cancelResult = reader?.cancel?.();
+    if (cancelResult && typeof cancelResult.catch === 'function') {
+      cancelResult.catch(() => {});
+    }
+  } catch (_) {
+    // Best-effort cleanup only; the timeout error is the user-facing result.
+  }
+}
+
 async function runWithTimeout(operation, config = {}) {
   const timeoutMs = Number(config.timeoutMs || 8000);
   const label = config.label || 'Request';
@@ -32,6 +43,29 @@ async function runWithTimeout(operation, config = {}) {
     ]);
   } finally {
     clearTimeout(timeoutId);
+  }
+}
+
+async function readStreamText(reader) {
+  const decoder = new TextDecoder();
+  let text = '';
+
+  try {
+    while (true) {
+      const chunk = await reader.read();
+      if (chunk?.done) break;
+      const value = chunk?.value;
+      if (typeof value === 'string') text += value;
+      else if (value !== undefined && value !== null) text += decoder.decode(value, { stream: true });
+    }
+    text += decoder.decode();
+    return text;
+  } finally {
+    try {
+      reader.releaseLock?.();
+    } catch (_) {
+      // Releasing can fail after cancellation; the reader has still been canceled.
+    }
   }
 }
 
@@ -94,6 +128,18 @@ async function fetchWithTimeout(url, options = {}, config = {}) {
 }
 
 function readResponseTextWithTimeout(response, config = {}) {
+  const reader = response?.body?.getReader?.();
+  if (reader) {
+    return runWithTimeout(
+      () => readStreamText(reader),
+      {
+        ...config,
+        label: config.label || 'Response body',
+        onTimeout: () => cancelReader(reader),
+      }
+    );
+  }
+
   return runWithTimeout(
     () => response.text(),
     {
@@ -104,7 +150,12 @@ function readResponseTextWithTimeout(response, config = {}) {
   );
 }
 
-function readResponseJsonWithTimeout(response, config = {}) {
+async function readResponseJsonWithTimeout(response, config = {}) {
+  if (response?.body?.getReader) {
+    const text = await readResponseTextWithTimeout(response, config);
+    return JSON.parse(text);
+  }
+
   return runWithTimeout(
     () => response.json(),
     {

--- a/server/_fetch.js
+++ b/server/_fetch.js
@@ -1,3 +1,40 @@
+function createTimeoutError(label, timeoutMs) {
+  return new Error(`${label} timed out after ${timeoutMs}ms`);
+}
+
+function cancelResponseBody(response) {
+  try {
+    const cancelResult = response?.body?.cancel?.();
+    if (cancelResult && typeof cancelResult.catch === 'function') {
+      cancelResult.catch(() => {});
+    }
+  } catch (_) {
+    // Best-effort cleanup only; the timeout error is the user-facing result.
+  }
+}
+
+async function runWithTimeout(operation, config = {}) {
+  const timeoutMs = Number(config.timeoutMs || 8000);
+  const label = config.label || 'Request';
+  let timeoutId;
+
+  const timeoutPromise = new Promise((_, reject) => {
+    timeoutId = setTimeout(() => {
+      if (typeof config.onTimeout === 'function') config.onTimeout();
+      reject(createTimeoutError(label, timeoutMs));
+    }, timeoutMs);
+  });
+
+  try {
+    return await Promise.race([
+      Promise.resolve().then(operation),
+      timeoutPromise,
+    ]);
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
 async function fetchWithTimeout(url, options = {}, config = {}) {
   const timeoutMs = Number(config.timeoutMs || 8000);
   const fetchImpl = config.fetchImpl || fetch;
@@ -7,7 +44,7 @@ async function fetchWithTimeout(url, options = {}, config = {}) {
   let timedOut = false;
   let callerAbortHandler = null;
 
-  const timeoutError = () => new Error(`Request timed out after ${timeoutMs}ms`);
+  const timeoutError = () => createTimeoutError('Request', timeoutMs);
 
   const timeoutPromise = new Promise((_, reject) => {
     timeoutId = setTimeout(() => {
@@ -32,17 +69,19 @@ async function fetchWithTimeout(url, options = {}, config = {}) {
     else callerSignal.addEventListener('abort', callerAbortHandler, { once: true });
   }) : null;
 
-  const fetchPromise = fetchImpl(url, {
-    ...options,
-    signal: controller.signal,
-  }).catch(error => {
-    if (timedOut && error?.name === 'AbortError') {
-      throw timeoutError();
-    }
-    throw error;
-  });
-
   try {
+    const fetchPromise = Promise.resolve()
+      .then(() => fetchImpl(url, {
+        ...options,
+        signal: controller.signal,
+      }))
+      .catch(error => {
+        if (timedOut && error?.name === 'AbortError') {
+          throw timeoutError();
+        }
+        throw error;
+      });
+
     return await Promise.race(
       callerAbortPromise ? [fetchPromise, timeoutPromise, callerAbortPromise] : [fetchPromise, timeoutPromise]
     );
@@ -54,4 +93,30 @@ async function fetchWithTimeout(url, options = {}, config = {}) {
   }
 }
 
-module.exports = { fetchWithTimeout };
+function readResponseTextWithTimeout(response, config = {}) {
+  return runWithTimeout(
+    () => response.text(),
+    {
+      ...config,
+      label: config.label || 'Response body',
+      onTimeout: () => cancelResponseBody(response),
+    }
+  );
+}
+
+function readResponseJsonWithTimeout(response, config = {}) {
+  return runWithTimeout(
+    () => response.json(),
+    {
+      ...config,
+      label: config.label || 'Response body',
+      onTimeout: () => cancelResponseBody(response),
+    }
+  );
+}
+
+module.exports = {
+  fetchWithTimeout,
+  readResponseJsonWithTimeout,
+  readResponseTextWithTimeout,
+};

--- a/server/_font-proxy.js
+++ b/server/_font-proxy.js
@@ -1,3 +1,9 @@
+import {
+  fetchWithTimeout,
+  readResponseArrayBufferWithTimeout,
+  readResponseTextWithTimeout,
+} from './_fetch.js';
+
 const GOOGLE_CSS_BASE = 'https://fonts.googleapis.com/css2';
 const FONTS_HOST = 'fonts.gstatic.com';
 
@@ -68,16 +74,16 @@ function assertAllowedFontUrl(rawUrl = '') {
 
 export async function proxyFontStylesheet({ set = '', font = '' } = {}) {
   const targetUrl = getFontCssUrl({ set, font });
-  const response = await fetch(targetUrl, {
+  const response = await fetchWithTimeout(targetUrl, {
     headers: {
       'user-agent': 'Mozilla/5.0 (compatible; ElRoysFontProxy/1.0)',
       accept: 'text/css,*/*;q=0.1',
     },
-  });
+  }, { timeoutMs: 8000 });
   if (!response.ok) {
     throw { status: response.status || 502, message: 'Failed to load font stylesheet' };
   }
-  const css = await response.text();
+  const css = await readResponseTextWithTimeout(response, { timeoutMs: 8000 });
   return {
     body: rewriteFontCss(css),
     contentType: response.headers.get('content-type') || 'text/css; charset=utf-8',
@@ -87,15 +93,15 @@ export async function proxyFontStylesheet({ set = '', font = '' } = {}) {
 
 export async function proxyFontFile(url = '') {
   const targetUrl = assertAllowedFontUrl(url);
-  const response = await fetch(targetUrl, {
+  const response = await fetchWithTimeout(targetUrl, {
     headers: {
       'user-agent': 'Mozilla/5.0 (compatible; ElRoysFontProxy/1.0)',
     },
-  });
+  }, { timeoutMs: 8000 });
   if (!response.ok) {
     throw { status: response.status || 502, message: 'Failed to load font file' };
   }
-  const arrayBuffer = await response.arrayBuffer();
+  const arrayBuffer = await readResponseArrayBufferWithTimeout(response, { timeoutMs: 8000 });
   return {
     body: Buffer.from(arrayBuffer),
     contentType: response.headers.get('content-type') || 'font/woff2',

--- a/server/_landing-import.js
+++ b/server/_landing-import.js
@@ -1,4 +1,5 @@
 import { isIP } from 'node:net';
+import { fetchWithTimeout } from './_fetch.js';
 
 function normalizeWhitespace(value = '') {
   return String(value || '').replace(/\s+/g, ' ').trim();
@@ -161,12 +162,12 @@ function pickJsonLdValue(nodes = [], typeName = '', getter = () => '') {
 }
 
 async function fetchRemoteHtml(url = '') {
-  const response = await fetch(url, {
+  const response = await fetchWithTimeout(url, {
     headers: {
       'user-agent': 'Mozilla/5.0 (compatible; ElRoysLandingImport/1.0; +https://el-roys-drink-menu.vercel.app)',
       'accept': 'text/html,application/xhtml+xml',
     },
-  });
+  }, { timeoutMs: 8000 });
   const html = await response.text();
   if (!response.ok) {
     throw new Error(`Remote source responded ${response.status}.`);

--- a/server/_landing-import.js
+++ b/server/_landing-import.js
@@ -1,5 +1,5 @@
 import { isIP } from 'node:net';
-import { fetchWithTimeout } from './_fetch.js';
+import { fetchWithTimeout, readResponseTextWithTimeout } from './_fetch.js';
 
 function normalizeWhitespace(value = '') {
   return String(value || '').replace(/\s+/g, ' ').trim();
@@ -168,7 +168,7 @@ async function fetchRemoteHtml(url = '') {
       'accept': 'text/html,application/xhtml+xml',
     },
   }, { timeoutMs: 8000 });
-  const html = await response.text();
+  const html = await readResponseTextWithTimeout(response, { timeoutMs: 8000 });
   if (!response.ok) {
     throw new Error(`Remote source responded ${response.status}.`);
   }

--- a/server/_notification-delivery.js
+++ b/server/_notification-delivery.js
@@ -1,4 +1,5 @@
 import { getSupabaseServerConfig, serviceHeaders } from './_supabase.js';
+import { fetchWithTimeout } from './_fetch.js';
 
 function summarizeNotificationResults(results = {}) {
   const entries = Object.entries(results || {}).filter(([channel]) => !!channel);
@@ -83,11 +84,11 @@ export async function deliverMenuNotification(menuId, safeText) {
   const gmBotId = envVal('groupme', 'env_key', 'GROUPME_BOT_ID');
   if (gmEnabled && gmBotId) {
     try {
-      const r = await fetch('https://api.groupme.com/v3/bots/post', {
+      const r = await fetchWithTimeout('https://api.groupme.com/v3/bots/post', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ bot_id: gmBotId, text: safeText }),
-      });
+      }, { timeoutMs: 5000 });
       results.groupme = (r.ok || r.status === 202) ? 'ok' : `error:${r.status}`;
     } catch (error) {
       results.groupme = `error:${error.message}`;
@@ -114,14 +115,14 @@ export async function deliverMenuNotification(menuId, safeText) {
       for (const to of toNums) {
         try {
           const body = new URLSearchParams({ From: fromNum, To: to, Body: safeText });
-          const r = await fetch(apiUrl, {
+          const r = await fetchWithTimeout(apiUrl, {
             method: 'POST',
             headers: {
               Authorization: `Basic ${basicAuth}`,
               'Content-Type': 'application/x-www-form-urlencoded',
             },
             body: body.toString(),
-          });
+          }, { timeoutMs: 5000 });
           if (!r.ok) errors.push(`${to}:${r.status}`);
         } catch (error) {
           errors.push(`${to}:${error.message}`);
@@ -137,11 +138,11 @@ export async function deliverMenuNotification(menuId, safeText) {
   const discWebhookUrl = envVal('discord', 'env_key', 'DISCORD_WEBHOOK_URL');
   if (discEnabled && discWebhookUrl) {
     try {
-      const r = await fetch(discWebhookUrl, {
+      const r = await fetchWithTimeout(discWebhookUrl, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ content: safeText }),
-      });
+      }, { timeoutMs: 5000 });
       results.discord = r.ok ? 'ok' : `error:${r.status}`;
     } catch (error) {
       results.discord = `error:${error.message}`;
@@ -157,11 +158,11 @@ export async function deliverMenuNotification(menuId, safeText) {
       const headers = { 'Content-Type': 'application/json' };
       const secret = envVal('webhook', 'env_key_secret', 'GENERIC_WEBHOOK_SECRET');
       if (secret) headers['X-Webhook-Secret'] = secret;
-      const r = await fetch(whUrl, {
+      const r = await fetchWithTimeout(whUrl, {
         method: 'POST',
         headers,
         body: JSON.stringify({ text: safeText, menu_id: menuId }),
-      });
+      }, { timeoutMs: 5000 });
       results.webhook = r.ok ? 'ok' : `error:${r.status}`;
     } catch (error) {
       results.webhook = `error:${error.message}`;

--- a/server/_product-lookup.js
+++ b/server/_product-lookup.js
@@ -1,3 +1,5 @@
+import { fetchWithTimeout } from './_fetch.js';
+
 function cleanText(value = '') {
   return String(value || '').replace(/\s+/g, ' ').trim();
 }
@@ -23,9 +25,10 @@ export async function lookupProductByBarcode(barcode = '') {
   const normalizedBarcode = cleanText(barcode).replace(/\s+/g, '');
   if (!normalizedBarcode) throw { status: 400, message: 'Enter a barcode first.' };
 
-  const response = await fetch(
+  const response = await fetchWithTimeout(
     `https://world.openfoodfacts.org/api/v2/product/${encodeURIComponent(normalizedBarcode)}.json?fields=product_name,product_name_en,generic_name,generic_name_en,ingredients_text,ingredients_text_en,brands,quantity,packaging,packaging_text,status`,
-    { headers: { Accept: 'application/json' } }
+    { headers: { Accept: 'application/json' } },
+    { timeoutMs: 8000 }
   );
   if (!response.ok) {
     throw { status: 502, message: 'Open Food Facts is unavailable right now.' };

--- a/server/_product-lookup.js
+++ b/server/_product-lookup.js
@@ -1,4 +1,4 @@
-import { fetchWithTimeout } from './_fetch.js';
+import { fetchWithTimeout, readResponseJsonWithTimeout } from './_fetch.js';
 
 function cleanText(value = '') {
   return String(value || '').replace(/\s+/g, ' ').trim();
@@ -34,7 +34,7 @@ export async function lookupProductByBarcode(barcode = '') {
     throw { status: 502, message: 'Open Food Facts is unavailable right now.' };
   }
 
-  const payload = await response.json().catch(() => null);
+  const payload = await readResponseJsonWithTimeout(response, { timeoutMs: 8000 }).catch(() => null);
   if (!payload || payload.status !== 1 || !payload.product) {
     throw { status: 404, message: 'No product was found for that barcode.' };
   }

--- a/server/_request.js
+++ b/server/_request.js
@@ -28,8 +28,13 @@ function readHeaderValue(headers, name) {
   return '';
 }
 
+function normalizeMaxBytes(value) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : 1024 * 1024;
+}
+
 export async function parseJsonBody(req, options = {}) {
-  const maxBytes = Number(options.maxBytes || 1024 * 1024);
+  const maxBytes = normalizeMaxBytes(options.maxBytes || 1024 * 1024);
   const contentType = String(readHeaderValue(req?.headers, 'content-type'));
   const text = await readRequestText(req, maxBytes);
   if (!text.trim()) return {};

--- a/server/_request.js
+++ b/server/_request.js
@@ -19,9 +19,18 @@ export async function readRequestText(req, maxBytes = 1024 * 1024) {
   return '';
 }
 
+function readHeaderValue(headers, name) {
+  if (!headers || typeof headers !== 'object') return '';
+  const target = String(name || '').toLowerCase();
+  for (const [key, value] of Object.entries(headers)) {
+    if (String(key).toLowerCase() === target) return value;
+  }
+  return '';
+}
+
 export async function parseJsonBody(req, options = {}) {
   const maxBytes = Number(options.maxBytes || 1024 * 1024);
-  const contentType = String(req?.headers?.['content-type'] || req?.headers?.['Content-Type'] || '');
+  const contentType = String(readHeaderValue(req?.headers, 'content-type'));
   const text = await readRequestText(req, maxBytes);
   if (!text.trim()) return {};
   if (!/^application\/json\b/i.test(contentType)) {

--- a/server/_request.js
+++ b/server/_request.js
@@ -1,3 +1,39 @@
+export async function readRequestText(req, maxBytes = 1024 * 1024) {
+  if (typeof req?.body === 'string') {
+    if (Buffer.byteLength(req.body) > maxBytes) throw new Error('Request body too large');
+    return req.body;
+  }
+
+  if (typeof req?.[Symbol.asyncIterator] === 'function') {
+    const chunks = [];
+    let total = 0;
+    for await (const chunk of req) {
+      const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
+      total += buffer.length;
+      if (total > maxBytes) throw new Error('Request body too large');
+      chunks.push(buffer);
+    }
+    return Buffer.concat(chunks).toString('utf8');
+  }
+
+  return '';
+}
+
+export async function parseJsonBody(req, options = {}) {
+  const maxBytes = Number(options.maxBytes || 1024 * 1024);
+  const contentType = String(req?.headers?.['content-type'] || req?.headers?.['Content-Type'] || '');
+  const text = await readRequestText(req, maxBytes);
+  if (!text.trim()) return {};
+  if (!/^application\/json\b/i.test(contentType)) {
+    throw new Error('Content-Type must be application/json');
+  }
+  try {
+    return JSON.parse(text);
+  } catch (_) {
+    throw new Error('Invalid JSON body');
+  }
+}
+
 export function parseRequestBody(req) {
   const incoming = req?.body;
   if (!incoming) return {};
@@ -32,3 +68,5 @@ export function readAction(req, body = null) {
   const value = fromBody || readQueryValue(req, 'action') || readQueryValue(req, 'mode') || '';
   return String(value || '').trim().toLowerCase();
 }
+
+export const getRequestUrl = readUrl;

--- a/server/_request.js
+++ b/server/_request.js
@@ -1,6 +1,6 @@
 export async function readRequestText(req, maxBytes = 1024 * 1024) {
   if (typeof req?.body === 'string') {
-    if (Buffer.byteLength(req.body) > maxBytes) throw new Error('Request body too large');
+    if (Buffer.byteLength(req.body) > maxBytes) throwRequestError(413, 'Request body too large');
     return req.body;
   }
 
@@ -10,7 +10,7 @@ export async function readRequestText(req, maxBytes = 1024 * 1024) {
     for await (const chunk of req) {
       const buffer = Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk);
       total += buffer.length;
-      if (total > maxBytes) throw new Error('Request body too large');
+      if (total > maxBytes) throwRequestError(413, 'Request body too large');
       chunks.push(buffer);
     }
     return Buffer.concat(chunks).toString('utf8');
@@ -33,33 +33,37 @@ function normalizeMaxBytes(value) {
   return Number.isFinite(parsed) && parsed > 0 ? parsed : 1024 * 1024;
 }
 
+function throwRequestError(status, message) {
+  const error = new Error(message);
+  error.status = status;
+  throw error;
+}
+
 export async function parseJsonBody(req, options = {}) {
+  if (req?.body && typeof req.body === 'object' && !Array.isArray(req.body) && !Buffer.isBuffer(req.body)) {
+    return req.body;
+  }
+
   const maxBytes = normalizeMaxBytes(options.maxBytes || 1024 * 1024);
   const contentType = String(readHeaderValue(req?.headers, 'content-type'));
   const text = await readRequestText(req, maxBytes);
   if (!text.trim()) return {};
   if (!/^application\/json\b/i.test(contentType)) {
-    throw new Error('Content-Type must be application/json');
+    throwRequestError(415, 'Content-Type must be application/json');
   }
   try {
     return JSON.parse(text);
   } catch (_) {
-    throw new Error('Invalid JSON body');
+    throwRequestError(400, 'Invalid JSON body');
   }
 }
 
-export function parseRequestBody(req) {
-  const incoming = req?.body;
-  if (!incoming) return {};
-  if (typeof incoming === 'string') {
-    try {
-      const parsed = JSON.parse(incoming);
-      return parsed && typeof parsed === 'object' ? parsed : {};
-    } catch (_) {
-      throw { status: 400, message: 'Invalid JSON body' };
-    }
+export async function parseRequestBody(req, options = {}) {
+  const parsed = await parseJsonBody(req, options);
+  if (req && (typeof req.body === 'string' || typeof req[Symbol.asyncIterator] === 'function')) {
+    req.body = parsed;
   }
-  return incoming && typeof incoming === 'object' ? incoming : {};
+  return parsed;
 }
 
 export function readUrl(req) {

--- a/server/_untappd.js
+++ b/server/_untappd.js
@@ -1,3 +1,5 @@
+import { fetchWithTimeout } from './_fetch.js';
+
 const UNTAPPD_BASE_URL = 'https://api.untappd.com/v4/';
 const SEARCH_LIMIT = 5;
 
@@ -140,12 +142,12 @@ function buildPreviewDescription(beer = {}) {
 }
 
 async function readUntappdJson(url, userAgent) {
-  const response = await fetch(url, {
+  const response = await fetchWithTimeout(url, {
     headers: {
       Accept: 'application/json',
       'User-Agent': userAgent,
     },
-  });
+  }, { timeoutMs: 8000 });
 
   if (!response.ok) {
     throw { status: 502, message: 'Untappd is unavailable right now.' };

--- a/server/_untappd.js
+++ b/server/_untappd.js
@@ -1,4 +1,4 @@
-import { fetchWithTimeout } from './_fetch.js';
+import { fetchWithTimeout, readResponseJsonWithTimeout } from './_fetch.js';
 
 const UNTAPPD_BASE_URL = 'https://api.untappd.com/v4/';
 const SEARCH_LIMIT = 5;
@@ -153,7 +153,7 @@ async function readUntappdJson(url, userAgent) {
     throw { status: 502, message: 'Untappd is unavailable right now.' };
   }
 
-  return response.json().catch(() => null);
+  return readResponseJsonWithTimeout(response, { timeoutMs: 8000 }).catch(() => null);
 }
 
 function mapSearchResults(payload = {}) {

--- a/sitemap.xml
+++ b/sitemap.xml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">
+  <url>
+    <loc>https://el-roys-drink-menu.vercel.app/</loc>
+  </url>
+  <url>
+    <loc>https://el-roys-drink-menu.vercel.app/leroyslounge</loc>
+  </url>
+  <url>
+    <loc>https://el-roys-drink-menu.vercel.app/elroyscantina</loc>
+  </url>
+</urlset>

--- a/tests/public-launch-surface.test.cjs
+++ b/tests/public-launch-surface.test.cjs
@@ -35,3 +35,19 @@ test('vercel config defines launch security headers', () => {
   assert.match(csp, /connect-src 'self' https:\/\/\*\.supabase\.co https:\/\/world\.openfoodfacts\.org https:\/\/api\.untappd\.com https:\/\/api\.groupme\.com https:\/\/api\.twilio\.com https:\/\/discord\.com https:\/\/discordapp\.com/);
   assert.match(csp, /form-action 'self'/);
 });
+
+test('public launch files exist', () => {
+  for (const file of ['robots.txt', 'sitemap.xml', '404.html', '500.html']) {
+    assert.ok(fs.existsSync(file), `${file} must exist before launch`);
+  }
+});
+
+test('public html shells include launch metadata', () => {
+  for (const file of ['index.html', 'leroyslounge/index.html', 'elroyscantina/index.html']) {
+    const html = fs.readFileSync(file, 'utf8');
+    assert.match(html, /<meta name="description"/, `${file} missing meta description`);
+    assert.match(html, /<link rel="canonical"/, `${file} missing canonical link`);
+    assert.match(html, /<meta property="og:title"/, `${file} missing Open Graph title`);
+    assert.match(html, /<meta name="twitter:card"/, `${file} missing Twitter card`);
+  }
+});

--- a/tests/public-launch-surface.test.cjs
+++ b/tests/public-launch-surface.test.cjs
@@ -1,0 +1,22 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+
+test('vercel config defines launch security headers', () => {
+  const config = JSON.parse(fs.readFileSync('vercel.json', 'utf8'));
+  assert.ok(Array.isArray(config.headers), 'vercel.json must define headers');
+  const headerNames = new Set(
+    config.headers.flatMap(entry => (entry.headers || []).map(header => header.key.toLowerCase()))
+  );
+
+  for (const required of [
+    'content-security-policy',
+    'strict-transport-security',
+    'x-content-type-options',
+    'referrer-policy',
+    'permissions-policy',
+    'x-frame-options',
+  ]) {
+    assert.ok(headerNames.has(required), `missing ${required}`);
+  }
+});

--- a/tests/public-launch-surface.test.cjs
+++ b/tests/public-launch-surface.test.cjs
@@ -5,18 +5,33 @@ const fs = require('node:fs');
 test('vercel config defines launch security headers', () => {
   const config = JSON.parse(fs.readFileSync('vercel.json', 'utf8'));
   assert.ok(Array.isArray(config.headers), 'vercel.json must define headers');
-  const headerNames = new Set(
-    config.headers.flatMap(entry => (entry.headers || []).map(header => header.key.toLowerCase()))
+  const launchEntry = config.headers.find(entry => entry.source === '/(.*)');
+  assert.ok(launchEntry, 'vercel.json must define catch-all launch headers');
+  assert.ok(Array.isArray(launchEntry.headers), 'catch-all launch headers must define headers');
+
+  const headers = new Map(
+    launchEntry.headers.map(header => [header.key.toLowerCase(), header.value])
   );
 
-  for (const required of [
-    'content-security-policy',
-    'strict-transport-security',
-    'x-content-type-options',
-    'referrer-policy',
-    'permissions-policy',
-    'x-frame-options',
-  ]) {
-    assert.ok(headerNames.has(required), `missing ${required}`);
-  }
+  assert.equal(
+    headers.get('strict-transport-security'),
+    'max-age=31536000; includeSubDomains; preload'
+  );
+  assert.equal(headers.get('x-content-type-options'), 'nosniff');
+  assert.equal(headers.get('referrer-policy'), 'strict-origin-when-cross-origin');
+  assert.equal(headers.get('permissions-policy'), 'camera=(self), microphone=(), geolocation=(), payment=()');
+  assert.equal(headers.get('x-frame-options'), 'DENY');
+
+  const csp = headers.get('content-security-policy');
+  assert.ok(csp, 'missing content-security-policy');
+  assert.match(csp, /default-src 'self'/);
+  assert.match(csp, /base-uri 'self'/);
+  assert.match(csp, /object-src 'none'/);
+  assert.match(csp, /frame-ancestors 'none'/);
+  assert.match(csp, /img-src 'self' data: https:/);
+  assert.match(csp, /font-src 'self' data:/);
+  assert.match(csp, /style-src 'self' 'unsafe-inline'/);
+  assert.match(csp, /script-src 'self' 'unsafe-inline'/);
+  assert.match(csp, /connect-src 'self' https:\/\/\*\.supabase\.co https:\/\/world\.openfoodfacts\.org https:\/\/api\.untappd\.com https:\/\/api\.groupme\.com https:\/\/api\.twilio\.com https:\/\/discord\.com https:\/\/discordapp\.com/);
+  assert.match(csp, /form-action 'self'/);
 });

--- a/tests/server-fetch-timeout.test.cjs
+++ b/tests/server-fetch-timeout.test.cjs
@@ -1,6 +1,13 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { fetchWithTimeout } = require('../server/_fetch.js');
+const {
+  fetchWithTimeout,
+  readResponseTextWithTimeout,
+} = require('../server/_fetch.js');
+
+function delay(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms));
+}
 
 test('fetchWithTimeout aborts hung requests', async () => {
   const started = Date.now();
@@ -65,4 +72,40 @@ test('fetchWithTimeout forwards caller aborts to the fetch signal', async () => 
   assert.ok(receivedSignal);
   assert.notEqual(receivedSignal, callerController.signal);
   assert.equal(receivedSignal.aborted, true);
+});
+
+test('fetchWithTimeout cleans up timeout when fetchImpl throws synchronously', async () => {
+  const unhandled = [];
+  const onUnhandled = reason => {
+    unhandled.push(reason);
+  };
+
+  process.on('unhandledRejection', onUnhandled);
+  try {
+    await assert.rejects(
+      () => fetchWithTimeout('https://example.test/sync-fail', {}, {
+        timeoutMs: 10,
+        fetchImpl: () => {
+          throw new Error('sync fetch failure');
+        },
+      }),
+      /sync fetch failure/
+    );
+
+    await delay(30);
+    assert.deepEqual(unhandled, []);
+  } finally {
+    process.removeListener('unhandledRejection', onUnhandled);
+  }
+});
+
+test('readResponseTextWithTimeout rejects when the body read stalls', async () => {
+  const response = {
+    text: () => new Promise(() => {}),
+  };
+
+  await assert.rejects(
+    () => readResponseTextWithTimeout(response, { timeoutMs: 10 }),
+    /timed out/
+  );
 });

--- a/tests/server-fetch-timeout.test.cjs
+++ b/tests/server-fetch-timeout.test.cjs
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const {
   fetchWithTimeout,
+  readResponseJsonWithTimeout,
   readResponseTextWithTimeout,
 } = require('../server/_fetch.js');
 
@@ -107,5 +108,62 @@ test('readResponseTextWithTimeout rejects when the body read stalls', async () =
   await assert.rejects(
     () => readResponseTextWithTimeout(response, { timeoutMs: 10 }),
     /timed out/
+  );
+});
+
+test('readResponseTextWithTimeout cancels the active stream reader on timeout', async () => {
+  let cancelCount = 0;
+  const response = {
+    body: {
+      getReader() {
+        return {
+          read: () => new Promise(() => {}),
+          cancel() {
+            cancelCount += 1;
+            return Promise.resolve();
+          },
+          releaseLock() {},
+        };
+      },
+    },
+    text() {
+      throw new Error('text fallback should not be used for streams');
+    },
+  };
+
+  await assert.rejects(
+    () => readResponseTextWithTimeout(response, { timeoutMs: 10 }),
+    /timed out/
+  );
+
+  assert.equal(cancelCount, 1);
+});
+
+test('readResponseJsonWithTimeout parses JSON through the timeout-bound text reader', async () => {
+  const encoder = new TextEncoder();
+  let reads = 0;
+  const response = {
+    body: {
+      getReader() {
+        return {
+          async read() {
+            reads += 1;
+            if (reads === 1) return { done: false, value: encoder.encode('{"ok":') };
+            if (reads === 2) return { done: false, value: encoder.encode('true}') };
+            return { done: true };
+          },
+          cancel() {},
+          releaseLock() {},
+        };
+      },
+    },
+    json() {
+      throw new Error('json fallback should not be used for streams');
+    },
+  };
+
+  assert.deepEqual(
+    await readResponseJsonWithTimeout(response, { timeoutMs: 100 }),
+    { ok: true }
   );
 });

--- a/tests/server-fetch-timeout.test.cjs
+++ b/tests/server-fetch-timeout.test.cjs
@@ -21,3 +21,48 @@ test('fetchWithTimeout clears timeout after success', async () => {
   });
   assert.equal(response.ok, true);
 });
+
+test('fetchWithTimeout aborts the fetch signal on timeout when caller supplied a signal', async () => {
+  const callerController = new AbortController();
+  let receivedSignal = null;
+
+  await assert.rejects(
+    () => fetchWithTimeout('https://example.invalid/hang', {
+      signal: callerController.signal,
+    }, {
+      timeoutMs: 10,
+      fetchImpl: (_url, options) => {
+        receivedSignal = options.signal;
+        return new Promise(() => {});
+      },
+    }),
+    /timed out/
+  );
+
+  assert.ok(receivedSignal);
+  assert.notEqual(receivedSignal, callerController.signal);
+  assert.equal(receivedSignal.aborted, true);
+  assert.equal(callerController.signal.aborted, false);
+});
+
+test('fetchWithTimeout forwards caller aborts to the fetch signal', async () => {
+  const callerController = new AbortController();
+  let receivedSignal = null;
+
+  const request = fetchWithTimeout('https://example.invalid/hang', {
+    signal: callerController.signal,
+  }, {
+    timeoutMs: 1000,
+    fetchImpl: (_url, options) => {
+      receivedSignal = options.signal;
+      return new Promise(() => {});
+    },
+  });
+
+  callerController.abort(new Error('caller stopped request'));
+
+  await assert.rejects(request, /caller stopped request/);
+  assert.ok(receivedSignal);
+  assert.notEqual(receivedSignal, callerController.signal);
+  assert.equal(receivedSignal.aborted, true);
+});

--- a/tests/server-fetch-timeout.test.cjs
+++ b/tests/server-fetch-timeout.test.cjs
@@ -1,0 +1,23 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { fetchWithTimeout } = require('../server/_fetch.js');
+
+test('fetchWithTimeout aborts hung requests', async () => {
+  const started = Date.now();
+  await assert.rejects(
+    () => fetchWithTimeout('https://example.invalid/hang', {}, {
+      timeoutMs: 10,
+      fetchImpl: () => new Promise(() => {}),
+    }),
+    /timed out/
+  );
+  assert.ok(Date.now() - started < 500, 'timeout should not hang the test process');
+});
+
+test('fetchWithTimeout clears timeout after success', async () => {
+  const response = await fetchWithTimeout('https://example.test/ok', {}, {
+    timeoutMs: 100,
+    fetchImpl: async () => ({ ok: true, status: 200 }),
+  });
+  assert.equal(response.ok, true);
+});

--- a/tests/server-fetch-timeout.test.cjs
+++ b/tests/server-fetch-timeout.test.cjs
@@ -2,6 +2,7 @@ const test = require('node:test');
 const assert = require('node:assert/strict');
 const {
   fetchWithTimeout,
+  readResponseArrayBufferWithTimeout,
   readResponseJsonWithTimeout,
   readResponseTextWithTimeout,
 } = require('../server/_fetch.js');
@@ -166,4 +167,58 @@ test('readResponseJsonWithTimeout parses JSON through the timeout-bound text rea
     await readResponseJsonWithTimeout(response, { timeoutMs: 100 }),
     { ok: true }
   );
+});
+
+test('readResponseArrayBufferWithTimeout assembles stream bytes', async () => {
+  const response = {
+    body: {
+      getReader() {
+        let reads = 0;
+        return {
+          async read() {
+            reads += 1;
+            if (reads === 1) return { done: false, value: new Uint8Array([1, 2]) };
+            if (reads === 2) return { done: false, value: new Uint8Array([3]) };
+            return { done: true };
+          },
+          cancel() {},
+          releaseLock() {},
+        };
+      },
+    },
+    arrayBuffer() {
+      throw new Error('arrayBuffer fallback should not be used for streams');
+    },
+  };
+
+  const buffer = await readResponseArrayBufferWithTimeout(response, { timeoutMs: 100 });
+  assert.deepEqual(Array.from(new Uint8Array(buffer)), [1, 2, 3]);
+});
+
+test('readResponseArrayBufferWithTimeout cancels the active stream reader on timeout', async () => {
+  let cancelCount = 0;
+  const response = {
+    body: {
+      getReader() {
+        return {
+          read: () => new Promise(() => {}),
+          cancel() {
+            cancelCount += 1;
+            return Promise.resolve();
+          },
+          releaseLock() {},
+        };
+      },
+    },
+    arrayBuffer() {
+      throw new Error('arrayBuffer fallback should not be used for streams');
+    },
+  };
+
+  await assert.rejects(
+    () => readResponseArrayBufferWithTimeout(response, { timeoutMs: 10 }),
+    /timed out/
+  );
+
+  assert.equal(cancelCount, 1);
 });

--- a/tests/server-request-hardening.test.cjs
+++ b/tests/server-request-hardening.test.cjs
@@ -1,8 +1,8 @@
 const test = require('node:test');
 const assert = require('node:assert/strict');
-const { parseJsonBody } = require('../server/_request.js');
+const { parseJsonBody, parseRequestBody } = require('../server/_request.js');
 
-function makeReq({ body = '', headers = {}, method = 'POST' } = {}) {
+function makeStreamReq({ body = '', headers = {}, method = 'POST' } = {}) {
   return {
     method,
     headers,
@@ -23,7 +23,7 @@ function makeStringBodyReq({ body = '', headers = {}, method = 'POST' } = {}) {
 test('parseJsonBody rejects oversized JSON bodies', async () => {
   const body = JSON.stringify({ value: 'x'.repeat(1024 * 1024 + 1) });
   await assert.rejects(
-    () => parseJsonBody(makeReq({
+    () => parseJsonBody(makeStreamReq({
       body,
       headers: { 'content-type': 'application/json' },
     }), { maxBytes: 1024 }),
@@ -33,7 +33,7 @@ test('parseJsonBody rejects oversized JSON bodies', async () => {
 
 test('parseJsonBody rejects non-json content types when body is present', async () => {
   await assert.rejects(
-    () => parseJsonBody(makeReq({
+    () => parseJsonBody(makeStreamReq({
       body: '{"ok":true}',
       headers: { 'content-type': 'text/plain' },
     })),
@@ -42,7 +42,7 @@ test('parseJsonBody rejects non-json content types when body is present', async 
 });
 
 test('parseJsonBody returns parsed JSON for valid bounded JSON body', async () => {
-  const parsed = await parseJsonBody(makeReq({
+  const parsed = await parseJsonBody(makeStreamReq({
     body: '{"ok":true}',
     headers: { 'content-type': 'application/json; charset=utf-8' },
   }));
@@ -50,7 +50,7 @@ test('parseJsonBody returns parsed JSON for valid bounded JSON body', async () =
 });
 
 test('parseJsonBody accepts case-insensitive content-type headers', async () => {
-  const parsed = await parseJsonBody(makeReq({
+  const parsed = await parseJsonBody(makeStreamReq({
     body: '{"ok":true}',
     headers: { 'CONTENT-TYPE': 'application/json; charset=utf-8' },
   }));
@@ -67,7 +67,7 @@ test('parseJsonBody returns parsed JSON from string request bodies', async () =>
 
 test('parseJsonBody rejects invalid JSON bodies', async () => {
   await assert.rejects(
-    () => parseJsonBody(makeReq({
+    () => parseJsonBody(makeStreamReq({
       body: '{"ok":',
       headers: { 'content-type': 'application/json' },
     })),
@@ -76,7 +76,7 @@ test('parseJsonBody rejects invalid JSON bodies', async () => {
 });
 
 test('parseJsonBody returns empty object for whitespace bodies', async () => {
-  const parsed = await parseJsonBody(makeReq({
+  const parsed = await parseJsonBody(makeStreamReq({
     body: '   \n\t  ',
     headers: { 'content-type': 'application/json' },
   }));
@@ -86,10 +86,65 @@ test('parseJsonBody returns empty object for whitespace bodies', async () => {
 test('parseJsonBody falls back to the default size limit for invalid maxBytes options', async () => {
   const body = JSON.stringify({ value: 'x'.repeat(1024 * 1024 + 1) });
   await assert.rejects(
-    () => parseJsonBody(makeReq({
+    () => parseJsonBody(makeStreamReq({
       body,
       headers: { 'content-type': 'application/json' },
     }), { maxBytes: 'not-a-number' }),
     /Request body too large/
+  );
+});
+
+test('parseJsonBody preserves pre-parsed object request bodies', async () => {
+  const body = { ok: true };
+  const parsed = await parseJsonBody(makeStringBodyReq({
+    body,
+    headers: { 'content-type': 'application/json' },
+  }));
+  assert.equal(parsed, body);
+});
+
+test('parseRequestBody caches parsed string request bodies for downstream consumers', async () => {
+  const req = makeStringBodyReq({
+    body: '{"action":"save_live"}',
+    headers: { 'content-type': 'application/json' },
+  });
+  const parsed = await parseRequestBody(req);
+  assert.deepEqual(parsed, { action: 'save_live' });
+  assert.equal(req.body, parsed);
+});
+
+test('parseRequestBody caches parsed stream request bodies for downstream consumers', async () => {
+  const req = makeStreamReq({
+    body: '{"action":"save_live"}',
+    headers: { 'content-type': 'application/json' },
+  });
+  const parsed = await parseRequestBody(req);
+  assert.deepEqual(parsed, { action: 'save_live' });
+  assert.equal(req.body, parsed);
+});
+
+test('parseJsonBody exposes request error status codes', async () => {
+  await assert.rejects(
+    () => parseJsonBody(makeStreamReq({
+      body: '{"ok":true}',
+      headers: { 'content-type': 'text/plain' },
+    })),
+    { status: 415, message: 'Content-Type must be application/json' }
+  );
+
+  await assert.rejects(
+    () => parseJsonBody(makeStreamReq({
+      body: '{"ok":',
+      headers: { 'content-type': 'application/json' },
+    })),
+    { status: 400, message: 'Invalid JSON body' }
+  );
+
+  await assert.rejects(
+    () => parseJsonBody(makeStreamReq({
+      body: '{"ok":true}',
+      headers: { 'content-type': 'application/json' },
+    }), { maxBytes: 1 }),
+    { status: 413, message: 'Request body too large' }
   );
 });

--- a/tests/server-request-hardening.test.cjs
+++ b/tests/server-request-hardening.test.cjs
@@ -1,0 +1,42 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const { parseJsonBody } = require('../server/_request.js');
+
+function makeReq({ body = '', headers = {}, method = 'POST' } = {}) {
+  return {
+    method,
+    headers,
+    async *[Symbol.asyncIterator]() {
+      yield Buffer.from(body);
+    },
+  };
+}
+
+test('parseJsonBody rejects oversized JSON bodies', async () => {
+  const body = JSON.stringify({ value: 'x'.repeat(1024 * 1024 + 1) });
+  await assert.rejects(
+    () => parseJsonBody(makeReq({
+      body,
+      headers: { 'content-type': 'application/json' },
+    }), { maxBytes: 1024 }),
+    /Request body too large/
+  );
+});
+
+test('parseJsonBody rejects non-json content types when body is present', async () => {
+  await assert.rejects(
+    () => parseJsonBody(makeReq({
+      body: '{"ok":true}',
+      headers: { 'content-type': 'text/plain' },
+    })),
+    /Content-Type must be application\/json/
+  );
+});
+
+test('parseJsonBody returns parsed JSON for valid bounded JSON body', async () => {
+  const parsed = await parseJsonBody(makeReq({
+    body: '{"ok":true}',
+    headers: { 'content-type': 'application/json; charset=utf-8' },
+  }));
+  assert.deepEqual(parsed, { ok: true });
+});

--- a/tests/server-request-hardening.test.cjs
+++ b/tests/server-request-hardening.test.cjs
@@ -12,6 +12,14 @@ function makeReq({ body = '', headers = {}, method = 'POST' } = {}) {
   };
 }
 
+function makeStringBodyReq({ body = '', headers = {}, method = 'POST' } = {}) {
+  return {
+    method,
+    headers,
+    body,
+  };
+}
+
 test('parseJsonBody rejects oversized JSON bodies', async () => {
   const body = JSON.stringify({ value: 'x'.repeat(1024 * 1024 + 1) });
   await assert.rejects(
@@ -47,4 +55,41 @@ test('parseJsonBody accepts case-insensitive content-type headers', async () => 
     headers: { 'CONTENT-TYPE': 'application/json; charset=utf-8' },
   }));
   assert.deepEqual(parsed, { ok: true });
+});
+
+test('parseJsonBody returns parsed JSON from string request bodies', async () => {
+  const parsed = await parseJsonBody(makeStringBodyReq({
+    body: '{"ok":true}',
+    headers: { 'content-type': 'application/json' },
+  }));
+  assert.deepEqual(parsed, { ok: true });
+});
+
+test('parseJsonBody rejects invalid JSON bodies', async () => {
+  await assert.rejects(
+    () => parseJsonBody(makeReq({
+      body: '{"ok":',
+      headers: { 'content-type': 'application/json' },
+    })),
+    /Invalid JSON body/
+  );
+});
+
+test('parseJsonBody returns empty object for whitespace bodies', async () => {
+  const parsed = await parseJsonBody(makeReq({
+    body: '   \n\t  ',
+    headers: { 'content-type': 'application/json' },
+  }));
+  assert.deepEqual(parsed, {});
+});
+
+test('parseJsonBody falls back to the default size limit for invalid maxBytes options', async () => {
+  const body = JSON.stringify({ value: 'x'.repeat(1024 * 1024 + 1) });
+  await assert.rejects(
+    () => parseJsonBody(makeReq({
+      body,
+      headers: { 'content-type': 'application/json' },
+    }), { maxBytes: 'not-a-number' }),
+    /Request body too large/
+  );
 });

--- a/tests/server-request-hardening.test.cjs
+++ b/tests/server-request-hardening.test.cjs
@@ -40,3 +40,11 @@ test('parseJsonBody returns parsed JSON for valid bounded JSON body', async () =
   }));
   assert.deepEqual(parsed, { ok: true });
 });
+
+test('parseJsonBody accepts case-insensitive content-type headers', async () => {
+  const parsed = await parseJsonBody(makeReq({
+    body: '{"ok":true}',
+    headers: { 'CONTENT-TYPE': 'application/json; charset=utf-8' },
+  }));
+  assert.deepEqual(parsed, { ok: true });
+});

--- a/vercel.json
+++ b/vercel.json
@@ -1,4 +1,20 @@
 {
+  "headers": [
+    {
+      "source": "/(.*)",
+      "headers": [
+        {
+          "key": "Content-Security-Policy",
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' https://*.supabase.co https://world.openfoodfacts.org https://api.untappd.com https://api.groupme.com https://api.twilio.com https://discord.com https://discordapp.com; form-action 'self'"
+        },
+        { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
+        { "key": "X-Content-Type-Options", "value": "nosniff" },
+        { "key": "Referrer-Policy", "value": "strict-origin-when-cross-origin" },
+        { "key": "Permissions-Policy", "value": "camera=(self), microphone=(), geolocation=(), payment=()" },
+        { "key": "X-Frame-Options", "value": "DENY" }
+      ]
+    }
+  ],
   "rewrites": [
     { "source": "/leroyslounge", "destination": "/leroyslounge/index.html" },
     { "source": "/leroyslounge/", "destination": "/leroyslounge/index.html" },

--- a/vercel.json
+++ b/vercel.json
@@ -5,7 +5,7 @@
       "headers": [
         {
           "key": "Content-Security-Policy",
-          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self'; connect-src 'self' https://*.supabase.co https://world.openfoodfacts.org https://api.untappd.com https://api.groupme.com https://api.twilio.com https://discord.com https://discordapp.com; form-action 'self'"
+          "value": "default-src 'self'; base-uri 'self'; object-src 'none'; frame-ancestors 'none'; img-src 'self' data: https:; font-src 'self' data:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-inline'; connect-src 'self' https://*.supabase.co https://world.openfoodfacts.org https://api.untappd.com https://api.groupme.com https://api.twilio.com https://discord.com https://discordapp.com; form-action 'self'"
         },
         { "key": "Strict-Transport-Security", "value": "max-age=31536000; includeSubDomains; preload" },
         { "key": "X-Content-Type-Options", "value": "nosniff" },


### PR DESCRIPTION
## Summary
- Add production launch headers, public metadata, crawler files, and static error pages.
- Harden JSON request parsing and timeout-bound external provider fetch/body reads, including font proxy paths.
- Protect iOS offline draft files and created draft directories with file protection.

## Test Plan
- [x] node --check app.js
- [x] node scripts/check-html-script-order.cjs
- [x] node --test tests/public-launch-surface.test.cjs tests/server-request-hardening.test.cjs tests/server-fetch-timeout.test.cjs
- [x] DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer xcodebuild -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,name=iPhone 16' -sdk iphonesimulator CODE_SIGNING_ALLOWED=NO test

## Notes
- Full Node suite was 316/317 in the global nested worktree because tests/runtime-helpers.test.cjs expects a repo path ending in El-Roys-Drink-Menu/app.js; this was present at baseline and is not caused by this branch.