### PR TITLE
[codex] Add conditional iOS launch gate

### DIFF
--- a/.github/workflows/ios-launch-gate.yml
+++ b/.github/workflows/ios-launch-gate.yml
@@ -1,0 +1,102 @@
+name: iOS Launch Gate
+
+on:
+  pull_request:
+  push:
+
+permissions:
+  contents: read
+  checks: read
+  statuses: read
+  pull-requests: read
+
+jobs:
+  xcode-cloud-gate:
+    name: Xcode Cloud Gate
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Detect iOS changes
+        id: changes
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            files="$(gh api --paginate \
+              repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/files \
+              --jq '.[].filename')"
+          else
+            before="${{ github.event.before }}"
+            after="${{ github.sha }}"
+
+            if [ "$before" = "0000000000000000000000000000000000000000" ]; then
+              files="$(git diff-tree --no-commit-id --name-only -r "$after")"
+            else
+              files="$(git diff --name-only "$before" "$after")"
+            fi
+          fi
+
+          if printf '%s\n' "$files" | grep -q '^ios/'; then
+            echo "ios_changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "ios_changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Pass when no iOS files changed
+        if: steps.changes.outputs.ios_changed == 'false'
+        run: echo "No ios/ changes; Xcode Cloud is not required."
+
+      - name: Wait for Xcode Cloud
+        if: steps.changes.outputs.ios_changed == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          XCODE_CONTEXT: ElRoysManagerApp | Branch Protection
+          SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+        run: |
+          set -euo pipefail
+
+          echo "ios/ changed; waiting for Xcode Cloud status: $XCODE_CONTEXT"
+          echo "Commit: $SHA"
+
+          deadline=$((SECONDS + 3600))
+
+          while [ "$SECONDS" -lt "$deadline" ]; do
+            state="$(gh api repos/${{ github.repository }}/commits/$SHA/status \
+              --jq --arg context "$XCODE_CONTEXT" '
+                .statuses
+                | map(select(.context == $context))
+                | sort_by(.updated_at)
+                | last
+                | .state // "missing"
+              ')"
+
+            echo "Xcode Cloud state: $state"
+
+            case "$state" in
+              success)
+                echo "Xcode Cloud passed."
+                exit 0
+                ;;
+              failure|error)
+                echo "Xcode Cloud failed."
+                exit 1
+                ;;
+              pending|missing)
+                sleep 30
+                ;;
+              *)
+                echo "Unexpected Xcode Cloud state: $state"
+                sleep 30
+                ;;
+            esac
+          done
+
+          echo "Timed out waiting for Xcode Cloud."
+          exit 1

--- a/tests/ci-release-gates.test.cjs
+++ b/tests/ci-release-gates.test.cjs
@@ -44,3 +44,22 @@ test('launch gates workflow leaves iOS CI to Xcode Cloud', () => {
   assert.match(xcodeCloudDocs, /TestFlight/);
   assert.match(releaseRunbook, /Xcode Cloud/);
 });
+
+test('iOS launch gate only waits for Xcode Cloud when ios files change', () => {
+  const workflow = read('.github/workflows/ios-launch-gate.yml');
+
+  assert.match(workflow, /^name:\s*iOS Launch Gate$/m);
+  assert.match(workflow, /^\s*pull_request:/m);
+  assert.match(workflow, /^\s*push:/m);
+  assert.match(workflow, /name:\s*Xcode Cloud Gate/);
+  assert.match(workflow, /pulls\/\$\{\{ github\.event\.pull_request\.number \}\}\/files/);
+  assert.match(workflow, /grep -q '\^ios\/'/);
+  assert.match(workflow, /if:\s*steps\.changes\.outputs\.ios_changed == 'false'/);
+  assert.match(workflow, /No ios\/ changes; Xcode Cloud is not required\./);
+  assert.match(workflow, /if:\s*steps\.changes\.outputs\.ios_changed == 'true'/);
+  assert.match(workflow, /XCODE_CONTEXT:\s*ElRoysManagerApp \| Branch Protection/);
+  assert.match(workflow, /commits\/\$SHA\/status/);
+  assert.match(workflow, /case "\$state" in/);
+  assert.match(workflow, /success\)/);
+  assert.match(workflow, /failure\|error\)/);
+});


### PR DESCRIPTION
## Summary

Adds an always-running `iOS Launch Gate` GitHub Actions workflow that conditionally gates Xcode Cloud.

## Why

The direct Xcode Cloud branch-protection check can remain pending on PRs without `ios/` changes because Xcode Cloud only triggers for branches that touch `ios/`. This workflow gives GitHub one required check that always reports while still requiring Xcode Cloud when iOS files actually changed.

## What changed

- Added `.github/workflows/ios-launch-gate.yml`.
- The workflow detects changed files for both pull requests and pushes.
- It passes immediately when no paths under `ios/` changed.
- It polls the `ElRoysManagerApp | Branch Protection` commit status until it passes, fails, errors, or times out when `ios/` changed.
- Added a launch-gate contract test covering the conditional behavior.

## Validation

- `node --check app.js`
- `find api server core -name '*.js' -print0 | xargs -0 -n 1 node --check`
- `node scripts/check-html-script-order.cjs`
- `node --test tests/ci-release-gates.test.cjs`
- `node --test tests/*.test.cjs tests/boundaries/*.test.cjs`

## Follow-up after merge

In classic branch protection for `main`, remove the direct `ElRoysManagerApp | Branch Protection` required check and require `iOS Launch Gate / Xcode Cloud Gate` instead.