### PR TITLE
Normalize persisted item visibility before Supabase writes

### DIFF
--- a/server/_menu-write.js
+++ b/server/_menu-write.js
@@ -64,6 +64,15 @@ function normalizeRecipe(recipe = []) {
   return [];
 }
 
+function normalizePersistentVisibility() {
+  return 'public';
+}
+
+function normalizePersistentOnMenu(item = {}) {
+  if (item?.on_menu === false || item?.onMenu === false) return false;
+  return String(item?.visibility || '').trim().toLowerCase() !== 'off_menu';
+}
+
 function isUuid(value = '') {
   return /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i.test(String(value || '').trim());
 }
@@ -96,8 +105,8 @@ function normalizeSnapshot(snapshot = {}) {
         recipe: normalizeRecipe(item?.recipe),
         price: item?.price == null ? null : String(item.price || ''),
         is_eighty_sixed: !!item?.is_eighty_sixed,
-        on_menu: item?.on_menu !== false,
-        visibility: String(item?.visibility || 'public'),
+        on_menu: normalizePersistentOnMenu(item),
+        visibility: normalizePersistentVisibility(item?.visibility),
         upcharges: cloneItemUpcharges(item?.upcharges),
         show_description: item?.show_description !== false,
         show_recipe: !!item?.show_recipe,

--- a/tests/phase8-server-write-boundaries.test.cjs
+++ b/tests/phase8-server-write-boundaries.test.cjs
@@ -130,6 +130,97 @@ test('server live-save write path normalizes local item ids before persisting it
   assert.match(payload[0].id, /^[0-9a-f-]{36}$/i);
 });
 
+test('server live-save write path stores off-menu items with DB-safe visibility', async () => {
+  process.env.SUPABASE_URL = 'https://example.supabase.co';
+  process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';
+
+  const module = await importApiModule('server/_menu-write.js');
+  const originalFetch = global.fetch;
+  const fetchCalls = [];
+
+  global.fetch = async (url, options = {}) => {
+    const href = String(url);
+    fetchCalls.push({ url: href, options });
+
+    if (href.includes('/menu_meta?')) {
+      return {
+        ok: true,
+        async json() {
+          return [{ last_updated_ts: 10 }];
+        },
+      };
+    }
+
+    if (href.includes('/categories?on_conflict=')) {
+      return {
+        ok: true,
+        async json() {
+          return [];
+        },
+      };
+    }
+
+    if (href.includes('/categories?menu_id=')) {
+      return {
+        ok: true,
+        async json() {
+          return [{ id: 'category-uuid-1', key: 'snacks' }];
+        },
+      };
+    }
+
+    if (href.includes('/items?category_id=in.(')) {
+      return {
+        ok: true,
+        async json() {
+          return [];
+        },
+      };
+    }
+
+    if (href.endsWith('/rest/v1/items')) {
+      return {
+        ok: true,
+        async json() {
+          return [];
+        },
+      };
+    }
+
+    throw new Error(`Unexpected fetch: ${href}`);
+  };
+
+  try {
+    await module.saveLiveMenuForMenu({
+      menuId: '00000000-0000-0000-0000-000000000021',
+      snapshot: {
+        cats: [{
+          id: 'local-category-1',
+          key: 'snacks',
+          label: 'Snacks',
+          items: [{
+            id: 'item-hidden',
+            name: 'Hidden Fries',
+            visibility: 'off_menu',
+          }],
+        }],
+        meta: {},
+      },
+      expectedLiveRevision: 10,
+      actor: { id: 'user-1', name: 'Tester', role: 'manager' },
+    });
+  } finally {
+    global.fetch = originalFetch;
+  }
+
+  const itemPersistCall = fetchCalls.find(call => call.url.endsWith('/rest/v1/items'));
+  assert.ok(itemPersistCall, 'expected item persistence request');
+  const payload = JSON.parse(itemPersistCall.options.body);
+  assert.equal(payload.length, 1);
+  assert.equal(payload[0].visibility, 'public');
+  assert.equal(payload[0].on_menu, false);
+});
+
 test('server live-save write path round-trips featured_enabled into persisted item rows', async () => {
   process.env.SUPABASE_URL = 'https://example.supabase.co';
   process.env.SUPABASE_SERVICE_ROLE_KEY = 'service-role-key';


### PR DESCRIPTION
## Summary
- Normalize item writes so persisted rows always use `visibility: public`, matching the current database constraint.
- Derive `on_menu` from legacy `off_menu` inputs so hidden items still save correctly without violating the constraint.
- Add a boundary test covering off-menu item persistence through the live-save write path.

## Testing
- `node --test tests/phase8-server-write-boundaries.test.cjs`
- `node --check app.js`
- `node --check server/_menu-write.js`