### PR TITLE
[codex] Purge legacy featured specials

### DIFF
--- a/.github/workflows/ios-launch-gate.yml
+++ b/.github/workflows/ios-launch-gate.yml
@@ -36,13 +36,30 @@ jobs:
           else
             before="${{ github.event.before }}"
             after="${{ github.sha }}"
+            default_branch="${{ github.event.repository.default_branch }}"
+            default_ref="origin/$default_branch"
 
             if [ "$before" = "0000000000000000000000000000000000000000" ]; then
               files="$(git diff-tree --no-commit-id --name-only -r "$after")"
               ios_sha="$(git log -n 1 --format=%H "$after" -- ios/ || true)"
-            else
+            elif git cat-file -e "$before^{commit}" 2>/dev/null; then
               files="$(git diff --name-only "$before" "$after")"
               ios_sha="$(git log -n 1 --format=%H "$before..$after" -- ios/ || true)"
+            else
+              echo "Push before SHA $before is unavailable; falling back to $default_ref."
+              fallback_base=""
+              if git rev-parse --verify --quiet "$default_ref" >/dev/null; then
+                fallback_base="$(git merge-base "$default_ref" "$after" || true)"
+              fi
+
+              if [ -n "$fallback_base" ]; then
+                files="$(git diff --name-only "$fallback_base" "$after")"
+                ios_sha="$(git log -n 1 --format=%H "$fallback_base..$after" -- ios/ || true)"
+              else
+                echo "No default branch merge base found; inspecting the pushed commit only."
+                files="$(git diff-tree --no-commit-id --name-only -r "$after")"
+                ios_sha="$(git log -n 1 --format=%H "$after" -- ios/ || true)"
+              fi
             fi
           fi
 

--- a/core/session/menu-publish-workflow.js
+++ b/core/session/menu-publish-workflow.js
@@ -252,13 +252,14 @@
             last_sent_ts: ts,
             last_sent_state: lastSentState,
             last_sent_categories: (preview.diff || []).map(section => section.id),
+            last_sent_featured: [],
             draft_state: livePersisted ? {} : (context.meta?.draft_state || {}),
             draft_saved_ts: livePersisted ? null : (context.meta?.draft_saved_ts || null),
             draft_saved_by_user_id: livePersisted ? null : (context.meta?.draft_saved_by_user_id ?? undefined),
             draft_saved_by_name: livePersisted ? '' : (context.meta?.draft_saved_by_name ?? undefined),
             draft_saved_source: livePersisted ? '' : (context.meta?.draft_saved_source ?? undefined),
           },
-          optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source'],
+          optionalFields: ['draft_saved_by_user_id', 'draft_saved_by_name', 'draft_saved_source', 'last_sent_featured'],
         }));
 
         let successMessage = `✅ ${menuName} saved live.`;

--- a/server/_menu-queue.js
+++ b/server/_menu-queue.js
@@ -139,6 +139,7 @@ export function normalizeLegacyFeaturedBaseline({
 
   const snapshotCategories = readSnapshotCategories(snapshot);
   const currentFeaturedCategory = snapshotCategories.find(category => isFeaturedSpecialsCategory(category));
+  const hasCanonicalFeaturedCategory = String(currentFeaturedCategory?.key || '').trim() === 'featured_specials';
   const baselineLookupCategories = Object.entries(normalizedState).map(([key, items]) => ({
     key,
     items: asArray(items),
@@ -181,6 +182,7 @@ export function normalizeLegacyFeaturedBaseline({
   legacyFeaturedEntries.forEach(entry => {
     const itemId = String(entry?.id || '').trim();
     if (!itemId || itemIds.has(itemId)) return;
+    if (hasCanonicalFeaturedCategory) return;
 
     // Reconstruct a one-time featured baseline from the last-sent document first,
     // then fall back to the current snapshot or richer legacy metadata when needed.

--- a/tests/boundaries/menu-publish-workflow.boundary.test.cjs
+++ b/tests/boundaries/menu-publish-workflow.boundary.test.cjs
@@ -201,7 +201,8 @@ test('workflow execute advances queue baseline after successful send', async () 
     notificationRevision: 1000,
     notificationBaselineRevision: 1000,
   });
-  assert.equal(Object.prototype.hasOwnProperty.call(patchCalls[0].patch, 'last_sent_featured'), false);
+  assert.deepEqual(patchCalls[0].patch.last_sent_featured, []);
+  assert.ok(patchCalls[0].optionalFields.includes('last_sent_featured'));
   assert.deepEqual(result.queue.featuredSiblingMenusSynced, []);
   assert.ok(auditCalls.some(call => call.eventType === 'send_notification'));
   assert.ok(result.audit.loggedEvents.includes('send_notification'));

--- a/tests/ci-release-gates.test.cjs
+++ b/tests/ci-release-gates.test.cjs
@@ -55,6 +55,9 @@ test('iOS launch gate only waits for Xcode Cloud when ios files change', () => {
   assert.match(workflow, /base="\$\{\{ github\.event\.pull_request\.base\.sha \}\}"/);
   assert.match(workflow, /head="\$\{\{ github\.event\.pull_request\.head\.sha \}\}"/);
   assert.match(workflow, /files="\$\(git diff --name-only "\$base\.\.\.\$head"\)"/);
+  assert.match(workflow, /default_branch="\$\{\{ github\.event\.repository\.default_branch \}\}"/);
+  assert.match(workflow, /git cat-file -e "\$before\^\{commit\}"/);
+  assert.match(workflow, /fallback_base="\$\(git merge-base "\$default_ref" "\$after" \|\| true\)"/);
   assert.match(workflow, /grep -q '\^ios\/'/);
   assert.match(workflow, /if:\s*steps\.changes\.outputs\.ios_changed == 'false'/);
   assert.match(workflow, /No ios\/ changes; Xcode Cloud is not required\./);

--- a/tests/phase7-server-read-boundaries.test.cjs
+++ b/tests/phase7-server-read-boundaries.test.cjs
@@ -526,7 +526,7 @@ test('legacy last_sent_featured does not create false featured_specials queue li
   assert.deepEqual(queueState.unsentItemIds, []);
 });
 
-test('legacy last_sent_featured still surfaces a first-cutover featured_specials removal from lookup state', async () => {
+test('legacy last_sent_featured does not resurrect removed specials once featured_specials is canonical', async () => {
   const queueHelper = await importApiModule('server/_menu-queue.js');
   const snapshot = {
     cats: [
@@ -556,6 +556,34 @@ test('legacy last_sent_featured still surfaces a first-cutover featured_specials
     lastSentState,
   });
 
+  assert.deepEqual(lastSentState.featured_specials, []);
+  assert.equal(queueState.hasNotificationChanges, false);
+  assert.deepEqual(queueState.diff, []);
+  assert.deepEqual(queueState.unsentItemIds, []);
+});
+
+test('legacy snapshots without featured_specials still surface a first-cutover removal from lookup state', async () => {
+  const queueHelper = await importApiModule('server/_menu-queue.js');
+  const snapshot = {
+    cats: [{
+      key: 'cocktails',
+      label: 'Cocktails',
+      icon: '🍹',
+      items: [{ id: 'legacy-1', name: 'House Marg', featured_enabled: false, on_menu: true, visibility: 'public' }],
+    }],
+  };
+  const lastSentState = queueHelper.normalizeLegacyFeaturedBaseline({
+    snapshot,
+    lastSentState: {
+      cocktails: [{ id: 'legacy-1', name: 'House Marg', onMenu: true, visibility: 'public', eightySixed: false }],
+    },
+    lastSentFeatured: ['legacy-1'],
+  });
+  const queueState = queueHelper.buildCategoryQueueState({
+    snapshot,
+    lastSentState,
+  });
+
   assert.equal(lastSentState.featured_specials.length, 1);
   assert.equal(lastSentState.featured_specials[0].id, 'legacy-1');
   assert.equal(lastSentState.featured_specials[0].name, 'House Marg');
@@ -566,9 +594,9 @@ test('legacy last_sent_featured still surfaces a first-cutover featured_specials
   assert.equal(queueState.hasNotificationChanges, true);
   assert.deepEqual(queueState.diff, [{
     id: 'featured_specials',
-    icon: '⭐',
-    label: 'Featured Specials',
-    displayOrder: 0,
+    icon: '',
+    label: 'featured_specials',
+    displayOrder: Number.MAX_SAFE_INTEGER - 1000 + 1,
     added: [],
     removed: ['House Marg'],
     eightySixed: [],


### PR DESCRIPTION
## What changed

- Stop legacy `last_sent_featured` metadata from reconstructing removed specials once a menu has the canonical `featured_specials` category.
- Clear `last_sent_featured` to an empty array whenever the publish workflow advances the sent baseline.
- Add regression coverage for canonical featured-specials purging and for the successful-send metadata patch.

## Why

Older removed specials from the pre-`featured_specials` transport could remain in `menu_meta.last_sent_featured`. Each Send Update folded those stale IDs back into the featured baseline, making the same removed specials appear again and again.

## Impact

Managers can send updates without stale removed specials being requeued from legacy metadata. True first-cutover legacy snapshots that still lack `featured_specials` keep their one-time migration behavior.

## Validation

- `node --test tests/phase7-server-read-boundaries.test.cjs`
- `node --test tests/boundaries/menu-publish-workflow.boundary.test.cjs`
- `node --test tests/phase9-publish-specials-boundaries.test.cjs`
- `node --test tests/phase21-menu-queue-diff-boundaries.test.cjs`
- `node --test tests/phase22-category-governance.test.cjs`
- `node --test tests/architecture-boundaries.test.cjs`
- `node --test tests/boundaries/session.boundary.test.cjs`
- `node --test tests/phase2-session-boundaries.test.cjs`
- `node --check app.js`
- `node --check core/session/menu-publish-workflow.js && node --check server/_menu-queue.js`