### PR TITLE
[codex] polish iOS save boundaries

### DIFF
--- a/core/session/menu-publish-workflow.js
+++ b/core/session/menu-publish-workflow.js
@@ -33,6 +33,40 @@
       .filter(Boolean));
   }
 
+  function normalizeRevisionValue(value) {
+    if (value == null || value === '') return null;
+    const numeric = Number(value);
+    return Number.isFinite(numeric) ? numeric : null;
+  }
+
+  function buildPostCommitRevisions(revisions = {}, {
+    livePersisted = false,
+    baselineAdvanced = false,
+    ts = null,
+  } = {}) {
+    const commitTs = normalizeRevisionValue(ts);
+    const liveRevision = livePersisted
+      ? (commitTs ?? normalizeRevisionValue(revisions.liveRevision))
+      : normalizeRevisionValue(revisions.liveRevision);
+    const draftRevision = livePersisted
+      ? null
+      : normalizeRevisionValue(revisions.draftRevision);
+    const previousBaseline = normalizeRevisionValue(
+      revisions.lastSentRevision ?? revisions.notificationBaselineRevision ?? revisions.notificationRevision
+    );
+    const lastSentRevision = baselineAdvanced
+      ? (commitTs ?? previousBaseline)
+      : previousBaseline;
+
+    return {
+      liveRevision,
+      draftRevision,
+      lastSentRevision,
+      notificationRevision: lastSentRevision,
+      notificationBaselineRevision: lastSentRevision,
+    };
+  }
+
   function createMenuPublishWorkflow({ ports }) {
     if (!ports) throw new Error('ports are required');
     const SUPPORTED_INTENTS = new Set(['save', 'send', 'save-and-send']);
@@ -241,7 +275,11 @@
           ts,
           operationId,
           preview,
-          revisions,
+          revisions: buildPostCommitRevisions(revisions, {
+            livePersisted,
+            baselineAdvanced,
+            ts,
+          }),
           livePersistence: {
             attempted: command.intent !== 'send',
             persisted: livePersisted,

--- a/ios/ElRoysManagerApp/App/AppModel.swift
+++ b/ios/ElRoysManagerApp/App/AppModel.swift
@@ -603,9 +603,11 @@ final class AppModel {
       }
 
       let selection = shouldNotify ? Array(model.selectedPreviewChangeIDs) : []
+      let publishMode = model.publishMode(for: preview, shouldNotify: shouldNotify)
       let response = try await model.services.publish.publish(
         menuId: menuId,
         snapshot: snapshot,
+        mode: publishMode,
         selectedChangeIds: selection,
         expectedLiveRevision: workspace.workspace.revisions.liveRevision,
         expectedDraftRevision: expectedDraftRevision,
@@ -644,6 +646,7 @@ final class AppModel {
       model.applyPublishResponseLocally(
         response,
         preview: preview,
+        committedMode: publishMode,
         previousWorkspace: workspace,
         currentDocument: currentDocument
       )
@@ -1196,13 +1199,16 @@ final class AppModel {
   private func applyPublishResponseLocally(
     _ response: PublishResponse,
     preview: MenuPreviewPayload?,
+    committedMode: String,
     previousWorkspace: MenuWorkspacePayload,
     currentDocument: EditableMenuDocument
   ) {
     guard var workspace = currentEditorWorkspace else { return }
 
-    let publishMode = preview?.mode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() ?? ""
-    let didPersistLive = publishMode.isEmpty ? hasLiveMenuChanges : publishMode != "send"
+    let publishMode = committedMode.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+    let didPersistLive = publishMode.isEmpty
+      ? hasLiveMenuChanges
+      : publishMode != "send"
 
     var nextDocument = currentDocument
     nextDocument.normalizePersistentItemIdentifiersForRuntime()
@@ -1212,10 +1218,15 @@ final class AppModel {
     )
 
     if didPersistLive,
-       let liveRevision = nextRevisions.liveRevision ?? response.ts {
+       let liveRevision = response.ts ?? nextRevisions.liveRevision {
       nextRevisions.liveRevision = liveRevision
       workspace.meta.lastUpdatedTs = liveRevision
       nextDocument.meta.lastUpdatedTs = liveRevision
+    }
+
+    if let baselineRevision = response.ts ?? nextRevisions.notificationBaselineRevision ?? nextRevisions.lastSentRevision {
+      nextRevisions.lastSentRevision = baselineRevision
+      nextRevisions.notificationBaselineRevision = baselineRevision
     }
 
     if let lastSentRevision = nextRevisions.lastSentRevision {
@@ -1522,6 +1533,19 @@ final class AppModel {
       return Set(sectionChangeIDs)
     }
     return Set(preview.selectionDefaults)
+  }
+
+  private func publishMode(for preview: MenuPreviewPayload?, shouldNotify: Bool) -> String {
+    if !shouldNotify {
+      return "save"
+    }
+    let mode = preview?.mode
+      .trimmingCharacters(in: .whitespacesAndNewlines)
+      .lowercased() ?? ""
+    if mode == "save" || mode == "send" || mode == "save-and-send" {
+      return mode
+    }
+    return hasLiveMenuChanges ? "save-and-send" : "send"
   }
 
   private func serverHasUnsentChanges(in workspace: MenuWorkspacePayload?) -> Bool {

--- a/ios/ElRoysManagerApp/Clients/BackendClients.swift
+++ b/ios/ElRoysManagerApp/Clients/BackendClients.swift
@@ -67,7 +67,7 @@ protocol LiveSaveClienting {
 
 protocol PublishClienting {
   func preview(menuId: String, snapshot: MenuSnapshotPayload, expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse
-  func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse
+  func publish(menuId: String, snapshot: MenuSnapshotPayload, mode: String, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse
 }
 
 protocol HistoryClienting {
@@ -177,6 +177,7 @@ private struct PublishRequest: Encodable {
   var menuId: String
   var snapshot: MenuSnapshotPayload
   var source: String
+  var mode: String
   var selectedChangeIds: [String]?
   var expectedLiveRevision: Int?
   var expectedDraftRevision: Int?
@@ -559,6 +560,7 @@ final class PublishClient: PublishClienting {
         menuId: menuId,
         snapshot: snapshot,
         source: source,
+        mode: "preview",
         selectedChangeIds: nil,
         expectedLiveRevision: expectedLiveRevision,
         expectedDraftRevision: expectedDraftRevision,
@@ -567,7 +569,7 @@ final class PublishClient: PublishClienting {
     )
   }
 
-  func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
+  func publish(menuId: String, snapshot: MenuSnapshotPayload, mode: String, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
     try await http.request(
       path: "api/manager",
       method: .post,
@@ -577,6 +579,7 @@ final class PublishClient: PublishClienting {
         menuId: menuId,
         snapshot: snapshot,
         source: source,
+        mode: mode,
         selectedChangeIds: selectedChangeIds,
         expectedLiveRevision: expectedLiveRevision,
         expectedDraftRevision: expectedDraftRevision,

--- a/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
+++ b/ios/ElRoysManagerAppTests/MenuDocumentTests.swift
@@ -2479,10 +2479,123 @@ final class MenuDocumentTests: XCTestCase {
     await model.publishSelectedChanges(shouldNotify: false)
 
     XCTAssertEqual(publishClient.publishCallCount, 1)
+    XCTAssertEqual(publishClient.lastPublishMode, "save")
     XCTAssertEqual(publishClient.lastPublishSelectedChangeIds, [])
+    XCTAssertEqual(model.currentEditorWorkspace?.workspace.revisions.liveRevision, 40)
+    XCTAssertEqual(model.currentEditorWorkspace?.workspace.revisions.lastSentRevision, 40)
     XCTAssertFalse(model.hasServerUnsentChanges)
     XCTAssertEqual(model.menuStatusLabel, "Live")
     XCTAssertEqual(model.notice?.title, "Saved")
+  }
+
+  @MainActor
+  func testPublishAdoptsTimestampWhenManagerApiReturnsPreSaveRevisions() async throws {
+    let notificationChangeIDs = ["beer::added::ipa"]
+    let initialWorkspace = makeWorkspace(
+      categories: [
+        MenuCategoryPayload(
+          id: "beer",
+          menuId: "menu",
+          key: "beer",
+          label: "Beer",
+          icon: "",
+          color: "",
+          sub: "",
+          placeholder: "",
+          displayOrder: 0,
+          items: [makeItem(id: "item-1", name: "Pilsner")]
+        )
+      ],
+      revisions: WorkspaceRevisions(
+        liveRevision: 30,
+        draftRevision: nil,
+        lastSentRevision: 30,
+        notificationBaselineRevision: 30
+      ),
+      menuStatus: "Live",
+      hasUnsentChanges: false
+    )
+    let publishClient = StubPublishClient(
+      previewResponse: PublishResponse(
+        ok: true,
+        action: "preview",
+        ts: nil,
+        preview: try makePreviewPayload(
+          mode: "save-and-send",
+          selectionDefaults: notificationChangeIDs,
+          notificationChangeIDs: notificationChangeIDs
+        ),
+        currentRevisions: WorkspaceRevisions(
+          liveRevision: 30,
+          draftRevision: nil,
+          lastSentRevision: 30,
+          notificationBaselineRevision: 30
+        ),
+        notificationStatus: nil,
+        warnings: nil,
+        warningMessage: nil,
+        successMessage: nil,
+        selectedChangeIds: nil
+      ),
+      publishResponse: PublishResponse(
+        ok: true,
+        action: "publish",
+        ts: 40,
+        preview: nil,
+        currentRevisions: WorkspaceRevisions(
+          liveRevision: 30,
+          draftRevision: nil,
+          lastSentRevision: 30,
+          notificationBaselineRevision: 30
+        ),
+        notificationStatus: NotificationStatus(
+          ok: true,
+          skipped: false,
+          partial: false,
+          statusCode: 200,
+          summary: nil,
+          results: nil
+        ),
+        warnings: nil,
+        warningMessage: nil,
+        successMessage: nil,
+        selectedChangeIds: notificationChangeIDs
+      )
+    )
+    let model = AppModel(
+      environment: AppEnvironment(
+        name: .preview,
+        baseURL: exampleURL,
+        publicOrigin: exampleURL,
+        displayName: "Preview"
+      ),
+      services: makeServices(
+        workspaceClient: StubWorkspaceClient(payloads: [initialWorkspace]),
+        historyClient: StubHistoryClient(payload: makeHistoryPayload()),
+        publishClient: publishClient
+      ),
+      sessionStore: TestSessionStore(),
+      offlineDraftStore: TestOfflineDraftStore()
+    )
+    model.authSession = makeAuthSession()
+
+    await model.loadEditor(menuId: "menu")
+    guard var beer = model.currentEditorDocument?.itemRecord(for: "item-1")?.item else {
+      XCTFail("Expected seeded item")
+      return
+    }
+    beer.name = "House Pilsner"
+    model.upsertItem(beer, categoryKey: "beer", originalCategoryKey: "beer")
+    await model.loadPublishPreview()
+
+    await model.publishSelectedChanges()
+
+    XCTAssertEqual(publishClient.lastPublishMode, "save-and-send")
+    XCTAssertEqual(model.currentEditorWorkspace?.workspace.revisions.liveRevision, 40)
+    XCTAssertEqual(model.currentEditorWorkspace?.workspace.revisions.lastSentRevision, 40)
+    XCTAssertEqual(model.currentEditorWorkspace?.workspace.revisions.notificationBaselineRevision, 40)
+    XCTAssertFalse(model.hasServerUnsentChanges)
+    XCTAssertFalse(model.canLoadPublishPreview)
   }
 
   @MainActor
@@ -4236,6 +4349,7 @@ private final class StubPublishClient: PublishClienting {
   private(set) var lastPublishExpectedLiveRevision: Int?
   private(set) var lastPublishExpectedDraftRevision: Int?
   private(set) var lastPublishExpectedNotificationRevision: Int?
+  private(set) var lastPublishMode: String?
   private(set) var lastPublishSelectedChangeIds: [String]?
 
   init(previewResponse: PublishResponse? = nil, publishResponse: PublishResponse? = nil) {
@@ -4255,9 +4369,10 @@ private final class StubPublishClient: PublishClienting {
     return previewResponse
   }
 
-  func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
+  func publish(menuId: String, snapshot: MenuSnapshotPayload, mode: String, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
     publishCallCount += 1
     lastPublishSnapshot = snapshot
+    lastPublishMode = mode
     lastPublishSelectedChangeIds = selectedChangeIds
     lastPublishExpectedLiveRevision = expectedLiveRevision
     lastPublishExpectedDraftRevision = expectedDraftRevision

--- a/ios/ElRoysManagerAppTests/TestSupport.swift
+++ b/ios/ElRoysManagerAppTests/TestSupport.swift
@@ -444,7 +444,7 @@ final class RouteStateStubPublishClient: PublishClienting {
     throw RouteStateTestError.message("Unused in this test")
   }
 
-  func publish(menuId: String, snapshot: MenuSnapshotPayload, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
+  func publish(menuId: String, snapshot: MenuSnapshotPayload, mode: String, selectedChangeIds: [String], expectedLiveRevision: Int?, expectedDraftRevision: Int?, expectedNotificationRevision: Int?, accessToken: String, source: String) async throws -> PublishResponse {
     throw RouteStateTestError.message("Unused in this test")
   }
 }

--- a/tests/boundaries/menu-publish-workflow.boundary.test.cjs
+++ b/tests/boundaries/menu-publish-workflow.boundary.test.cjs
@@ -194,6 +194,13 @@ test('workflow execute advances queue baseline after successful send', async () 
   assert.equal(saveCalls.length, 1);
   assert.ok(patchCalls.some(call => call.patch.last_sent_ts === 1000));
   assert.deepEqual(patchCalls[0].patch.last_sent_state, DEFAULT_LAST_SENT_STATE);
+  assert.deepEqual(result.revisions, {
+    liveRevision: 1000,
+    draftRevision: null,
+    lastSentRevision: 1000,
+    notificationRevision: 1000,
+    notificationBaselineRevision: 1000,
+  });
   assert.equal(Object.prototype.hasOwnProperty.call(patchCalls[0].patch, 'last_sent_featured'), false);
   assert.deepEqual(result.queue.featuredSiblingMenusSynced, []);
   assert.ok(auditCalls.some(call => call.eventType === 'send_notification'));

--- a/tests/ios-source-contracts.test.cjs
+++ b/tests/ios-source-contracts.test.cjs
@@ -181,6 +181,17 @@ test('iOS backend client exposes string public menu revision fetch', () => {
   assert.match(source, /URLQueryItem\(name: "menu_id", value: menuId\)/);
 });
 
+test('iOS publish requests preserve the server preview mode at manager API boundary', () => {
+  const backendClients = read('ios/ElRoysManagerApp/Clients/BackendClients.swift');
+  const appModel = read('ios/ElRoysManagerApp/App/AppModel.swift');
+
+  assert.match(backendClients, /private struct PublishRequest: Encodable\s*\{[\s\S]*var mode: String/);
+  assert.match(backendClients, /func publish\(menuId: String, snapshot: MenuSnapshotPayload, mode: String, selectedChangeIds: \[String\]/);
+  assert.match(backendClients, /PublishRequest\([\s\S]*mode: mode/);
+  assert.match(appModel, /let publishMode = model\.publishMode\(for: preview, shouldNotify: shouldNotify\)/);
+  assert.match(appModel, /services\.publish\.publish\([\s\S]*mode: publishMode/);
+});
+
 test('iOS editor monitor gates public revision before fetching full workspace', () => {
   const source = read('ios/ElRoysManagerApp/App/AppModel.swift');
   const body = sourceBetween(


### PR DESCRIPTION
## Summary

- Return post-commit menu revisions from the shared publish workflow so clients adopt the saved live and notification baseline timestamps after successful saves/sends.
- Send the server preview mode through the iOS manager publish request instead of re-inferring every publish as a combined save/send.
- Rebaseline iOS local editor state from the manager API timestamp when the API response still contains pre-save revisions, and expand tests around quiet save, send, and manager API source contracts.

## Why

The iOS manager flow could keep stale save/send boundaries after a successful manager API publish. That made the app more likely to classify its own save as a remote "Live Menu and Queue Update" and could lead to noisy notifications or revision-conflict style manager API errors.

## Impact

Managers should see quieter saves, cleaner post-publish local state, and fewer repeat queue/update prompts after iOS save or send actions.

## Validation

- `node --test tests/ios-source-contracts.test.cjs tests/boundaries/menu-publish-workflow.boundary.test.cjs tests/boundaries/publish.boundary.test.cjs`
- `xcodebuild test -project ios/ElRoysManagerApp.xcodeproj -scheme ElRoysManagerApp -destination 'platform=iOS Simulator,name=iPhone 16' -only-testing:ElRoysManagerAppTests/MenuDocumentTests`